### PR TITLE
Temporarily disable triggering downstream Brimcap/Zui CI

### DIFF
--- a/.github/workflows/notify-downstream-merge.yaml
+++ b/.github/workflows/notify-downstream-merge.yaml
@@ -29,16 +29,19 @@ jobs:
         merged=$(jq .pull_request.merged "${GITHUB_EVENT_PATH}")
         echo "merged=$merged" >> $GITHUB_OUTPUT
       id: vars
-    - name: Post PR closed event, if the close was a merge
-      if: steps.vars.outputs.merged == 'true' && ! contains(github.event.pull_request.labels.*.name, 'skip-notify-downstream')
-      run: |
-        jq '.' "${GITHUB_EVENT_PATH}"
-        # Get what we want from the pull request event, craft a
-        # repository dispatch event, and send it.
-        # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
-        # https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
-        jq '.pull_request | { "event_type": "zed-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' "${GITHUB_EVENT_PATH}" > payload.json
-        curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" https://api.github.com/repos/brimdata/${{ matrix.repo }}/dispatches --data @payload.json
+    # During the "Super" renaming we've temporarily disabled the triggering of
+    # downstream Brimcap/Zui CI because we know they will break while things
+    # are in flux.
+    #- name: Post PR closed event, if the close was a merge
+    #  if: steps.vars.outputs.merged == 'true' && ! contains(github.event.pull_request.labels.*.name, 'skip-notify-downstream')
+    #  run: |
+    #    jq '.' "${GITHUB_EVENT_PATH}"
+    #    # Get what we want from the pull request event, craft a
+    #    # repository dispatch event, and send it.
+    #    # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
+    #    # https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
+    #    jq '.pull_request | { "event_type": "zed-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' "${GITHUB_EVENT_PATH}" > payload.json
+    #    curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" https://api.github.com/repos/brimdata/${{ matrix.repo }}/dispatches --data @payload.json
     - name: Queue merged commits for an Autoperf run
       if: steps.vars.outputs.merged == 'true' && ! contains(github.event.pull_request.labels.*.name, 'skip-autoperf')
       run: |


### PR DESCRIPTION
## What's Changing

This disables the triggering of the downstream Brimcap/Zui CI when Zed PRs merge.

## Why

We've known the other projects will break temporarily during the "Super" renames, e.g., due to changes in the package/command names. Since the renaming will happen in multiple passes and we don't want to be distracted by repeated Slack notifications of expected failures, we'll just disable the triggering entirely for now until things have settled and we make the necessary changes in those projects.

## Details

We've already seen the first such breakage in Brimcap [here](https://github.com/brimdata/brimcap/actions/runs/11371055850). Zui will surely soon follow once #5346 merges.

I fiddled in some personal repos to see which was the best way to disable this. My first idea was just to change the `strategy.matrix.repo` from `[brimcap, zui]` to `[]` but I found Actions wouldn't accept that as a valid Workflow YAML, so I'm just commenting out the block instead.