### PR TITLE
Update GoReleaser config for zed->super rename

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,21 +1,7 @@
 builds:
-  - main: ./cmd/zed
-    id: zed
-    binary: zed
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -s -X github.com/brimdata/super/cli.version={{ .Tag }}
-    goarch:
-      - amd64
-      - arm64
-    goos:
-      - linux
-      - windows
-      - darwin
-  - main: ./cmd/zq
-    id: zq
-    binary: zq
+  - main: ./cmd/super
+    id: sup
+    binary: super
     env:
       - CGO_ENABLED=0
     ldflags:
@@ -28,7 +14,7 @@ builds:
       - windows
       - darwin
 archives:
-  - name_template: zed-{{ .Tag }}.{{ .Os }}-{{ .Arch }}
+  - name_template: super-{{ .Tag }}.{{ .Os }}-{{ .Arch }}
     format_overrides:
       - goos: windows
         format: zip
@@ -39,7 +25,7 @@ release:
   header: |
     View [change log](CHANGELOG.md#{{ replace .Tag "." "" }}).
 brews:
-  - name: zed
+  - name: super
     repository:
       owner: brimdata
       name: homebrew-tap
@@ -48,26 +34,12 @@ brews:
       email: bot@brimdata.io
     homepage: https://github.com/brimdata/super
     description: |
-      A command-line tool for creating, configuring, ingesting into, querying,
-      and orchestrating Zed data lakes.
+      SuperSQL or SuperPipe querying of common file formats
+      (CSV/JSON/Parquet/etc.) or SuperDB data lakes
     install: |
-      bin.install "zed"
-  - name: zq
-    repository:
-      owner: brimdata
-      name: homebrew-tap
-    commit_author:
-      name: brim-bot
-      email: bot@brimdata.io
-    homepage: https://github.com/brimdata/super
-    description: |
-      A command-line tool for processing data in diverse input formats,
-      providing search, analytics, and extensive transormations using the Zed
-      query language.
-    install: |
-      bin.install "zq"
+      bin.install "super"
 checksum:
-  name_template: 'zed-checksums.txt'
+  name_template: 'super-checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Version }}-{{ .ShortCommit }}"
 changelog:


### PR DESCRIPTION
## What's Changing

This prepares the GoReleaser config for our next GA release that will be in the "super" era.

## Why

While contemplating the "super" rewrite of the [Installation](https://zed.brimdata.io/docs/next/install) docs page I immediately saw the `brew` step and recognized it needs adjusting.

## Details

Steps I took to test:

1. Forked to my personal repo at https://github.com/philrz/super
2. Modified the GoReleaser config to populate a personal Homebrew tap at https://github.com/philrz/homebrew-tap
3. Tagged a test release `v1.19.0` of "super"
4. Successfully installed and ran it

```
$ brew install philrz/tap/super
==> Tapping philrz/tap
Cloning into '/usr/local/Homebrew/Library/Taps/philrz/homebrew-tap'...
remote: Enumerating objects: 7, done.
remote: Counting objects: 100% (7/7), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 7 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (7/7), done.
Resolving deltas: 100% (1/1), done.
Tapped 1 formula (14 files, 9.8KB).
==> Fetching philrz/tap/super
==> Downloading https://github.com/philrz/super/releases/download/v1.19.0/super-
==> Downloading from https://objects.githubusercontent.com/github-production-rel
######################################################################### 100.0%
==> Installing super from philrz/tap
🍺  /usr/local/Cellar/super/1.19.0: 5 files, 44.0MB, built in 6 seconds
==> Running `brew cleanup super`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

$ which super
/usr/local/bin/super

$ super -version
Version: v1.19.0

$ super query -c 'file sample.zng | count()'
31(uint64)
```

Since this collapses the separate `zq` and `zed` binaries down to the single `super` binary, I recognized the "description" needed adjusting. I poked at how these appear in `brew info` of some other tools and they tend to be shorter than what we had before. Some examples:

* DuckDB - "Embeddable SQL OLAP Database Management System"
* Postgres - "Object-relational database system"
* MySQL - "Open source relational database management system"

Since we're the new kid in town I figure a bit more detail is justified, but it's still just a first attempt. @mccanne feel free to chime in with adjustments, or we can always fiddle later.

Once we actually have a proper GA release of super, we can revisit this config to see if we can jump through the hoops to get into the set of "core" Homebrew formulas.