### PR TITLE
rework delete-where AST

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -659,8 +659,10 @@ type (
 		Kind       string   `json:"kind" unpack:""`
 		KeywordPos int      `json:"keyword_pos"`
 		Spec       PoolSpec `json:"spec"`
-		Delete     bool     `json:"delete"`
 		EndPos     int      `json:"end_pos"`
+	}
+	Delete struct {
+		Kind string `json:"kind" unpack:""`
 	}
 )
 
@@ -676,18 +678,21 @@ type Source interface {
 	Source()
 }
 
-func (*Pool) Source() {}
-func (*File) Source() {}
-func (*HTTP) Source() {}
-func (*Pass) Source() {}
+func (*Pool) Source()   {}
+func (*File) Source()   {}
+func (*HTTP) Source()   {}
+func (*Pass) Source()   {}
+func (*Delete) Source() {}
 
 func (x *Pool) Pos() int { return x.KeywordPos }
 func (x *File) Pos() int { return x.KeywordPos }
 func (x *HTTP) Pos() int { return x.KeywordPos }
+func (*Delete) Pos() int { return 0 }
 
 func (x *Pool) End() int { return x.EndPos }
 func (x *File) End() int { return x.EndPos }
 func (x *HTTP) End() int { return x.EndPos }
+func (*Delete) End() int { return 0 }
 
 type SortExpr struct {
 	Kind  string `json:"kind" unpack:""`
@@ -794,6 +799,7 @@ func (*Load) OpAST()         {}
 func (*Assert) OpAST()       {}
 func (*Output) OpAST()       {}
 func (*Debug) OpAST()        {}
+func (*Delete) OpAST()       {}
 
 func (x *Scope) Pos() int {
 	if x.Decls != nil {

--- a/compiler/lake.go
+++ b/compiler/lake.go
@@ -84,23 +84,7 @@ func newDeleteJob(rctx *runtime.Context, in ast.Seq, src *data.Source, head *lak
 	if len(seq) != 1 {
 		return nil, &InvalidDeleteWhereQuery{}
 	}
-	// add trunk
-	seq.Prepend(&ast.From{
-		Kind: "from",
-		Trunks: []ast.Trunk{{
-			Kind: "Trunk",
-			Source: &ast.Pool{
-				Kind:   "Pool",
-				Delete: true,
-				Spec: ast.PoolSpec{
-					Pool: &ast.String{
-						Kind: "String",
-						Text: "HEAD",
-					},
-				},
-			},
-		}},
-	})
+	seq.Prepend(&ast.Delete{Kind: "Delete"})
 	entry, err := semantic.Analyze(rctx.Context, seq, src, head)
 	if err != nil {
 		return nil, err

--- a/service/ztests/query-bad-commit.yaml
+++ b/service/ztests/query-bad-commit.yaml
@@ -10,6 +10,6 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      "doesnotexist": branch not found at line 1, column 1:
+      "doesnotexist": branch not found at line 1, column 6:
       from test@doesnotexist
-      ~~~~~~~~~~~~~~~~~~~~~~
+           ~~~~


### PR DESCRIPTION
This commit refactors the deletion structure in the AST to remove the Delete flag from the pool and instead have a special ast.Delete object to represent a deletion scan.

This is needed by a subsequent PR that will normalize the "from" structures to be better aligned wiht SQL syntax.