### PR TITLE
handle unions in spread collections

### DIFF
--- a/runtime/sam/expr/values.go
+++ b/runtime/sam/expr/values.go
@@ -313,9 +313,15 @@ func (c *collectionBuilder) append(val zed.Value) {
 }
 
 func (c *collectionBuilder) appendSpread(inner zed.Type, b zcode.Bytes) {
+	union, _ := zed.TypeUnder(inner).(*zed.TypeUnion)
 	for it := b.Iter(); !it.Done(); {
-		c.types = append(c.types, inner)
-		c.bytes = append(c.bytes, it.Next())
+		typ := inner
+		bytes := it.Next()
+		if union != nil {
+			typ, bytes = union.Untag(bytes)
+		}
+		c.types = append(c.types, typ)
+		c.bytes = append(c.bytes, bytes)
 	}
 }
 

--- a/runtime/sam/expr/ztests/array-spread.yaml
+++ b/runtime/sam/expr/ztests/array-spread.yaml
@@ -1,0 +1,6 @@
+zed: yield [...this]
+
+input: &input |
+  [{a:1},{b:2}]
+
+output: *input


### PR DESCRIPTION
This commit fixes the collection handling code in the sam expression evaluator so that union values are properly deunioned when assembling elements into a spread collection.

Fixes #5339