### PR TITLE
remove ast.Trunk

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -598,10 +598,10 @@ type (
 		KeywordPos int    `json:"keyword_pos"`
 	}
 	From struct {
-		Kind       string  `json:"kind" unpack:""`
-		KeywordPos int     `json:"keyword_pos"`
-		Trunks     []Trunk `json:"trunks"`
-		Rparen     int     `json:"rparen"`
+		Kind       string `json:"kind" unpack:""`
+		KeywordPos int    `json:"keyword_pos"`
+		Trunks     []Seq  `json:"trunks"`
+		Rparen     int    `json:"rparen"`
 	}
 	Load struct {
 		Kind       string `json:"kind" unpack:""`
@@ -706,21 +706,6 @@ func (s SortExpr) End() int {
 		s.Order.End()
 	}
 	return s.Expr.End()
-}
-
-type Trunk struct {
-	Kind   string `json:"kind" unpack:""`
-	Source Source `json:"source"`
-	Seq    Seq    `json:"seq"`
-}
-
-func (t *Trunk) Pos() int { return t.Source.Pos() }
-
-func (t *Trunk) End() int {
-	if len(t.Seq) > 0 {
-		return t.Seq.End()
-	}
-	return t.Source.End()
 }
 
 type Case struct {

--- a/compiler/ast/unpack.go
+++ b/compiler/ast/unpack.go
@@ -48,7 +48,6 @@ var unpacker = unpack.New(
 	Merge{},
 	Output{},
 	Over{},
-	Trunk{},
 	astzed.Map{},
 	MapExpr{},
 	Shape{},

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -24,63 +24,63 @@ var g = &grammar{
 	rules: []*rule{
 		{
 			name: "start",
-			pos:  position{line: 11, col: 1, offset: 150},
+			pos:  position{line: 11, col: 1, offset: 154},
 			expr: &choiceExpr{
-				pos: position{line: 12, col: 5, offset: 160},
+				pos: position{line: 12, col: 5, offset: 164},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 12, col: 5, offset: 160},
+						pos: position{line: 12, col: 5, offset: 164},
 						run: (*parser).callonstart2,
 						expr: &seqExpr{
-							pos: position{line: 12, col: 5, offset: 160},
+							pos: position{line: 12, col: 5, offset: 164},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 12, col: 5, offset: 160},
+									pos:  position{line: 12, col: 5, offset: 164},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 12, col: 8, offset: 163},
+									pos:   position{line: 12, col: 8, offset: 167},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 12, col: 14, offset: 169},
+										pos:  position{line: 12, col: 14, offset: 173},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 12, col: 20, offset: 175},
+									pos:  position{line: 12, col: 20, offset: 179},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 12, col: 23, offset: 178},
+									pos:  position{line: 12, col: 23, offset: 182},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 13, col: 5, offset: 215},
+						pos: position{line: 13, col: 5, offset: 219},
 						run: (*parser).callonstart9,
 						expr: &seqExpr{
-							pos: position{line: 13, col: 5, offset: 215},
+							pos: position{line: 13, col: 5, offset: 219},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 13, col: 5, offset: 215},
+									pos:  position{line: 13, col: 5, offset: 219},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 13, col: 8, offset: 218},
+									pos:   position{line: 13, col: 8, offset: 222},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 13, col: 12, offset: 222},
+										pos:  position{line: 13, col: 12, offset: 226},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 13, col: 16, offset: 226},
+									pos:  position{line: 13, col: 16, offset: 230},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 13, col: 19, offset: 229},
+									pos:  position{line: 13, col: 19, offset: 233},
 									name: "EOF",
 								},
 							},
@@ -93,29 +93,29 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 15, col: 1, offset: 254},
+			pos:  position{line: 15, col: 1, offset: 258},
 			expr: &actionExpr{
-				pos: position{line: 16, col: 5, offset: 264},
+				pos: position{line: 16, col: 5, offset: 268},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 16, col: 5, offset: 264},
+					pos: position{line: 16, col: 5, offset: 268},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 16, col: 5, offset: 264},
+							pos:   position{line: 16, col: 5, offset: 268},
 							label: "decls",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 16, col: 11, offset: 270},
+								pos: position{line: 16, col: 11, offset: 274},
 								expr: &ruleRefExpr{
-									pos:  position{line: 16, col: 11, offset: 270},
+									pos:  position{line: 16, col: 11, offset: 274},
 									name: "Decl",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 16, col: 17, offset: 276},
+							pos:   position{line: 16, col: 17, offset: 280},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 16, col: 22, offset: 281},
+								pos:  position{line: 16, col: 22, offset: 285},
 								name: "Seq",
 							},
 						},
@@ -127,28 +127,28 @@ var g = &grammar{
 		},
 		{
 			name: "Seq",
-			pos:  position{line: 24, col: 1, offset: 433},
+			pos:  position{line: 24, col: 1, offset: 437},
 			expr: &actionExpr{
-				pos: position{line: 25, col: 5, offset: 441},
+				pos: position{line: 25, col: 5, offset: 445},
 				run: (*parser).callonSeq1,
 				expr: &seqExpr{
-					pos: position{line: 25, col: 5, offset: 441},
+					pos: position{line: 25, col: 5, offset: 445},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 25, col: 5, offset: 441},
+							pos:   position{line: 25, col: 5, offset: 445},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 25, col: 11, offset: 447},
+								pos:  position{line: 25, col: 11, offset: 451},
 								name: "Operation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 25, col: 21, offset: 457},
+							pos:   position{line: 25, col: 21, offset: 461},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 25, col: 26, offset: 462},
+								pos: position{line: 25, col: 26, offset: 466},
 								expr: &ruleRefExpr{
-									pos:  position{line: 25, col: 26, offset: 462},
+									pos:  position{line: 25, col: 26, offset: 466},
 									name: "SeqTail",
 								},
 							},
@@ -161,30 +161,30 @@ var g = &grammar{
 		},
 		{
 			name: "SeqTail",
-			pos:  position{line: 29, col: 1, offset: 519},
+			pos:  position{line: 29, col: 1, offset: 523},
 			expr: &actionExpr{
-				pos: position{line: 29, col: 11, offset: 529},
+				pos: position{line: 29, col: 11, offset: 533},
 				run: (*parser).callonSeqTail1,
 				expr: &seqExpr{
-					pos: position{line: 29, col: 11, offset: 529},
+					pos: position{line: 29, col: 11, offset: 533},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 29, col: 11, offset: 529},
+							pos:  position{line: 29, col: 11, offset: 533},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 29, col: 14, offset: 532},
+							pos:  position{line: 29, col: 14, offset: 536},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 29, col: 19, offset: 537},
+							pos:  position{line: 29, col: 19, offset: 541},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 29, col: 22, offset: 540},
+							pos:   position{line: 29, col: 22, offset: 544},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 29, col: 24, offset: 542},
+								pos:  position{line: 29, col: 24, offset: 546},
 								name: "Operation",
 							},
 						},
@@ -196,40 +196,40 @@ var g = &grammar{
 		},
 		{
 			name: "Decl",
-			pos:  position{line: 31, col: 1, offset: 571},
+			pos:  position{line: 31, col: 1, offset: 575},
 			expr: &actionExpr{
-				pos: position{line: 32, col: 5, offset: 580},
+				pos: position{line: 32, col: 5, offset: 584},
 				run: (*parser).callonDecl1,
 				expr: &seqExpr{
-					pos: position{line: 32, col: 5, offset: 580},
+					pos: position{line: 32, col: 5, offset: 584},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 32, col: 5, offset: 580},
+							pos:   position{line: 32, col: 5, offset: 584},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 32, col: 8, offset: 583},
+								pos: position{line: 32, col: 8, offset: 587},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 32, col: 8, offset: 583},
+										pos:  position{line: 32, col: 8, offset: 587},
 										name: "ConstDecl",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 32, col: 20, offset: 595},
+										pos:  position{line: 32, col: 20, offset: 599},
 										name: "FuncDecl",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 32, col: 31, offset: 606},
+										pos:  position{line: 32, col: 31, offset: 610},
 										name: "OpDecl",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 32, col: 40, offset: 615},
+										pos:  position{line: 32, col: 40, offset: 619},
 										name: "TypeDecl",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 32, col: 50, offset: 625},
+							pos:  position{line: 32, col: 50, offset: 629},
 							name: "_",
 						},
 					},
@@ -240,50 +240,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConstDecl",
-			pos:  position{line: 34, col: 1, offset: 646},
+			pos:  position{line: 34, col: 1, offset: 650},
 			expr: &actionExpr{
-				pos: position{line: 35, col: 5, offset: 660},
+				pos: position{line: 35, col: 5, offset: 664},
 				run: (*parser).callonConstDecl1,
 				expr: &seqExpr{
-					pos: position{line: 35, col: 5, offset: 660},
+					pos: position{line: 35, col: 5, offset: 664},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 35, col: 5, offset: 660},
+							pos:        position{line: 35, col: 5, offset: 664},
 							val:        "const",
 							ignoreCase: false,
 							want:       "\"const\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 35, col: 13, offset: 668},
+							pos:  position{line: 35, col: 13, offset: 672},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 35, col: 15, offset: 670},
+							pos:   position{line: 35, col: 15, offset: 674},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 35, col: 20, offset: 675},
+								pos:  position{line: 35, col: 20, offset: 679},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 35, col: 31, offset: 686},
+							pos:  position{line: 35, col: 31, offset: 690},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 35, col: 34, offset: 689},
+							pos:        position{line: 35, col: 34, offset: 693},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 35, col: 38, offset: 693},
+							pos:  position{line: 35, col: 38, offset: 697},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 35, col: 41, offset: 696},
+							pos:   position{line: 35, col: 41, offset: 700},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 35, col: 46, offset: 701},
+								pos:  position{line: 35, col: 46, offset: 705},
 								name: "Expr",
 							},
 						},
@@ -295,104 +295,104 @@ var g = &grammar{
 		},
 		{
 			name: "FuncDecl",
-			pos:  position{line: 44, col: 1, offset: 887},
+			pos:  position{line: 44, col: 1, offset: 891},
 			expr: &actionExpr{
-				pos: position{line: 45, col: 5, offset: 900},
+				pos: position{line: 45, col: 5, offset: 904},
 				run: (*parser).callonFuncDecl1,
 				expr: &seqExpr{
-					pos: position{line: 45, col: 5, offset: 900},
+					pos: position{line: 45, col: 5, offset: 904},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 45, col: 5, offset: 900},
+							pos:        position{line: 45, col: 5, offset: 904},
 							val:        "func",
 							ignoreCase: false,
 							want:       "\"func\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 45, col: 12, offset: 907},
+							pos:  position{line: 45, col: 12, offset: 911},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 45, col: 14, offset: 909},
+							pos:   position{line: 45, col: 14, offset: 913},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 45, col: 19, offset: 914},
+								pos:  position{line: 45, col: 19, offset: 918},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 45, col: 30, offset: 925},
+							pos:  position{line: 45, col: 30, offset: 929},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 45, col: 33, offset: 928},
+							pos:        position{line: 45, col: 33, offset: 932},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 45, col: 37, offset: 932},
+							pos:  position{line: 45, col: 37, offset: 936},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 45, col: 40, offset: 935},
+							pos:   position{line: 45, col: 40, offset: 939},
 							label: "params",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 45, col: 47, offset: 942},
+								pos: position{line: 45, col: 47, offset: 946},
 								expr: &ruleRefExpr{
-									pos:  position{line: 45, col: 47, offset: 942},
+									pos:  position{line: 45, col: 47, offset: 946},
 									name: "Identifiers",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 45, col: 60, offset: 955},
+							pos:  position{line: 45, col: 60, offset: 959},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 45, col: 63, offset: 958},
+							pos:        position{line: 45, col: 63, offset: 962},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 45, col: 67, offset: 962},
+							pos:  position{line: 45, col: 67, offset: 966},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 45, col: 70, offset: 965},
+							pos:        position{line: 45, col: 70, offset: 969},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 45, col: 74, offset: 969},
+							pos:  position{line: 45, col: 74, offset: 973},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 45, col: 77, offset: 972},
+							pos:        position{line: 45, col: 77, offset: 976},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 45, col: 81, offset: 976},
+							pos:  position{line: 45, col: 81, offset: 980},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 45, col: 84, offset: 979},
+							pos:   position{line: 45, col: 84, offset: 983},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 45, col: 89, offset: 984},
+								pos:  position{line: 45, col: 89, offset: 988},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 45, col: 94, offset: 989},
+							pos:  position{line: 45, col: 94, offset: 993},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 45, col: 97, offset: 992},
+							pos:        position{line: 45, col: 97, offset: 996},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -405,104 +405,104 @@ var g = &grammar{
 		},
 		{
 			name: "OpDecl",
-			pos:  position{line: 56, col: 1, offset: 1242},
+			pos:  position{line: 56, col: 1, offset: 1246},
 			expr: &actionExpr{
-				pos: position{line: 57, col: 5, offset: 1253},
+				pos: position{line: 57, col: 5, offset: 1257},
 				run: (*parser).callonOpDecl1,
 				expr: &seqExpr{
-					pos: position{line: 57, col: 5, offset: 1253},
+					pos: position{line: 57, col: 5, offset: 1257},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 57, col: 5, offset: 1253},
+							pos:        position{line: 57, col: 5, offset: 1257},
 							val:        "op",
 							ignoreCase: false,
 							want:       "\"op\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 57, col: 10, offset: 1258},
+							pos:  position{line: 57, col: 10, offset: 1262},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 57, col: 12, offset: 1260},
+							pos:   position{line: 57, col: 12, offset: 1264},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 57, col: 17, offset: 1265},
+								pos:  position{line: 57, col: 17, offset: 1269},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 57, col: 28, offset: 1276},
+							pos:  position{line: 57, col: 28, offset: 1280},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 57, col: 31, offset: 1279},
+							pos:        position{line: 57, col: 31, offset: 1283},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 57, col: 35, offset: 1283},
+							pos:  position{line: 57, col: 35, offset: 1287},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 57, col: 38, offset: 1286},
+							pos:   position{line: 57, col: 38, offset: 1290},
 							label: "params",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 57, col: 45, offset: 1293},
+								pos: position{line: 57, col: 45, offset: 1297},
 								expr: &ruleRefExpr{
-									pos:  position{line: 57, col: 45, offset: 1293},
+									pos:  position{line: 57, col: 45, offset: 1297},
 									name: "Identifiers",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 57, col: 58, offset: 1306},
+							pos:  position{line: 57, col: 58, offset: 1310},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 57, col: 61, offset: 1309},
+							pos:        position{line: 57, col: 61, offset: 1313},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 57, col: 65, offset: 1313},
+							pos:  position{line: 57, col: 65, offset: 1317},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 57, col: 68, offset: 1316},
+							pos:        position{line: 57, col: 68, offset: 1320},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 57, col: 72, offset: 1320},
+							pos:  position{line: 57, col: 72, offset: 1324},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 57, col: 75, offset: 1323},
+							pos:        position{line: 57, col: 75, offset: 1327},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 57, col: 79, offset: 1327},
+							pos:  position{line: 57, col: 79, offset: 1331},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 57, col: 82, offset: 1330},
+							pos:   position{line: 57, col: 82, offset: 1334},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 57, col: 87, offset: 1335},
+								pos:  position{line: 57, col: 87, offset: 1339},
 								name: "OpDeclBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 57, col: 98, offset: 1346},
+							pos:  position{line: 57, col: 98, offset: 1350},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 57, col: 101, offset: 1349},
+							pos:        position{line: 57, col: 101, offset: 1353},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -515,30 +515,30 @@ var g = &grammar{
 		},
 		{
 			name: "OpDeclBody",
-			pos:  position{line: 68, col: 1, offset: 1601},
+			pos:  position{line: 68, col: 1, offset: 1605},
 			expr: &choiceExpr{
-				pos: position{line: 69, col: 5, offset: 1616},
+				pos: position{line: 69, col: 5, offset: 1620},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 69, col: 5, offset: 1616},
+						pos: position{line: 69, col: 5, offset: 1620},
 						run: (*parser).callonOpDeclBody2,
 						expr: &labeledExpr{
-							pos:   position{line: 69, col: 5, offset: 1616},
+							pos:   position{line: 69, col: 5, offset: 1620},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 69, col: 11, offset: 1622},
+								pos:  position{line: 69, col: 11, offset: 1626},
 								name: "Scope",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 70, col: 5, offset: 1661},
+						pos: position{line: 70, col: 5, offset: 1665},
 						run: (*parser).callonOpDeclBody5,
 						expr: &labeledExpr{
-							pos:   position{line: 70, col: 5, offset: 1661},
+							pos:   position{line: 70, col: 5, offset: 1665},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 70, col: 9, offset: 1665},
+								pos:  position{line: 70, col: 9, offset: 1669},
 								name: "Seq",
 							},
 						},
@@ -550,50 +550,50 @@ var g = &grammar{
 		},
 		{
 			name: "TypeDecl",
-			pos:  position{line: 72, col: 1, offset: 1690},
+			pos:  position{line: 72, col: 1, offset: 1694},
 			expr: &actionExpr{
-				pos: position{line: 73, col: 5, offset: 1703},
+				pos: position{line: 73, col: 5, offset: 1707},
 				run: (*parser).callonTypeDecl1,
 				expr: &seqExpr{
-					pos: position{line: 73, col: 5, offset: 1703},
+					pos: position{line: 73, col: 5, offset: 1707},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 73, col: 5, offset: 1703},
+							pos:        position{line: 73, col: 5, offset: 1707},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 73, col: 12, offset: 1710},
+							pos:  position{line: 73, col: 12, offset: 1714},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 73, col: 14, offset: 1712},
+							pos:   position{line: 73, col: 14, offset: 1716},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 73, col: 19, offset: 1717},
+								pos:  position{line: 73, col: 19, offset: 1721},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 73, col: 30, offset: 1728},
+							pos:  position{line: 73, col: 30, offset: 1732},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 73, col: 33, offset: 1731},
+							pos:        position{line: 73, col: 33, offset: 1735},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 73, col: 37, offset: 1735},
+							pos:  position{line: 73, col: 37, offset: 1739},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 73, col: 40, offset: 1738},
+							pos:   position{line: 73, col: 40, offset: 1742},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 73, col: 44, offset: 1742},
+								pos:  position{line: 73, col: 44, offset: 1746},
 								name: "Type",
 							},
 						},
@@ -605,49 +605,49 @@ var g = &grammar{
 		},
 		{
 			name: "Operation",
-			pos:  position{line: 82, col: 1, offset: 1920},
+			pos:  position{line: 82, col: 1, offset: 1924},
 			expr: &choiceExpr{
-				pos: position{line: 83, col: 5, offset: 1934},
+				pos: position{line: 83, col: 5, offset: 1938},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 83, col: 5, offset: 1934},
+						pos: position{line: 83, col: 5, offset: 1938},
 						run: (*parser).callonOperation2,
 						expr: &seqExpr{
-							pos: position{line: 83, col: 5, offset: 1934},
+							pos: position{line: 83, col: 5, offset: 1938},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 83, col: 5, offset: 1934},
+									pos:        position{line: 83, col: 5, offset: 1938},
 									val:        "fork",
 									ignoreCase: false,
 									want:       "\"fork\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 83, col: 12, offset: 1941},
+									pos:  position{line: 83, col: 12, offset: 1945},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 83, col: 15, offset: 1944},
+									pos:        position{line: 83, col: 15, offset: 1948},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 83, col: 19, offset: 1948},
+									pos:   position{line: 83, col: 19, offset: 1952},
 									label: "paths",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 83, col: 25, offset: 1954},
+										pos: position{line: 83, col: 25, offset: 1958},
 										expr: &ruleRefExpr{
-											pos:  position{line: 83, col: 25, offset: 1954},
+											pos:  position{line: 83, col: 25, offset: 1958},
 											name: "Leg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 83, col: 30, offset: 1959},
+									pos:  position{line: 83, col: 30, offset: 1963},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 83, col: 33, offset: 1962},
+									pos:        position{line: 83, col: 33, offset: 1966},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -656,56 +656,56 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 95, col: 5, offset: 2262},
+						pos: position{line: 95, col: 5, offset: 2266},
 						run: (*parser).callonOperation12,
 						expr: &seqExpr{
-							pos: position{line: 95, col: 5, offset: 2262},
+							pos: position{line: 95, col: 5, offset: 2266},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 95, col: 5, offset: 2262},
+									pos:        position{line: 95, col: 5, offset: 2266},
 									val:        "switch",
 									ignoreCase: false,
 									want:       "\"switch\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 95, col: 14, offset: 2271},
+									pos:  position{line: 95, col: 14, offset: 2275},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 95, col: 16, offset: 2273},
+									pos:   position{line: 95, col: 16, offset: 2277},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 95, col: 21, offset: 2278},
+										pos:  position{line: 95, col: 21, offset: 2282},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 95, col: 26, offset: 2283},
+									pos:  position{line: 95, col: 26, offset: 2287},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 95, col: 28, offset: 2285},
+									pos:        position{line: 95, col: 28, offset: 2289},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 95, col: 32, offset: 2289},
+									pos:   position{line: 95, col: 32, offset: 2293},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 95, col: 38, offset: 2295},
+										pos: position{line: 95, col: 38, offset: 2299},
 										expr: &ruleRefExpr{
-											pos:  position{line: 95, col: 38, offset: 2295},
+											pos:  position{line: 95, col: 38, offset: 2299},
 											name: "SwitchLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 95, col: 49, offset: 2306},
+									pos:  position{line: 95, col: 49, offset: 2310},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 95, col: 52, offset: 2309},
+									pos:        position{line: 95, col: 52, offset: 2313},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -714,44 +714,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 104, col: 5, offset: 2537},
+						pos: position{line: 104, col: 5, offset: 2541},
 						run: (*parser).callonOperation25,
 						expr: &seqExpr{
-							pos: position{line: 104, col: 5, offset: 2537},
+							pos: position{line: 104, col: 5, offset: 2541},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 104, col: 5, offset: 2537},
+									pos:        position{line: 104, col: 5, offset: 2541},
 									val:        "switch",
 									ignoreCase: false,
 									want:       "\"switch\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 104, col: 14, offset: 2546},
+									pos:  position{line: 104, col: 14, offset: 2550},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 104, col: 17, offset: 2549},
+									pos:        position{line: 104, col: 17, offset: 2553},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 104, col: 21, offset: 2553},
+									pos:   position{line: 104, col: 21, offset: 2557},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 104, col: 27, offset: 2559},
+										pos: position{line: 104, col: 27, offset: 2563},
 										expr: &ruleRefExpr{
-											pos:  position{line: 104, col: 27, offset: 2559},
+											pos:  position{line: 104, col: 27, offset: 2563},
 											name: "SwitchLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 104, col: 38, offset: 2570},
+									pos:  position{line: 104, col: 38, offset: 2574},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 104, col: 41, offset: 2573},
+									pos:        position{line: 104, col: 41, offset: 2577},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -760,44 +760,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 112, col: 5, offset: 2768},
+						pos: position{line: 112, col: 5, offset: 2772},
 						run: (*parser).callonOperation35,
 						expr: &seqExpr{
-							pos: position{line: 112, col: 5, offset: 2768},
+							pos: position{line: 112, col: 5, offset: 2772},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 112, col: 5, offset: 2768},
+									pos:        position{line: 112, col: 5, offset: 2772},
 									val:        "from",
 									ignoreCase: false,
 									want:       "\"from\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 112, col: 12, offset: 2775},
+									pos:  position{line: 112, col: 12, offset: 2779},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 112, col: 15, offset: 2778},
+									pos:        position{line: 112, col: 15, offset: 2782},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 112, col: 19, offset: 2782},
+									pos:   position{line: 112, col: 19, offset: 2786},
 									label: "trunks",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 112, col: 26, offset: 2789},
+										pos: position{line: 112, col: 26, offset: 2793},
 										expr: &ruleRefExpr{
-											pos:  position{line: 112, col: 26, offset: 2789},
+											pos:  position{line: 112, col: 26, offset: 2793},
 											name: "FromLeg",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 112, col: 35, offset: 2798},
+									pos:  position{line: 112, col: 35, offset: 2802},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 112, col: 38, offset: 2801},
+									pos:        position{line: 112, col: 38, offset: 2805},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -806,35 +806,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 120, col: 5, offset: 2995},
+						pos: position{line: 120, col: 5, offset: 2997},
 						run: (*parser).callonOperation45,
 						expr: &seqExpr{
-							pos: position{line: 120, col: 5, offset: 2995},
+							pos: position{line: 120, col: 5, offset: 2997},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 120, col: 5, offset: 2995},
+									pos:        position{line: 120, col: 5, offset: 2997},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 120, col: 9, offset: 2999},
+									pos:  position{line: 120, col: 9, offset: 3001},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 120, col: 12, offset: 3002},
+									pos:   position{line: 120, col: 12, offset: 3004},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 120, col: 18, offset: 3008},
+										pos:  position{line: 120, col: 18, offset: 3010},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 120, col: 24, offset: 3014},
+									pos:  position{line: 120, col: 24, offset: 3016},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 120, col: 27, offset: 3017},
+									pos:        position{line: 120, col: 27, offset: 3019},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -843,31 +843,31 @@ var g = &grammar{
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 121, col: 5, offset: 3047},
+						pos:   position{line: 121, col: 5, offset: 3049},
 						label: "op",
 						expr: &ruleRefExpr{
-							pos:  position{line: 121, col: 8, offset: 3050},
+							pos:  position{line: 121, col: 8, offset: 3052},
 							name: "Operator",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 122, col: 5, offset: 3063},
+						pos: position{line: 122, col: 5, offset: 3065},
 						run: (*parser).callonOperation55,
 						expr: &seqExpr{
-							pos: position{line: 122, col: 5, offset: 3063},
+							pos: position{line: 122, col: 5, offset: 3065},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 122, col: 5, offset: 3063},
+									pos:   position{line: 122, col: 5, offset: 3065},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 122, col: 7, offset: 3065},
+										pos:  position{line: 122, col: 7, offset: 3067},
 										name: "OpAssignment",
 									},
 								},
 								&andExpr{
-									pos: position{line: 122, col: 20, offset: 3078},
+									pos: position{line: 122, col: 20, offset: 3080},
 									expr: &ruleRefExpr{
-										pos:  position{line: 122, col: 21, offset: 3079},
+										pos:  position{line: 122, col: 21, offset: 3081},
 										name: "EndOfOp",
 									},
 								},
@@ -875,39 +875,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 123, col: 5, offset: 3109},
+						pos: position{line: 123, col: 5, offset: 3111},
 						run: (*parser).callonOperation61,
 						expr: &seqExpr{
-							pos: position{line: 123, col: 5, offset: 3109},
+							pos: position{line: 123, col: 5, offset: 3111},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 123, col: 5, offset: 3109},
+									pos: position{line: 123, col: 5, offset: 3111},
 									expr: &seqExpr{
-										pos: position{line: 123, col: 7, offset: 3111},
+										pos: position{line: 123, col: 7, offset: 3113},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 123, col: 7, offset: 3111},
+												pos:  position{line: 123, col: 7, offset: 3113},
 												name: "Function",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 123, col: 16, offset: 3120},
+												pos:  position{line: 123, col: 16, offset: 3122},
 												name: "EndOfOp",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 123, col: 25, offset: 3129},
+									pos:   position{line: 123, col: 25, offset: 3131},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 123, col: 27, offset: 3131},
+										pos:  position{line: 123, col: 27, offset: 3133},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 123, col: 39, offset: 3143},
+									pos: position{line: 123, col: 39, offset: 3145},
 									expr: &ruleRefExpr{
-										pos:  position{line: 123, col: 40, offset: 3144},
+										pos:  position{line: 123, col: 40, offset: 3146},
 										name: "EndOfOp",
 									},
 								},
@@ -915,26 +915,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 124, col: 5, offset: 3174},
+						pos: position{line: 124, col: 5, offset: 3176},
 						run: (*parser).callonOperation71,
 						expr: &seqExpr{
-							pos: position{line: 124, col: 5, offset: 3174},
+							pos: position{line: 124, col: 5, offset: 3176},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 124, col: 5, offset: 3174},
+									pos:        position{line: 124, col: 5, offset: 3176},
 									val:        "search",
 									ignoreCase: false,
 									want:       "\"search\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 124, col: 14, offset: 3183},
+									pos:  position{line: 124, col: 14, offset: 3185},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 124, col: 16, offset: 3185},
+									pos:   position{line: 124, col: 16, offset: 3187},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 124, col: 21, offset: 3190},
+										pos:  position{line: 124, col: 21, offset: 3192},
 										name: "SearchBoolean",
 									},
 								},
@@ -942,37 +942,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 127, col: 5, offset: 3306},
+						pos: position{line: 127, col: 5, offset: 3308},
 						run: (*parser).callonOperation77,
 						expr: &labeledExpr{
-							pos:   position{line: 127, col: 5, offset: 3306},
+							pos:   position{line: 127, col: 5, offset: 3308},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 127, col: 10, offset: 3311},
+								pos:  position{line: 127, col: 10, offset: 3313},
 								name: "SearchBoolean",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 130, col: 5, offset: 3403},
+						pos: position{line: 130, col: 5, offset: 3405},
 						run: (*parser).callonOperation80,
 						expr: &labeledExpr{
-							pos:   position{line: 130, col: 5, offset: 3403},
+							pos:   position{line: 130, col: 5, offset: 3405},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 130, col: 10, offset: 3408},
+								pos:  position{line: 130, col: 10, offset: 3410},
 								name: "Cast",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 133, col: 5, offset: 3489},
+						pos: position{line: 133, col: 5, offset: 3491},
 						run: (*parser).callonOperation83,
 						expr: &labeledExpr{
-							pos:   position{line: 133, col: 5, offset: 3489},
+							pos:   position{line: 133, col: 5, offset: 3491},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 133, col: 10, offset: 3494},
+								pos:  position{line: 133, col: 10, offset: 3496},
 								name: "Expr",
 							},
 						},
@@ -984,39 +984,39 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 137, col: 1, offset: 3574},
+			pos:  position{line: 137, col: 1, offset: 3576},
 			expr: &seqExpr{
-				pos: position{line: 137, col: 11, offset: 3584},
+				pos: position{line: 137, col: 11, offset: 3586},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 137, col: 11, offset: 3584},
+						pos:  position{line: 137, col: 11, offset: 3586},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 137, col: 15, offset: 3588},
+						pos: position{line: 137, col: 15, offset: 3590},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 137, col: 15, offset: 3588},
+								pos:  position{line: 137, col: 15, offset: 3590},
 								name: "Pipe",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 137, col: 22, offset: 3595},
+								pos:  position{line: 137, col: 22, offset: 3597},
 								name: "SearchKeywordGuard",
 							},
 							&litMatcher{
-								pos:        position{line: 137, col: 43, offset: 3616},
+								pos:        position{line: 137, col: 43, offset: 3618},
 								val:        "=>",
 								ignoreCase: false,
 								want:       "\"=>\"",
 							},
 							&litMatcher{
-								pos:        position{line: 137, col: 50, offset: 3623},
+								pos:        position{line: 137, col: 50, offset: 3625},
 								val:        ")",
 								ignoreCase: false,
 								want:       "\")\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 137, col: 56, offset: 3629},
+								pos:  position{line: 137, col: 56, offset: 3631},
 								name: "EOF",
 							},
 						},
@@ -1028,29 +1028,29 @@ var g = &grammar{
 		},
 		{
 			name: "Pipe",
-			pos:  position{line: 138, col: 1, offset: 3634},
+			pos:  position{line: 138, col: 1, offset: 3636},
 			expr: &seqExpr{
-				pos: position{line: 138, col: 8, offset: 3641},
+				pos: position{line: 138, col: 8, offset: 3643},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 138, col: 8, offset: 3641},
+						pos:        position{line: 138, col: 8, offset: 3643},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&notExpr{
-						pos: position{line: 138, col: 12, offset: 3645},
+						pos: position{line: 138, col: 12, offset: 3647},
 						expr: &choiceExpr{
-							pos: position{line: 138, col: 14, offset: 3647},
+							pos: position{line: 138, col: 14, offset: 3649},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 138, col: 14, offset: 3647},
+									pos:        position{line: 138, col: 14, offset: 3649},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&litMatcher{
-									pos:        position{line: 138, col: 20, offset: 3653},
+									pos:        position{line: 138, col: 20, offset: 3655},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
@@ -1065,32 +1065,32 @@ var g = &grammar{
 		},
 		{
 			name: "Leg",
-			pos:  position{line: 140, col: 1, offset: 3659},
+			pos:  position{line: 140, col: 1, offset: 3661},
 			expr: &actionExpr{
-				pos: position{line: 140, col: 7, offset: 3665},
+				pos: position{line: 140, col: 7, offset: 3667},
 				run: (*parser).callonLeg1,
 				expr: &seqExpr{
-					pos: position{line: 140, col: 7, offset: 3665},
+					pos: position{line: 140, col: 7, offset: 3667},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 140, col: 7, offset: 3665},
+							pos:  position{line: 140, col: 7, offset: 3667},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 140, col: 10, offset: 3668},
+							pos:        position{line: 140, col: 10, offset: 3670},
 							val:        "=>",
 							ignoreCase: false,
 							want:       "\"=>\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 140, col: 15, offset: 3673},
+							pos:  position{line: 140, col: 15, offset: 3675},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 140, col: 18, offset: 3676},
+							pos:   position{line: 140, col: 18, offset: 3678},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 140, col: 22, offset: 3680},
+								pos:  position{line: 140, col: 22, offset: 3682},
 								name: "Seq",
 							},
 						},
@@ -1102,30 +1102,30 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchLeg",
-			pos:  position{line: 142, col: 1, offset: 3705},
+			pos:  position{line: 142, col: 1, offset: 3707},
 			expr: &actionExpr{
-				pos: position{line: 143, col: 5, offset: 3719},
+				pos: position{line: 143, col: 5, offset: 3721},
 				run: (*parser).callonSwitchLeg1,
 				expr: &seqExpr{
-					pos: position{line: 143, col: 5, offset: 3719},
+					pos: position{line: 143, col: 5, offset: 3721},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 143, col: 5, offset: 3719},
+							pos:  position{line: 143, col: 5, offset: 3721},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 143, col: 8, offset: 3722},
+							pos:   position{line: 143, col: 8, offset: 3724},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 143, col: 13, offset: 3727},
+								pos:  position{line: 143, col: 13, offset: 3729},
 								name: "Case",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 143, col: 18, offset: 3732},
+							pos:   position{line: 143, col: 18, offset: 3734},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 143, col: 23, offset: 3737},
+								pos:  position{line: 143, col: 23, offset: 3739},
 								name: "Leg",
 							},
 						},
@@ -1137,31 +1137,31 @@ var g = &grammar{
 		},
 		{
 			name: "Case",
-			pos:  position{line: 151, col: 1, offset: 3883},
+			pos:  position{line: 151, col: 1, offset: 3885},
 			expr: &choiceExpr{
-				pos: position{line: 152, col: 5, offset: 3892},
+				pos: position{line: 152, col: 5, offset: 3894},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 152, col: 5, offset: 3892},
+						pos: position{line: 152, col: 5, offset: 3894},
 						run: (*parser).callonCase2,
 						expr: &seqExpr{
-							pos: position{line: 152, col: 5, offset: 3892},
+							pos: position{line: 152, col: 5, offset: 3894},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 152, col: 5, offset: 3892},
+									pos:        position{line: 152, col: 5, offset: 3894},
 									val:        "case",
 									ignoreCase: false,
 									want:       "\"case\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 152, col: 12, offset: 3899},
+									pos:  position{line: 152, col: 12, offset: 3901},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 152, col: 14, offset: 3901},
+									pos:   position{line: 152, col: 14, offset: 3903},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 152, col: 19, offset: 3906},
+										pos:  position{line: 152, col: 19, offset: 3908},
 										name: "Expr",
 									},
 								},
@@ -1169,10 +1169,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 153, col: 5, offset: 3936},
+						pos: position{line: 153, col: 5, offset: 3938},
 						run: (*parser).callonCase8,
 						expr: &litMatcher{
-							pos:        position{line: 153, col: 5, offset: 3936},
+							pos:        position{line: 153, col: 5, offset: 3938},
 							val:        "default",
 							ignoreCase: false,
 							want:       "\"default\"",
@@ -1185,50 +1185,58 @@ var g = &grammar{
 		},
 		{
 			name: "FromLeg",
-			pos:  position{line: 155, col: 1, offset: 3967},
+			pos:  position{line: 155, col: 1, offset: 3969},
 			expr: &actionExpr{
-				pos: position{line: 156, col: 5, offset: 3979},
+				pos: position{line: 156, col: 5, offset: 3981},
 				run: (*parser).callonFromLeg1,
 				expr: &seqExpr{
-					pos: position{line: 156, col: 5, offset: 3979},
+					pos: position{line: 156, col: 5, offset: 3981},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 156, col: 5, offset: 3979},
+							pos:  position{line: 156, col: 5, offset: 3981},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 156, col: 8, offset: 3982},
+							pos:   position{line: 156, col: 8, offset: 3984},
 							label: "source",
 							expr: &ruleRefExpr{
-								pos:  position{line: 156, col: 15, offset: 3989},
+								pos:  position{line: 156, col: 15, offset: 3991},
 								name: "FromSource",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 156, col: 26, offset: 4000},
-							label: "opt",
+							pos:   position{line: 156, col: 26, offset: 4002},
+							label: "seq",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 156, col: 30, offset: 4004},
-								expr: &seqExpr{
-									pos: position{line: 156, col: 31, offset: 4005},
-									exprs: []any{
-										&ruleRefExpr{
-											pos:  position{line: 156, col: 31, offset: 4005},
-											name: "__",
-										},
-										&litMatcher{
-											pos:        position{line: 156, col: 34, offset: 4008},
-											val:        "=>",
-											ignoreCase: false,
-											want:       "\"=>\"",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 156, col: 39, offset: 4013},
-											name: "__",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 156, col: 42, offset: 4016},
-											name: "Seq",
+								pos: position{line: 156, col: 30, offset: 4006},
+								expr: &actionExpr{
+									pos: position{line: 156, col: 31, offset: 4007},
+									run: (*parser).callonFromLeg8,
+									expr: &seqExpr{
+										pos: position{line: 156, col: 31, offset: 4007},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 156, col: 31, offset: 4007},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 156, col: 34, offset: 4010},
+												val:        "=>",
+												ignoreCase: false,
+												want:       "\"=>\"",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 156, col: 39, offset: 4015},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 156, col: 42, offset: 4018},
+												label: "s",
+												expr: &ruleRefExpr{
+													pos:  position{line: 156, col: 44, offset: 4020},
+													name: "Seq",
+												},
+											},
 										},
 									},
 								},
@@ -1242,24 +1250,24 @@ var g = &grammar{
 		},
 		{
 			name: "FromSource",
-			pos:  position{line: 164, col: 1, offset: 4191},
+			pos:  position{line: 164, col: 1, offset: 4200},
 			expr: &choiceExpr{
-				pos: position{line: 165, col: 5, offset: 4206},
+				pos: position{line: 165, col: 5, offset: 4215},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 165, col: 5, offset: 4206},
+						pos:  position{line: 165, col: 5, offset: 4215},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 166, col: 5, offset: 4215},
+						pos:  position{line: 166, col: 5, offset: 4224},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 167, col: 5, offset: 4223},
+						pos:  position{line: 167, col: 5, offset: 4232},
 						name: "Pool",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 168, col: 5, offset: 4232},
+						pos:  position{line: 168, col: 5, offset: 4241},
 						name: "PassOp",
 					},
 				},
@@ -1269,63 +1277,63 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 170, col: 1, offset: 4240},
+			pos:  position{line: 170, col: 1, offset: 4249},
 			expr: &seqExpr{
-				pos: position{line: 170, col: 13, offset: 4252},
+				pos: position{line: 170, col: 13, offset: 4261},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 170, col: 13, offset: 4252},
+						pos:  position{line: 170, col: 13, offset: 4261},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 170, col: 17, offset: 4256},
+						pos: position{line: 170, col: 17, offset: 4265},
 						alternatives: []any{
 							&seqExpr{
-								pos: position{line: 170, col: 18, offset: 4257},
+								pos: position{line: 170, col: 18, offset: 4266},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 170, col: 18, offset: 4257},
+										pos: position{line: 170, col: 18, offset: 4266},
 										expr: &litMatcher{
-											pos:        position{line: 170, col: 19, offset: 4258},
+											pos:        position{line: 170, col: 19, offset: 4267},
 											val:        "=>",
 											ignoreCase: false,
 											want:       "\"=>\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 170, col: 24, offset: 4263},
+										pos:  position{line: 170, col: 24, offset: 4272},
 										name: "Comparator",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 170, col: 38, offset: 4277},
+								pos:  position{line: 170, col: 38, offset: 4286},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 170, col: 57, offset: 4296},
+								pos:  position{line: 170, col: 57, offset: 4305},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 170, col: 82, offset: 4321},
+								pos:        position{line: 170, col: 82, offset: 4330},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&litMatcher{
-								pos:        position{line: 170, col: 88, offset: 4327},
+								pos:        position{line: 170, col: 88, offset: 4336},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 							&litMatcher{
-								pos:        position{line: 170, col: 94, offset: 4333},
+								pos:        position{line: 170, col: 94, offset: 4342},
 								val:        "[",
 								ignoreCase: false,
 								want:       "\"[\"",
 							},
 							&litMatcher{
-								pos:        position{line: 170, col: 100, offset: 4339},
+								pos:        position{line: 170, col: 100, offset: 4348},
 								val:        "~",
 								ignoreCase: false,
 								want:       "\"~\"",
@@ -1339,63 +1347,63 @@ var g = &grammar{
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 172, col: 1, offset: 4345},
+			pos:  position{line: 172, col: 1, offset: 4354},
 			expr: &actionExpr{
-				pos: position{line: 172, col: 14, offset: 4358},
+				pos: position{line: 172, col: 14, offset: 4367},
 				run: (*parser).callonComparator1,
 				expr: &choiceExpr{
-					pos: position{line: 172, col: 15, offset: 4359},
+					pos: position{line: 172, col: 15, offset: 4368},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 172, col: 15, offset: 4359},
+							pos:        position{line: 172, col: 15, offset: 4368},
 							val:        "==",
 							ignoreCase: false,
 							want:       "\"==\"",
 						},
 						&litMatcher{
-							pos:        position{line: 172, col: 22, offset: 4366},
+							pos:        position{line: 172, col: 22, offset: 4375},
 							val:        "!=",
 							ignoreCase: false,
 							want:       "\"!=\"",
 						},
 						&seqExpr{
-							pos: position{line: 172, col: 30, offset: 4374},
+							pos: position{line: 172, col: 30, offset: 4383},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 172, col: 30, offset: 4374},
+									pos:        position{line: 172, col: 30, offset: 4383},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&notExpr{
-									pos: position{line: 172, col: 35, offset: 4379},
+									pos: position{line: 172, col: 35, offset: 4388},
 									expr: &ruleRefExpr{
-										pos:  position{line: 172, col: 36, offset: 4380},
+										pos:  position{line: 172, col: 36, offset: 4389},
 										name: "IdentifierRest",
 									},
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 172, col: 54, offset: 4398},
+							pos:        position{line: 172, col: 54, offset: 4407},
 							val:        "<=",
 							ignoreCase: false,
 							want:       "\"<=\"",
 						},
 						&litMatcher{
-							pos:        position{line: 172, col: 61, offset: 4405},
+							pos:        position{line: 172, col: 61, offset: 4414},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&litMatcher{
-							pos:        position{line: 172, col: 67, offset: 4411},
+							pos:        position{line: 172, col: 67, offset: 4420},
 							val:        ">=",
 							ignoreCase: false,
 							want:       "\">=\"",
 						},
 						&litMatcher{
-							pos:        position{line: 172, col: 74, offset: 4418},
+							pos:        position{line: 172, col: 74, offset: 4427},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -1408,28 +1416,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 174, col: 1, offset: 4455},
+			pos:  position{line: 174, col: 1, offset: 4464},
 			expr: &actionExpr{
-				pos: position{line: 175, col: 5, offset: 4473},
+				pos: position{line: 175, col: 5, offset: 4482},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 175, col: 5, offset: 4473},
+					pos: position{line: 175, col: 5, offset: 4482},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 175, col: 5, offset: 4473},
+							pos:   position{line: 175, col: 5, offset: 4482},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 175, col: 11, offset: 4479},
+								pos:  position{line: 175, col: 11, offset: 4488},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 175, col: 21, offset: 4489},
+							pos:   position{line: 175, col: 21, offset: 4498},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 175, col: 26, offset: 4494},
+								pos: position{line: 175, col: 26, offset: 4503},
 								expr: &ruleRefExpr{
-									pos:  position{line: 175, col: 26, offset: 4494},
+									pos:  position{line: 175, col: 26, offset: 4503},
 									name: "SearchOrTerm",
 								},
 							},
@@ -1442,30 +1450,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 179, col: 1, offset: 4568},
+			pos:  position{line: 179, col: 1, offset: 4577},
 			expr: &actionExpr{
-				pos: position{line: 179, col: 16, offset: 4583},
+				pos: position{line: 179, col: 16, offset: 4592},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 179, col: 16, offset: 4583},
+					pos: position{line: 179, col: 16, offset: 4592},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 179, col: 16, offset: 4583},
+							pos:  position{line: 179, col: 16, offset: 4592},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 179, col: 18, offset: 4585},
+							pos:  position{line: 179, col: 18, offset: 4594},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 179, col: 26, offset: 4593},
+							pos:  position{line: 179, col: 26, offset: 4602},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 179, col: 28, offset: 4595},
+							pos:   position{line: 179, col: 28, offset: 4604},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 179, col: 30, offset: 4597},
+								pos:  position{line: 179, col: 30, offset: 4606},
 								name: "SearchAnd",
 							},
 						},
@@ -1477,73 +1485,73 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 181, col: 1, offset: 4639},
+			pos:  position{line: 181, col: 1, offset: 4648},
 			expr: &actionExpr{
-				pos: position{line: 182, col: 5, offset: 4653},
+				pos: position{line: 182, col: 5, offset: 4662},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 182, col: 5, offset: 4653},
+					pos: position{line: 182, col: 5, offset: 4662},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 182, col: 5, offset: 4653},
+							pos:   position{line: 182, col: 5, offset: 4662},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 182, col: 11, offset: 4659},
+								pos:  position{line: 182, col: 11, offset: 4668},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 183, col: 5, offset: 4676},
+							pos:   position{line: 183, col: 5, offset: 4685},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 183, col: 10, offset: 4681},
+								pos: position{line: 183, col: 10, offset: 4690},
 								expr: &actionExpr{
-									pos: position{line: 183, col: 11, offset: 4682},
+									pos: position{line: 183, col: 11, offset: 4691},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 183, col: 11, offset: 4682},
+										pos: position{line: 183, col: 11, offset: 4691},
 										exprs: []any{
 											&zeroOrOneExpr{
-												pos: position{line: 183, col: 11, offset: 4682},
+												pos: position{line: 183, col: 11, offset: 4691},
 												expr: &seqExpr{
-													pos: position{line: 183, col: 12, offset: 4683},
+													pos: position{line: 183, col: 12, offset: 4692},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 183, col: 12, offset: 4683},
+															pos:  position{line: 183, col: 12, offset: 4692},
 															name: "_",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 183, col: 14, offset: 4685},
+															pos:  position{line: 183, col: 14, offset: 4694},
 															name: "AndToken",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 183, col: 25, offset: 4696},
+												pos:  position{line: 183, col: 25, offset: 4705},
 												name: "_",
 											},
 											&notExpr{
-												pos: position{line: 183, col: 27, offset: 4698},
+												pos: position{line: 183, col: 27, offset: 4707},
 												expr: &choiceExpr{
-													pos: position{line: 183, col: 29, offset: 4700},
+													pos: position{line: 183, col: 29, offset: 4709},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 183, col: 29, offset: 4700},
+															pos:  position{line: 183, col: 29, offset: 4709},
 															name: "OrToken",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 183, col: 39, offset: 4710},
+															pos:  position{line: 183, col: 39, offset: 4719},
 															name: "SearchKeywordGuard",
 														},
 													},
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 183, col: 59, offset: 4730},
+												pos:   position{line: 183, col: 59, offset: 4739},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 183, col: 64, offset: 4735},
+													pos:  position{line: 183, col: 64, offset: 4744},
 													name: "SearchFactor",
 												},
 											},
@@ -1560,42 +1568,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchKeywordGuard",
-			pos:  position{line: 187, col: 1, offset: 4845},
+			pos:  position{line: 187, col: 1, offset: 4854},
 			expr: &choiceExpr{
-				pos: position{line: 188, col: 5, offset: 4868},
+				pos: position{line: 188, col: 5, offset: 4877},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 188, col: 5, offset: 4868},
+						pos: position{line: 188, col: 5, offset: 4877},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 188, col: 5, offset: 4868},
+								pos:  position{line: 188, col: 5, offset: 4877},
 								name: "FromSource",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 188, col: 16, offset: 4879},
+								pos:  position{line: 188, col: 16, offset: 4888},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 188, col: 19, offset: 4882},
+								pos:        position{line: 188, col: 19, offset: 4891},
 								val:        "=>",
 								ignoreCase: false,
 								want:       "\"=>\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 188, col: 24, offset: 4887},
+								pos:  position{line: 188, col: 24, offset: 4896},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 189, col: 5, offset: 4894},
+						pos: position{line: 189, col: 5, offset: 4903},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 189, col: 5, offset: 4894},
+								pos:  position{line: 189, col: 5, offset: 4903},
 								name: "Case",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 189, col: 10, offset: 4899},
+								pos:  position{line: 189, col: 10, offset: 4908},
 								name: "__",
 							},
 						},
@@ -1607,43 +1615,43 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 191, col: 1, offset: 4903},
+			pos:  position{line: 191, col: 1, offset: 4912},
 			expr: &choiceExpr{
-				pos: position{line: 192, col: 5, offset: 4920},
+				pos: position{line: 192, col: 5, offset: 4929},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 192, col: 5, offset: 4920},
+						pos: position{line: 192, col: 5, offset: 4929},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 192, col: 5, offset: 4920},
+							pos: position{line: 192, col: 5, offset: 4929},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 192, col: 6, offset: 4921},
+									pos: position{line: 192, col: 6, offset: 4930},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 192, col: 6, offset: 4921},
+											pos: position{line: 192, col: 6, offset: 4930},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 192, col: 6, offset: 4921},
+													pos:  position{line: 192, col: 6, offset: 4930},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 192, col: 15, offset: 4930},
+													pos:  position{line: 192, col: 15, offset: 4939},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 192, col: 19, offset: 4934},
+											pos: position{line: 192, col: 19, offset: 4943},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 192, col: 19, offset: 4934},
+													pos:        position{line: 192, col: 19, offset: 4943},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 192, col: 23, offset: 4938},
+													pos:  position{line: 192, col: 23, offset: 4947},
 													name: "__",
 												},
 											},
@@ -1651,10 +1659,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 192, col: 27, offset: 4942},
+									pos:   position{line: 192, col: 27, offset: 4951},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 192, col: 29, offset: 4944},
+										pos:  position{line: 192, col: 29, offset: 4953},
 										name: "SearchFactor",
 									},
 								},
@@ -1662,35 +1670,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 199, col: 5, offset: 5092},
+						pos: position{line: 199, col: 5, offset: 5101},
 						run: (*parser).callonSearchFactor13,
 						expr: &seqExpr{
-							pos: position{line: 199, col: 5, offset: 5092},
+							pos: position{line: 199, col: 5, offset: 5101},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 199, col: 5, offset: 5092},
+									pos:        position{line: 199, col: 5, offset: 5101},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 199, col: 9, offset: 5096},
+									pos:  position{line: 199, col: 9, offset: 5105},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 199, col: 12, offset: 5099},
+									pos:   position{line: 199, col: 12, offset: 5108},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 199, col: 17, offset: 5104},
+										pos:  position{line: 199, col: 17, offset: 5113},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 199, col: 31, offset: 5118},
+									pos:  position{line: 199, col: 31, offset: 5127},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 199, col: 34, offset: 5121},
+									pos:        position{line: 199, col: 34, offset: 5130},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -1699,7 +1707,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 200, col: 5, offset: 5150},
+						pos:  position{line: 200, col: 5, offset: 5159},
 						name: "SearchExpr",
 					},
 				},
@@ -1709,53 +1717,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 202, col: 1, offset: 5162},
+			pos:  position{line: 202, col: 1, offset: 5171},
 			expr: &choiceExpr{
-				pos: position{line: 203, col: 5, offset: 5177},
+				pos: position{line: 203, col: 5, offset: 5186},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 203, col: 5, offset: 5177},
+						pos:  position{line: 203, col: 5, offset: 5186},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 204, col: 5, offset: 5188},
+						pos:  position{line: 204, col: 5, offset: 5197},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 205, col: 5, offset: 5197},
+						pos: position{line: 205, col: 5, offset: 5206},
 						run: (*parser).callonSearchExpr4,
 						expr: &seqExpr{
-							pos: position{line: 205, col: 5, offset: 5197},
+							pos: position{line: 205, col: 5, offset: 5206},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 205, col: 5, offset: 5197},
+									pos:   position{line: 205, col: 5, offset: 5206},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 205, col: 7, offset: 5199},
+										pos:  position{line: 205, col: 7, offset: 5208},
 										name: "SearchValue",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 205, col: 20, offset: 5212},
+									pos: position{line: 205, col: 20, offset: 5221},
 									alternatives: []any{
 										&notExpr{
-											pos: position{line: 205, col: 20, offset: 5212},
+											pos: position{line: 205, col: 20, offset: 5221},
 											expr: &ruleRefExpr{
-												pos:  position{line: 205, col: 21, offset: 5213},
+												pos:  position{line: 205, col: 21, offset: 5222},
 												name: "ExprGuard",
 											},
 										},
 										&andExpr{
-											pos: position{line: 205, col: 33, offset: 5225},
+											pos: position{line: 205, col: 33, offset: 5234},
 											expr: &seqExpr{
-												pos: position{line: 205, col: 35, offset: 5227},
+												pos: position{line: 205, col: 35, offset: 5236},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 205, col: 35, offset: 5227},
+														pos:  position{line: 205, col: 35, offset: 5236},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 205, col: 37, offset: 5229},
+														pos:  position{line: 205, col: 37, offset: 5238},
 														name: "Glob",
 													},
 												},
@@ -1767,21 +1775,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 213, col: 5, offset: 5399},
+						pos: position{line: 213, col: 5, offset: 5408},
 						run: (*parser).callonSearchExpr15,
 						expr: &seqExpr{
-							pos: position{line: 213, col: 5, offset: 5399},
+							pos: position{line: 213, col: 5, offset: 5408},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 213, col: 5, offset: 5399},
+									pos:        position{line: 213, col: 5, offset: 5408},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 213, col: 9, offset: 5403},
+									pos: position{line: 213, col: 9, offset: 5412},
 									expr: &ruleRefExpr{
-										pos:  position{line: 213, col: 10, offset: 5404},
+										pos:  position{line: 213, col: 10, offset: 5413},
 										name: "ExprGuard",
 									},
 								},
@@ -1789,7 +1797,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 216, col: 5, offset: 5504},
+						pos:  position{line: 216, col: 5, offset: 5513},
 						name: "SearchPredicate",
 					},
 				},
@@ -1799,45 +1807,45 @@ var g = &grammar{
 		},
 		{
 			name: "SearchPredicate",
-			pos:  position{line: 218, col: 1, offset: 5521},
+			pos:  position{line: 218, col: 1, offset: 5530},
 			expr: &choiceExpr{
-				pos: position{line: 219, col: 5, offset: 5541},
+				pos: position{line: 219, col: 5, offset: 5550},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 219, col: 5, offset: 5541},
+						pos: position{line: 219, col: 5, offset: 5550},
 						run: (*parser).callonSearchPredicate2,
 						expr: &seqExpr{
-							pos: position{line: 219, col: 5, offset: 5541},
+							pos: position{line: 219, col: 5, offset: 5550},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 219, col: 5, offset: 5541},
+									pos:   position{line: 219, col: 5, offset: 5550},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 219, col: 9, offset: 5545},
+										pos:  position{line: 219, col: 9, offset: 5554},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 219, col: 22, offset: 5558},
+									pos:  position{line: 219, col: 22, offset: 5567},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 219, col: 25, offset: 5561},
+									pos:   position{line: 219, col: 25, offset: 5570},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 219, col: 28, offset: 5564},
+										pos:  position{line: 219, col: 28, offset: 5573},
 										name: "Comparator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 219, col: 39, offset: 5575},
+									pos:  position{line: 219, col: 39, offset: 5584},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 219, col: 42, offset: 5578},
+									pos:   position{line: 219, col: 42, offset: 5587},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 219, col: 46, offset: 5582},
+										pos:  position{line: 219, col: 46, offset: 5591},
 										name: "AdditiveExpr",
 									},
 								},
@@ -1845,13 +1853,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 227, col: 5, offset: 5761},
+						pos: position{line: 227, col: 5, offset: 5770},
 						run: (*parser).callonSearchPredicate12,
 						expr: &labeledExpr{
-							pos:   position{line: 227, col: 5, offset: 5761},
+							pos:   position{line: 227, col: 5, offset: 5770},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 227, col: 7, offset: 5763},
+								pos:  position{line: 227, col: 7, offset: 5772},
 								name: "Function",
 							},
 						},
@@ -1863,32 +1871,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 229, col: 1, offset: 5791},
+			pos:  position{line: 229, col: 1, offset: 5800},
 			expr: &choiceExpr{
-				pos: position{line: 230, col: 5, offset: 5807},
+				pos: position{line: 230, col: 5, offset: 5816},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 230, col: 5, offset: 5807},
+						pos:  position{line: 230, col: 5, offset: 5816},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 231, col: 5, offset: 5819},
+						pos: position{line: 231, col: 5, offset: 5828},
 						run: (*parser).callonSearchValue3,
 						expr: &seqExpr{
-							pos: position{line: 231, col: 5, offset: 5819},
+							pos: position{line: 231, col: 5, offset: 5828},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 231, col: 5, offset: 5819},
+									pos: position{line: 231, col: 5, offset: 5828},
 									expr: &ruleRefExpr{
-										pos:  position{line: 231, col: 6, offset: 5820},
+										pos:  position{line: 231, col: 6, offset: 5829},
 										name: "RegexpPattern",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 231, col: 20, offset: 5834},
+									pos:   position{line: 231, col: 20, offset: 5843},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 231, col: 22, offset: 5836},
+										pos:  position{line: 231, col: 22, offset: 5845},
 										name: "KeyWord",
 									},
 								},
@@ -1902,15 +1910,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNode",
-			pos:  position{line: 235, col: 1, offset: 5909},
+			pos:  position{line: 235, col: 1, offset: 5918},
 			expr: &actionExpr{
-				pos: position{line: 236, col: 5, offset: 5931},
+				pos: position{line: 236, col: 5, offset: 5940},
 				run: (*parser).callonQuotedStringNode1,
 				expr: &labeledExpr{
-					pos:   position{line: 236, col: 5, offset: 5931},
+					pos:   position{line: 236, col: 5, offset: 5940},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 236, col: 7, offset: 5933},
+						pos:  position{line: 236, col: 7, offset: 5942},
 						name: "QuotedString",
 					},
 				},
@@ -1920,15 +1928,15 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 240, col: 1, offset: 6053},
+			pos:  position{line: 240, col: 1, offset: 6062},
 			expr: &actionExpr{
-				pos: position{line: 241, col: 5, offset: 6062},
+				pos: position{line: 241, col: 5, offset: 6071},
 				run: (*parser).callonGlob1,
 				expr: &labeledExpr{
-					pos:   position{line: 241, col: 5, offset: 6062},
+					pos:   position{line: 241, col: 5, offset: 6071},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 241, col: 13, offset: 6070},
+						pos:  position{line: 241, col: 13, offset: 6079},
 						name: "GlobPattern",
 					},
 				},
@@ -1938,15 +1946,15 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 245, col: 1, offset: 6186},
+			pos:  position{line: 245, col: 1, offset: 6195},
 			expr: &actionExpr{
-				pos: position{line: 246, col: 5, offset: 6197},
+				pos: position{line: 246, col: 5, offset: 6206},
 				run: (*parser).callonRegexp1,
 				expr: &labeledExpr{
-					pos:   position{line: 246, col: 5, offset: 6197},
+					pos:   position{line: 246, col: 5, offset: 6206},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 246, col: 13, offset: 6205},
+						pos:  position{line: 246, col: 13, offset: 6214},
 						name: "RegexpPattern",
 					},
 				},
@@ -1956,36 +1964,36 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 252, col: 1, offset: 6351},
+			pos:  position{line: 252, col: 1, offset: 6360},
 			expr: &choiceExpr{
-				pos: position{line: 253, col: 5, offset: 6367},
+				pos: position{line: 253, col: 5, offset: 6376},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 253, col: 5, offset: 6367},
+						pos: position{line: 253, col: 5, offset: 6376},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 253, col: 5, offset: 6367},
+							pos: position{line: 253, col: 5, offset: 6376},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 253, col: 5, offset: 6367},
+									pos: position{line: 253, col: 5, offset: 6376},
 									expr: &ruleRefExpr{
-										pos:  position{line: 253, col: 5, offset: 6367},
+										pos:  position{line: 253, col: 5, offset: 6376},
 										name: "Summarize",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 253, col: 16, offset: 6378},
+									pos:   position{line: 253, col: 16, offset: 6387},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 253, col: 21, offset: 6383},
+										pos:  position{line: 253, col: 21, offset: 6392},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 253, col: 33, offset: 6395},
+									pos:   position{line: 253, col: 33, offset: 6404},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 253, col: 39, offset: 6401},
+										pos:  position{line: 253, col: 39, offset: 6410},
 										name: "LimitArg",
 									},
 								},
@@ -1993,40 +2001,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 6596},
+						pos: position{line: 261, col: 5, offset: 6605},
 						run: (*parser).callonAggregation10,
 						expr: &seqExpr{
-							pos: position{line: 261, col: 5, offset: 6596},
+							pos: position{line: 261, col: 5, offset: 6605},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 261, col: 5, offset: 6596},
+									pos: position{line: 261, col: 5, offset: 6605},
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 5, offset: 6596},
+										pos:  position{line: 261, col: 5, offset: 6605},
 										name: "Summarize",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 16, offset: 6607},
+									pos:   position{line: 261, col: 16, offset: 6616},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 21, offset: 6612},
+										pos:  position{line: 261, col: 21, offset: 6621},
 										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 36, offset: 6627},
+									pos:   position{line: 261, col: 36, offset: 6636},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 261, col: 41, offset: 6632},
+										pos: position{line: 261, col: 41, offset: 6641},
 										expr: &seqExpr{
-											pos: position{line: 261, col: 42, offset: 6633},
+											pos: position{line: 261, col: 42, offset: 6642},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 261, col: 42, offset: 6633},
+													pos:  position{line: 261, col: 42, offset: 6642},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 261, col: 44, offset: 6635},
+													pos:  position{line: 261, col: 44, offset: 6644},
 													name: "GroupByKeys",
 												},
 											},
@@ -2034,10 +2042,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 261, col: 58, offset: 6649},
+									pos:   position{line: 261, col: 58, offset: 6658},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 64, offset: 6655},
+										pos:  position{line: 261, col: 64, offset: 6664},
 										name: "LimitArg",
 									},
 								},
@@ -2051,18 +2059,18 @@ var g = &grammar{
 		},
 		{
 			name: "Summarize",
-			pos:  position{line: 274, col: 1, offset: 6949},
+			pos:  position{line: 274, col: 1, offset: 6958},
 			expr: &seqExpr{
-				pos: position{line: 274, col: 13, offset: 6961},
+				pos: position{line: 274, col: 13, offset: 6970},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 274, col: 13, offset: 6961},
+						pos:        position{line: 274, col: 13, offset: 6970},
 						val:        "summarize",
 						ignoreCase: false,
 						want:       "\"summarize\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 274, col: 25, offset: 6973},
+						pos:  position{line: 274, col: 25, offset: 6982},
 						name: "_",
 					},
 				},
@@ -2072,26 +2080,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 276, col: 1, offset: 6976},
+			pos:  position{line: 276, col: 1, offset: 6985},
 			expr: &actionExpr{
-				pos: position{line: 277, col: 5, offset: 6992},
+				pos: position{line: 277, col: 5, offset: 7001},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 277, col: 5, offset: 6992},
+					pos: position{line: 277, col: 5, offset: 7001},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 5, offset: 6992},
+							pos:  position{line: 277, col: 5, offset: 7001},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 13, offset: 7000},
+							pos:  position{line: 277, col: 13, offset: 7009},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 277, col: 15, offset: 7002},
+							pos:   position{line: 277, col: 15, offset: 7011},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 23, offset: 7010},
+								pos:  position{line: 277, col: 23, offset: 7019},
 								name: "FlexAssignments",
 							},
 						},
@@ -2103,45 +2111,45 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 279, col: 1, offset: 7051},
+			pos:  position{line: 279, col: 1, offset: 7060},
 			expr: &choiceExpr{
-				pos: position{line: 280, col: 5, offset: 7064},
+				pos: position{line: 280, col: 5, offset: 7073},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 280, col: 5, offset: 7064},
+						pos: position{line: 280, col: 5, offset: 7073},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 280, col: 5, offset: 7064},
+							pos: position{line: 280, col: 5, offset: 7073},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 280, col: 5, offset: 7064},
+									pos:  position{line: 280, col: 5, offset: 7073},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 280, col: 7, offset: 7066},
+									pos:        position{line: 280, col: 7, offset: 7075},
 									val:        "with",
 									ignoreCase: false,
 									want:       "\"with\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 280, col: 14, offset: 7073},
+									pos:  position{line: 280, col: 14, offset: 7082},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 280, col: 16, offset: 7075},
+									pos:        position{line: 280, col: 16, offset: 7084},
 									val:        "-limit",
 									ignoreCase: false,
 									want:       "\"-limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 280, col: 25, offset: 7084},
+									pos:  position{line: 280, col: 25, offset: 7093},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 280, col: 27, offset: 7086},
+									pos:   position{line: 280, col: 27, offset: 7095},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 280, col: 33, offset: 7092},
+										pos:  position{line: 280, col: 33, offset: 7101},
 										name: "UInt",
 									},
 								},
@@ -2149,10 +2157,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 281, col: 5, offset: 7123},
+						pos: position{line: 281, col: 5, offset: 7132},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 281, col: 5, offset: 7123},
+							pos:        position{line: 281, col: 5, offset: 7132},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -2165,22 +2173,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 286, col: 1, offset: 7383},
+			pos:  position{line: 286, col: 1, offset: 7392},
 			expr: &choiceExpr{
-				pos: position{line: 287, col: 5, offset: 7402},
+				pos: position{line: 287, col: 5, offset: 7411},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 5, offset: 7402},
+						pos:  position{line: 287, col: 5, offset: 7411},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 288, col: 5, offset: 7417},
+						pos: position{line: 288, col: 5, offset: 7426},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 288, col: 5, offset: 7417},
+							pos:   position{line: 288, col: 5, offset: 7426},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 288, col: 10, offset: 7422},
+								pos:  position{line: 288, col: 10, offset: 7431},
 								name: "Expr",
 							},
 						},
@@ -2192,51 +2200,51 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 290, col: 1, offset: 7498},
+			pos:  position{line: 290, col: 1, offset: 7507},
 			expr: &actionExpr{
-				pos: position{line: 291, col: 5, offset: 7518},
+				pos: position{line: 291, col: 5, offset: 7527},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 291, col: 5, offset: 7518},
+					pos: position{line: 291, col: 5, offset: 7527},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 291, col: 5, offset: 7518},
+							pos:   position{line: 291, col: 5, offset: 7527},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 291, col: 11, offset: 7524},
+								pos:  position{line: 291, col: 11, offset: 7533},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 291, col: 26, offset: 7539},
+							pos:   position{line: 291, col: 26, offset: 7548},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 291, col: 31, offset: 7544},
+								pos: position{line: 291, col: 31, offset: 7553},
 								expr: &actionExpr{
-									pos: position{line: 291, col: 32, offset: 7545},
+									pos: position{line: 291, col: 32, offset: 7554},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 291, col: 32, offset: 7545},
+										pos: position{line: 291, col: 32, offset: 7554},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 291, col: 32, offset: 7545},
+												pos:  position{line: 291, col: 32, offset: 7554},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 291, col: 35, offset: 7548},
+												pos:        position{line: 291, col: 35, offset: 7557},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 291, col: 39, offset: 7552},
+												pos:  position{line: 291, col: 39, offset: 7561},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 291, col: 42, offset: 7555},
+												pos:   position{line: 291, col: 42, offset: 7564},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 291, col: 47, offset: 7560},
+													pos:  position{line: 291, col: 47, offset: 7569},
 													name: "FlexAssignment",
 												},
 											},
@@ -2253,43 +2261,43 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignment",
-			pos:  position{line: 295, col: 1, offset: 7646},
+			pos:  position{line: 295, col: 1, offset: 7655},
 			expr: &choiceExpr{
-				pos: position{line: 296, col: 5, offset: 7664},
+				pos: position{line: 296, col: 5, offset: 7673},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 296, col: 5, offset: 7664},
+						pos: position{line: 296, col: 5, offset: 7673},
 						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 296, col: 5, offset: 7664},
+							pos: position{line: 296, col: 5, offset: 7673},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 296, col: 5, offset: 7664},
+									pos:   position{line: 296, col: 5, offset: 7673},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 296, col: 10, offset: 7669},
+										pos:  position{line: 296, col: 10, offset: 7678},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 296, col: 15, offset: 7674},
+									pos:  position{line: 296, col: 15, offset: 7683},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 296, col: 18, offset: 7677},
+									pos:        position{line: 296, col: 18, offset: 7686},
 									val:        ":=",
 									ignoreCase: false,
 									want:       "\":=\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 296, col: 23, offset: 7682},
+									pos:  position{line: 296, col: 23, offset: 7691},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 296, col: 26, offset: 7685},
+									pos:   position{line: 296, col: 26, offset: 7694},
 									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 296, col: 30, offset: 7689},
+										pos:  position{line: 296, col: 30, offset: 7698},
 										name: "Agg",
 									},
 								},
@@ -2297,13 +2305,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 299, col: 5, offset: 7796},
+						pos: position{line: 299, col: 5, offset: 7805},
 						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 299, col: 5, offset: 7796},
+							pos:   position{line: 299, col: 5, offset: 7805},
 							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 299, col: 9, offset: 7800},
+								pos:  position{line: 299, col: 9, offset: 7809},
 								name: "Agg",
 							},
 						},
@@ -2315,56 +2323,56 @@ var g = &grammar{
 		},
 		{
 			name: "Agg",
-			pos:  position{line: 303, col: 1, offset: 7884},
+			pos:  position{line: 303, col: 1, offset: 7893},
 			expr: &actionExpr{
-				pos: position{line: 304, col: 5, offset: 7892},
+				pos: position{line: 304, col: 5, offset: 7901},
 				run: (*parser).callonAgg1,
 				expr: &seqExpr{
-					pos: position{line: 304, col: 5, offset: 7892},
+					pos: position{line: 304, col: 5, offset: 7901},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 304, col: 5, offset: 7892},
+							pos: position{line: 304, col: 5, offset: 7901},
 							expr: &ruleRefExpr{
-								pos:  position{line: 304, col: 6, offset: 7893},
+								pos:  position{line: 304, col: 6, offset: 7902},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 304, col: 16, offset: 7903},
+							pos:   position{line: 304, col: 16, offset: 7912},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 304, col: 19, offset: 7906},
+								pos:  position{line: 304, col: 19, offset: 7915},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 304, col: 27, offset: 7914},
+							pos:  position{line: 304, col: 27, offset: 7923},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 304, col: 30, offset: 7917},
+							pos:        position{line: 304, col: 30, offset: 7926},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 304, col: 34, offset: 7921},
+							pos:  position{line: 304, col: 34, offset: 7930},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 304, col: 37, offset: 7924},
+							pos:   position{line: 304, col: 37, offset: 7933},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 304, col: 42, offset: 7929},
+								pos: position{line: 304, col: 42, offset: 7938},
 								expr: &choiceExpr{
-									pos: position{line: 304, col: 43, offset: 7930},
+									pos: position{line: 304, col: 43, offset: 7939},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 304, col: 43, offset: 7930},
+											pos:  position{line: 304, col: 43, offset: 7939},
 											name: "OverExpr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 304, col: 54, offset: 7941},
+											pos:  position{line: 304, col: 54, offset: 7950},
 											name: "Expr",
 										},
 									},
@@ -2372,17 +2380,17 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 304, col: 61, offset: 7948},
+							pos:  position{line: 304, col: 61, offset: 7957},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 304, col: 64, offset: 7951},
+							pos:   position{line: 304, col: 64, offset: 7960},
 							label: "rparen",
 							expr: &actionExpr{
-								pos: position{line: 304, col: 72, offset: 7959},
+								pos: position{line: 304, col: 72, offset: 7968},
 								run: (*parser).callonAgg17,
 								expr: &litMatcher{
-									pos:        position{line: 304, col: 72, offset: 7959},
+									pos:        position{line: 304, col: 72, offset: 7968},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -2390,16 +2398,16 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 304, col: 106, offset: 7993},
+							pos: position{line: 304, col: 106, offset: 8002},
 							expr: &seqExpr{
-								pos: position{line: 304, col: 108, offset: 7995},
+								pos: position{line: 304, col: 108, offset: 8004},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 304, col: 108, offset: 7995},
+										pos:  position{line: 304, col: 108, offset: 8004},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 304, col: 111, offset: 7998},
+										pos:        position{line: 304, col: 111, offset: 8007},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -2408,12 +2416,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 304, col: 116, offset: 8003},
+							pos:   position{line: 304, col: 116, offset: 8012},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 304, col: 122, offset: 8009},
+								pos: position{line: 304, col: 122, offset: 8018},
 								expr: &ruleRefExpr{
-									pos:  position{line: 304, col: 122, offset: 8009},
+									pos:  position{line: 304, col: 122, offset: 8018},
 									name: "WhereClause",
 								},
 							},
@@ -2426,20 +2434,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 320, col: 1, offset: 8336},
+			pos:  position{line: 320, col: 1, offset: 8345},
 			expr: &choiceExpr{
-				pos: position{line: 321, col: 5, offset: 8348},
+				pos: position{line: 321, col: 5, offset: 8357},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 321, col: 5, offset: 8348},
+						pos:  position{line: 321, col: 5, offset: 8357},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 5, offset: 8367},
+						pos:  position{line: 322, col: 5, offset: 8376},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 5, offset: 8380},
+						pos:  position{line: 323, col: 5, offset: 8389},
 						name: "OrToken",
 					},
 				},
@@ -2449,32 +2457,32 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 325, col: 1, offset: 8389},
+			pos:  position{line: 325, col: 1, offset: 8398},
 			expr: &actionExpr{
-				pos: position{line: 325, col: 15, offset: 8403},
+				pos: position{line: 325, col: 15, offset: 8412},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 325, col: 15, offset: 8403},
+					pos: position{line: 325, col: 15, offset: 8412},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 325, col: 15, offset: 8403},
+							pos:  position{line: 325, col: 15, offset: 8412},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 325, col: 17, offset: 8405},
+							pos:        position{line: 325, col: 17, offset: 8414},
 							val:        "where",
 							ignoreCase: false,
 							want:       "\"where\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 325, col: 25, offset: 8413},
+							pos:  position{line: 325, col: 25, offset: 8422},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 325, col: 27, offset: 8415},
+							pos:   position{line: 325, col: 27, offset: 8424},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 325, col: 32, offset: 8420},
+								pos:  position{line: 325, col: 32, offset: 8429},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -2486,45 +2494,45 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 327, col: 1, offset: 8456},
+			pos:  position{line: 327, col: 1, offset: 8465},
 			expr: &actionExpr{
-				pos: position{line: 328, col: 5, offset: 8475},
+				pos: position{line: 328, col: 5, offset: 8484},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 328, col: 5, offset: 8475},
+					pos: position{line: 328, col: 5, offset: 8484},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 328, col: 5, offset: 8475},
+							pos:   position{line: 328, col: 5, offset: 8484},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 328, col: 11, offset: 8481},
+								pos:  position{line: 328, col: 11, offset: 8490},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 328, col: 25, offset: 8495},
+							pos:   position{line: 328, col: 25, offset: 8504},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 328, col: 30, offset: 8500},
+								pos: position{line: 328, col: 30, offset: 8509},
 								expr: &seqExpr{
-									pos: position{line: 328, col: 31, offset: 8501},
+									pos: position{line: 328, col: 31, offset: 8510},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 328, col: 31, offset: 8501},
+											pos:  position{line: 328, col: 31, offset: 8510},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 328, col: 34, offset: 8504},
+											pos:        position{line: 328, col: 34, offset: 8513},
 											val:        ",",
 											ignoreCase: false,
 											want:       "\",\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 328, col: 38, offset: 8508},
+											pos:  position{line: 328, col: 38, offset: 8517},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 328, col: 41, offset: 8511},
+											pos:  position{line: 328, col: 41, offset: 8520},
 											name: "AggAssignment",
 										},
 									},
@@ -2539,104 +2547,104 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 338, col: 1, offset: 8708},
+			pos:  position{line: 338, col: 1, offset: 8717},
 			expr: &choiceExpr{
-				pos: position{line: 339, col: 5, offset: 8721},
+				pos: position{line: 339, col: 5, offset: 8730},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 339, col: 5, offset: 8721},
+						pos:  position{line: 339, col: 5, offset: 8730},
 						name: "AssertOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 340, col: 5, offset: 8734},
+						pos:  position{line: 340, col: 5, offset: 8743},
 						name: "SortOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 341, col: 5, offset: 8745},
+						pos:  position{line: 341, col: 5, offset: 8754},
 						name: "TopOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 342, col: 5, offset: 8755},
+						pos:  position{line: 342, col: 5, offset: 8764},
 						name: "CutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 343, col: 5, offset: 8765},
+						pos:  position{line: 343, col: 5, offset: 8774},
 						name: "DropOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 344, col: 5, offset: 8776},
+						pos:  position{line: 344, col: 5, offset: 8785},
 						name: "HeadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 345, col: 5, offset: 8787},
+						pos:  position{line: 345, col: 5, offset: 8796},
 						name: "TailOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 346, col: 5, offset: 8798},
+						pos:  position{line: 346, col: 5, offset: 8807},
 						name: "WhereOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 347, col: 5, offset: 8810},
+						pos:  position{line: 347, col: 5, offset: 8819},
 						name: "UniqOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 348, col: 5, offset: 8821},
+						pos:  position{line: 348, col: 5, offset: 8830},
 						name: "PutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 349, col: 5, offset: 8831},
+						pos:  position{line: 349, col: 5, offset: 8840},
 						name: "RenameOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 350, col: 5, offset: 8844},
+						pos:  position{line: 350, col: 5, offset: 8853},
 						name: "FuseOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 351, col: 5, offset: 8855},
+						pos:  position{line: 351, col: 5, offset: 8864},
 						name: "ShapeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 352, col: 5, offset: 8867},
+						pos:  position{line: 352, col: 5, offset: 8876},
 						name: "JoinOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 353, col: 5, offset: 8878},
+						pos:  position{line: 353, col: 5, offset: 8887},
 						name: "SampleOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 354, col: 5, offset: 8891},
+						pos:  position{line: 354, col: 5, offset: 8900},
 						name: "FromOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 355, col: 5, offset: 8902},
+						pos:  position{line: 355, col: 5, offset: 8911},
 						name: "PassOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 356, col: 5, offset: 8913},
+						pos:  position{line: 356, col: 5, offset: 8922},
 						name: "ExplodeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 357, col: 5, offset: 8927},
+						pos:  position{line: 357, col: 5, offset: 8936},
 						name: "MergeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 358, col: 5, offset: 8939},
+						pos:  position{line: 358, col: 5, offset: 8948},
 						name: "OverOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 359, col: 5, offset: 8950},
+						pos:  position{line: 359, col: 5, offset: 8959},
 						name: "YieldOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 360, col: 5, offset: 8962},
+						pos:  position{line: 360, col: 5, offset: 8971},
 						name: "LoadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 361, col: 5, offset: 8973},
+						pos:  position{line: 361, col: 5, offset: 8982},
 						name: "OutputOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 362, col: 5, offset: 8986},
+						pos:  position{line: 362, col: 5, offset: 8995},
 						name: "DebugOp",
 					},
 				},
@@ -2646,34 +2654,34 @@ var g = &grammar{
 		},
 		{
 			name: "AssertOp",
-			pos:  position{line: 364, col: 1, offset: 8995},
+			pos:  position{line: 364, col: 1, offset: 9004},
 			expr: &actionExpr{
-				pos: position{line: 365, col: 5, offset: 9008},
+				pos: position{line: 365, col: 5, offset: 9017},
 				run: (*parser).callonAssertOp1,
 				expr: &seqExpr{
-					pos: position{line: 365, col: 5, offset: 9008},
+					pos: position{line: 365, col: 5, offset: 9017},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 365, col: 5, offset: 9008},
+							pos:        position{line: 365, col: 5, offset: 9017},
 							val:        "assert",
 							ignoreCase: false,
 							want:       "\"assert\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 365, col: 14, offset: 9017},
+							pos:  position{line: 365, col: 14, offset: 9026},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 365, col: 16, offset: 9019},
+							pos:   position{line: 365, col: 16, offset: 9028},
 							label: "expr",
 							expr: &actionExpr{
-								pos: position{line: 365, col: 22, offset: 9025},
+								pos: position{line: 365, col: 22, offset: 9034},
 								run: (*parser).callonAssertOp6,
 								expr: &labeledExpr{
-									pos:   position{line: 365, col: 22, offset: 9025},
+									pos:   position{line: 365, col: 22, offset: 9034},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 365, col: 24, offset: 9027},
+										pos:  position{line: 365, col: 24, offset: 9036},
 										name: "Expr",
 									},
 								},
@@ -2687,54 +2695,54 @@ var g = &grammar{
 		},
 		{
 			name: "SortOp",
-			pos:  position{line: 374, col: 1, offset: 9270},
+			pos:  position{line: 374, col: 1, offset: 9279},
 			expr: &actionExpr{
-				pos: position{line: 375, col: 5, offset: 9281},
+				pos: position{line: 375, col: 5, offset: 9290},
 				run: (*parser).callonSortOp1,
 				expr: &seqExpr{
-					pos: position{line: 375, col: 5, offset: 9281},
+					pos: position{line: 375, col: 5, offset: 9290},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 375, col: 5, offset: 9281},
+							pos:        position{line: 375, col: 5, offset: 9290},
 							val:        "sort",
 							ignoreCase: false,
 							want:       "\"sort\"",
 						},
 						&andExpr{
-							pos: position{line: 375, col: 12, offset: 9288},
+							pos: position{line: 375, col: 12, offset: 9297},
 							expr: &ruleRefExpr{
-								pos:  position{line: 375, col: 13, offset: 9289},
+								pos:  position{line: 375, col: 13, offset: 9298},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 375, col: 18, offset: 9294},
+							pos:   position{line: 375, col: 18, offset: 9303},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 375, col: 23, offset: 9299},
+								pos:  position{line: 375, col: 23, offset: 9308},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 375, col: 32, offset: 9308},
+							pos:   position{line: 375, col: 32, offset: 9317},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 375, col: 38, offset: 9314},
+								pos: position{line: 375, col: 38, offset: 9323},
 								expr: &actionExpr{
-									pos: position{line: 375, col: 39, offset: 9315},
+									pos: position{line: 375, col: 39, offset: 9324},
 									run: (*parser).callonSortOp10,
 									expr: &seqExpr{
-										pos: position{line: 375, col: 39, offset: 9315},
+										pos: position{line: 375, col: 39, offset: 9324},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 375, col: 39, offset: 9315},
+												pos:  position{line: 375, col: 39, offset: 9324},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 375, col: 42, offset: 9318},
+												pos:   position{line: 375, col: 42, offset: 9327},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 375, col: 44, offset: 9320},
+													pos:  position{line: 375, col: 44, offset: 9329},
 													name: "SortExprs",
 												},
 											},
@@ -2751,30 +2759,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 391, col: 1, offset: 9702},
+			pos:  position{line: 391, col: 1, offset: 9711},
 			expr: &actionExpr{
-				pos: position{line: 391, col: 12, offset: 9713},
+				pos: position{line: 391, col: 12, offset: 9722},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 391, col: 12, offset: 9713},
+					pos:   position{line: 391, col: 12, offset: 9722},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 391, col: 17, offset: 9718},
+						pos: position{line: 391, col: 17, offset: 9727},
 						expr: &actionExpr{
-							pos: position{line: 391, col: 18, offset: 9719},
+							pos: position{line: 391, col: 18, offset: 9728},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 391, col: 18, offset: 9719},
+								pos: position{line: 391, col: 18, offset: 9728},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 391, col: 18, offset: 9719},
+										pos:  position{line: 391, col: 18, offset: 9728},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 391, col: 20, offset: 9721},
+										pos:   position{line: 391, col: 20, offset: 9730},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 391, col: 22, offset: 9723},
+											pos:  position{line: 391, col: 22, offset: 9732},
 											name: "SortArg",
 										},
 									},
@@ -2789,53 +2797,53 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 393, col: 1, offset: 9780},
+			pos:  position{line: 393, col: 1, offset: 9789},
 			expr: &choiceExpr{
-				pos: position{line: 394, col: 5, offset: 9792},
+				pos: position{line: 394, col: 5, offset: 9801},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 394, col: 5, offset: 9792},
+						pos: position{line: 394, col: 5, offset: 9801},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 394, col: 5, offset: 9792},
+							pos:        position{line: 394, col: 5, offset: 9801},
 							val:        "-r",
 							ignoreCase: false,
 							want:       "\"-r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 395, col: 5, offset: 9859},
+						pos: position{line: 395, col: 5, offset: 9868},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 395, col: 5, offset: 9859},
+							pos: position{line: 395, col: 5, offset: 9868},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 395, col: 5, offset: 9859},
+									pos:        position{line: 395, col: 5, offset: 9868},
 									val:        "-nulls",
 									ignoreCase: false,
 									want:       "\"-nulls\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 395, col: 14, offset: 9868},
+									pos:  position{line: 395, col: 14, offset: 9877},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 395, col: 16, offset: 9870},
+									pos:   position{line: 395, col: 16, offset: 9879},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 395, col: 23, offset: 9877},
+										pos: position{line: 395, col: 23, offset: 9886},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 395, col: 24, offset: 9878},
+											pos: position{line: 395, col: 24, offset: 9887},
 											alternatives: []any{
 												&litMatcher{
-													pos:        position{line: 395, col: 24, offset: 9878},
+													pos:        position{line: 395, col: 24, offset: 9887},
 													val:        "first",
 													ignoreCase: false,
 													want:       "\"first\"",
 												},
 												&litMatcher{
-													pos:        position{line: 395, col: 34, offset: 9888},
+													pos:        position{line: 395, col: 34, offset: 9897},
 													val:        "last",
 													ignoreCase: false,
 													want:       "\"last\"",
@@ -2854,46 +2862,46 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 399, col: 1, offset: 10007},
+			pos:  position{line: 399, col: 1, offset: 10016},
 			expr: &actionExpr{
-				pos: position{line: 400, col: 5, offset: 10017},
+				pos: position{line: 400, col: 5, offset: 10026},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 400, col: 5, offset: 10017},
+					pos: position{line: 400, col: 5, offset: 10026},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 400, col: 5, offset: 10017},
+							pos:        position{line: 400, col: 5, offset: 10026},
 							val:        "top",
 							ignoreCase: false,
 							want:       "\"top\"",
 						},
 						&andExpr{
-							pos: position{line: 400, col: 11, offset: 10023},
+							pos: position{line: 400, col: 11, offset: 10032},
 							expr: &ruleRefExpr{
-								pos:  position{line: 400, col: 12, offset: 10024},
+								pos:  position{line: 400, col: 12, offset: 10033},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 400, col: 17, offset: 10029},
+							pos:   position{line: 400, col: 17, offset: 10038},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 400, col: 23, offset: 10035},
+								pos: position{line: 400, col: 23, offset: 10044},
 								expr: &actionExpr{
-									pos: position{line: 400, col: 24, offset: 10036},
+									pos: position{line: 400, col: 24, offset: 10045},
 									run: (*parser).callonTopOp8,
 									expr: &seqExpr{
-										pos: position{line: 400, col: 24, offset: 10036},
+										pos: position{line: 400, col: 24, offset: 10045},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 400, col: 24, offset: 10036},
+												pos:  position{line: 400, col: 24, offset: 10045},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 400, col: 26, offset: 10038},
+												pos:   position{line: 400, col: 26, offset: 10047},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 400, col: 28, offset: 10040},
+													pos:  position{line: 400, col: 28, offset: 10049},
 													name: "Expr",
 												},
 											},
@@ -2903,19 +2911,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 400, col: 53, offset: 10065},
+							pos:   position{line: 400, col: 53, offset: 10074},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 400, col: 59, offset: 10071},
+								pos: position{line: 400, col: 59, offset: 10080},
 								expr: &seqExpr{
-									pos: position{line: 400, col: 60, offset: 10072},
+									pos: position{line: 400, col: 60, offset: 10081},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 400, col: 60, offset: 10072},
+											pos:  position{line: 400, col: 60, offset: 10081},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 400, col: 62, offset: 10074},
+											pos:        position{line: 400, col: 62, offset: 10083},
 											val:        "-flush",
 											ignoreCase: false,
 											want:       "\"-flush\"",
@@ -2925,25 +2933,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 400, col: 73, offset: 10085},
+							pos:   position{line: 400, col: 73, offset: 10094},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 400, col: 80, offset: 10092},
+								pos: position{line: 400, col: 80, offset: 10101},
 								expr: &actionExpr{
-									pos: position{line: 400, col: 81, offset: 10093},
+									pos: position{line: 400, col: 81, offset: 10102},
 									run: (*parser).callonTopOp20,
 									expr: &seqExpr{
-										pos: position{line: 400, col: 81, offset: 10093},
+										pos: position{line: 400, col: 81, offset: 10102},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 400, col: 81, offset: 10093},
+												pos:  position{line: 400, col: 81, offset: 10102},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 400, col: 83, offset: 10095},
+												pos:   position{line: 400, col: 83, offset: 10104},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 400, col: 85, offset: 10097},
+													pos:  position{line: 400, col: 85, offset: 10106},
 													name: "FieldExprs",
 												},
 											},
@@ -2960,28 +2968,28 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 417, col: 1, offset: 10444},
+			pos:  position{line: 417, col: 1, offset: 10453},
 			expr: &actionExpr{
-				pos: position{line: 418, col: 5, offset: 10454},
+				pos: position{line: 418, col: 5, offset: 10463},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 418, col: 5, offset: 10454},
+					pos: position{line: 418, col: 5, offset: 10463},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 418, col: 5, offset: 10454},
+							pos:        position{line: 418, col: 5, offset: 10463},
 							val:        "cut",
 							ignoreCase: false,
 							want:       "\"cut\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 418, col: 11, offset: 10460},
+							pos:  position{line: 418, col: 11, offset: 10469},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 418, col: 13, offset: 10462},
+							pos:   position{line: 418, col: 13, offset: 10471},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 418, col: 18, offset: 10467},
+								pos:  position{line: 418, col: 18, offset: 10476},
 								name: "FlexAssignments",
 							},
 						},
@@ -2993,28 +3001,28 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 426, col: 1, offset: 10628},
+			pos:  position{line: 426, col: 1, offset: 10637},
 			expr: &actionExpr{
-				pos: position{line: 427, col: 5, offset: 10639},
+				pos: position{line: 427, col: 5, offset: 10648},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 427, col: 5, offset: 10639},
+					pos: position{line: 427, col: 5, offset: 10648},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 427, col: 5, offset: 10639},
+							pos:        position{line: 427, col: 5, offset: 10648},
 							val:        "drop",
 							ignoreCase: false,
 							want:       "\"drop\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 427, col: 12, offset: 10646},
+							pos:  position{line: 427, col: 12, offset: 10655},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 427, col: 14, offset: 10648},
+							pos:   position{line: 427, col: 14, offset: 10657},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 19, offset: 10653},
+								pos:  position{line: 427, col: 19, offset: 10662},
 								name: "FieldExprs",
 							},
 						},
@@ -3026,38 +3034,38 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 435, col: 1, offset: 10811},
+			pos:  position{line: 435, col: 1, offset: 10820},
 			expr: &choiceExpr{
-				pos: position{line: 436, col: 5, offset: 10822},
+				pos: position{line: 436, col: 5, offset: 10831},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 436, col: 5, offset: 10822},
+						pos: position{line: 436, col: 5, offset: 10831},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 436, col: 5, offset: 10822},
+							pos: position{line: 436, col: 5, offset: 10831},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 436, col: 5, offset: 10822},
+									pos:        position{line: 436, col: 5, offset: 10831},
 									val:        "head",
 									ignoreCase: false,
 									want:       "\"head\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 436, col: 12, offset: 10829},
+									pos:  position{line: 436, col: 12, offset: 10838},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 436, col: 14, offset: 10831},
+									pos: position{line: 436, col: 14, offset: 10840},
 									expr: &ruleRefExpr{
-										pos:  position{line: 436, col: 15, offset: 10832},
+										pos:  position{line: 436, col: 15, offset: 10841},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 436, col: 23, offset: 10840},
+									pos:   position{line: 436, col: 23, offset: 10849},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 436, col: 29, offset: 10846},
+										pos:  position{line: 436, col: 29, offset: 10855},
 										name: "Expr",
 									},
 								},
@@ -3065,28 +3073,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 443, col: 5, offset: 10989},
+						pos: position{line: 443, col: 5, offset: 10998},
 						run: (*parser).callonHeadOp10,
 						expr: &seqExpr{
-							pos: position{line: 443, col: 5, offset: 10989},
+							pos: position{line: 443, col: 5, offset: 10998},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 443, col: 5, offset: 10989},
+									pos:        position{line: 443, col: 5, offset: 10998},
 									val:        "head",
 									ignoreCase: false,
 									want:       "\"head\"",
 								},
 								&notExpr{
-									pos: position{line: 443, col: 12, offset: 10996},
+									pos: position{line: 443, col: 12, offset: 11005},
 									expr: &seqExpr{
-										pos: position{line: 443, col: 14, offset: 10998},
+										pos: position{line: 443, col: 14, offset: 11007},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 443, col: 14, offset: 10998},
+												pos:  position{line: 443, col: 14, offset: 11007},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 443, col: 17, offset: 11001},
+												pos:        position{line: 443, col: 17, offset: 11010},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3095,9 +3103,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 443, col: 22, offset: 11006},
+									pos: position{line: 443, col: 22, offset: 11015},
 									expr: &ruleRefExpr{
-										pos:  position{line: 443, col: 23, offset: 11007},
+										pos:  position{line: 443, col: 23, offset: 11016},
 										name: "EOKW",
 									},
 								},
@@ -3111,38 +3119,38 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 450, col: 1, offset: 11114},
+			pos:  position{line: 450, col: 1, offset: 11123},
 			expr: &choiceExpr{
-				pos: position{line: 451, col: 5, offset: 11125},
+				pos: position{line: 451, col: 5, offset: 11134},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 451, col: 5, offset: 11125},
+						pos: position{line: 451, col: 5, offset: 11134},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 451, col: 5, offset: 11125},
+							pos: position{line: 451, col: 5, offset: 11134},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 451, col: 5, offset: 11125},
+									pos:        position{line: 451, col: 5, offset: 11134},
 									val:        "tail",
 									ignoreCase: false,
 									want:       "\"tail\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 451, col: 12, offset: 11132},
+									pos:  position{line: 451, col: 12, offset: 11141},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 451, col: 14, offset: 11134},
+									pos: position{line: 451, col: 14, offset: 11143},
 									expr: &ruleRefExpr{
-										pos:  position{line: 451, col: 15, offset: 11135},
+										pos:  position{line: 451, col: 15, offset: 11144},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 451, col: 23, offset: 11143},
+									pos:   position{line: 451, col: 23, offset: 11152},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 451, col: 29, offset: 11149},
+										pos:  position{line: 451, col: 29, offset: 11158},
 										name: "Expr",
 									},
 								},
@@ -3150,28 +3158,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 458, col: 5, offset: 11292},
+						pos: position{line: 458, col: 5, offset: 11301},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 458, col: 5, offset: 11292},
+							pos: position{line: 458, col: 5, offset: 11301},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 458, col: 5, offset: 11292},
+									pos:        position{line: 458, col: 5, offset: 11301},
 									val:        "tail",
 									ignoreCase: false,
 									want:       "\"tail\"",
 								},
 								&notExpr{
-									pos: position{line: 458, col: 12, offset: 11299},
+									pos: position{line: 458, col: 12, offset: 11308},
 									expr: &seqExpr{
-										pos: position{line: 458, col: 14, offset: 11301},
+										pos: position{line: 458, col: 14, offset: 11310},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 458, col: 14, offset: 11301},
+												pos:  position{line: 458, col: 14, offset: 11310},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 458, col: 17, offset: 11304},
+												pos:        position{line: 458, col: 17, offset: 11313},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3180,9 +3188,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 458, col: 22, offset: 11309},
+									pos: position{line: 458, col: 22, offset: 11318},
 									expr: &ruleRefExpr{
-										pos:  position{line: 458, col: 23, offset: 11310},
+										pos:  position{line: 458, col: 23, offset: 11319},
 										name: "EOKW",
 									},
 								},
@@ -3196,28 +3204,28 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 465, col: 1, offset: 11417},
+			pos:  position{line: 465, col: 1, offset: 11426},
 			expr: &actionExpr{
-				pos: position{line: 466, col: 5, offset: 11429},
+				pos: position{line: 466, col: 5, offset: 11438},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 466, col: 5, offset: 11429},
+					pos: position{line: 466, col: 5, offset: 11438},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 466, col: 5, offset: 11429},
+							pos:        position{line: 466, col: 5, offset: 11438},
 							val:        "where",
 							ignoreCase: false,
 							want:       "\"where\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 466, col: 13, offset: 11437},
+							pos:  position{line: 466, col: 13, offset: 11446},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 466, col: 15, offset: 11439},
+							pos:   position{line: 466, col: 15, offset: 11448},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 466, col: 20, offset: 11444},
+								pos:  position{line: 466, col: 20, offset: 11453},
 								name: "Expr",
 							},
 						},
@@ -3229,28 +3237,28 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 474, col: 1, offset: 11584},
+			pos:  position{line: 474, col: 1, offset: 11593},
 			expr: &choiceExpr{
-				pos: position{line: 475, col: 5, offset: 11595},
+				pos: position{line: 475, col: 5, offset: 11604},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 475, col: 5, offset: 11595},
+						pos: position{line: 475, col: 5, offset: 11604},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 475, col: 5, offset: 11595},
+							pos: position{line: 475, col: 5, offset: 11604},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 475, col: 5, offset: 11595},
+									pos:        position{line: 475, col: 5, offset: 11604},
 									val:        "uniq",
 									ignoreCase: false,
 									want:       "\"uniq\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 475, col: 12, offset: 11602},
+									pos:  position{line: 475, col: 12, offset: 11611},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 475, col: 14, offset: 11604},
+									pos:        position{line: 475, col: 14, offset: 11613},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3259,28 +3267,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 478, col: 5, offset: 11702},
+						pos: position{line: 478, col: 5, offset: 11711},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 478, col: 5, offset: 11702},
+							pos: position{line: 478, col: 5, offset: 11711},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 478, col: 5, offset: 11702},
+									pos:        position{line: 478, col: 5, offset: 11711},
 									val:        "uniq",
 									ignoreCase: false,
 									want:       "\"uniq\"",
 								},
 								&notExpr{
-									pos: position{line: 478, col: 12, offset: 11709},
+									pos: position{line: 478, col: 12, offset: 11718},
 									expr: &seqExpr{
-										pos: position{line: 478, col: 14, offset: 11711},
+										pos: position{line: 478, col: 14, offset: 11720},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 478, col: 14, offset: 11711},
+												pos:  position{line: 478, col: 14, offset: 11720},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 478, col: 17, offset: 11714},
+												pos:        position{line: 478, col: 17, offset: 11723},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3289,9 +3297,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 478, col: 22, offset: 11719},
+									pos: position{line: 478, col: 22, offset: 11728},
 									expr: &ruleRefExpr{
-										pos:  position{line: 478, col: 23, offset: 11720},
+										pos:  position{line: 478, col: 23, offset: 11729},
 										name: "EOKW",
 									},
 								},
@@ -3305,28 +3313,28 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 482, col: 1, offset: 11802},
+			pos:  position{line: 482, col: 1, offset: 11811},
 			expr: &actionExpr{
-				pos: position{line: 483, col: 5, offset: 11812},
+				pos: position{line: 483, col: 5, offset: 11821},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 483, col: 5, offset: 11812},
+					pos: position{line: 483, col: 5, offset: 11821},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 483, col: 5, offset: 11812},
+							pos:        position{line: 483, col: 5, offset: 11821},
 							val:        "put",
 							ignoreCase: false,
 							want:       "\"put\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 483, col: 11, offset: 11818},
+							pos:  position{line: 483, col: 11, offset: 11827},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 483, col: 13, offset: 11820},
+							pos:   position{line: 483, col: 13, offset: 11829},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 483, col: 18, offset: 11825},
+								pos:  position{line: 483, col: 18, offset: 11834},
 								name: "Assignments",
 							},
 						},
@@ -3338,61 +3346,61 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 491, col: 1, offset: 11988},
+			pos:  position{line: 491, col: 1, offset: 11997},
 			expr: &actionExpr{
-				pos: position{line: 492, col: 5, offset: 12001},
+				pos: position{line: 492, col: 5, offset: 12010},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 492, col: 5, offset: 12001},
+					pos: position{line: 492, col: 5, offset: 12010},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 492, col: 5, offset: 12001},
+							pos:        position{line: 492, col: 5, offset: 12010},
 							val:        "rename",
 							ignoreCase: false,
 							want:       "\"rename\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 492, col: 14, offset: 12010},
+							pos:  position{line: 492, col: 14, offset: 12019},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 492, col: 16, offset: 12012},
+							pos:   position{line: 492, col: 16, offset: 12021},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 492, col: 22, offset: 12018},
+								pos:  position{line: 492, col: 22, offset: 12027},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 492, col: 33, offset: 12029},
+							pos:   position{line: 492, col: 33, offset: 12038},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 492, col: 38, offset: 12034},
+								pos: position{line: 492, col: 38, offset: 12043},
 								expr: &actionExpr{
-									pos: position{line: 492, col: 39, offset: 12035},
+									pos: position{line: 492, col: 39, offset: 12044},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 492, col: 39, offset: 12035},
+										pos: position{line: 492, col: 39, offset: 12044},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 492, col: 39, offset: 12035},
+												pos:  position{line: 492, col: 39, offset: 12044},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 492, col: 42, offset: 12038},
+												pos:        position{line: 492, col: 42, offset: 12047},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 492, col: 46, offset: 12042},
+												pos:  position{line: 492, col: 46, offset: 12051},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 492, col: 49, offset: 12045},
+												pos:   position{line: 492, col: 49, offset: 12054},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 492, col: 52, offset: 12048},
+													pos:  position{line: 492, col: 52, offset: 12057},
 													name: "Assignment",
 												},
 											},
@@ -3409,30 +3417,30 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 505, col: 1, offset: 12524},
+			pos:  position{line: 505, col: 1, offset: 12535},
 			expr: &actionExpr{
-				pos: position{line: 506, col: 5, offset: 12535},
+				pos: position{line: 506, col: 5, offset: 12546},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 506, col: 5, offset: 12535},
+					pos: position{line: 506, col: 5, offset: 12546},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 506, col: 5, offset: 12535},
+							pos:        position{line: 506, col: 5, offset: 12546},
 							val:        "fuse",
 							ignoreCase: false,
 							want:       "\"fuse\"",
 						},
 						&notExpr{
-							pos: position{line: 506, col: 12, offset: 12542},
+							pos: position{line: 506, col: 12, offset: 12553},
 							expr: &seqExpr{
-								pos: position{line: 506, col: 14, offset: 12544},
+								pos: position{line: 506, col: 14, offset: 12555},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 506, col: 14, offset: 12544},
+										pos:  position{line: 506, col: 14, offset: 12555},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 506, col: 17, offset: 12547},
+										pos:        position{line: 506, col: 17, offset: 12558},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3441,9 +3449,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 506, col: 22, offset: 12552},
+							pos: position{line: 506, col: 22, offset: 12563},
 							expr: &ruleRefExpr{
-								pos:  position{line: 506, col: 23, offset: 12553},
+								pos:  position{line: 506, col: 23, offset: 12564},
 								name: "EOKW",
 							},
 						},
@@ -3455,30 +3463,30 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 510, col: 1, offset: 12635},
+			pos:  position{line: 510, col: 1, offset: 12646},
 			expr: &actionExpr{
-				pos: position{line: 511, col: 5, offset: 12647},
+				pos: position{line: 511, col: 5, offset: 12658},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 511, col: 5, offset: 12647},
+					pos: position{line: 511, col: 5, offset: 12658},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 511, col: 5, offset: 12647},
+							pos:        position{line: 511, col: 5, offset: 12658},
 							val:        "shape",
 							ignoreCase: false,
 							want:       "\"shape\"",
 						},
 						&notExpr{
-							pos: position{line: 511, col: 13, offset: 12655},
+							pos: position{line: 511, col: 13, offset: 12666},
 							expr: &seqExpr{
-								pos: position{line: 511, col: 15, offset: 12657},
+								pos: position{line: 511, col: 15, offset: 12668},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 511, col: 15, offset: 12657},
+										pos:  position{line: 511, col: 15, offset: 12668},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 511, col: 18, offset: 12660},
+										pos:        position{line: 511, col: 18, offset: 12671},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3487,9 +3495,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 511, col: 23, offset: 12665},
+							pos: position{line: 511, col: 23, offset: 12676},
 							expr: &ruleRefExpr{
-								pos:  position{line: 511, col: 24, offset: 12666},
+								pos:  position{line: 511, col: 24, offset: 12677},
 								name: "EOKW",
 							},
 						},
@@ -3501,77 +3509,77 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 515, col: 1, offset: 12750},
+			pos:  position{line: 515, col: 1, offset: 12761},
 			expr: &actionExpr{
-				pos: position{line: 516, col: 5, offset: 12761},
+				pos: position{line: 516, col: 5, offset: 12772},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 516, col: 5, offset: 12761},
+					pos: position{line: 516, col: 5, offset: 12772},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 516, col: 5, offset: 12761},
+							pos:   position{line: 516, col: 5, offset: 12772},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 11, offset: 12767},
+								pos:  position{line: 516, col: 11, offset: 12778},
 								name: "JoinStyle",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 21, offset: 12777},
+							pos:        position{line: 516, col: 21, offset: 12788},
 							val:        "join",
 							ignoreCase: false,
 							want:       "\"join\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 516, col: 28, offset: 12784},
+							pos:   position{line: 516, col: 28, offset: 12795},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 39, offset: 12795},
+								pos:  position{line: 516, col: 39, offset: 12806},
 								name: "JoinRightInput",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 54, offset: 12810},
+							pos:        position{line: 516, col: 54, offset: 12821},
 							val:        "on",
 							ignoreCase: false,
 							want:       "\"on\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 516, col: 59, offset: 12815},
+							pos:  position{line: 516, col: 59, offset: 12826},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 516, col: 61, offset: 12817},
+							pos:   position{line: 516, col: 61, offset: 12828},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 65, offset: 12821},
+								pos:  position{line: 516, col: 65, offset: 12832},
 								name: "JoinKey",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 516, col: 73, offset: 12829},
+							pos:   position{line: 516, col: 73, offset: 12840},
 							label: "optKey",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 516, col: 80, offset: 12836},
+								pos: position{line: 516, col: 80, offset: 12847},
 								expr: &seqExpr{
-									pos: position{line: 516, col: 81, offset: 12837},
+									pos: position{line: 516, col: 81, offset: 12848},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 516, col: 81, offset: 12837},
+											pos:  position{line: 516, col: 81, offset: 12848},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 516, col: 84, offset: 12840},
+											pos:        position{line: 516, col: 84, offset: 12851},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 516, col: 88, offset: 12844},
+											pos:  position{line: 516, col: 88, offset: 12855},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 516, col: 91, offset: 12847},
+											pos:  position{line: 516, col: 91, offset: 12858},
 											name: "JoinKey",
 										},
 									},
@@ -3579,19 +3587,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 516, col: 101, offset: 12857},
+							pos:   position{line: 516, col: 101, offset: 12868},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 516, col: 109, offset: 12865},
+								pos: position{line: 516, col: 109, offset: 12876},
 								expr: &seqExpr{
-									pos: position{line: 516, col: 110, offset: 12866},
+									pos: position{line: 516, col: 110, offset: 12877},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 516, col: 110, offset: 12866},
+											pos:  position{line: 516, col: 110, offset: 12877},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 516, col: 112, offset: 12868},
+											pos:  position{line: 516, col: 112, offset: 12879},
 											name: "FlexAssignments",
 										},
 									},
@@ -3606,91 +3614,91 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 535, col: 1, offset: 13331},
+			pos:  position{line: 535, col: 1, offset: 13342},
 			expr: &choiceExpr{
-				pos: position{line: 536, col: 5, offset: 13345},
+				pos: position{line: 536, col: 5, offset: 13356},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 536, col: 5, offset: 13345},
+						pos: position{line: 536, col: 5, offset: 13356},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 536, col: 5, offset: 13345},
+							pos: position{line: 536, col: 5, offset: 13356},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 536, col: 5, offset: 13345},
+									pos:        position{line: 536, col: 5, offset: 13356},
 									val:        "anti",
 									ignoreCase: false,
 									want:       "\"anti\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 536, col: 12, offset: 13352},
+									pos:  position{line: 536, col: 12, offset: 13363},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 537, col: 5, offset: 13382},
+						pos: position{line: 537, col: 5, offset: 13393},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 537, col: 5, offset: 13382},
+							pos: position{line: 537, col: 5, offset: 13393},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 537, col: 5, offset: 13382},
+									pos:        position{line: 537, col: 5, offset: 13393},
 									val:        "inner",
 									ignoreCase: false,
 									want:       "\"inner\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 537, col: 13, offset: 13390},
+									pos:  position{line: 537, col: 13, offset: 13401},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 13420},
+						pos: position{line: 538, col: 5, offset: 13431},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 538, col: 5, offset: 13420},
+							pos: position{line: 538, col: 5, offset: 13431},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 538, col: 5, offset: 13420},
+									pos:        position{line: 538, col: 5, offset: 13431},
 									val:        "left",
 									ignoreCase: false,
 									want:       "\"left\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 538, col: 13, offset: 13428},
+									pos:  position{line: 538, col: 13, offset: 13439},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 539, col: 5, offset: 13457},
+						pos: position{line: 539, col: 5, offset: 13468},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 539, col: 5, offset: 13457},
+							pos: position{line: 539, col: 5, offset: 13468},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 539, col: 5, offset: 13457},
+									pos:        position{line: 539, col: 5, offset: 13468},
 									val:        "right",
 									ignoreCase: false,
 									want:       "\"right\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 539, col: 13, offset: 13465},
+									pos:  position{line: 539, col: 13, offset: 13476},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 540, col: 5, offset: 13495},
+						pos: position{line: 540, col: 5, offset: 13506},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 540, col: 5, offset: 13495},
+							pos:        position{line: 540, col: 5, offset: 13506},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3703,60 +3711,60 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 542, col: 1, offset: 13530},
+			pos:  position{line: 542, col: 1, offset: 13541},
 			expr: &choiceExpr{
-				pos: position{line: 543, col: 5, offset: 13549},
+				pos: position{line: 543, col: 5, offset: 13560},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 543, col: 5, offset: 13549},
+						pos: position{line: 543, col: 5, offset: 13560},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 543, col: 5, offset: 13549},
+							pos: position{line: 543, col: 5, offset: 13560},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 543, col: 5, offset: 13549},
+									pos:  position{line: 543, col: 5, offset: 13560},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 543, col: 8, offset: 13552},
+									pos:        position{line: 543, col: 8, offset: 13563},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 543, col: 12, offset: 13556},
+									pos:  position{line: 543, col: 12, offset: 13567},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 543, col: 15, offset: 13559},
+									pos:   position{line: 543, col: 15, offset: 13570},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 543, col: 17, offset: 13561},
+										pos:  position{line: 543, col: 17, offset: 13572},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 543, col: 21, offset: 13565},
+									pos:  position{line: 543, col: 21, offset: 13576},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 543, col: 24, offset: 13568},
+									pos:        position{line: 543, col: 24, offset: 13579},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 543, col: 28, offset: 13572},
+									pos:  position{line: 543, col: 28, offset: 13583},
 									name: "__",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 544, col: 5, offset: 13597},
+						pos: position{line: 544, col: 5, offset: 13608},
 						run: (*parser).callonJoinRightInput12,
 						expr: &ruleRefExpr{
-							pos:  position{line: 544, col: 5, offset: 13597},
+							pos:  position{line: 544, col: 5, offset: 13608},
 							name: "_",
 						},
 					},
@@ -3767,36 +3775,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 546, col: 1, offset: 13620},
+			pos:  position{line: 546, col: 1, offset: 13631},
 			expr: &choiceExpr{
-				pos: position{line: 547, col: 5, offset: 13632},
+				pos: position{line: 547, col: 5, offset: 13643},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 547, col: 5, offset: 13632},
+						pos:  position{line: 547, col: 5, offset: 13643},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 13641},
+						pos: position{line: 548, col: 5, offset: 13652},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 548, col: 5, offset: 13641},
+							pos: position{line: 548, col: 5, offset: 13652},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 548, col: 5, offset: 13641},
+									pos:        position{line: 548, col: 5, offset: 13652},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 548, col: 9, offset: 13645},
+									pos:   position{line: 548, col: 9, offset: 13656},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 548, col: 14, offset: 13650},
+										pos:  position{line: 548, col: 14, offset: 13661},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 548, col: 19, offset: 13655},
+									pos:        position{line: 548, col: 19, offset: 13666},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3811,46 +3819,46 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 550, col: 1, offset: 13681},
+			pos:  position{line: 550, col: 1, offset: 13692},
 			expr: &actionExpr{
-				pos: position{line: 551, col: 5, offset: 13694},
+				pos: position{line: 551, col: 5, offset: 13705},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 551, col: 5, offset: 13694},
+					pos: position{line: 551, col: 5, offset: 13705},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 551, col: 5, offset: 13694},
+							pos:        position{line: 551, col: 5, offset: 13705},
 							val:        "sample",
 							ignoreCase: false,
 							want:       "\"sample\"",
 						},
 						&andExpr{
-							pos: position{line: 551, col: 14, offset: 13703},
+							pos: position{line: 551, col: 14, offset: 13714},
 							expr: &ruleRefExpr{
-								pos:  position{line: 551, col: 15, offset: 13704},
+								pos:  position{line: 551, col: 15, offset: 13715},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 551, col: 20, offset: 13709},
+							pos:   position{line: 551, col: 20, offset: 13720},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 551, col: 25, offset: 13714},
+								pos: position{line: 551, col: 25, offset: 13725},
 								expr: &actionExpr{
-									pos: position{line: 551, col: 26, offset: 13715},
+									pos: position{line: 551, col: 26, offset: 13726},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 551, col: 26, offset: 13715},
+										pos: position{line: 551, col: 26, offset: 13726},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 551, col: 26, offset: 13715},
+												pos:  position{line: 551, col: 26, offset: 13726},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 551, col: 28, offset: 13717},
+												pos:   position{line: 551, col: 28, offset: 13728},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 551, col: 30, offset: 13719},
+													pos:  position{line: 551, col: 30, offset: 13730},
 													name: "Lval",
 												},
 											},
@@ -3867,15 +3875,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 564, col: 1, offset: 14170},
+			pos:  position{line: 564, col: 1, offset: 14181},
 			expr: &actionExpr{
-				pos: position{line: 565, col: 5, offset: 14187},
+				pos: position{line: 565, col: 5, offset: 14198},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 565, col: 5, offset: 14187},
+					pos:   position{line: 565, col: 5, offset: 14198},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 565, col: 7, offset: 14189},
+						pos:  position{line: 565, col: 7, offset: 14200},
 						name: "Assignments",
 					},
 				},
@@ -3885,71 +3893,71 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 572, col: 1, offset: 14338},
+			pos:  position{line: 572, col: 1, offset: 14349},
 			expr: &actionExpr{
-				pos: position{line: 573, col: 5, offset: 14349},
+				pos: position{line: 573, col: 5, offset: 14360},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 573, col: 5, offset: 14349},
+					pos: position{line: 573, col: 5, offset: 14360},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 573, col: 5, offset: 14349},
+							pos:        position{line: 573, col: 5, offset: 14360},
 							val:        "load",
 							ignoreCase: false,
 							want:       "\"load\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 573, col: 12, offset: 14356},
+							pos:  position{line: 573, col: 12, offset: 14367},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 14, offset: 14358},
+							pos:   position{line: 573, col: 14, offset: 14369},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 573, col: 19, offset: 14363},
+								pos:  position{line: 573, col: 19, offset: 14374},
 								name: "PoolNameString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 34, offset: 14378},
+							pos:   position{line: 573, col: 34, offset: 14389},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 573, col: 41, offset: 14385},
+								pos: position{line: 573, col: 41, offset: 14396},
 								expr: &ruleRefExpr{
-									pos:  position{line: 573, col: 41, offset: 14385},
+									pos:  position{line: 573, col: 41, offset: 14396},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 53, offset: 14397},
+							pos:   position{line: 573, col: 53, offset: 14408},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 573, col: 60, offset: 14404},
+								pos: position{line: 573, col: 60, offset: 14415},
 								expr: &ruleRefExpr{
-									pos:  position{line: 573, col: 60, offset: 14404},
+									pos:  position{line: 573, col: 60, offset: 14415},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 71, offset: 14415},
+							pos:   position{line: 573, col: 71, offset: 14426},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 573, col: 79, offset: 14423},
+								pos: position{line: 573, col: 79, offset: 14434},
 								expr: &ruleRefExpr{
-									pos:  position{line: 573, col: 79, offset: 14423},
+									pos:  position{line: 573, col: 79, offset: 14434},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 91, offset: 14435},
+							pos:   position{line: 573, col: 91, offset: 14446},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 573, col: 96, offset: 14440},
+								pos: position{line: 573, col: 96, offset: 14451},
 								expr: &ruleRefExpr{
-									pos:  position{line: 573, col: 96, offset: 14440},
+									pos:  position{line: 573, col: 96, offset: 14451},
 									name: "MetaArg",
 								},
 							},
@@ -3962,32 +3970,32 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 586, col: 1, offset: 14787},
+			pos:  position{line: 586, col: 1, offset: 14798},
 			expr: &actionExpr{
-				pos: position{line: 587, col: 5, offset: 14801},
+				pos: position{line: 587, col: 5, offset: 14812},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 587, col: 5, offset: 14801},
+					pos: position{line: 587, col: 5, offset: 14812},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 587, col: 5, offset: 14801},
+							pos:  position{line: 587, col: 5, offset: 14812},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 587, col: 7, offset: 14803},
+							pos:        position{line: 587, col: 7, offset: 14814},
 							val:        "author",
 							ignoreCase: false,
 							want:       "\"author\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 587, col: 16, offset: 14812},
+							pos:  position{line: 587, col: 16, offset: 14823},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 587, col: 18, offset: 14814},
+							pos:   position{line: 587, col: 18, offset: 14825},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 587, col: 22, offset: 14818},
+								pos:  position{line: 587, col: 22, offset: 14829},
 								name: "QuotedString",
 							},
 						},
@@ -3999,32 +4007,32 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 589, col: 1, offset: 14852},
+			pos:  position{line: 589, col: 1, offset: 14863},
 			expr: &actionExpr{
-				pos: position{line: 590, col: 5, offset: 14867},
+				pos: position{line: 590, col: 5, offset: 14878},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 590, col: 5, offset: 14867},
+					pos: position{line: 590, col: 5, offset: 14878},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 590, col: 5, offset: 14867},
+							pos:  position{line: 590, col: 5, offset: 14878},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 590, col: 7, offset: 14869},
+							pos:        position{line: 590, col: 7, offset: 14880},
 							val:        "message",
 							ignoreCase: false,
 							want:       "\"message\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 590, col: 17, offset: 14879},
+							pos:  position{line: 590, col: 17, offset: 14890},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 590, col: 19, offset: 14881},
+							pos:   position{line: 590, col: 19, offset: 14892},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 590, col: 23, offset: 14885},
+								pos:  position{line: 590, col: 23, offset: 14896},
 								name: "QuotedString",
 							},
 						},
@@ -4036,32 +4044,32 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 592, col: 1, offset: 14919},
+			pos:  position{line: 592, col: 1, offset: 14930},
 			expr: &actionExpr{
-				pos: position{line: 593, col: 5, offset: 14931},
+				pos: position{line: 593, col: 5, offset: 14942},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 593, col: 5, offset: 14931},
+					pos: position{line: 593, col: 5, offset: 14942},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 593, col: 5, offset: 14931},
+							pos:  position{line: 593, col: 5, offset: 14942},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 593, col: 7, offset: 14933},
+							pos:        position{line: 593, col: 7, offset: 14944},
 							val:        "meta",
 							ignoreCase: false,
 							want:       "\"meta\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 593, col: 14, offset: 14940},
+							pos:  position{line: 593, col: 14, offset: 14951},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 593, col: 16, offset: 14942},
+							pos:   position{line: 593, col: 16, offset: 14953},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 593, col: 20, offset: 14946},
+								pos:  position{line: 593, col: 20, offset: 14957},
 								name: "QuotedString",
 							},
 						},
@@ -4073,31 +4081,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 595, col: 1, offset: 14980},
+			pos:  position{line: 595, col: 1, offset: 14991},
 			expr: &actionExpr{
-				pos: position{line: 596, col: 5, offset: 14995},
+				pos: position{line: 596, col: 5, offset: 15006},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 596, col: 5, offset: 14995},
+					pos: position{line: 596, col: 5, offset: 15006},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 596, col: 5, offset: 14995},
+							pos:        position{line: 596, col: 5, offset: 15006},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 596, col: 9, offset: 14999},
+							pos:   position{line: 596, col: 9, offset: 15010},
 							label: "branch",
 							expr: &choiceExpr{
-								pos: position{line: 596, col: 17, offset: 15007},
+								pos: position{line: 596, col: 17, offset: 15018},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 596, col: 17, offset: 15007},
+										pos:  position{line: 596, col: 17, offset: 15018},
 										name: "PoolIdentifier",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 596, col: 34, offset: 15024},
+										pos:  position{line: 596, col: 34, offset: 15035},
 										name: "QuotedString",
 									},
 								},
@@ -4111,28 +4119,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 598, col: 1, offset: 15062},
+			pos:  position{line: 598, col: 1, offset: 15073},
 			expr: &actionExpr{
-				pos: position{line: 599, col: 5, offset: 15075},
+				pos: position{line: 599, col: 5, offset: 15086},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 599, col: 5, offset: 15075},
+					pos: position{line: 599, col: 5, offset: 15086},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 599, col: 5, offset: 15075},
+							pos:        position{line: 599, col: 5, offset: 15086},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 14, offset: 15084},
+							pos:  position{line: 599, col: 14, offset: 15095},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 599, col: 16, offset: 15086},
+							pos:   position{line: 599, col: 16, offset: 15097},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 599, col: 21, offset: 15091},
+								pos:  position{line: 599, col: 21, offset: 15102},
 								name: "Identifier",
 							},
 						},
@@ -4144,46 +4152,46 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 607, col: 1, offset: 15238},
+			pos:  position{line: 607, col: 1, offset: 15249},
 			expr: &actionExpr{
-				pos: position{line: 608, col: 5, offset: 15250},
+				pos: position{line: 608, col: 5, offset: 15261},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 608, col: 5, offset: 15250},
+					pos: position{line: 608, col: 5, offset: 15261},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 608, col: 5, offset: 15250},
+							pos:        position{line: 608, col: 5, offset: 15261},
 							val:        "debug",
 							ignoreCase: false,
 							want:       "\"debug\"",
 						},
 						&andExpr{
-							pos: position{line: 608, col: 13, offset: 15258},
+							pos: position{line: 608, col: 13, offset: 15269},
 							expr: &ruleRefExpr{
-								pos:  position{line: 608, col: 14, offset: 15259},
+								pos:  position{line: 608, col: 14, offset: 15270},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 608, col: 19, offset: 15264},
+							pos:   position{line: 608, col: 19, offset: 15275},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 608, col: 24, offset: 15269},
+								pos: position{line: 608, col: 24, offset: 15280},
 								expr: &actionExpr{
-									pos: position{line: 608, col: 25, offset: 15270},
+									pos: position{line: 608, col: 25, offset: 15281},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 608, col: 25, offset: 15270},
+										pos: position{line: 608, col: 25, offset: 15281},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 608, col: 25, offset: 15270},
+												pos:  position{line: 608, col: 25, offset: 15281},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 608, col: 27, offset: 15272},
+												pos:   position{line: 608, col: 27, offset: 15283},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 608, col: 29, offset: 15274},
+													pos:  position{line: 608, col: 29, offset: 15285},
 													name: "Expr",
 												},
 											},
@@ -4200,20 +4208,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 619, col: 1, offset: 15480},
+			pos:  position{line: 619, col: 1, offset: 15491},
 			expr: &choiceExpr{
-				pos: position{line: 620, col: 5, offset: 15491},
+				pos: position{line: 620, col: 5, offset: 15502},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 620, col: 5, offset: 15491},
+						pos:  position{line: 620, col: 5, offset: 15502},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 621, col: 5, offset: 15500},
+						pos:  position{line: 621, col: 5, offset: 15511},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 622, col: 5, offset: 15508},
+						pos:  position{line: 622, col: 5, offset: 15519},
 						name: "From",
 					},
 				},
@@ -4223,49 +4231,49 @@ var g = &grammar{
 		},
 		{
 			name: "File",
-			pos:  position{line: 624, col: 1, offset: 15514},
+			pos:  position{line: 624, col: 1, offset: 15525},
 			expr: &actionExpr{
-				pos: position{line: 625, col: 5, offset: 15523},
+				pos: position{line: 625, col: 5, offset: 15534},
 				run: (*parser).callonFile1,
 				expr: &seqExpr{
-					pos: position{line: 625, col: 5, offset: 15523},
+					pos: position{line: 625, col: 5, offset: 15534},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 625, col: 5, offset: 15523},
+							pos:        position{line: 625, col: 5, offset: 15534},
 							val:        "file",
 							ignoreCase: false,
 							want:       "\"file\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 625, col: 12, offset: 15530},
+							pos:  position{line: 625, col: 12, offset: 15541},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 625, col: 14, offset: 15532},
+							pos:   position{line: 625, col: 14, offset: 15543},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 625, col: 19, offset: 15537},
+								pos:  position{line: 625, col: 19, offset: 15548},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 625, col: 24, offset: 15542},
+							pos:   position{line: 625, col: 24, offset: 15553},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 625, col: 31, offset: 15549},
+								pos: position{line: 625, col: 31, offset: 15560},
 								expr: &ruleRefExpr{
-									pos:  position{line: 625, col: 31, offset: 15549},
+									pos:  position{line: 625, col: 31, offset: 15560},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 625, col: 42, offset: 15560},
+							pos:   position{line: 625, col: 42, offset: 15571},
 							label: "sortKeys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 625, col: 51, offset: 15569},
+								pos: position{line: 625, col: 51, offset: 15580},
 								expr: &ruleRefExpr{
-									pos:  position{line: 625, col: 51, offset: 15569},
+									pos:  position{line: 625, col: 51, offset: 15580},
 									name: "OrderArg",
 								},
 							},
@@ -4278,28 +4286,28 @@ var g = &grammar{
 		},
 		{
 			name: "From",
-			pos:  position{line: 636, col: 1, offset: 15848},
+			pos:  position{line: 636, col: 1, offset: 15859},
 			expr: &actionExpr{
-				pos: position{line: 637, col: 5, offset: 15857},
+				pos: position{line: 637, col: 5, offset: 15868},
 				run: (*parser).callonFrom1,
 				expr: &seqExpr{
-					pos: position{line: 637, col: 5, offset: 15857},
+					pos: position{line: 637, col: 5, offset: 15868},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 637, col: 5, offset: 15857},
+							pos:        position{line: 637, col: 5, offset: 15868},
 							val:        "from",
 							ignoreCase: false,
 							want:       "\"from\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 637, col: 12, offset: 15864},
+							pos:  position{line: 637, col: 12, offset: 15875},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 637, col: 14, offset: 15866},
+							pos:   position{line: 637, col: 14, offset: 15877},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 637, col: 19, offset: 15871},
+								pos:  position{line: 637, col: 19, offset: 15882},
 								name: "PoolSpec",
 							},
 						},
@@ -4311,28 +4319,28 @@ var g = &grammar{
 		},
 		{
 			name: "Pool",
-			pos:  position{line: 646, col: 1, offset: 16059},
+			pos:  position{line: 646, col: 1, offset: 16070},
 			expr: &actionExpr{
-				pos: position{line: 647, col: 5, offset: 16068},
+				pos: position{line: 647, col: 5, offset: 16079},
 				run: (*parser).callonPool1,
 				expr: &seqExpr{
-					pos: position{line: 647, col: 5, offset: 16068},
+					pos: position{line: 647, col: 5, offset: 16079},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 647, col: 5, offset: 16068},
+							pos:        position{line: 647, col: 5, offset: 16079},
 							val:        "pool",
 							ignoreCase: false,
 							want:       "\"pool\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 647, col: 12, offset: 16075},
+							pos:  position{line: 647, col: 12, offset: 16086},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 647, col: 14, offset: 16077},
+							pos:   position{line: 647, col: 14, offset: 16088},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 647, col: 19, offset: 16082},
+								pos:  position{line: 647, col: 19, offset: 16093},
 								name: "PoolSpec",
 							},
 						},
@@ -4344,82 +4352,82 @@ var g = &grammar{
 		},
 		{
 			name: "Get",
-			pos:  position{line: 656, col: 1, offset: 16270},
+			pos:  position{line: 656, col: 1, offset: 16281},
 			expr: &actionExpr{
-				pos: position{line: 657, col: 5, offset: 16278},
+				pos: position{line: 657, col: 5, offset: 16289},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 657, col: 5, offset: 16278},
+					pos: position{line: 657, col: 5, offset: 16289},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 657, col: 5, offset: 16278},
+							pos:        position{line: 657, col: 5, offset: 16289},
 							val:        "get",
 							ignoreCase: false,
 							want:       "\"get\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 657, col: 11, offset: 16284},
+							pos:  position{line: 657, col: 11, offset: 16295},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 13, offset: 16286},
+							pos:   position{line: 657, col: 13, offset: 16297},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 657, col: 17, offset: 16290},
+								pos:  position{line: 657, col: 17, offset: 16301},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 22, offset: 16295},
+							pos:   position{line: 657, col: 22, offset: 16306},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 657, col: 29, offset: 16302},
+								pos: position{line: 657, col: 29, offset: 16313},
 								expr: &ruleRefExpr{
-									pos:  position{line: 657, col: 29, offset: 16302},
+									pos:  position{line: 657, col: 29, offset: 16313},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 40, offset: 16313},
+							pos:   position{line: 657, col: 40, offset: 16324},
 							label: "sortKeys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 657, col: 49, offset: 16322},
+								pos: position{line: 657, col: 49, offset: 16333},
 								expr: &ruleRefExpr{
-									pos:  position{line: 657, col: 49, offset: 16322},
+									pos:  position{line: 657, col: 49, offset: 16333},
 									name: "OrderArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 59, offset: 16332},
+							pos:   position{line: 657, col: 59, offset: 16343},
 							label: "method",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 657, col: 66, offset: 16339},
+								pos: position{line: 657, col: 66, offset: 16350},
 								expr: &ruleRefExpr{
-									pos:  position{line: 657, col: 66, offset: 16339},
+									pos:  position{line: 657, col: 66, offset: 16350},
 									name: "MethodArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 77, offset: 16350},
+							pos:   position{line: 657, col: 77, offset: 16361},
 							label: "headers",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 657, col: 85, offset: 16358},
+								pos: position{line: 657, col: 85, offset: 16369},
 								expr: &ruleRefExpr{
-									pos:  position{line: 657, col: 85, offset: 16358},
+									pos:  position{line: 657, col: 85, offset: 16369},
 									name: "HeadersArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 97, offset: 16370},
+							pos:   position{line: 657, col: 97, offset: 16381},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 657, col: 102, offset: 16375},
+								pos: position{line: 657, col: 102, offset: 16386},
 								expr: &ruleRefExpr{
-									pos:  position{line: 657, col: 102, offset: 16375},
+									pos:  position{line: 657, col: 102, offset: 16386},
 									name: "BodyArg",
 								},
 							},
@@ -4432,39 +4440,39 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 674, col: 1, offset: 16820},
+			pos:  position{line: 674, col: 1, offset: 16831},
 			expr: &actionExpr{
-				pos: position{line: 674, col: 13, offset: 16832},
+				pos: position{line: 674, col: 13, offset: 16843},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 674, col: 13, offset: 16832},
+					pos: position{line: 674, col: 13, offset: 16843},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 674, col: 13, offset: 16832},
+							pos:  position{line: 674, col: 13, offset: 16843},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 674, col: 15, offset: 16834},
+							pos:        position{line: 674, col: 15, offset: 16845},
 							val:        "method",
 							ignoreCase: false,
 							want:       "\"method\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 674, col: 24, offset: 16843},
+							pos:  position{line: 674, col: 24, offset: 16854},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 674, col: 26, offset: 16845},
+							pos:   position{line: 674, col: 26, offset: 16856},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 674, col: 29, offset: 16848},
+								pos: position{line: 674, col: 29, offset: 16859},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 674, col: 29, offset: 16848},
+										pos:  position{line: 674, col: 29, offset: 16859},
 										name: "IdentifierName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 674, col: 46, offset: 16865},
+										pos:  position{line: 674, col: 46, offset: 16876},
 										name: "QuotedString",
 									},
 								},
@@ -4478,32 +4486,32 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 676, col: 1, offset: 16898},
+			pos:  position{line: 676, col: 1, offset: 16909},
 			expr: &actionExpr{
-				pos: position{line: 676, col: 14, offset: 16911},
+				pos: position{line: 676, col: 14, offset: 16922},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 676, col: 14, offset: 16911},
+					pos: position{line: 676, col: 14, offset: 16922},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 676, col: 14, offset: 16911},
+							pos:  position{line: 676, col: 14, offset: 16922},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 676, col: 16, offset: 16913},
+							pos:        position{line: 676, col: 16, offset: 16924},
 							val:        "headers",
 							ignoreCase: false,
 							want:       "\"headers\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 676, col: 26, offset: 16923},
+							pos:  position{line: 676, col: 26, offset: 16934},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 676, col: 28, offset: 16925},
+							pos:   position{line: 676, col: 28, offset: 16936},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 676, col: 30, offset: 16927},
+								pos:  position{line: 676, col: 30, offset: 16938},
 								name: "Record",
 							},
 						},
@@ -4515,39 +4523,39 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 678, col: 1, offset: 16953},
+			pos:  position{line: 678, col: 1, offset: 16964},
 			expr: &actionExpr{
-				pos: position{line: 678, col: 11, offset: 16963},
+				pos: position{line: 678, col: 11, offset: 16974},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 678, col: 11, offset: 16963},
+					pos: position{line: 678, col: 11, offset: 16974},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 678, col: 11, offset: 16963},
+							pos:  position{line: 678, col: 11, offset: 16974},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 678, col: 13, offset: 16965},
+							pos:        position{line: 678, col: 13, offset: 16976},
 							val:        "body",
 							ignoreCase: false,
 							want:       "\"body\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 678, col: 20, offset: 16972},
+							pos:  position{line: 678, col: 20, offset: 16983},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 678, col: 22, offset: 16974},
+							pos:   position{line: 678, col: 22, offset: 16985},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 678, col: 25, offset: 16977},
+								pos: position{line: 678, col: 25, offset: 16988},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 678, col: 25, offset: 16977},
+										pos:  position{line: 678, col: 25, offset: 16988},
 										name: "IdentifierName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 678, col: 42, offset: 16994},
+										pos:  position{line: 678, col: 42, offset: 17005},
 										name: "QuotedString",
 									},
 								},
@@ -4561,21 +4569,21 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 680, col: 1, offset: 17027},
+			pos:  position{line: 680, col: 1, offset: 17038},
 			expr: &choiceExpr{
-				pos: position{line: 681, col: 5, offset: 17036},
+				pos: position{line: 681, col: 5, offset: 17047},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 681, col: 5, offset: 17036},
+						pos:  position{line: 681, col: 5, offset: 17047},
 						name: "QuotedStringNode",
 					},
 					&actionExpr{
-						pos: position{line: 682, col: 5, offset: 17057},
+						pos: position{line: 682, col: 5, offset: 17068},
 						run: (*parser).callonPath3,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 682, col: 5, offset: 17057},
+							pos: position{line: 682, col: 5, offset: 17068},
 							expr: &charClassMatcher{
-								pos:        position{line: 682, col: 5, offset: 17057},
+								pos:        position{line: 682, col: 5, offset: 17068},
 								val:        "[0-9a-zA-Z!@$%^&*_=<>,./?:[\\]{}~+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -4591,32 +4599,32 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 687, col: 1, offset: 17227},
+			pos:  position{line: 687, col: 1, offset: 17238},
 			expr: &actionExpr{
-				pos: position{line: 688, col: 5, offset: 17238},
+				pos: position{line: 688, col: 5, offset: 17249},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 688, col: 5, offset: 17238},
+					pos: position{line: 688, col: 5, offset: 17249},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 688, col: 5, offset: 17238},
+							pos:  position{line: 688, col: 5, offset: 17249},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 688, col: 7, offset: 17240},
+							pos:        position{line: 688, col: 7, offset: 17251},
 							val:        "at",
 							ignoreCase: false,
 							want:       "\"at\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 688, col: 12, offset: 17245},
+							pos:  position{line: 688, col: 12, offset: 17256},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 688, col: 14, offset: 17247},
+							pos:   position{line: 688, col: 14, offset: 17258},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 688, col: 17, offset: 17250},
+								pos:  position{line: 688, col: 17, offset: 17261},
 								name: "KSUID",
 							},
 						},
@@ -4628,14 +4636,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 691, col: 1, offset: 17316},
+			pos:  position{line: 691, col: 1, offset: 17327},
 			expr: &actionExpr{
-				pos: position{line: 691, col: 9, offset: 17324},
+				pos: position{line: 691, col: 9, offset: 17335},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 691, col: 9, offset: 17324},
+					pos: position{line: 691, col: 9, offset: 17335},
 					expr: &charClassMatcher{
-						pos:        position{line: 691, col: 10, offset: 17325},
+						pos:        position{line: 691, col: 10, offset: 17336},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -4648,51 +4656,51 @@ var g = &grammar{
 		},
 		{
 			name: "PoolSpec",
-			pos:  position{line: 693, col: 1, offset: 17371},
+			pos:  position{line: 693, col: 1, offset: 17382},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 17384},
+				pos: position{line: 694, col: 5, offset: 17395},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 694, col: 5, offset: 17384},
+						pos: position{line: 694, col: 5, offset: 17395},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 694, col: 5, offset: 17384},
+							pos: position{line: 694, col: 5, offset: 17395},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 694, col: 5, offset: 17384},
+									pos:   position{line: 694, col: 5, offset: 17395},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 10, offset: 17389},
+										pos:  position{line: 694, col: 10, offset: 17400},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 694, col: 19, offset: 17398},
+									pos:   position{line: 694, col: 19, offset: 17409},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 694, col: 26, offset: 17405},
+										pos: position{line: 694, col: 26, offset: 17416},
 										expr: &ruleRefExpr{
-											pos:  position{line: 694, col: 26, offset: 17405},
+											pos:  position{line: 694, col: 26, offset: 17416},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 694, col: 38, offset: 17417},
+									pos:   position{line: 694, col: 38, offset: 17428},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 694, col: 43, offset: 17422},
+										pos: position{line: 694, col: 43, offset: 17433},
 										expr: &ruleRefExpr{
-											pos:  position{line: 694, col: 43, offset: 17422},
+											pos:  position{line: 694, col: 43, offset: 17433},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 694, col: 53, offset: 17432},
+									pos:   position{line: 694, col: 53, offset: 17443},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 57, offset: 17436},
+										pos:  position{line: 694, col: 57, offset: 17447},
 										name: "TapArg",
 									},
 								},
@@ -4700,13 +4708,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 702, col: 5, offset: 17630},
+						pos: position{line: 702, col: 5, offset: 17641},
 						run: (*parser).callonPoolSpec14,
 						expr: &labeledExpr{
-							pos:   position{line: 702, col: 5, offset: 17630},
+							pos:   position{line: 702, col: 5, offset: 17641},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 10, offset: 17635},
+								pos:  position{line: 702, col: 10, offset: 17646},
 								name: "PoolMeta",
 							},
 						},
@@ -4718,24 +4726,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 706, col: 1, offset: 17705},
+			pos:  position{line: 706, col: 1, offset: 17716},
 			expr: &actionExpr{
-				pos: position{line: 707, col: 5, offset: 17720},
+				pos: position{line: 707, col: 5, offset: 17731},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 707, col: 5, offset: 17720},
+					pos: position{line: 707, col: 5, offset: 17731},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 707, col: 5, offset: 17720},
+							pos:        position{line: 707, col: 5, offset: 17731},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 707, col: 9, offset: 17724},
+							pos:   position{line: 707, col: 9, offset: 17735},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 707, col: 16, offset: 17731},
+								pos:  position{line: 707, col: 16, offset: 17742},
 								name: "PoolNameString",
 							},
 						},
@@ -4747,24 +4755,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 709, col: 1, offset: 17770},
+			pos:  position{line: 709, col: 1, offset: 17781},
 			expr: &actionExpr{
-				pos: position{line: 710, col: 5, offset: 17783},
+				pos: position{line: 710, col: 5, offset: 17794},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 710, col: 5, offset: 17783},
+					pos: position{line: 710, col: 5, offset: 17794},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 710, col: 5, offset: 17783},
+							pos:        position{line: 710, col: 5, offset: 17794},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 710, col: 9, offset: 17787},
+							pos:   position{line: 710, col: 9, offset: 17798},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 710, col: 14, offset: 17792},
+								pos:  position{line: 710, col: 14, offset: 17803},
 								name: "PoolIdentifier",
 							},
 						},
@@ -4776,34 +4784,34 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 712, col: 1, offset: 17829},
+			pos:  position{line: 712, col: 1, offset: 17840},
 			expr: &choiceExpr{
-				pos: position{line: 713, col: 5, offset: 17842},
+				pos: position{line: 713, col: 5, offset: 17853},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 713, col: 5, offset: 17842},
+						pos:  position{line: 713, col: 5, offset: 17853},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 714, col: 5, offset: 17853},
+						pos:  position{line: 714, col: 5, offset: 17864},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 715, col: 5, offset: 17862},
+						pos: position{line: 715, col: 5, offset: 17873},
 						run: (*parser).callonPoolName4,
 						expr: &seqExpr{
-							pos: position{line: 715, col: 5, offset: 17862},
+							pos: position{line: 715, col: 5, offset: 17873},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 715, col: 5, offset: 17862},
+									pos:        position{line: 715, col: 5, offset: 17873},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 715, col: 9, offset: 17866},
+									pos: position{line: 715, col: 9, offset: 17877},
 									expr: &ruleRefExpr{
-										pos:  position{line: 715, col: 10, offset: 17867},
+										pos:  position{line: 715, col: 10, offset: 17878},
 										name: "ExprGuard",
 									},
 								},
@@ -4811,17 +4819,17 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 716, col: 5, offset: 17961},
+						pos:  position{line: 716, col: 5, offset: 17972},
 						name: "QuotedStringNode",
 					},
 					&actionExpr{
-						pos: position{line: 717, col: 5, offset: 17982},
+						pos: position{line: 717, col: 5, offset: 17993},
 						run: (*parser).callonPoolName10,
 						expr: &labeledExpr{
-							pos:   position{line: 717, col: 5, offset: 17982},
+							pos:   position{line: 717, col: 5, offset: 17993},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 717, col: 10, offset: 17987},
+								pos:  position{line: 717, col: 10, offset: 17998},
 								name: "PoolNameString",
 							},
 						},
@@ -4833,20 +4841,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolNameString",
-			pos:  position{line: 719, col: 1, offset: 18091},
+			pos:  position{line: 719, col: 1, offset: 18102},
 			expr: &choiceExpr{
-				pos: position{line: 720, col: 5, offset: 18110},
+				pos: position{line: 720, col: 5, offset: 18121},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 720, col: 5, offset: 18110},
+						pos:  position{line: 720, col: 5, offset: 18121},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 721, col: 5, offset: 18129},
+						pos:  position{line: 721, col: 5, offset: 18140},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 722, col: 5, offset: 18139},
+						pos:  position{line: 722, col: 5, offset: 18150},
 						name: "QuotedString",
 					},
 				},
@@ -4856,22 +4864,22 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 724, col: 1, offset: 18153},
+			pos:  position{line: 724, col: 1, offset: 18164},
 			expr: &actionExpr{
-				pos: position{line: 725, col: 5, offset: 18172},
+				pos: position{line: 725, col: 5, offset: 18183},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 725, col: 5, offset: 18172},
+					pos: position{line: 725, col: 5, offset: 18183},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 725, col: 6, offset: 18173},
+							pos: position{line: 725, col: 6, offset: 18184},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 725, col: 6, offset: 18173},
+									pos:  position{line: 725, col: 6, offset: 18184},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 725, col: 24, offset: 18191},
+									pos:        position{line: 725, col: 24, offset: 18202},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -4879,16 +4887,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 725, col: 29, offset: 18196},
+							pos: position{line: 725, col: 29, offset: 18207},
 							expr: &choiceExpr{
-								pos: position{line: 725, col: 30, offset: 18197},
+								pos: position{line: 725, col: 30, offset: 18208},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 725, col: 30, offset: 18197},
+										pos:  position{line: 725, col: 30, offset: 18208},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 725, col: 47, offset: 18214},
+										pos:        position{line: 725, col: 47, offset: 18225},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -4904,32 +4912,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 727, col: 1, offset: 18252},
+			pos:  position{line: 727, col: 1, offset: 18263},
 			expr: &actionExpr{
-				pos: position{line: 728, col: 5, offset: 18265},
+				pos: position{line: 728, col: 5, offset: 18276},
 				run: (*parser).callonOrderArg1,
 				expr: &seqExpr{
-					pos: position{line: 728, col: 5, offset: 18265},
+					pos: position{line: 728, col: 5, offset: 18276},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 728, col: 5, offset: 18265},
+							pos:  position{line: 728, col: 5, offset: 18276},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 728, col: 7, offset: 18267},
+							pos:        position{line: 728, col: 7, offset: 18278},
 							val:        "order",
 							ignoreCase: false,
 							want:       "\"order\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 728, col: 15, offset: 18275},
+							pos:  position{line: 728, col: 15, offset: 18286},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 728, col: 17, offset: 18277},
+							pos:   position{line: 728, col: 17, offset: 18288},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 728, col: 23, offset: 18283},
+								pos:  position{line: 728, col: 23, offset: 18294},
 								name: "SortExprs",
 							},
 						},
@@ -4941,51 +4949,51 @@ var g = &grammar{
 		},
 		{
 			name: "SortExprs",
-			pos:  position{line: 732, col: 1, offset: 18326},
+			pos:  position{line: 732, col: 1, offset: 18337},
 			expr: &actionExpr{
-				pos: position{line: 733, col: 5, offset: 18340},
+				pos: position{line: 733, col: 5, offset: 18351},
 				run: (*parser).callonSortExprs1,
 				expr: &seqExpr{
-					pos: position{line: 733, col: 5, offset: 18340},
+					pos: position{line: 733, col: 5, offset: 18351},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 733, col: 5, offset: 18340},
+							pos:   position{line: 733, col: 5, offset: 18351},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 733, col: 11, offset: 18346},
+								pos:  position{line: 733, col: 11, offset: 18357},
 								name: "SortExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 733, col: 20, offset: 18355},
+							pos:   position{line: 733, col: 20, offset: 18366},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 733, col: 25, offset: 18360},
+								pos: position{line: 733, col: 25, offset: 18371},
 								expr: &actionExpr{
-									pos: position{line: 733, col: 26, offset: 18361},
+									pos: position{line: 733, col: 26, offset: 18372},
 									run: (*parser).callonSortExprs7,
 									expr: &seqExpr{
-										pos: position{line: 733, col: 26, offset: 18361},
+										pos: position{line: 733, col: 26, offset: 18372},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 733, col: 26, offset: 18361},
+												pos:  position{line: 733, col: 26, offset: 18372},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 733, col: 29, offset: 18364},
+												pos:        position{line: 733, col: 29, offset: 18375},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 733, col: 33, offset: 18368},
+												pos:  position{line: 733, col: 33, offset: 18379},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 733, col: 36, offset: 18371},
+												pos:   position{line: 733, col: 36, offset: 18382},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 733, col: 38, offset: 18373},
+													pos:  position{line: 733, col: 38, offset: 18384},
 													name: "SortExpr",
 												},
 											},
@@ -5002,41 +5010,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortExpr",
-			pos:  position{line: 737, col: 1, offset: 18450},
+			pos:  position{line: 737, col: 1, offset: 18461},
 			expr: &actionExpr{
-				pos: position{line: 738, col: 5, offset: 18463},
+				pos: position{line: 738, col: 5, offset: 18474},
 				run: (*parser).callonSortExpr1,
 				expr: &seqExpr{
-					pos: position{line: 738, col: 5, offset: 18463},
+					pos: position{line: 738, col: 5, offset: 18474},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 738, col: 5, offset: 18463},
+							pos:   position{line: 738, col: 5, offset: 18474},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 738, col: 7, offset: 18465},
+								pos:  position{line: 738, col: 7, offset: 18476},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 738, col: 12, offset: 18470},
+							pos:   position{line: 738, col: 12, offset: 18481},
 							label: "order",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 738, col: 18, offset: 18476},
+								pos: position{line: 738, col: 18, offset: 18487},
 								expr: &actionExpr{
-									pos: position{line: 738, col: 19, offset: 18477},
+									pos: position{line: 738, col: 19, offset: 18488},
 									run: (*parser).callonSortExpr7,
 									expr: &seqExpr{
-										pos: position{line: 738, col: 19, offset: 18477},
+										pos: position{line: 738, col: 19, offset: 18488},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 738, col: 19, offset: 18477},
+												pos:  position{line: 738, col: 19, offset: 18488},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 738, col: 21, offset: 18479},
+												pos:   position{line: 738, col: 21, offset: 18490},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 738, col: 23, offset: 18481},
+													pos:  position{line: 738, col: 23, offset: 18492},
 													name: "OrderSpec",
 												},
 											},
@@ -5053,21 +5061,21 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSpec",
-			pos:  position{line: 746, col: 1, offset: 18674},
+			pos:  position{line: 746, col: 1, offset: 18685},
 			expr: &actionExpr{
-				pos: position{line: 747, col: 5, offset: 18688},
+				pos: position{line: 747, col: 5, offset: 18699},
 				run: (*parser).callonOrderSpec1,
 				expr: &choiceExpr{
-					pos: position{line: 747, col: 6, offset: 18689},
+					pos: position{line: 747, col: 6, offset: 18700},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 747, col: 6, offset: 18689},
+							pos:        position{line: 747, col: 6, offset: 18700},
 							val:        "asc",
 							ignoreCase: false,
 							want:       "\"asc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 747, col: 14, offset: 18697},
+							pos:        position{line: 747, col: 14, offset: 18708},
 							val:        "desc",
 							ignoreCase: false,
 							want:       "\"desc\"",
@@ -5080,22 +5088,22 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 751, col: 1, offset: 18797},
+			pos:  position{line: 751, col: 1, offset: 18808},
 			expr: &choiceExpr{
-				pos: position{line: 752, col: 5, offset: 18808},
+				pos: position{line: 752, col: 5, offset: 18819},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 752, col: 5, offset: 18808},
+						pos: position{line: 752, col: 5, offset: 18819},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 752, col: 5, offset: 18808},
+							pos: position{line: 752, col: 5, offset: 18819},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 752, col: 5, offset: 18808},
+									pos:  position{line: 752, col: 5, offset: 18819},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 752, col: 7, offset: 18810},
+									pos:        position{line: 752, col: 7, offset: 18821},
 									val:        "tap",
 									ignoreCase: false,
 									want:       "\"tap\"",
@@ -5104,10 +5112,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 753, col: 5, offset: 18841},
+						pos: position{line: 753, col: 5, offset: 18852},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 753, col: 5, offset: 18841},
+							pos:        position{line: 753, col: 5, offset: 18852},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -5120,32 +5128,32 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 755, col: 1, offset: 18867},
+			pos:  position{line: 755, col: 1, offset: 18878},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 18881},
+				pos: position{line: 756, col: 5, offset: 18892},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 756, col: 5, offset: 18881},
+					pos: position{line: 756, col: 5, offset: 18892},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 5, offset: 18881},
+							pos:  position{line: 756, col: 5, offset: 18892},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 756, col: 7, offset: 18883},
+							pos:        position{line: 756, col: 7, offset: 18894},
 							val:        "format",
 							ignoreCase: false,
 							want:       "\"format\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 16, offset: 18892},
+							pos:  position{line: 756, col: 16, offset: 18903},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 18, offset: 18894},
+							pos:   position{line: 756, col: 18, offset: 18905},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 22, offset: 18898},
+								pos:  position{line: 756, col: 22, offset: 18909},
 								name: "IdentifierName",
 							},
 						},
@@ -5157,30 +5165,30 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 758, col: 1, offset: 18934},
+			pos:  position{line: 758, col: 1, offset: 18945},
 			expr: &actionExpr{
-				pos: position{line: 759, col: 5, offset: 18945},
+				pos: position{line: 759, col: 5, offset: 18956},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 759, col: 5, offset: 18945},
+					pos: position{line: 759, col: 5, offset: 18956},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 759, col: 5, offset: 18945},
+							pos:        position{line: 759, col: 5, offset: 18956},
 							val:        "pass",
 							ignoreCase: false,
 							want:       "\"pass\"",
 						},
 						&notExpr{
-							pos: position{line: 759, col: 12, offset: 18952},
+							pos: position{line: 759, col: 12, offset: 18963},
 							expr: &seqExpr{
-								pos: position{line: 759, col: 14, offset: 18954},
+								pos: position{line: 759, col: 14, offset: 18965},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 759, col: 14, offset: 18954},
+										pos:  position{line: 759, col: 14, offset: 18965},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 759, col: 17, offset: 18957},
+										pos:        position{line: 759, col: 17, offset: 18968},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5189,9 +5197,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 759, col: 22, offset: 18962},
+							pos: position{line: 759, col: 22, offset: 18973},
 							expr: &ruleRefExpr{
-								pos:  position{line: 759, col: 23, offset: 18963},
+								pos:  position{line: 759, col: 23, offset: 18974},
 								name: "EOKW",
 							},
 						},
@@ -5203,46 +5211,46 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 765, col: 1, offset: 19167},
+			pos:  position{line: 765, col: 1, offset: 19178},
 			expr: &actionExpr{
-				pos: position{line: 766, col: 5, offset: 19181},
+				pos: position{line: 766, col: 5, offset: 19192},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 766, col: 5, offset: 19181},
+					pos: position{line: 766, col: 5, offset: 19192},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 766, col: 5, offset: 19181},
+							pos:        position{line: 766, col: 5, offset: 19192},
 							val:        "explode",
 							ignoreCase: false,
 							want:       "\"explode\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 766, col: 15, offset: 19191},
+							pos:  position{line: 766, col: 15, offset: 19202},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 766, col: 17, offset: 19193},
+							pos:   position{line: 766, col: 17, offset: 19204},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 766, col: 22, offset: 19198},
+								pos:  position{line: 766, col: 22, offset: 19209},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 766, col: 28, offset: 19204},
+							pos:   position{line: 766, col: 28, offset: 19215},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 766, col: 32, offset: 19208},
+								pos:  position{line: 766, col: 32, offset: 19219},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 766, col: 40, offset: 19216},
+							pos:   position{line: 766, col: 40, offset: 19227},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 766, col: 43, offset: 19219},
+								pos: position{line: 766, col: 43, offset: 19230},
 								expr: &ruleRefExpr{
-									pos:  position{line: 766, col: 43, offset: 19219},
+									pos:  position{line: 766, col: 43, offset: 19230},
 									name: "AsArg",
 								},
 							},
@@ -5255,28 +5263,28 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 779, col: 1, offset: 19477},
+			pos:  position{line: 779, col: 1, offset: 19488},
 			expr: &actionExpr{
-				pos: position{line: 780, col: 5, offset: 19489},
+				pos: position{line: 780, col: 5, offset: 19500},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 780, col: 5, offset: 19489},
+					pos: position{line: 780, col: 5, offset: 19500},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 780, col: 5, offset: 19489},
+							pos:        position{line: 780, col: 5, offset: 19500},
 							val:        "merge",
 							ignoreCase: false,
 							want:       "\"merge\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 780, col: 13, offset: 19497},
+							pos:  position{line: 780, col: 13, offset: 19508},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 780, col: 15, offset: 19499},
+							pos:   position{line: 780, col: 15, offset: 19510},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 780, col: 20, offset: 19504},
+								pos:  position{line: 780, col: 20, offset: 19515},
 								name: "Expr",
 							},
 						},
@@ -5288,49 +5296,49 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 788, col: 1, offset: 19644},
+			pos:  position{line: 788, col: 1, offset: 19655},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 5, offset: 19655},
+				pos: position{line: 789, col: 5, offset: 19666},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 5, offset: 19655},
+					pos: position{line: 789, col: 5, offset: 19666},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 789, col: 5, offset: 19655},
+							pos:        position{line: 789, col: 5, offset: 19666},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 12, offset: 19662},
+							pos:  position{line: 789, col: 12, offset: 19673},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 14, offset: 19664},
+							pos:   position{line: 789, col: 14, offset: 19675},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 20, offset: 19670},
+								pos:  position{line: 789, col: 20, offset: 19681},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 26, offset: 19676},
+							pos:   position{line: 789, col: 26, offset: 19687},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 789, col: 33, offset: 19683},
+								pos: position{line: 789, col: 33, offset: 19694},
 								expr: &ruleRefExpr{
-									pos:  position{line: 789, col: 33, offset: 19683},
+									pos:  position{line: 789, col: 33, offset: 19694},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 41, offset: 19691},
+							pos:   position{line: 789, col: 41, offset: 19702},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 789, col: 46, offset: 19696},
+								pos: position{line: 789, col: 46, offset: 19707},
 								expr: &ruleRefExpr{
-									pos:  position{line: 789, col: 46, offset: 19696},
+									pos:  position{line: 789, col: 46, offset: 19707},
 									name: "Lateral",
 								},
 							},
@@ -5343,54 +5351,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 804, col: 1, offset: 20045},
+			pos:  position{line: 804, col: 1, offset: 20056},
 			expr: &choiceExpr{
-				pos: position{line: 805, col: 5, offset: 20057},
+				pos: position{line: 805, col: 5, offset: 20068},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 805, col: 5, offset: 20057},
+						pos: position{line: 805, col: 5, offset: 20068},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 805, col: 5, offset: 20057},
+							pos: position{line: 805, col: 5, offset: 20068},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 805, col: 5, offset: 20057},
+									pos:  position{line: 805, col: 5, offset: 20068},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 805, col: 8, offset: 20060},
+									pos:        position{line: 805, col: 8, offset: 20071},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 805, col: 13, offset: 20065},
+									pos:  position{line: 805, col: 13, offset: 20076},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 805, col: 16, offset: 20068},
+									pos:        position{line: 805, col: 16, offset: 20079},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 805, col: 20, offset: 20072},
+									pos:  position{line: 805, col: 20, offset: 20083},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 805, col: 23, offset: 20075},
+									pos:   position{line: 805, col: 23, offset: 20086},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 805, col: 29, offset: 20081},
+										pos:  position{line: 805, col: 29, offset: 20092},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 805, col: 35, offset: 20087},
+									pos:  position{line: 805, col: 35, offset: 20098},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 805, col: 38, offset: 20090},
+									pos:        position{line: 805, col: 38, offset: 20101},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5399,49 +5407,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 808, col: 5, offset: 20174},
+						pos: position{line: 808, col: 5, offset: 20185},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 808, col: 5, offset: 20174},
+							pos: position{line: 808, col: 5, offset: 20185},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 808, col: 5, offset: 20174},
+									pos:  position{line: 808, col: 5, offset: 20185},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 808, col: 8, offset: 20177},
+									pos:        position{line: 808, col: 8, offset: 20188},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 808, col: 13, offset: 20182},
+									pos:  position{line: 808, col: 13, offset: 20193},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 808, col: 16, offset: 20185},
+									pos:        position{line: 808, col: 16, offset: 20196},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 808, col: 20, offset: 20189},
+									pos:  position{line: 808, col: 20, offset: 20200},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 808, col: 23, offset: 20192},
+									pos:   position{line: 808, col: 23, offset: 20203},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 808, col: 27, offset: 20196},
+										pos:  position{line: 808, col: 27, offset: 20207},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 808, col: 31, offset: 20200},
+									pos:  position{line: 808, col: 31, offset: 20211},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 808, col: 34, offset: 20203},
+									pos:        position{line: 808, col: 34, offset: 20214},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5456,65 +5464,65 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 812, col: 1, offset: 20262},
+			pos:  position{line: 812, col: 1, offset: 20273},
 			expr: &actionExpr{
-				pos: position{line: 813, col: 5, offset: 20273},
+				pos: position{line: 813, col: 5, offset: 20284},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 813, col: 5, offset: 20273},
+					pos: position{line: 813, col: 5, offset: 20284},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 813, col: 5, offset: 20273},
+							pos:  position{line: 813, col: 5, offset: 20284},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 813, col: 7, offset: 20275},
+							pos:        position{line: 813, col: 7, offset: 20286},
 							val:        "with",
 							ignoreCase: false,
 							want:       "\"with\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 813, col: 14, offset: 20282},
+							pos:  position{line: 813, col: 14, offset: 20293},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 813, col: 16, offset: 20284},
+							pos:   position{line: 813, col: 16, offset: 20295},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 813, col: 22, offset: 20290},
+								pos:  position{line: 813, col: 22, offset: 20301},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 813, col: 39, offset: 20307},
+							pos:   position{line: 813, col: 39, offset: 20318},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 813, col: 44, offset: 20312},
+								pos: position{line: 813, col: 44, offset: 20323},
 								expr: &actionExpr{
-									pos: position{line: 813, col: 45, offset: 20313},
+									pos: position{line: 813, col: 45, offset: 20324},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 813, col: 45, offset: 20313},
+										pos: position{line: 813, col: 45, offset: 20324},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 813, col: 45, offset: 20313},
+												pos:  position{line: 813, col: 45, offset: 20324},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 813, col: 48, offset: 20316},
+												pos:        position{line: 813, col: 48, offset: 20327},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 813, col: 52, offset: 20320},
+												pos:  position{line: 813, col: 52, offset: 20331},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 813, col: 55, offset: 20323},
+												pos:   position{line: 813, col: 55, offset: 20334},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 813, col: 57, offset: 20325},
+													pos:  position{line: 813, col: 57, offset: 20336},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5531,45 +5539,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 817, col: 1, offset: 20410},
+			pos:  position{line: 817, col: 1, offset: 20421},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 5, offset: 20431},
+				pos: position{line: 818, col: 5, offset: 20442},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 5, offset: 20431},
+					pos: position{line: 818, col: 5, offset: 20442},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 818, col: 5, offset: 20431},
+							pos:   position{line: 818, col: 5, offset: 20442},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 10, offset: 20436},
+								pos:  position{line: 818, col: 10, offset: 20447},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 21, offset: 20447},
+							pos:   position{line: 818, col: 21, offset: 20458},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 818, col: 25, offset: 20451},
+								pos: position{line: 818, col: 25, offset: 20462},
 								expr: &seqExpr{
-									pos: position{line: 818, col: 26, offset: 20452},
+									pos: position{line: 818, col: 26, offset: 20463},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 818, col: 26, offset: 20452},
+											pos:  position{line: 818, col: 26, offset: 20463},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 818, col: 29, offset: 20455},
+											pos:        position{line: 818, col: 29, offset: 20466},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 818, col: 33, offset: 20459},
+											pos:  position{line: 818, col: 33, offset: 20470},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 818, col: 36, offset: 20462},
+											pos:  position{line: 818, col: 36, offset: 20473},
 											name: "Expr",
 										},
 									},
@@ -5584,28 +5592,28 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 829, col: 1, offset: 20665},
+			pos:  position{line: 829, col: 1, offset: 20676},
 			expr: &actionExpr{
-				pos: position{line: 830, col: 5, offset: 20677},
+				pos: position{line: 830, col: 5, offset: 20688},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 830, col: 5, offset: 20677},
+					pos: position{line: 830, col: 5, offset: 20688},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 830, col: 5, offset: 20677},
+							pos:        position{line: 830, col: 5, offset: 20688},
 							val:        "yield",
 							ignoreCase: false,
 							want:       "\"yield\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 830, col: 13, offset: 20685},
+							pos:  position{line: 830, col: 13, offset: 20696},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 830, col: 15, offset: 20687},
+							pos:   position{line: 830, col: 15, offset: 20698},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 830, col: 21, offset: 20693},
+								pos:  position{line: 830, col: 21, offset: 20704},
 								name: "Exprs",
 							},
 						},
@@ -5617,32 +5625,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 838, col: 1, offset: 20850},
+			pos:  position{line: 838, col: 1, offset: 20861},
 			expr: &actionExpr{
-				pos: position{line: 839, col: 5, offset: 20862},
+				pos: position{line: 839, col: 5, offset: 20873},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 839, col: 5, offset: 20862},
+					pos: position{line: 839, col: 5, offset: 20873},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 839, col: 5, offset: 20862},
+							pos:  position{line: 839, col: 5, offset: 20873},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 839, col: 7, offset: 20864},
+							pos:        position{line: 839, col: 7, offset: 20875},
 							val:        "by",
 							ignoreCase: false,
 							want:       "\"by\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 839, col: 12, offset: 20869},
+							pos:  position{line: 839, col: 12, offset: 20880},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 839, col: 14, offset: 20871},
+							pos:   position{line: 839, col: 14, offset: 20882},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 839, col: 18, offset: 20875},
+								pos:  position{line: 839, col: 18, offset: 20886},
 								name: "Type",
 							},
 						},
@@ -5654,32 +5662,32 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 841, col: 1, offset: 20901},
+			pos:  position{line: 841, col: 1, offset: 20912},
 			expr: &actionExpr{
-				pos: position{line: 842, col: 5, offset: 20911},
+				pos: position{line: 842, col: 5, offset: 20922},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 842, col: 5, offset: 20911},
+					pos: position{line: 842, col: 5, offset: 20922},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 842, col: 5, offset: 20911},
+							pos:  position{line: 842, col: 5, offset: 20922},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 842, col: 7, offset: 20913},
+							pos:        position{line: 842, col: 7, offset: 20924},
 							val:        "as",
 							ignoreCase: false,
 							want:       "\"as\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 842, col: 12, offset: 20918},
+							pos:  position{line: 842, col: 12, offset: 20929},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 842, col: 14, offset: 20920},
+							pos:   position{line: 842, col: 14, offset: 20931},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 18, offset: 20924},
+								pos:  position{line: 842, col: 18, offset: 20935},
 								name: "Lval",
 							},
 						},
@@ -5691,9 +5699,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 846, col: 1, offset: 20975},
+			pos:  position{line: 846, col: 1, offset: 20986},
 			expr: &ruleRefExpr{
-				pos:  position{line: 846, col: 8, offset: 20982},
+				pos:  position{line: 846, col: 8, offset: 20993},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5701,51 +5709,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 848, col: 1, offset: 20993},
+			pos:  position{line: 848, col: 1, offset: 21004},
 			expr: &actionExpr{
-				pos: position{line: 849, col: 5, offset: 21003},
+				pos: position{line: 849, col: 5, offset: 21014},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 849, col: 5, offset: 21003},
+					pos: position{line: 849, col: 5, offset: 21014},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 849, col: 5, offset: 21003},
+							pos:   position{line: 849, col: 5, offset: 21014},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 849, col: 11, offset: 21009},
+								pos:  position{line: 849, col: 11, offset: 21020},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 849, col: 16, offset: 21014},
+							pos:   position{line: 849, col: 16, offset: 21025},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 849, col: 21, offset: 21019},
+								pos: position{line: 849, col: 21, offset: 21030},
 								expr: &actionExpr{
-									pos: position{line: 849, col: 22, offset: 21020},
+									pos: position{line: 849, col: 22, offset: 21031},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 849, col: 22, offset: 21020},
+										pos: position{line: 849, col: 22, offset: 21031},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 849, col: 22, offset: 21020},
+												pos:  position{line: 849, col: 22, offset: 21031},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 849, col: 25, offset: 21023},
+												pos:        position{line: 849, col: 25, offset: 21034},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 849, col: 29, offset: 21027},
+												pos:  position{line: 849, col: 29, offset: 21038},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 849, col: 32, offset: 21030},
+												pos:   position{line: 849, col: 32, offset: 21041},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 849, col: 37, offset: 21035},
+													pos:  position{line: 849, col: 37, offset: 21046},
 													name: "Lval",
 												},
 											},
@@ -5762,9 +5770,9 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 853, col: 1, offset: 21111},
+			pos:  position{line: 853, col: 1, offset: 21122},
 			expr: &ruleRefExpr{
-				pos:  position{line: 853, col: 13, offset: 21123},
+				pos:  position{line: 853, col: 13, offset: 21134},
 				name: "Lval",
 			},
 			leader:        false,
@@ -5772,51 +5780,51 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 855, col: 1, offset: 21129},
+			pos:  position{line: 855, col: 1, offset: 21140},
 			expr: &actionExpr{
-				pos: position{line: 856, col: 5, offset: 21144},
+				pos: position{line: 856, col: 5, offset: 21155},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 856, col: 5, offset: 21144},
+					pos: position{line: 856, col: 5, offset: 21155},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 856, col: 5, offset: 21144},
+							pos:   position{line: 856, col: 5, offset: 21155},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 856, col: 11, offset: 21150},
+								pos:  position{line: 856, col: 11, offset: 21161},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 856, col: 21, offset: 21160},
+							pos:   position{line: 856, col: 21, offset: 21171},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 856, col: 26, offset: 21165},
+								pos: position{line: 856, col: 26, offset: 21176},
 								expr: &actionExpr{
-									pos: position{line: 856, col: 27, offset: 21166},
+									pos: position{line: 856, col: 27, offset: 21177},
 									run: (*parser).callonFieldExprs7,
 									expr: &seqExpr{
-										pos: position{line: 856, col: 27, offset: 21166},
+										pos: position{line: 856, col: 27, offset: 21177},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 856, col: 27, offset: 21166},
+												pos:  position{line: 856, col: 27, offset: 21177},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 856, col: 30, offset: 21169},
+												pos:        position{line: 856, col: 30, offset: 21180},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 856, col: 34, offset: 21173},
+												pos:  position{line: 856, col: 34, offset: 21184},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 856, col: 37, offset: 21176},
+												pos:   position{line: 856, col: 37, offset: 21187},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 856, col: 39, offset: 21178},
+													pos:  position{line: 856, col: 39, offset: 21189},
 													name: "FieldExpr",
 												},
 											},
@@ -5833,51 +5841,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 860, col: 1, offset: 21255},
+			pos:  position{line: 860, col: 1, offset: 21266},
 			expr: &actionExpr{
-				pos: position{line: 861, col: 5, offset: 21271},
+				pos: position{line: 861, col: 5, offset: 21282},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 861, col: 5, offset: 21271},
+					pos: position{line: 861, col: 5, offset: 21282},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 861, col: 5, offset: 21271},
+							pos:   position{line: 861, col: 5, offset: 21282},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 861, col: 11, offset: 21277},
+								pos:  position{line: 861, col: 11, offset: 21288},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 22, offset: 21288},
+							pos:   position{line: 861, col: 22, offset: 21299},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 861, col: 27, offset: 21293},
+								pos: position{line: 861, col: 27, offset: 21304},
 								expr: &actionExpr{
-									pos: position{line: 861, col: 28, offset: 21294},
+									pos: position{line: 861, col: 28, offset: 21305},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 861, col: 28, offset: 21294},
+										pos: position{line: 861, col: 28, offset: 21305},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 861, col: 28, offset: 21294},
+												pos:  position{line: 861, col: 28, offset: 21305},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 861, col: 31, offset: 21297},
+												pos:        position{line: 861, col: 31, offset: 21308},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 861, col: 35, offset: 21301},
+												pos:  position{line: 861, col: 35, offset: 21312},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 861, col: 38, offset: 21304},
+												pos:   position{line: 861, col: 38, offset: 21315},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 861, col: 40, offset: 21306},
+													pos:  position{line: 861, col: 40, offset: 21317},
 													name: "Assignment",
 												},
 											},
@@ -5894,40 +5902,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 865, col: 1, offset: 21381},
+			pos:  position{line: 865, col: 1, offset: 21392},
 			expr: &actionExpr{
-				pos: position{line: 866, col: 5, offset: 21396},
+				pos: position{line: 866, col: 5, offset: 21407},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 866, col: 5, offset: 21396},
+					pos: position{line: 866, col: 5, offset: 21407},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 866, col: 5, offset: 21396},
+							pos:   position{line: 866, col: 5, offset: 21407},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 866, col: 9, offset: 21400},
+								pos:  position{line: 866, col: 9, offset: 21411},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 866, col: 14, offset: 21405},
+							pos:  position{line: 866, col: 14, offset: 21416},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 866, col: 17, offset: 21408},
+							pos:        position{line: 866, col: 17, offset: 21419},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 866, col: 22, offset: 21413},
+							pos:  position{line: 866, col: 22, offset: 21424},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 866, col: 25, offset: 21416},
+							pos:   position{line: 866, col: 25, offset: 21427},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 866, col: 29, offset: 21420},
+								pos:  position{line: 866, col: 29, offset: 21431},
 								name: "Expr",
 							},
 						},
@@ -5939,9 +5947,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 874, col: 1, offset: 21568},
+			pos:  position{line: 874, col: 1, offset: 21579},
 			expr: &ruleRefExpr{
-				pos:  position{line: 874, col: 8, offset: 21575},
+				pos:  position{line: 874, col: 8, offset: 21586},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -5949,63 +5957,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 876, col: 1, offset: 21592},
+			pos:  position{line: 876, col: 1, offset: 21603},
 			expr: &actionExpr{
-				pos: position{line: 877, col: 5, offset: 21612},
+				pos: position{line: 877, col: 5, offset: 21623},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 877, col: 5, offset: 21612},
+					pos: position{line: 877, col: 5, offset: 21623},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 877, col: 5, offset: 21612},
+							pos:   position{line: 877, col: 5, offset: 21623},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 877, col: 10, offset: 21617},
+								pos:  position{line: 877, col: 10, offset: 21628},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 877, col: 24, offset: 21631},
+							pos:   position{line: 877, col: 24, offset: 21642},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 877, col: 28, offset: 21635},
+								pos: position{line: 877, col: 28, offset: 21646},
 								expr: &seqExpr{
-									pos: position{line: 877, col: 29, offset: 21636},
+									pos: position{line: 877, col: 29, offset: 21647},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 877, col: 29, offset: 21636},
+											pos:  position{line: 877, col: 29, offset: 21647},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 877, col: 32, offset: 21639},
+											pos:        position{line: 877, col: 32, offset: 21650},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 877, col: 36, offset: 21643},
+											pos:  position{line: 877, col: 36, offset: 21654},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 877, col: 39, offset: 21646},
+											pos:  position{line: 877, col: 39, offset: 21657},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 877, col: 44, offset: 21651},
+											pos:  position{line: 877, col: 44, offset: 21662},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 877, col: 47, offset: 21654},
+											pos:        position{line: 877, col: 47, offset: 21665},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 877, col: 51, offset: 21658},
+											pos:  position{line: 877, col: 51, offset: 21669},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 877, col: 54, offset: 21661},
+											pos:  position{line: 877, col: 54, offset: 21672},
 											name: "Expr",
 										},
 									},
@@ -6020,53 +6028,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 890, col: 1, offset: 21957},
+			pos:  position{line: 890, col: 1, offset: 21968},
 			expr: &actionExpr{
-				pos: position{line: 891, col: 5, offset: 21975},
+				pos: position{line: 891, col: 5, offset: 21986},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 891, col: 5, offset: 21975},
+					pos: position{line: 891, col: 5, offset: 21986},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 891, col: 5, offset: 21975},
+							pos:   position{line: 891, col: 5, offset: 21986},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 891, col: 11, offset: 21981},
+								pos:  position{line: 891, col: 11, offset: 21992},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 892, col: 5, offset: 22000},
+							pos:   position{line: 892, col: 5, offset: 22011},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 892, col: 10, offset: 22005},
+								pos: position{line: 892, col: 10, offset: 22016},
 								expr: &actionExpr{
-									pos: position{line: 892, col: 11, offset: 22006},
+									pos: position{line: 892, col: 11, offset: 22017},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 892, col: 11, offset: 22006},
+										pos: position{line: 892, col: 11, offset: 22017},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 892, col: 11, offset: 22006},
+												pos:  position{line: 892, col: 11, offset: 22017},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 892, col: 14, offset: 22009},
+												pos:   position{line: 892, col: 14, offset: 22020},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 892, col: 17, offset: 22012},
+													pos:  position{line: 892, col: 17, offset: 22023},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 892, col: 25, offset: 22020},
+												pos:  position{line: 892, col: 25, offset: 22031},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 892, col: 28, offset: 22023},
+												pos:   position{line: 892, col: 28, offset: 22034},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 892, col: 33, offset: 22028},
+													pos:  position{line: 892, col: 33, offset: 22039},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6083,53 +6091,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 896, col: 1, offset: 22139},
+			pos:  position{line: 896, col: 1, offset: 22150},
 			expr: &actionExpr{
-				pos: position{line: 897, col: 5, offset: 22158},
+				pos: position{line: 897, col: 5, offset: 22169},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 897, col: 5, offset: 22158},
+					pos: position{line: 897, col: 5, offset: 22169},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 897, col: 5, offset: 22158},
+							pos:   position{line: 897, col: 5, offset: 22169},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 897, col: 11, offset: 22164},
+								pos:  position{line: 897, col: 11, offset: 22175},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 898, col: 5, offset: 22183},
+							pos:   position{line: 898, col: 5, offset: 22194},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 898, col: 10, offset: 22188},
+								pos: position{line: 898, col: 10, offset: 22199},
 								expr: &actionExpr{
-									pos: position{line: 898, col: 11, offset: 22189},
+									pos: position{line: 898, col: 11, offset: 22200},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 898, col: 11, offset: 22189},
+										pos: position{line: 898, col: 11, offset: 22200},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 11, offset: 22189},
+												pos:  position{line: 898, col: 11, offset: 22200},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 898, col: 14, offset: 22192},
+												pos:   position{line: 898, col: 14, offset: 22203},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 898, col: 17, offset: 22195},
+													pos:  position{line: 898, col: 17, offset: 22206},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 26, offset: 22204},
+												pos:  position{line: 898, col: 26, offset: 22215},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 898, col: 29, offset: 22207},
+												pos:   position{line: 898, col: 29, offset: 22218},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 898, col: 34, offset: 22212},
+													pos:  position{line: 898, col: 34, offset: 22223},
 													name: "ComparisonExpr",
 												},
 											},
@@ -6146,73 +6154,73 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 902, col: 1, offset: 22323},
+			pos:  position{line: 902, col: 1, offset: 22334},
 			expr: &actionExpr{
-				pos: position{line: 903, col: 5, offset: 22342},
+				pos: position{line: 903, col: 5, offset: 22353},
 				run: (*parser).callonComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 903, col: 5, offset: 22342},
+					pos: position{line: 903, col: 5, offset: 22353},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 903, col: 5, offset: 22342},
+							pos:   position{line: 903, col: 5, offset: 22353},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 903, col: 9, offset: 22346},
+								pos:  position{line: 903, col: 9, offset: 22357},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 903, col: 22, offset: 22359},
+							pos:   position{line: 903, col: 22, offset: 22370},
 							label: "opAndRHS",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 903, col: 31, offset: 22368},
+								pos: position{line: 903, col: 31, offset: 22379},
 								expr: &choiceExpr{
-									pos: position{line: 903, col: 32, offset: 22369},
+									pos: position{line: 903, col: 32, offset: 22380},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 903, col: 32, offset: 22369},
+											pos: position{line: 903, col: 32, offset: 22380},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 903, col: 32, offset: 22369},
+													pos:  position{line: 903, col: 32, offset: 22380},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 903, col: 35, offset: 22372},
+													pos:  position{line: 903, col: 35, offset: 22383},
 													name: "Comparator",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 903, col: 46, offset: 22383},
+													pos:  position{line: 903, col: 46, offset: 22394},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 903, col: 49, offset: 22386},
+													pos:  position{line: 903, col: 49, offset: 22397},
 													name: "AdditiveExpr",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 903, col: 64, offset: 22401},
+											pos: position{line: 903, col: 64, offset: 22412},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 903, col: 64, offset: 22401},
+													pos:  position{line: 903, col: 64, offset: 22412},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 903, col: 68, offset: 22405},
+													pos: position{line: 903, col: 68, offset: 22416},
 													run: (*parser).callonComparisonExpr15,
 													expr: &litMatcher{
-														pos:        position{line: 903, col: 68, offset: 22405},
+														pos:        position{line: 903, col: 68, offset: 22416},
 														val:        "~",
 														ignoreCase: false,
 														want:       "\"~\"",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 903, col: 104, offset: 22441},
+													pos:  position{line: 903, col: 104, offset: 22452},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 903, col: 107, offset: 22444},
+													pos:  position{line: 903, col: 107, offset: 22455},
 													name: "Regexp",
 												},
 											},
@@ -6229,53 +6237,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 915, col: 1, offset: 22708},
+			pos:  position{line: 915, col: 1, offset: 22719},
 			expr: &actionExpr{
-				pos: position{line: 916, col: 5, offset: 22725},
+				pos: position{line: 916, col: 5, offset: 22736},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 916, col: 5, offset: 22725},
+					pos: position{line: 916, col: 5, offset: 22736},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 916, col: 5, offset: 22725},
+							pos:   position{line: 916, col: 5, offset: 22736},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 916, col: 11, offset: 22731},
+								pos:  position{line: 916, col: 11, offset: 22742},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 917, col: 5, offset: 22754},
+							pos:   position{line: 917, col: 5, offset: 22765},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 917, col: 10, offset: 22759},
+								pos: position{line: 917, col: 10, offset: 22770},
 								expr: &actionExpr{
-									pos: position{line: 917, col: 11, offset: 22760},
+									pos: position{line: 917, col: 11, offset: 22771},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 917, col: 11, offset: 22760},
+										pos: position{line: 917, col: 11, offset: 22771},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 917, col: 11, offset: 22760},
+												pos:  position{line: 917, col: 11, offset: 22771},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 917, col: 14, offset: 22763},
+												pos:   position{line: 917, col: 14, offset: 22774},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 917, col: 17, offset: 22766},
+													pos:  position{line: 917, col: 17, offset: 22777},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 917, col: 34, offset: 22783},
+												pos:  position{line: 917, col: 34, offset: 22794},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 917, col: 37, offset: 22786},
+												pos:   position{line: 917, col: 37, offset: 22797},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 917, col: 42, offset: 22791},
+													pos:  position{line: 917, col: 42, offset: 22802},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6292,21 +6300,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 921, col: 1, offset: 22906},
+			pos:  position{line: 921, col: 1, offset: 22917},
 			expr: &actionExpr{
-				pos: position{line: 921, col: 20, offset: 22925},
+				pos: position{line: 921, col: 20, offset: 22936},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 921, col: 21, offset: 22926},
+					pos: position{line: 921, col: 21, offset: 22937},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 921, col: 21, offset: 22926},
+							pos:        position{line: 921, col: 21, offset: 22937},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 921, col: 27, offset: 22932},
+							pos:        position{line: 921, col: 27, offset: 22943},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6319,53 +6327,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 923, col: 1, offset: 22969},
+			pos:  position{line: 923, col: 1, offset: 22980},
 			expr: &actionExpr{
-				pos: position{line: 924, col: 5, offset: 22992},
+				pos: position{line: 924, col: 5, offset: 23003},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 924, col: 5, offset: 22992},
+					pos: position{line: 924, col: 5, offset: 23003},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 924, col: 5, offset: 22992},
+							pos:   position{line: 924, col: 5, offset: 23003},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 924, col: 11, offset: 22998},
+								pos:  position{line: 924, col: 11, offset: 23009},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 925, col: 5, offset: 23010},
+							pos:   position{line: 925, col: 5, offset: 23021},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 925, col: 10, offset: 23015},
+								pos: position{line: 925, col: 10, offset: 23026},
 								expr: &actionExpr{
-									pos: position{line: 925, col: 11, offset: 23016},
+									pos: position{line: 925, col: 11, offset: 23027},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 925, col: 11, offset: 23016},
+										pos: position{line: 925, col: 11, offset: 23027},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 925, col: 11, offset: 23016},
+												pos:  position{line: 925, col: 11, offset: 23027},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 925, col: 14, offset: 23019},
+												pos:   position{line: 925, col: 14, offset: 23030},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 925, col: 17, offset: 23022},
+													pos:  position{line: 925, col: 17, offset: 23033},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 925, col: 40, offset: 23045},
+												pos:  position{line: 925, col: 40, offset: 23056},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 925, col: 43, offset: 23048},
+												pos:   position{line: 925, col: 43, offset: 23059},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 925, col: 48, offset: 23053},
+													pos:  position{line: 925, col: 48, offset: 23064},
 													name: "NotExpr",
 												},
 											},
@@ -6382,27 +6390,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 929, col: 1, offset: 23157},
+			pos:  position{line: 929, col: 1, offset: 23168},
 			expr: &actionExpr{
-				pos: position{line: 929, col: 26, offset: 23182},
+				pos: position{line: 929, col: 26, offset: 23193},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 929, col: 27, offset: 23183},
+					pos: position{line: 929, col: 27, offset: 23194},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 929, col: 27, offset: 23183},
+							pos:        position{line: 929, col: 27, offset: 23194},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 929, col: 33, offset: 23189},
+							pos:        position{line: 929, col: 33, offset: 23200},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 929, col: 39, offset: 23195},
+							pos:        position{line: 929, col: 39, offset: 23206},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6415,43 +6423,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 931, col: 1, offset: 23232},
+			pos:  position{line: 931, col: 1, offset: 23243},
 			expr: &choiceExpr{
-				pos: position{line: 932, col: 5, offset: 23244},
+				pos: position{line: 932, col: 5, offset: 23255},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 932, col: 5, offset: 23244},
+						pos: position{line: 932, col: 5, offset: 23255},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 932, col: 5, offset: 23244},
+							pos: position{line: 932, col: 5, offset: 23255},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 932, col: 6, offset: 23245},
+									pos: position{line: 932, col: 6, offset: 23256},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 932, col: 6, offset: 23245},
+											pos: position{line: 932, col: 6, offset: 23256},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 932, col: 6, offset: 23245},
+													pos:  position{line: 932, col: 6, offset: 23256},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 932, col: 15, offset: 23254},
+													pos:  position{line: 932, col: 15, offset: 23265},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 932, col: 19, offset: 23258},
+											pos: position{line: 932, col: 19, offset: 23269},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 932, col: 19, offset: 23258},
+													pos:        position{line: 932, col: 19, offset: 23269},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 932, col: 23, offset: 23262},
+													pos:  position{line: 932, col: 23, offset: 23273},
 													name: "__",
 												},
 											},
@@ -6459,10 +6467,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 932, col: 27, offset: 23266},
+									pos:   position{line: 932, col: 27, offset: 23277},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 932, col: 29, offset: 23268},
+										pos:  position{line: 932, col: 29, offset: 23279},
 										name: "NotExpr",
 									},
 								},
@@ -6470,7 +6478,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 940, col: 5, offset: 23442},
+						pos:  position{line: 940, col: 5, offset: 23453},
 						name: "NegationExpr",
 					},
 				},
@@ -6480,38 +6488,38 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 942, col: 1, offset: 23456},
+			pos:  position{line: 942, col: 1, offset: 23467},
 			expr: &choiceExpr{
-				pos: position{line: 943, col: 5, offset: 23473},
+				pos: position{line: 943, col: 5, offset: 23484},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 943, col: 5, offset: 23473},
+						pos: position{line: 943, col: 5, offset: 23484},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 943, col: 5, offset: 23473},
+							pos: position{line: 943, col: 5, offset: 23484},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 943, col: 5, offset: 23473},
+									pos: position{line: 943, col: 5, offset: 23484},
 									expr: &ruleRefExpr{
-										pos:  position{line: 943, col: 6, offset: 23474},
+										pos:  position{line: 943, col: 6, offset: 23485},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 943, col: 14, offset: 23482},
+									pos:        position{line: 943, col: 14, offset: 23493},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 943, col: 18, offset: 23486},
+									pos:  position{line: 943, col: 18, offset: 23497},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 943, col: 21, offset: 23489},
+									pos:   position{line: 943, col: 21, offset: 23500},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 943, col: 23, offset: 23491},
+										pos:  position{line: 943, col: 23, offset: 23502},
 										name: "DerefExpr",
 									},
 								},
@@ -6519,7 +6527,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 951, col: 5, offset: 23667},
+						pos:  position{line: 951, col: 5, offset: 23678},
 						name: "DerefExpr",
 					},
 				},
@@ -6529,65 +6537,65 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 953, col: 1, offset: 23678},
+			pos:  position{line: 953, col: 1, offset: 23689},
 			expr: &choiceExpr{
-				pos: position{line: 954, col: 5, offset: 23692},
+				pos: position{line: 954, col: 5, offset: 23703},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 954, col: 5, offset: 23692},
+						pos: position{line: 954, col: 5, offset: 23703},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 954, col: 5, offset: 23692},
+							pos: position{line: 954, col: 5, offset: 23703},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 954, col: 5, offset: 23692},
+									pos:   position{line: 954, col: 5, offset: 23703},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 954, col: 10, offset: 23697},
+										pos:  position{line: 954, col: 10, offset: 23708},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 954, col: 20, offset: 23707},
+									pos:        position{line: 954, col: 20, offset: 23718},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 954, col: 24, offset: 23711},
+									pos:   position{line: 954, col: 24, offset: 23722},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 954, col: 29, offset: 23716},
+										pos:  position{line: 954, col: 29, offset: 23727},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 42, offset: 23729},
+									pos:  position{line: 954, col: 42, offset: 23740},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 954, col: 45, offset: 23732},
+									pos:        position{line: 954, col: 45, offset: 23743},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 49, offset: 23736},
+									pos:  position{line: 954, col: 49, offset: 23747},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 954, col: 52, offset: 23739},
+									pos:   position{line: 954, col: 52, offset: 23750},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 954, col: 55, offset: 23742},
+										pos: position{line: 954, col: 55, offset: 23753},
 										expr: &ruleRefExpr{
-											pos:  position{line: 954, col: 55, offset: 23742},
+											pos:  position{line: 954, col: 55, offset: 23753},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 954, col: 69, offset: 23756},
+									pos:        position{line: 954, col: 69, offset: 23767},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6596,49 +6604,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 966, col: 5, offset: 24007},
+						pos: position{line: 966, col: 5, offset: 24018},
 						run: (*parser).callonDerefExpr16,
 						expr: &seqExpr{
-							pos: position{line: 966, col: 5, offset: 24007},
+							pos: position{line: 966, col: 5, offset: 24018},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 966, col: 5, offset: 24007},
+									pos:   position{line: 966, col: 5, offset: 24018},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 966, col: 10, offset: 24012},
+										pos:  position{line: 966, col: 10, offset: 24023},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 966, col: 20, offset: 24022},
+									pos:        position{line: 966, col: 20, offset: 24033},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 966, col: 24, offset: 24026},
+									pos:  position{line: 966, col: 24, offset: 24037},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 966, col: 27, offset: 24029},
+									pos:        position{line: 966, col: 27, offset: 24040},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 966, col: 31, offset: 24033},
+									pos:  position{line: 966, col: 31, offset: 24044},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 966, col: 34, offset: 24036},
+									pos:   position{line: 966, col: 34, offset: 24047},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 966, col: 37, offset: 24039},
+										pos:  position{line: 966, col: 37, offset: 24050},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 966, col: 50, offset: 24052},
+									pos:        position{line: 966, col: 50, offset: 24063},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6647,35 +6655,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 974, col: 5, offset: 24228},
+						pos: position{line: 974, col: 5, offset: 24239},
 						run: (*parser).callonDerefExpr27,
 						expr: &seqExpr{
-							pos: position{line: 974, col: 5, offset: 24228},
+							pos: position{line: 974, col: 5, offset: 24239},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 974, col: 5, offset: 24228},
+									pos:   position{line: 974, col: 5, offset: 24239},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 974, col: 10, offset: 24233},
+										pos:  position{line: 974, col: 10, offset: 24244},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 974, col: 20, offset: 24243},
+									pos:        position{line: 974, col: 20, offset: 24254},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 974, col: 24, offset: 24247},
+									pos:   position{line: 974, col: 24, offset: 24258},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 974, col: 30, offset: 24253},
+										pos:  position{line: 974, col: 30, offset: 24264},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 974, col: 35, offset: 24258},
+									pos:        position{line: 974, col: 35, offset: 24269},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6684,30 +6692,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 982, col: 5, offset: 24440},
+						pos: position{line: 982, col: 5, offset: 24451},
 						run: (*parser).callonDerefExpr35,
 						expr: &seqExpr{
-							pos: position{line: 982, col: 5, offset: 24440},
+							pos: position{line: 982, col: 5, offset: 24451},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 982, col: 5, offset: 24440},
+									pos:   position{line: 982, col: 5, offset: 24451},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 982, col: 10, offset: 24445},
+										pos:  position{line: 982, col: 10, offset: 24456},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 982, col: 20, offset: 24455},
+									pos:        position{line: 982, col: 20, offset: 24466},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 982, col: 24, offset: 24459},
+									pos:   position{line: 982, col: 24, offset: 24470},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 982, col: 27, offset: 24462},
+										pos:  position{line: 982, col: 27, offset: 24473},
 										name: "Identifier",
 									},
 								},
@@ -6715,25 +6723,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 990, col: 5, offset: 24631},
+						pos: position{line: 990, col: 5, offset: 24642},
 						run: (*parser).callonDerefExpr42,
 						expr: &labeledExpr{
-							pos:   position{line: 990, col: 5, offset: 24631},
+							pos:   position{line: 990, col: 5, offset: 24642},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 990, col: 8, offset: 24634},
+								pos:  position{line: 990, col: 8, offset: 24645},
 								name: "FuncExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 993, col: 5, offset: 24676},
+						pos: position{line: 993, col: 5, offset: 24687},
 						run: (*parser).callonDerefExpr45,
 						expr: &labeledExpr{
-							pos:   position{line: 993, col: 5, offset: 24676},
+							pos:   position{line: 993, col: 5, offset: 24687},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 993, col: 10, offset: 24681},
+								pos:  position{line: 993, col: 10, offset: 24692},
 								name: "Primary",
 							},
 						},
@@ -6745,30 +6753,30 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 998, col: 1, offset: 24722},
+			pos:  position{line: 998, col: 1, offset: 24733},
 			expr: &choiceExpr{
-				pos: position{line: 999, col: 5, offset: 24735},
+				pos: position{line: 999, col: 5, offset: 24746},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 999, col: 5, offset: 24735},
+						pos: position{line: 999, col: 5, offset: 24746},
 						run: (*parser).callonFuncExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 999, col: 5, offset: 24735},
+							pos:   position{line: 999, col: 5, offset: 24746},
 							label: "cast",
 							expr: &ruleRefExpr{
-								pos:  position{line: 999, col: 10, offset: 24740},
+								pos:  position{line: 999, col: 10, offset: 24751},
 								name: "Cast",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1002, col: 5, offset: 24780},
+						pos: position{line: 1002, col: 5, offset: 24791},
 						run: (*parser).callonFuncExpr5,
 						expr: &labeledExpr{
-							pos:   position{line: 1002, col: 5, offset: 24780},
+							pos:   position{line: 1002, col: 5, offset: 24791},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1002, col: 8, offset: 24783},
+								pos:  position{line: 1002, col: 8, offset: 24794},
 								name: "Function",
 							},
 						},
@@ -6780,20 +6788,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1006, col: 1, offset: 24822},
+			pos:  position{line: 1006, col: 1, offset: 24833},
 			expr: &seqExpr{
-				pos: position{line: 1006, col: 13, offset: 24834},
+				pos: position{line: 1006, col: 13, offset: 24845},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 13, offset: 24834},
+						pos:  position{line: 1006, col: 13, offset: 24845},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 22, offset: 24843},
+						pos:  position{line: 1006, col: 22, offset: 24854},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1006, col: 25, offset: 24846},
+						pos:        position{line: 1006, col: 25, offset: 24857},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -6805,18 +6813,18 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1008, col: 1, offset: 24851},
+			pos:  position{line: 1008, col: 1, offset: 24862},
 			expr: &choiceExpr{
-				pos: position{line: 1009, col: 5, offset: 24864},
+				pos: position{line: 1009, col: 5, offset: 24875},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1009, col: 5, offset: 24864},
+						pos:        position{line: 1009, col: 5, offset: 24875},
 						val:        "not",
 						ignoreCase: false,
 						want:       "\"not\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1010, col: 5, offset: 24874},
+						pos:        position{line: 1010, col: 5, offset: 24885},
 						val:        "select",
 						ignoreCase: false,
 						want:       "\"select\"",
@@ -6828,58 +6836,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1012, col: 1, offset: 24884},
+			pos:  position{line: 1012, col: 1, offset: 24895},
 			expr: &actionExpr{
-				pos: position{line: 1013, col: 5, offset: 24893},
+				pos: position{line: 1013, col: 5, offset: 24904},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1013, col: 5, offset: 24893},
+					pos: position{line: 1013, col: 5, offset: 24904},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1013, col: 5, offset: 24893},
+							pos:   position{line: 1013, col: 5, offset: 24904},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1013, col: 9, offset: 24897},
+								pos:  position{line: 1013, col: 9, offset: 24908},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1013, col: 21, offset: 24909},
+							pos:  position{line: 1013, col: 21, offset: 24920},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1013, col: 24, offset: 24912},
+							pos:        position{line: 1013, col: 24, offset: 24923},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1013, col: 28, offset: 24916},
+							pos:  position{line: 1013, col: 28, offset: 24927},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1013, col: 31, offset: 24919},
+							pos:   position{line: 1013, col: 31, offset: 24930},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1013, col: 37, offset: 24925},
+								pos: position{line: 1013, col: 37, offset: 24936},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1013, col: 37, offset: 24925},
+										pos:  position{line: 1013, col: 37, offset: 24936},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1013, col: 48, offset: 24936},
+										pos:  position{line: 1013, col: 48, offset: 24947},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1013, col: 54, offset: 24942},
+							pos:  position{line: 1013, col: 54, offset: 24953},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1013, col: 57, offset: 24945},
+							pos:        position{line: 1013, col: 57, offset: 24956},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -6892,87 +6900,87 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1017, col: 1, offset: 25070},
+			pos:  position{line: 1017, col: 1, offset: 25081},
 			expr: &choiceExpr{
-				pos: position{line: 1018, col: 5, offset: 25083},
+				pos: position{line: 1018, col: 5, offset: 25094},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1018, col: 5, offset: 25083},
+						pos:  position{line: 1018, col: 5, offset: 25094},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1020, col: 5, offset: 25170},
+						pos: position{line: 1020, col: 5, offset: 25181},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1020, col: 5, offset: 25170},
+							pos: position{line: 1020, col: 5, offset: 25181},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1020, col: 5, offset: 25170},
+									pos:        position{line: 1020, col: 5, offset: 25181},
 									val:        "regexp",
 									ignoreCase: false,
 									want:       "\"regexp\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 14, offset: 25179},
+									pos:  position{line: 1020, col: 14, offset: 25190},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 17, offset: 25182},
+									pos:        position{line: 1020, col: 17, offset: 25193},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 21, offset: 25186},
+									pos:  position{line: 1020, col: 21, offset: 25197},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1020, col: 24, offset: 25189},
+									pos:   position{line: 1020, col: 24, offset: 25200},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1020, col: 29, offset: 25194},
+										pos:  position{line: 1020, col: 29, offset: 25205},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 45, offset: 25210},
+									pos:  position{line: 1020, col: 45, offset: 25221},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 48, offset: 25213},
+									pos:        position{line: 1020, col: 48, offset: 25224},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 52, offset: 25217},
+									pos:  position{line: 1020, col: 52, offset: 25228},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1020, col: 55, offset: 25220},
+									pos:   position{line: 1020, col: 55, offset: 25231},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1020, col: 60, offset: 25225},
+										pos:  position{line: 1020, col: 60, offset: 25236},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 65, offset: 25230},
+									pos:  position{line: 1020, col: 65, offset: 25241},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 68, offset: 25233},
+									pos:        position{line: 1020, col: 68, offset: 25244},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1020, col: 72, offset: 25237},
+									pos:   position{line: 1020, col: 72, offset: 25248},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1020, col: 78, offset: 25243},
+										pos: position{line: 1020, col: 78, offset: 25254},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1020, col: 78, offset: 25243},
+											pos:  position{line: 1020, col: 78, offset: 25254},
 											name: "WhereClause",
 										},
 									},
@@ -6981,100 +6989,100 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1024, col: 5, offset: 25398},
+						pos: position{line: 1024, col: 5, offset: 25409},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1024, col: 5, offset: 25398},
+							pos: position{line: 1024, col: 5, offset: 25409},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1024, col: 5, offset: 25398},
+									pos:        position{line: 1024, col: 5, offset: 25409},
 									val:        "regexp_replace",
 									ignoreCase: false,
 									want:       "\"regexp_replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1024, col: 22, offset: 25415},
+									pos:  position{line: 1024, col: 22, offset: 25426},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1024, col: 25, offset: 25418},
+									pos:        position{line: 1024, col: 25, offset: 25429},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1024, col: 29, offset: 25422},
+									pos:  position{line: 1024, col: 29, offset: 25433},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1024, col: 32, offset: 25425},
+									pos:   position{line: 1024, col: 32, offset: 25436},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1024, col: 37, offset: 25430},
+										pos:  position{line: 1024, col: 37, offset: 25441},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1024, col: 42, offset: 25435},
+									pos:  position{line: 1024, col: 42, offset: 25446},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1024, col: 45, offset: 25438},
+									pos:        position{line: 1024, col: 45, offset: 25449},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1024, col: 49, offset: 25442},
+									pos:  position{line: 1024, col: 49, offset: 25453},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1024, col: 52, offset: 25445},
+									pos:   position{line: 1024, col: 52, offset: 25456},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1024, col: 57, offset: 25450},
+										pos:  position{line: 1024, col: 57, offset: 25461},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1024, col: 73, offset: 25466},
+									pos:  position{line: 1024, col: 73, offset: 25477},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1024, col: 76, offset: 25469},
+									pos:        position{line: 1024, col: 76, offset: 25480},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1024, col: 80, offset: 25473},
+									pos:  position{line: 1024, col: 80, offset: 25484},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1024, col: 83, offset: 25476},
+									pos:   position{line: 1024, col: 83, offset: 25487},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1024, col: 88, offset: 25481},
+										pos:  position{line: 1024, col: 88, offset: 25492},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1024, col: 93, offset: 25486},
+									pos:  position{line: 1024, col: 93, offset: 25497},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1024, col: 96, offset: 25489},
+									pos:        position{line: 1024, col: 96, offset: 25500},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1024, col: 100, offset: 25493},
+									pos:   position{line: 1024, col: 100, offset: 25504},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1024, col: 106, offset: 25499},
+										pos: position{line: 1024, col: 106, offset: 25510},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1024, col: 106, offset: 25499},
+											pos:  position{line: 1024, col: 106, offset: 25510},
 											name: "WhereClause",
 										},
 									},
@@ -7083,65 +7091,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1028, col: 5, offset: 25668},
+						pos: position{line: 1028, col: 5, offset: 25679},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1028, col: 5, offset: 25668},
+							pos: position{line: 1028, col: 5, offset: 25679},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1028, col: 5, offset: 25668},
+									pos: position{line: 1028, col: 5, offset: 25679},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1028, col: 6, offset: 25669},
+										pos:  position{line: 1028, col: 6, offset: 25680},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1028, col: 16, offset: 25679},
+									pos:   position{line: 1028, col: 16, offset: 25690},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1028, col: 19, offset: 25682},
+										pos:  position{line: 1028, col: 19, offset: 25693},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 30, offset: 25693},
+									pos:  position{line: 1028, col: 30, offset: 25704},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1028, col: 33, offset: 25696},
+									pos:        position{line: 1028, col: 33, offset: 25707},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 37, offset: 25700},
+									pos:  position{line: 1028, col: 37, offset: 25711},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1028, col: 40, offset: 25703},
+									pos:   position{line: 1028, col: 40, offset: 25714},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1028, col: 45, offset: 25708},
+										pos:  position{line: 1028, col: 45, offset: 25719},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 58, offset: 25721},
+									pos:  position{line: 1028, col: 58, offset: 25732},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1028, col: 61, offset: 25724},
+									pos:        position{line: 1028, col: 61, offset: 25735},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1028, col: 65, offset: 25728},
+									pos:   position{line: 1028, col: 65, offset: 25739},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1028, col: 71, offset: 25734},
+										pos: position{line: 1028, col: 71, offset: 25745},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1028, col: 71, offset: 25734},
+											pos:  position{line: 1028, col: 71, offset: 25745},
 											name: "WhereClause",
 										},
 									},
@@ -7156,15 +7164,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1032, col: 1, offset: 25802},
+			pos:  position{line: 1032, col: 1, offset: 25813},
 			expr: &actionExpr{
-				pos: position{line: 1033, col: 5, offset: 25822},
+				pos: position{line: 1033, col: 5, offset: 25833},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1033, col: 5, offset: 25822},
+					pos:   position{line: 1033, col: 5, offset: 25833},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1033, col: 9, offset: 25826},
+						pos:  position{line: 1033, col: 9, offset: 25837},
 						name: "RegexpPattern",
 					},
 				},
@@ -7174,24 +7182,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1035, col: 1, offset: 25897},
+			pos:  position{line: 1035, col: 1, offset: 25908},
 			expr: &choiceExpr{
-				pos: position{line: 1036, col: 5, offset: 25914},
+				pos: position{line: 1036, col: 5, offset: 25925},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1036, col: 5, offset: 25914},
+						pos: position{line: 1036, col: 5, offset: 25925},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1036, col: 5, offset: 25914},
+							pos:   position{line: 1036, col: 5, offset: 25925},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1036, col: 7, offset: 25916},
+								pos:  position{line: 1036, col: 7, offset: 25927},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1037, col: 5, offset: 25954},
+						pos:  position{line: 1037, col: 5, offset: 25965},
 						name: "OptionalExprs",
 					},
 				},
@@ -7201,98 +7209,98 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1039, col: 1, offset: 25969},
+			pos:  position{line: 1039, col: 1, offset: 25980},
 			expr: &actionExpr{
-				pos: position{line: 1040, col: 5, offset: 25978},
+				pos: position{line: 1040, col: 5, offset: 25989},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1040, col: 5, offset: 25978},
+					pos: position{line: 1040, col: 5, offset: 25989},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1040, col: 5, offset: 25978},
+							pos:        position{line: 1040, col: 5, offset: 25989},
 							val:        "grep",
 							ignoreCase: false,
 							want:       "\"grep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1040, col: 12, offset: 25985},
+							pos:  position{line: 1040, col: 12, offset: 25996},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1040, col: 15, offset: 25988},
+							pos:        position{line: 1040, col: 15, offset: 25999},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1040, col: 19, offset: 25992},
+							pos:  position{line: 1040, col: 19, offset: 26003},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1040, col: 22, offset: 25995},
+							pos:   position{line: 1040, col: 22, offset: 26006},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1040, col: 31, offset: 26004},
+								pos: position{line: 1040, col: 31, offset: 26015},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1040, col: 31, offset: 26004},
+										pos:  position{line: 1040, col: 31, offset: 26015},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1040, col: 40, offset: 26013},
+										pos:  position{line: 1040, col: 40, offset: 26024},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1040, col: 47, offset: 26020},
+										pos:  position{line: 1040, col: 47, offset: 26031},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1040, col: 53, offset: 26026},
+							pos:  position{line: 1040, col: 53, offset: 26037},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1040, col: 56, offset: 26029},
+							pos:   position{line: 1040, col: 56, offset: 26040},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1040, col: 60, offset: 26033},
+								pos: position{line: 1040, col: 60, offset: 26044},
 								expr: &actionExpr{
-									pos: position{line: 1040, col: 61, offset: 26034},
+									pos: position{line: 1040, col: 61, offset: 26045},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1040, col: 61, offset: 26034},
+										pos: position{line: 1040, col: 61, offset: 26045},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1040, col: 61, offset: 26034},
+												pos:        position{line: 1040, col: 61, offset: 26045},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1040, col: 65, offset: 26038},
+												pos:  position{line: 1040, col: 65, offset: 26049},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1040, col: 68, offset: 26041},
+												pos:   position{line: 1040, col: 68, offset: 26052},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1040, col: 71, offset: 26044},
+													pos: position{line: 1040, col: 71, offset: 26055},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1040, col: 71, offset: 26044},
+															pos:  position{line: 1040, col: 71, offset: 26055},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1040, col: 82, offset: 26055},
+															pos:  position{line: 1040, col: 82, offset: 26066},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1040, col: 88, offset: 26061},
+												pos:  position{line: 1040, col: 88, offset: 26072},
 												name: "__",
 											},
 										},
@@ -7301,7 +7309,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1040, col: 111, offset: 26084},
+							pos:        position{line: 1040, col: 111, offset: 26095},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7314,19 +7322,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1053, col: 1, offset: 26345},
+			pos:  position{line: 1053, col: 1, offset: 26356},
 			expr: &choiceExpr{
-				pos: position{line: 1054, col: 5, offset: 26363},
+				pos: position{line: 1054, col: 5, offset: 26374},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1054, col: 5, offset: 26363},
+						pos:  position{line: 1054, col: 5, offset: 26374},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1055, col: 5, offset: 26373},
+						pos: position{line: 1055, col: 5, offset: 26384},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1055, col: 5, offset: 26373},
+							pos:  position{line: 1055, col: 5, offset: 26384},
 							name: "__",
 						},
 					},
@@ -7337,51 +7345,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1057, col: 1, offset: 26401},
+			pos:  position{line: 1057, col: 1, offset: 26412},
 			expr: &actionExpr{
-				pos: position{line: 1058, col: 5, offset: 26411},
+				pos: position{line: 1058, col: 5, offset: 26422},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1058, col: 5, offset: 26411},
+					pos: position{line: 1058, col: 5, offset: 26422},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1058, col: 5, offset: 26411},
+							pos:   position{line: 1058, col: 5, offset: 26422},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1058, col: 11, offset: 26417},
+								pos:  position{line: 1058, col: 11, offset: 26428},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1058, col: 16, offset: 26422},
+							pos:   position{line: 1058, col: 16, offset: 26433},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1058, col: 21, offset: 26427},
+								pos: position{line: 1058, col: 21, offset: 26438},
 								expr: &actionExpr{
-									pos: position{line: 1058, col: 22, offset: 26428},
+									pos: position{line: 1058, col: 22, offset: 26439},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1058, col: 22, offset: 26428},
+										pos: position{line: 1058, col: 22, offset: 26439},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1058, col: 22, offset: 26428},
+												pos:  position{line: 1058, col: 22, offset: 26439},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1058, col: 25, offset: 26431},
+												pos:        position{line: 1058, col: 25, offset: 26442},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1058, col: 29, offset: 26435},
+												pos:  position{line: 1058, col: 29, offset: 26446},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1058, col: 32, offset: 26438},
+												pos:   position{line: 1058, col: 32, offset: 26449},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1058, col: 34, offset: 26440},
+													pos:  position{line: 1058, col: 34, offset: 26451},
 													name: "Expr",
 												},
 											},
@@ -7398,64 +7406,64 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1062, col: 1, offset: 26513},
+			pos:  position{line: 1062, col: 1, offset: 26524},
 			expr: &choiceExpr{
-				pos: position{line: 1063, col: 5, offset: 26525},
+				pos: position{line: 1063, col: 5, offset: 26536},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1063, col: 5, offset: 26525},
+						pos:  position{line: 1063, col: 5, offset: 26536},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1064, col: 5, offset: 26536},
+						pos:  position{line: 1064, col: 5, offset: 26547},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1065, col: 5, offset: 26546},
+						pos:  position{line: 1065, col: 5, offset: 26557},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1066, col: 5, offset: 26554},
+						pos:  position{line: 1066, col: 5, offset: 26565},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 5, offset: 26562},
+						pos:  position{line: 1067, col: 5, offset: 26573},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1068, col: 5, offset: 26574},
+						pos:  position{line: 1068, col: 5, offset: 26585},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 26589},
+						pos: position{line: 1069, col: 5, offset: 26600},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1069, col: 5, offset: 26589},
+							pos: position{line: 1069, col: 5, offset: 26600},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1069, col: 5, offset: 26589},
+									pos:        position{line: 1069, col: 5, offset: 26600},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 9, offset: 26593},
+									pos:  position{line: 1069, col: 9, offset: 26604},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 12, offset: 26596},
+									pos:   position{line: 1069, col: 12, offset: 26607},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 17, offset: 26601},
+										pos:  position{line: 1069, col: 17, offset: 26612},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 26, offset: 26610},
+									pos:  position{line: 1069, col: 26, offset: 26621},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 29, offset: 26613},
+									pos:        position{line: 1069, col: 29, offset: 26624},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7464,35 +7472,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 26642},
+						pos: position{line: 1070, col: 5, offset: 26653},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1070, col: 5, offset: 26642},
+							pos: position{line: 1070, col: 5, offset: 26653},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1070, col: 5, offset: 26642},
+									pos:        position{line: 1070, col: 5, offset: 26653},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1070, col: 9, offset: 26646},
+									pos:  position{line: 1070, col: 9, offset: 26657},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1070, col: 12, offset: 26649},
+									pos:   position{line: 1070, col: 12, offset: 26660},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1070, col: 17, offset: 26654},
+										pos:  position{line: 1070, col: 17, offset: 26665},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1070, col: 22, offset: 26659},
+									pos:  position{line: 1070, col: 22, offset: 26670},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1070, col: 25, offset: 26662},
+									pos:        position{line: 1070, col: 25, offset: 26673},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7507,61 +7515,61 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1072, col: 1, offset: 26688},
+			pos:  position{line: 1072, col: 1, offset: 26699},
 			expr: &actionExpr{
-				pos: position{line: 1073, col: 5, offset: 26701},
+				pos: position{line: 1073, col: 5, offset: 26712},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1073, col: 5, offset: 26701},
+					pos: position{line: 1073, col: 5, offset: 26712},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1073, col: 5, offset: 26701},
+							pos:        position{line: 1073, col: 5, offset: 26712},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1073, col: 12, offset: 26708},
+							pos:  position{line: 1073, col: 12, offset: 26719},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 14, offset: 26710},
+							pos:   position{line: 1073, col: 14, offset: 26721},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1073, col: 20, offset: 26716},
+								pos:  position{line: 1073, col: 20, offset: 26727},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 26, offset: 26722},
+							pos:   position{line: 1073, col: 26, offset: 26733},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1073, col: 33, offset: 26729},
+								pos: position{line: 1073, col: 33, offset: 26740},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1073, col: 33, offset: 26729},
+									pos:  position{line: 1073, col: 33, offset: 26740},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1073, col: 41, offset: 26737},
+							pos:  position{line: 1073, col: 41, offset: 26748},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1073, col: 44, offset: 26740},
+							pos:        position{line: 1073, col: 44, offset: 26751},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1073, col: 48, offset: 26744},
+							pos:  position{line: 1073, col: 48, offset: 26755},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 51, offset: 26747},
+							pos:   position{line: 1073, col: 51, offset: 26758},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1073, col: 56, offset: 26752},
+								pos:  position{line: 1073, col: 56, offset: 26763},
 								name: "Seq",
 							},
 						},
@@ -7573,37 +7581,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1083, col: 1, offset: 26996},
+			pos:  position{line: 1083, col: 1, offset: 27007},
 			expr: &actionExpr{
-				pos: position{line: 1084, col: 5, offset: 27007},
+				pos: position{line: 1084, col: 5, offset: 27018},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1084, col: 5, offset: 27007},
+					pos: position{line: 1084, col: 5, offset: 27018},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1084, col: 5, offset: 27007},
+							pos:        position{line: 1084, col: 5, offset: 27018},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1084, col: 9, offset: 27011},
+							pos:  position{line: 1084, col: 9, offset: 27022},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1084, col: 12, offset: 27014},
+							pos:   position{line: 1084, col: 12, offset: 27025},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1084, col: 18, offset: 27020},
+								pos:  position{line: 1084, col: 18, offset: 27031},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1084, col: 30, offset: 27032},
+							pos:  position{line: 1084, col: 30, offset: 27043},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 33, offset: 27035},
+							pos:        position{line: 1084, col: 33, offset: 27046},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7616,31 +7624,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1093, col: 1, offset: 27237},
+			pos:  position{line: 1093, col: 1, offset: 27248},
 			expr: &choiceExpr{
-				pos: position{line: 1094, col: 5, offset: 27253},
+				pos: position{line: 1094, col: 5, offset: 27264},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1094, col: 5, offset: 27253},
+						pos: position{line: 1094, col: 5, offset: 27264},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1094, col: 5, offset: 27253},
+							pos: position{line: 1094, col: 5, offset: 27264},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1094, col: 5, offset: 27253},
+									pos:   position{line: 1094, col: 5, offset: 27264},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1094, col: 11, offset: 27259},
+										pos:  position{line: 1094, col: 11, offset: 27270},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1094, col: 22, offset: 27270},
+									pos:   position{line: 1094, col: 22, offset: 27281},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1094, col: 27, offset: 27275},
+										pos: position{line: 1094, col: 27, offset: 27286},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1094, col: 27, offset: 27275},
+											pos:  position{line: 1094, col: 27, offset: 27286},
 											name: "RecordElemTail",
 										},
 									},
@@ -7649,10 +7657,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1097, col: 5, offset: 27338},
+						pos: position{line: 1097, col: 5, offset: 27349},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1097, col: 5, offset: 27338},
+							pos:  position{line: 1097, col: 5, offset: 27349},
 							name: "__",
 						},
 					},
@@ -7663,32 +7671,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1099, col: 1, offset: 27362},
+			pos:  position{line: 1099, col: 1, offset: 27373},
 			expr: &actionExpr{
-				pos: position{line: 1099, col: 18, offset: 27379},
+				pos: position{line: 1099, col: 18, offset: 27390},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1099, col: 18, offset: 27379},
+					pos: position{line: 1099, col: 18, offset: 27390},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1099, col: 18, offset: 27379},
+							pos:  position{line: 1099, col: 18, offset: 27390},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1099, col: 21, offset: 27382},
+							pos:        position{line: 1099, col: 21, offset: 27393},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1099, col: 25, offset: 27386},
+							pos:  position{line: 1099, col: 25, offset: 27397},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1099, col: 28, offset: 27389},
+							pos:   position{line: 1099, col: 28, offset: 27400},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1099, col: 33, offset: 27394},
+								pos:  position{line: 1099, col: 33, offset: 27405},
 								name: "RecordElem",
 							},
 						},
@@ -7700,20 +7708,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1101, col: 1, offset: 27427},
+			pos:  position{line: 1101, col: 1, offset: 27438},
 			expr: &choiceExpr{
-				pos: position{line: 1102, col: 5, offset: 27442},
+				pos: position{line: 1102, col: 5, offset: 27453},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1102, col: 5, offset: 27442},
+						pos:  position{line: 1102, col: 5, offset: 27453},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1103, col: 5, offset: 27453},
+						pos:  position{line: 1103, col: 5, offset: 27464},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1104, col: 5, offset: 27463},
+						pos:  position{line: 1104, col: 5, offset: 27474},
 						name: "Identifier",
 					},
 				},
@@ -7723,28 +7731,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1106, col: 1, offset: 27475},
+			pos:  position{line: 1106, col: 1, offset: 27486},
 			expr: &actionExpr{
-				pos: position{line: 1107, col: 5, offset: 27486},
+				pos: position{line: 1107, col: 5, offset: 27497},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1107, col: 5, offset: 27486},
+					pos: position{line: 1107, col: 5, offset: 27497},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1107, col: 5, offset: 27486},
+							pos:        position{line: 1107, col: 5, offset: 27497},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1107, col: 11, offset: 27492},
+							pos:  position{line: 1107, col: 11, offset: 27503},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1107, col: 14, offset: 27495},
+							pos:   position{line: 1107, col: 14, offset: 27506},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1107, col: 19, offset: 27500},
+								pos:  position{line: 1107, col: 19, offset: 27511},
 								name: "Expr",
 							},
 						},
@@ -7756,40 +7764,40 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 1111, col: 1, offset: 27607},
+			pos:  position{line: 1111, col: 1, offset: 27618},
 			expr: &actionExpr{
-				pos: position{line: 1112, col: 5, offset: 27617},
+				pos: position{line: 1112, col: 5, offset: 27628},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 1112, col: 5, offset: 27617},
+					pos: position{line: 1112, col: 5, offset: 27628},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1112, col: 5, offset: 27617},
+							pos:   position{line: 1112, col: 5, offset: 27628},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1112, col: 10, offset: 27622},
+								pos:  position{line: 1112, col: 10, offset: 27633},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1112, col: 20, offset: 27632},
+							pos:  position{line: 1112, col: 20, offset: 27643},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1112, col: 23, offset: 27635},
+							pos:        position{line: 1112, col: 23, offset: 27646},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1112, col: 27, offset: 27639},
+							pos:  position{line: 1112, col: 27, offset: 27650},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1112, col: 30, offset: 27642},
+							pos:   position{line: 1112, col: 30, offset: 27653},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1112, col: 36, offset: 27648},
+								pos:  position{line: 1112, col: 36, offset: 27659},
 								name: "Expr",
 							},
 						},
@@ -7801,37 +7809,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1121, col: 1, offset: 27816},
+			pos:  position{line: 1121, col: 1, offset: 27827},
 			expr: &actionExpr{
-				pos: position{line: 1122, col: 5, offset: 27826},
+				pos: position{line: 1122, col: 5, offset: 27837},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1122, col: 5, offset: 27826},
+					pos: position{line: 1122, col: 5, offset: 27837},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1122, col: 5, offset: 27826},
+							pos:        position{line: 1122, col: 5, offset: 27837},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1122, col: 9, offset: 27830},
+							pos:  position{line: 1122, col: 9, offset: 27841},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1122, col: 12, offset: 27833},
+							pos:   position{line: 1122, col: 12, offset: 27844},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1122, col: 18, offset: 27839},
+								pos:  position{line: 1122, col: 18, offset: 27850},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1122, col: 30, offset: 27851},
+							pos:  position{line: 1122, col: 30, offset: 27862},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1122, col: 33, offset: 27854},
+							pos:        position{line: 1122, col: 33, offset: 27865},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -7844,37 +7852,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1131, col: 1, offset: 28054},
+			pos:  position{line: 1131, col: 1, offset: 28065},
 			expr: &actionExpr{
-				pos: position{line: 1132, col: 5, offset: 28062},
+				pos: position{line: 1132, col: 5, offset: 28073},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1132, col: 5, offset: 28062},
+					pos: position{line: 1132, col: 5, offset: 28073},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1132, col: 5, offset: 28062},
+							pos:        position{line: 1132, col: 5, offset: 28073},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1132, col: 10, offset: 28067},
+							pos:  position{line: 1132, col: 10, offset: 28078},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1132, col: 13, offset: 28070},
+							pos:   position{line: 1132, col: 13, offset: 28081},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1132, col: 19, offset: 28076},
+								pos:  position{line: 1132, col: 19, offset: 28087},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1132, col: 31, offset: 28088},
+							pos:  position{line: 1132, col: 31, offset: 28099},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1132, col: 34, offset: 28091},
+							pos:        position{line: 1132, col: 34, offset: 28102},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -7887,54 +7895,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1141, col: 1, offset: 28286},
+			pos:  position{line: 1141, col: 1, offset: 28297},
 			expr: &choiceExpr{
-				pos: position{line: 1142, col: 5, offset: 28302},
+				pos: position{line: 1142, col: 5, offset: 28313},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1142, col: 5, offset: 28302},
+						pos: position{line: 1142, col: 5, offset: 28313},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1142, col: 5, offset: 28302},
+							pos: position{line: 1142, col: 5, offset: 28313},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1142, col: 5, offset: 28302},
+									pos:   position{line: 1142, col: 5, offset: 28313},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1142, col: 11, offset: 28308},
+										pos:  position{line: 1142, col: 11, offset: 28319},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1142, col: 22, offset: 28319},
+									pos:   position{line: 1142, col: 22, offset: 28330},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1142, col: 27, offset: 28324},
+										pos: position{line: 1142, col: 27, offset: 28335},
 										expr: &actionExpr{
-											pos: position{line: 1142, col: 28, offset: 28325},
+											pos: position{line: 1142, col: 28, offset: 28336},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1142, col: 28, offset: 28325},
+												pos: position{line: 1142, col: 28, offset: 28336},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1142, col: 28, offset: 28325},
+														pos:  position{line: 1142, col: 28, offset: 28336},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1142, col: 31, offset: 28328},
+														pos:        position{line: 1142, col: 31, offset: 28339},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1142, col: 35, offset: 28332},
+														pos:  position{line: 1142, col: 35, offset: 28343},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1142, col: 38, offset: 28335},
+														pos:   position{line: 1142, col: 38, offset: 28346},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1142, col: 40, offset: 28337},
+															pos:  position{line: 1142, col: 40, offset: 28348},
 															name: "VectorElem",
 														},
 													},
@@ -7947,10 +7955,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1145, col: 5, offset: 28419},
+						pos: position{line: 1145, col: 5, offset: 28430},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1145, col: 5, offset: 28419},
+							pos:  position{line: 1145, col: 5, offset: 28430},
 							name: "__",
 						},
 					},
@@ -7961,22 +7969,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1147, col: 1, offset: 28443},
+			pos:  position{line: 1147, col: 1, offset: 28454},
 			expr: &choiceExpr{
-				pos: position{line: 1148, col: 5, offset: 28458},
+				pos: position{line: 1148, col: 5, offset: 28469},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1148, col: 5, offset: 28458},
+						pos:  position{line: 1148, col: 5, offset: 28469},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1149, col: 5, offset: 28469},
+						pos: position{line: 1149, col: 5, offset: 28480},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1149, col: 5, offset: 28469},
+							pos:   position{line: 1149, col: 5, offset: 28480},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1149, col: 7, offset: 28471},
+								pos:  position{line: 1149, col: 7, offset: 28482},
 								name: "Expr",
 							},
 						},
@@ -7988,37 +7996,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1151, col: 1, offset: 28551},
+			pos:  position{line: 1151, col: 1, offset: 28562},
 			expr: &actionExpr{
-				pos: position{line: 1152, col: 5, offset: 28559},
+				pos: position{line: 1152, col: 5, offset: 28570},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1152, col: 5, offset: 28559},
+					pos: position{line: 1152, col: 5, offset: 28570},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1152, col: 5, offset: 28559},
+							pos:        position{line: 1152, col: 5, offset: 28570},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1152, col: 10, offset: 28564},
+							pos:  position{line: 1152, col: 10, offset: 28575},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1152, col: 13, offset: 28567},
+							pos:   position{line: 1152, col: 13, offset: 28578},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1152, col: 19, offset: 28573},
+								pos:  position{line: 1152, col: 19, offset: 28584},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1152, col: 27, offset: 28581},
+							pos:  position{line: 1152, col: 27, offset: 28592},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1152, col: 30, offset: 28584},
+							pos:        position{line: 1152, col: 30, offset: 28595},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8031,31 +8039,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1161, col: 1, offset: 28780},
+			pos:  position{line: 1161, col: 1, offset: 28791},
 			expr: &choiceExpr{
-				pos: position{line: 1162, col: 5, offset: 28792},
+				pos: position{line: 1162, col: 5, offset: 28803},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1162, col: 5, offset: 28792},
+						pos: position{line: 1162, col: 5, offset: 28803},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1162, col: 5, offset: 28792},
+							pos: position{line: 1162, col: 5, offset: 28803},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1162, col: 5, offset: 28792},
+									pos:   position{line: 1162, col: 5, offset: 28803},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1162, col: 11, offset: 28798},
+										pos:  position{line: 1162, col: 11, offset: 28809},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1162, col: 17, offset: 28804},
+									pos:   position{line: 1162, col: 17, offset: 28815},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1162, col: 22, offset: 28809},
+										pos: position{line: 1162, col: 22, offset: 28820},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1162, col: 22, offset: 28809},
+											pos:  position{line: 1162, col: 22, offset: 28820},
 											name: "EntryTail",
 										},
 									},
@@ -8064,10 +8072,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1165, col: 5, offset: 28867},
+						pos: position{line: 1165, col: 5, offset: 28878},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1165, col: 5, offset: 28867},
+							pos:  position{line: 1165, col: 5, offset: 28878},
 							name: "__",
 						},
 					},
@@ -8078,32 +8086,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1168, col: 1, offset: 28892},
+			pos:  position{line: 1168, col: 1, offset: 28903},
 			expr: &actionExpr{
-				pos: position{line: 1168, col: 13, offset: 28904},
+				pos: position{line: 1168, col: 13, offset: 28915},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1168, col: 13, offset: 28904},
+					pos: position{line: 1168, col: 13, offset: 28915},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1168, col: 13, offset: 28904},
+							pos:  position{line: 1168, col: 13, offset: 28915},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1168, col: 16, offset: 28907},
+							pos:        position{line: 1168, col: 16, offset: 28918},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1168, col: 20, offset: 28911},
+							pos:  position{line: 1168, col: 20, offset: 28922},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1168, col: 23, offset: 28914},
+							pos:   position{line: 1168, col: 23, offset: 28925},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1168, col: 25, offset: 28916},
+								pos:  position{line: 1168, col: 25, offset: 28927},
 								name: "Entry",
 							},
 						},
@@ -8115,40 +8123,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1170, col: 1, offset: 28941},
+			pos:  position{line: 1170, col: 1, offset: 28952},
 			expr: &actionExpr{
-				pos: position{line: 1171, col: 5, offset: 28951},
+				pos: position{line: 1171, col: 5, offset: 28962},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1171, col: 5, offset: 28951},
+					pos: position{line: 1171, col: 5, offset: 28962},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1171, col: 5, offset: 28951},
+							pos:   position{line: 1171, col: 5, offset: 28962},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1171, col: 9, offset: 28955},
+								pos:  position{line: 1171, col: 9, offset: 28966},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1171, col: 14, offset: 28960},
+							pos:  position{line: 1171, col: 14, offset: 28971},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1171, col: 17, offset: 28963},
+							pos:        position{line: 1171, col: 17, offset: 28974},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1171, col: 21, offset: 28967},
+							pos:  position{line: 1171, col: 21, offset: 28978},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1171, col: 24, offset: 28970},
+							pos:   position{line: 1171, col: 24, offset: 28981},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1171, col: 30, offset: 28976},
+								pos:  position{line: 1171, col: 30, offset: 28987},
 								name: "Expr",
 							},
 						},
@@ -8160,56 +8168,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1177, col: 1, offset: 29090},
+			pos:  position{line: 1177, col: 1, offset: 29101},
 			expr: &choiceExpr{
-				pos: position{line: 1178, col: 5, offset: 29102},
+				pos: position{line: 1178, col: 5, offset: 29113},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1178, col: 5, offset: 29102},
+						pos:  position{line: 1178, col: 5, offset: 29113},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1179, col: 5, offset: 29118},
+						pos:  position{line: 1179, col: 5, offset: 29129},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1180, col: 5, offset: 29136},
+						pos:  position{line: 1180, col: 5, offset: 29147},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1181, col: 5, offset: 29148},
+						pos:  position{line: 1181, col: 5, offset: 29159},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1182, col: 5, offset: 29166},
+						pos:  position{line: 1182, col: 5, offset: 29177},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1183, col: 5, offset: 29185},
+						pos:  position{line: 1183, col: 5, offset: 29196},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 5, offset: 29202},
+						pos:  position{line: 1184, col: 5, offset: 29213},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1185, col: 5, offset: 29215},
+						pos:  position{line: 1185, col: 5, offset: 29226},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 5, offset: 29224},
+						pos:  position{line: 1186, col: 5, offset: 29235},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1187, col: 5, offset: 29241},
+						pos:  position{line: 1187, col: 5, offset: 29252},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1188, col: 5, offset: 29260},
+						pos:  position{line: 1188, col: 5, offset: 29271},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1189, col: 5, offset: 29279},
+						pos:  position{line: 1189, col: 5, offset: 29290},
 						name: "NullLiteral",
 					},
 				},
@@ -8219,28 +8227,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1191, col: 1, offset: 29292},
+			pos:  position{line: 1191, col: 1, offset: 29303},
 			expr: &choiceExpr{
-				pos: position{line: 1192, col: 5, offset: 29310},
+				pos: position{line: 1192, col: 5, offset: 29321},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1192, col: 5, offset: 29310},
+						pos: position{line: 1192, col: 5, offset: 29321},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 5, offset: 29310},
+							pos: position{line: 1192, col: 5, offset: 29321},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1192, col: 5, offset: 29310},
+									pos:   position{line: 1192, col: 5, offset: 29321},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 7, offset: 29312},
+										pos:  position{line: 1192, col: 7, offset: 29323},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1192, col: 14, offset: 29319},
+									pos: position{line: 1192, col: 14, offset: 29330},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 15, offset: 29320},
+										pos:  position{line: 1192, col: 15, offset: 29331},
 										name: "IdentifierRest",
 									},
 								},
@@ -8248,13 +8256,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1195, col: 5, offset: 29400},
+						pos: position{line: 1195, col: 5, offset: 29411},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1195, col: 5, offset: 29400},
+							pos:   position{line: 1195, col: 5, offset: 29411},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1195, col: 7, offset: 29402},
+								pos:  position{line: 1195, col: 7, offset: 29413},
 								name: "IP4Net",
 							},
 						},
@@ -8266,28 +8274,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1199, col: 1, offset: 29471},
+			pos:  position{line: 1199, col: 1, offset: 29482},
 			expr: &choiceExpr{
-				pos: position{line: 1200, col: 5, offset: 29490},
+				pos: position{line: 1200, col: 5, offset: 29501},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1200, col: 5, offset: 29490},
+						pos: position{line: 1200, col: 5, offset: 29501},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1200, col: 5, offset: 29490},
+							pos: position{line: 1200, col: 5, offset: 29501},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1200, col: 5, offset: 29490},
+									pos:   position{line: 1200, col: 5, offset: 29501},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1200, col: 7, offset: 29492},
+										pos:  position{line: 1200, col: 7, offset: 29503},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1200, col: 11, offset: 29496},
+									pos: position{line: 1200, col: 11, offset: 29507},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1200, col: 12, offset: 29497},
+										pos:  position{line: 1200, col: 12, offset: 29508},
 										name: "IdentifierRest",
 									},
 								},
@@ -8295,13 +8303,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1203, col: 5, offset: 29576},
+						pos: position{line: 1203, col: 5, offset: 29587},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1203, col: 5, offset: 29576},
+							pos:   position{line: 1203, col: 5, offset: 29587},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1203, col: 7, offset: 29578},
+								pos:  position{line: 1203, col: 7, offset: 29589},
 								name: "IP",
 							},
 						},
@@ -8313,15 +8321,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1207, col: 1, offset: 29642},
+			pos:  position{line: 1207, col: 1, offset: 29653},
 			expr: &actionExpr{
-				pos: position{line: 1208, col: 5, offset: 29659},
+				pos: position{line: 1208, col: 5, offset: 29670},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1208, col: 5, offset: 29659},
+					pos:   position{line: 1208, col: 5, offset: 29670},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1208, col: 7, offset: 29661},
+						pos:  position{line: 1208, col: 7, offset: 29672},
 						name: "FloatString",
 					},
 				},
@@ -8331,15 +8339,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1212, col: 1, offset: 29739},
+			pos:  position{line: 1212, col: 1, offset: 29750},
 			expr: &actionExpr{
-				pos: position{line: 1213, col: 5, offset: 29758},
+				pos: position{line: 1213, col: 5, offset: 29769},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1213, col: 5, offset: 29758},
+					pos:   position{line: 1213, col: 5, offset: 29769},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1213, col: 7, offset: 29760},
+						pos:  position{line: 1213, col: 7, offset: 29771},
 						name: "IntString",
 					},
 				},
@@ -8349,23 +8357,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1217, col: 1, offset: 29834},
+			pos:  position{line: 1217, col: 1, offset: 29845},
 			expr: &choiceExpr{
-				pos: position{line: 1218, col: 5, offset: 29853},
+				pos: position{line: 1218, col: 5, offset: 29864},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1218, col: 5, offset: 29853},
+						pos: position{line: 1218, col: 5, offset: 29864},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1218, col: 5, offset: 29853},
+							pos:  position{line: 1218, col: 5, offset: 29864},
 							name: "TrueToken",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1219, col: 5, offset: 29916},
+						pos: position{line: 1219, col: 5, offset: 29927},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1219, col: 5, offset: 29916},
+							pos:  position{line: 1219, col: 5, offset: 29927},
 							name: "FalseToken",
 						},
 					},
@@ -8376,12 +8384,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1221, col: 1, offset: 29977},
+			pos:  position{line: 1221, col: 1, offset: 29988},
 			expr: &actionExpr{
-				pos: position{line: 1222, col: 5, offset: 29993},
+				pos: position{line: 1222, col: 5, offset: 30004},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1222, col: 5, offset: 29993},
+					pos:  position{line: 1222, col: 5, offset: 30004},
 					name: "NullToken",
 				},
 			},
@@ -8390,23 +8398,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1224, col: 1, offset: 30048},
+			pos:  position{line: 1224, col: 1, offset: 30059},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 30065},
+				pos: position{line: 1225, col: 5, offset: 30076},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 30065},
+					pos: position{line: 1225, col: 5, offset: 30076},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1225, col: 5, offset: 30065},
+							pos:        position{line: 1225, col: 5, offset: 30076},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1225, col: 10, offset: 30070},
+							pos: position{line: 1225, col: 10, offset: 30081},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 10, offset: 30070},
+								pos:  position{line: 1225, col: 10, offset: 30081},
 								name: "HexDigit",
 							},
 						},
@@ -8418,29 +8426,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1229, col: 1, offset: 30144},
+			pos:  position{line: 1229, col: 1, offset: 30155},
 			expr: &actionExpr{
-				pos: position{line: 1230, col: 5, offset: 30160},
+				pos: position{line: 1230, col: 5, offset: 30171},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1230, col: 5, offset: 30160},
+					pos: position{line: 1230, col: 5, offset: 30171},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1230, col: 5, offset: 30160},
+							pos:        position{line: 1230, col: 5, offset: 30171},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1230, col: 9, offset: 30164},
+							pos:   position{line: 1230, col: 9, offset: 30175},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1230, col: 13, offset: 30168},
+								pos:  position{line: 1230, col: 13, offset: 30179},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1230, col: 18, offset: 30173},
+							pos:        position{line: 1230, col: 18, offset: 30184},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8453,16 +8461,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1239, col: 1, offset: 30354},
+			pos:  position{line: 1239, col: 1, offset: 30365},
 			expr: &choiceExpr{
-				pos: position{line: 1240, col: 5, offset: 30363},
+				pos: position{line: 1240, col: 5, offset: 30374},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1240, col: 5, offset: 30363},
+						pos:  position{line: 1240, col: 5, offset: 30374},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1241, col: 5, offset: 30381},
+						pos:  position{line: 1241, col: 5, offset: 30392},
 						name: "ComplexType",
 					},
 				},
@@ -8472,28 +8480,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1243, col: 1, offset: 30394},
+			pos:  position{line: 1243, col: 1, offset: 30405},
 			expr: &choiceExpr{
-				pos: position{line: 1244, col: 5, offset: 30412},
+				pos: position{line: 1244, col: 5, offset: 30423},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1244, col: 5, offset: 30412},
+						pos: position{line: 1244, col: 5, offset: 30423},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1244, col: 5, offset: 30412},
+							pos: position{line: 1244, col: 5, offset: 30423},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1244, col: 5, offset: 30412},
+									pos:   position{line: 1244, col: 5, offset: 30423},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1244, col: 10, offset: 30417},
+										pos:  position{line: 1244, col: 10, offset: 30428},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1244, col: 24, offset: 30431},
+									pos: position{line: 1244, col: 24, offset: 30442},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1244, col: 25, offset: 30432},
+										pos:  position{line: 1244, col: 25, offset: 30443},
 										name: "IdentifierRest",
 									},
 								},
@@ -8501,45 +8509,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1245, col: 5, offset: 30472},
+						pos: position{line: 1245, col: 5, offset: 30483},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1245, col: 5, offset: 30472},
+							pos: position{line: 1245, col: 5, offset: 30483},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1245, col: 5, offset: 30472},
+									pos:        position{line: 1245, col: 5, offset: 30483},
 									val:        "error",
 									ignoreCase: false,
 									want:       "\"error\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1245, col: 13, offset: 30480},
+									pos:  position{line: 1245, col: 13, offset: 30491},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1245, col: 16, offset: 30483},
+									pos:        position{line: 1245, col: 16, offset: 30494},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1245, col: 20, offset: 30487},
+									pos:  position{line: 1245, col: 20, offset: 30498},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1245, col: 23, offset: 30490},
+									pos:   position{line: 1245, col: 23, offset: 30501},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1245, col: 25, offset: 30492},
+										pos:  position{line: 1245, col: 25, offset: 30503},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1245, col: 30, offset: 30497},
+									pos:  position{line: 1245, col: 30, offset: 30508},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1245, col: 33, offset: 30500},
+									pos:        position{line: 1245, col: 33, offset: 30511},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8548,52 +8556,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1253, col: 5, offset: 30694},
+						pos: position{line: 1253, col: 5, offset: 30705},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1253, col: 5, offset: 30694},
+							pos: position{line: 1253, col: 5, offset: 30705},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1253, col: 5, offset: 30694},
+									pos:   position{line: 1253, col: 5, offset: 30705},
 									label: "name",
 									expr: &choiceExpr{
-										pos: position{line: 1253, col: 11, offset: 30700},
+										pos: position{line: 1253, col: 11, offset: 30711},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1253, col: 11, offset: 30700},
+												pos:  position{line: 1253, col: 11, offset: 30711},
 												name: "IdentifierName",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1253, col: 28, offset: 30717},
+												pos:  position{line: 1253, col: 28, offset: 30728},
 												name: "QuotedString",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1253, col: 42, offset: 30731},
+									pos:   position{line: 1253, col: 42, offset: 30742},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1253, col: 46, offset: 30735},
+										pos: position{line: 1253, col: 46, offset: 30746},
 										expr: &seqExpr{
-											pos: position{line: 1253, col: 47, offset: 30736},
+											pos: position{line: 1253, col: 47, offset: 30747},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1253, col: 47, offset: 30736},
+													pos:  position{line: 1253, col: 47, offset: 30747},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1253, col: 50, offset: 30739},
+													pos:        position{line: 1253, col: 50, offset: 30750},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1253, col: 54, offset: 30743},
+													pos:  position{line: 1253, col: 54, offset: 30754},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1253, col: 57, offset: 30746},
+													pos:  position{line: 1253, col: 57, offset: 30757},
 													name: "Type",
 												},
 											},
@@ -8604,31 +8612,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1264, col: 5, offset: 31084},
+						pos: position{line: 1264, col: 5, offset: 31095},
 						run: (*parser).callonAmbiguousType31,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 5, offset: 31084},
+							pos: position{line: 1264, col: 5, offset: 31095},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1264, col: 5, offset: 31084},
+									pos:        position{line: 1264, col: 5, offset: 31095},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1264, col: 9, offset: 31088},
+									pos:  position{line: 1264, col: 9, offset: 31099},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1264, col: 12, offset: 31091},
+									pos:   position{line: 1264, col: 12, offset: 31102},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1264, col: 18, offset: 31097},
+										pos:  position{line: 1264, col: 18, offset: 31108},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1264, col: 27, offset: 31106},
+									pos:        position{line: 1264, col: 27, offset: 31117},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8643,28 +8651,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1273, col: 1, offset: 31298},
+			pos:  position{line: 1273, col: 1, offset: 31309},
 			expr: &actionExpr{
-				pos: position{line: 1274, col: 5, offset: 31311},
+				pos: position{line: 1274, col: 5, offset: 31322},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1274, col: 5, offset: 31311},
+					pos: position{line: 1274, col: 5, offset: 31322},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1274, col: 5, offset: 31311},
+							pos:   position{line: 1274, col: 5, offset: 31322},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1274, col: 11, offset: 31317},
+								pos:  position{line: 1274, col: 11, offset: 31328},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1274, col: 16, offset: 31322},
+							pos:   position{line: 1274, col: 16, offset: 31333},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1274, col: 21, offset: 31327},
+								pos: position{line: 1274, col: 21, offset: 31338},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1274, col: 21, offset: 31327},
+									pos:  position{line: 1274, col: 21, offset: 31338},
 									name: "TypeListTail",
 								},
 							},
@@ -8677,32 +8685,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1278, col: 1, offset: 31385},
+			pos:  position{line: 1278, col: 1, offset: 31396},
 			expr: &actionExpr{
-				pos: position{line: 1278, col: 16, offset: 31400},
+				pos: position{line: 1278, col: 16, offset: 31411},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1278, col: 16, offset: 31400},
+					pos: position{line: 1278, col: 16, offset: 31411},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1278, col: 16, offset: 31400},
+							pos:  position{line: 1278, col: 16, offset: 31411},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1278, col: 19, offset: 31403},
+							pos:        position{line: 1278, col: 19, offset: 31414},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1278, col: 23, offset: 31407},
+							pos:  position{line: 1278, col: 23, offset: 31418},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1278, col: 26, offset: 31410},
+							pos:   position{line: 1278, col: 26, offset: 31421},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1278, col: 30, offset: 31414},
+								pos:  position{line: 1278, col: 30, offset: 31425},
 								name: "Type",
 							},
 						},
@@ -8714,40 +8722,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1280, col: 1, offset: 31440},
+			pos:  position{line: 1280, col: 1, offset: 31451},
 			expr: &choiceExpr{
-				pos: position{line: 1281, col: 5, offset: 31456},
+				pos: position{line: 1281, col: 5, offset: 31467},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1281, col: 5, offset: 31456},
+						pos: position{line: 1281, col: 5, offset: 31467},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1281, col: 5, offset: 31456},
+							pos: position{line: 1281, col: 5, offset: 31467},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1281, col: 5, offset: 31456},
+									pos:        position{line: 1281, col: 5, offset: 31467},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 9, offset: 31460},
+									pos:  position{line: 1281, col: 9, offset: 31471},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1281, col: 12, offset: 31463},
+									pos:   position{line: 1281, col: 12, offset: 31474},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1281, col: 19, offset: 31470},
+										pos:  position{line: 1281, col: 19, offset: 31481},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 33, offset: 31484},
+									pos:  position{line: 1281, col: 33, offset: 31495},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1281, col: 36, offset: 31487},
+									pos:        position{line: 1281, col: 36, offset: 31498},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -8756,35 +8764,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1289, col: 5, offset: 31699},
+						pos: position{line: 1289, col: 5, offset: 31710},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1289, col: 5, offset: 31699},
+							pos: position{line: 1289, col: 5, offset: 31710},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1289, col: 5, offset: 31699},
+									pos:        position{line: 1289, col: 5, offset: 31710},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1289, col: 9, offset: 31703},
+									pos:  position{line: 1289, col: 9, offset: 31714},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1289, col: 12, offset: 31706},
+									pos:   position{line: 1289, col: 12, offset: 31717},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1289, col: 16, offset: 31710},
+										pos:  position{line: 1289, col: 16, offset: 31721},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1289, col: 21, offset: 31715},
+									pos:  position{line: 1289, col: 21, offset: 31726},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1289, col: 24, offset: 31718},
+									pos:        position{line: 1289, col: 24, offset: 31729},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -8793,35 +8801,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1297, col: 5, offset: 31910},
+						pos: position{line: 1297, col: 5, offset: 31921},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1297, col: 5, offset: 31910},
+							pos: position{line: 1297, col: 5, offset: 31921},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1297, col: 5, offset: 31910},
+									pos:        position{line: 1297, col: 5, offset: 31921},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1297, col: 10, offset: 31915},
+									pos:  position{line: 1297, col: 10, offset: 31926},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1297, col: 13, offset: 31918},
+									pos:   position{line: 1297, col: 13, offset: 31929},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1297, col: 17, offset: 31922},
+										pos:  position{line: 1297, col: 17, offset: 31933},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1297, col: 22, offset: 31927},
+									pos:  position{line: 1297, col: 22, offset: 31938},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1297, col: 25, offset: 31930},
+									pos:        position{line: 1297, col: 25, offset: 31941},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -8830,57 +8838,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1305, col: 5, offset: 32117},
+						pos: position{line: 1305, col: 5, offset: 32128},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1305, col: 5, offset: 32117},
+							pos: position{line: 1305, col: 5, offset: 32128},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1305, col: 5, offset: 32117},
+									pos:        position{line: 1305, col: 5, offset: 32128},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1305, col: 10, offset: 32122},
+									pos:  position{line: 1305, col: 10, offset: 32133},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1305, col: 13, offset: 32125},
+									pos:   position{line: 1305, col: 13, offset: 32136},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1305, col: 21, offset: 32133},
+										pos:  position{line: 1305, col: 21, offset: 32144},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1305, col: 26, offset: 32138},
+									pos:  position{line: 1305, col: 26, offset: 32149},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1305, col: 29, offset: 32141},
+									pos:        position{line: 1305, col: 29, offset: 32152},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1305, col: 33, offset: 32145},
+									pos:  position{line: 1305, col: 33, offset: 32156},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1305, col: 36, offset: 32148},
+									pos:   position{line: 1305, col: 36, offset: 32159},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1305, col: 44, offset: 32156},
+										pos:  position{line: 1305, col: 44, offset: 32167},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1305, col: 49, offset: 32161},
+									pos:  position{line: 1305, col: 49, offset: 32172},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1305, col: 52, offset: 32164},
+									pos:        position{line: 1305, col: 52, offset: 32175},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -8895,35 +8903,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1315, col: 1, offset: 32387},
+			pos:  position{line: 1315, col: 1, offset: 32398},
 			expr: &choiceExpr{
-				pos: position{line: 1316, col: 5, offset: 32405},
+				pos: position{line: 1316, col: 5, offset: 32416},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 32405},
+						pos: position{line: 1316, col: 5, offset: 32416},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 5, offset: 32405},
+							pos: position{line: 1316, col: 5, offset: 32416},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1316, col: 5, offset: 32405},
+									pos:        position{line: 1316, col: 5, offset: 32416},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1316, col: 9, offset: 32409},
+									pos:   position{line: 1316, col: 9, offset: 32420},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1316, col: 11, offset: 32411},
+										pos: position{line: 1316, col: 11, offset: 32422},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1316, col: 11, offset: 32411},
+											pos:  position{line: 1316, col: 11, offset: 32422},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1316, col: 29, offset: 32429},
+									pos:        position{line: 1316, col: 29, offset: 32440},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8932,30 +8940,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 32493},
+						pos: position{line: 1317, col: 5, offset: 32504},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1317, col: 5, offset: 32493},
+							pos: position{line: 1317, col: 5, offset: 32504},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1317, col: 5, offset: 32493},
+									pos:        position{line: 1317, col: 5, offset: 32504},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1317, col: 9, offset: 32497},
+									pos:   position{line: 1317, col: 9, offset: 32508},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1317, col: 11, offset: 32499},
+										pos: position{line: 1317, col: 11, offset: 32510},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1317, col: 11, offset: 32499},
+											pos:  position{line: 1317, col: 11, offset: 32510},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1317, col: 29, offset: 32517},
+									pos:        position{line: 1317, col: 29, offset: 32528},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8970,35 +8978,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1319, col: 1, offset: 32578},
+			pos:  position{line: 1319, col: 1, offset: 32589},
 			expr: &choiceExpr{
-				pos: position{line: 1320, col: 5, offset: 32590},
+				pos: position{line: 1320, col: 5, offset: 32601},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1320, col: 5, offset: 32590},
+						pos: position{line: 1320, col: 5, offset: 32601},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1320, col: 5, offset: 32590},
+							pos: position{line: 1320, col: 5, offset: 32601},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1320, col: 5, offset: 32590},
+									pos:        position{line: 1320, col: 5, offset: 32601},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1320, col: 11, offset: 32596},
+									pos:   position{line: 1320, col: 11, offset: 32607},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1320, col: 13, offset: 32598},
+										pos: position{line: 1320, col: 13, offset: 32609},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1320, col: 13, offset: 32598},
+											pos:  position{line: 1320, col: 13, offset: 32609},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1320, col: 38, offset: 32623},
+									pos:        position{line: 1320, col: 38, offset: 32634},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9007,30 +9015,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1327, col: 5, offset: 32780},
+						pos: position{line: 1327, col: 5, offset: 32791},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1327, col: 5, offset: 32780},
+							pos: position{line: 1327, col: 5, offset: 32791},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1327, col: 5, offset: 32780},
+									pos:        position{line: 1327, col: 5, offset: 32791},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1327, col: 10, offset: 32785},
+									pos:   position{line: 1327, col: 10, offset: 32796},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1327, col: 12, offset: 32787},
+										pos: position{line: 1327, col: 12, offset: 32798},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1327, col: 12, offset: 32787},
+											pos:  position{line: 1327, col: 12, offset: 32798},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1327, col: 37, offset: 32812},
+									pos:        position{line: 1327, col: 37, offset: 32823},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9045,24 +9053,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1335, col: 1, offset: 32966},
+			pos:  position{line: 1335, col: 1, offset: 32977},
 			expr: &choiceExpr{
-				pos: position{line: 1336, col: 5, offset: 32994},
+				pos: position{line: 1336, col: 5, offset: 33005},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1336, col: 5, offset: 32994},
+						pos:  position{line: 1336, col: 5, offset: 33005},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1337, col: 5, offset: 33010},
+						pos: position{line: 1337, col: 5, offset: 33021},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1337, col: 5, offset: 33010},
+							pos:   position{line: 1337, col: 5, offset: 33021},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1337, col: 7, offset: 33012},
+								pos: position{line: 1337, col: 7, offset: 33023},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1337, col: 7, offset: 33012},
+									pos:  position{line: 1337, col: 7, offset: 33023},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9075,27 +9083,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1341, col: 1, offset: 33145},
+			pos:  position{line: 1341, col: 1, offset: 33156},
 			expr: &choiceExpr{
-				pos: position{line: 1342, col: 5, offset: 33173},
+				pos: position{line: 1342, col: 5, offset: 33184},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 33173},
+						pos: position{line: 1342, col: 5, offset: 33184},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1342, col: 5, offset: 33173},
+							pos: position{line: 1342, col: 5, offset: 33184},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1342, col: 5, offset: 33173},
+									pos:        position{line: 1342, col: 5, offset: 33184},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1342, col: 10, offset: 33178},
+									pos:   position{line: 1342, col: 10, offset: 33189},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1342, col: 12, offset: 33180},
+										pos:        position{line: 1342, col: 12, offset: 33191},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9105,25 +9113,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1343, col: 5, offset: 33206},
+						pos: position{line: 1343, col: 5, offset: 33217},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1343, col: 5, offset: 33206},
+							pos: position{line: 1343, col: 5, offset: 33217},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1343, col: 5, offset: 33206},
+									pos: position{line: 1343, col: 5, offset: 33217},
 									expr: &litMatcher{
-										pos:        position{line: 1343, col: 7, offset: 33208},
+										pos:        position{line: 1343, col: 7, offset: 33219},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1343, col: 12, offset: 33213},
+									pos:   position{line: 1343, col: 12, offset: 33224},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1343, col: 14, offset: 33215},
+										pos:  position{line: 1343, col: 14, offset: 33226},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9137,24 +9145,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1345, col: 1, offset: 33251},
+			pos:  position{line: 1345, col: 1, offset: 33262},
 			expr: &choiceExpr{
-				pos: position{line: 1346, col: 5, offset: 33279},
+				pos: position{line: 1346, col: 5, offset: 33290},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1346, col: 5, offset: 33279},
+						pos:  position{line: 1346, col: 5, offset: 33290},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1347, col: 5, offset: 33295},
+						pos: position{line: 1347, col: 5, offset: 33306},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1347, col: 5, offset: 33295},
+							pos:   position{line: 1347, col: 5, offset: 33306},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1347, col: 7, offset: 33297},
+								pos: position{line: 1347, col: 7, offset: 33308},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1347, col: 7, offset: 33297},
+									pos:  position{line: 1347, col: 7, offset: 33308},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9167,27 +9175,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1351, col: 1, offset: 33430},
+			pos:  position{line: 1351, col: 1, offset: 33441},
 			expr: &choiceExpr{
-				pos: position{line: 1352, col: 5, offset: 33458},
+				pos: position{line: 1352, col: 5, offset: 33469},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1352, col: 5, offset: 33458},
+						pos: position{line: 1352, col: 5, offset: 33469},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1352, col: 5, offset: 33458},
+							pos: position{line: 1352, col: 5, offset: 33469},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1352, col: 5, offset: 33458},
+									pos:        position{line: 1352, col: 5, offset: 33469},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1352, col: 10, offset: 33463},
+									pos:   position{line: 1352, col: 10, offset: 33474},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1352, col: 12, offset: 33465},
+										pos:        position{line: 1352, col: 12, offset: 33476},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9197,25 +9205,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1353, col: 5, offset: 33491},
+						pos: position{line: 1353, col: 5, offset: 33502},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1353, col: 5, offset: 33491},
+							pos: position{line: 1353, col: 5, offset: 33502},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1353, col: 5, offset: 33491},
+									pos: position{line: 1353, col: 5, offset: 33502},
 									expr: &litMatcher{
-										pos:        position{line: 1353, col: 7, offset: 33493},
+										pos:        position{line: 1353, col: 7, offset: 33504},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1353, col: 12, offset: 33498},
+									pos:   position{line: 1353, col: 12, offset: 33509},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1353, col: 14, offset: 33500},
+										pos:  position{line: 1353, col: 14, offset: 33511},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9229,37 +9237,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1355, col: 1, offset: 33536},
+			pos:  position{line: 1355, col: 1, offset: 33547},
 			expr: &actionExpr{
-				pos: position{line: 1356, col: 5, offset: 33552},
+				pos: position{line: 1356, col: 5, offset: 33563},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1356, col: 5, offset: 33552},
+					pos: position{line: 1356, col: 5, offset: 33563},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1356, col: 5, offset: 33552},
+							pos:        position{line: 1356, col: 5, offset: 33563},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1356, col: 9, offset: 33556},
+							pos:  position{line: 1356, col: 9, offset: 33567},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1356, col: 12, offset: 33559},
+							pos:   position{line: 1356, col: 12, offset: 33570},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1356, col: 14, offset: 33561},
+								pos:  position{line: 1356, col: 14, offset: 33572},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1356, col: 19, offset: 33566},
+							pos:  position{line: 1356, col: 19, offset: 33577},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1356, col: 22, offset: 33569},
+							pos:        position{line: 1356, col: 22, offset: 33580},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9272,129 +9280,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1365, col: 1, offset: 33747},
+			pos:  position{line: 1365, col: 1, offset: 33758},
 			expr: &actionExpr{
-				pos: position{line: 1366, col: 5, offset: 33765},
+				pos: position{line: 1366, col: 5, offset: 33776},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1366, col: 9, offset: 33769},
+					pos: position{line: 1366, col: 9, offset: 33780},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1366, col: 9, offset: 33769},
+							pos:        position{line: 1366, col: 9, offset: 33780},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 19, offset: 33779},
+							pos:        position{line: 1366, col: 19, offset: 33790},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 30, offset: 33790},
+							pos:        position{line: 1366, col: 30, offset: 33801},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 41, offset: 33801},
+							pos:        position{line: 1366, col: 41, offset: 33812},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1367, col: 9, offset: 33818},
+							pos:        position{line: 1367, col: 9, offset: 33829},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1367, col: 18, offset: 33827},
+							pos:        position{line: 1367, col: 18, offset: 33838},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1367, col: 28, offset: 33837},
+							pos:        position{line: 1367, col: 28, offset: 33848},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1367, col: 38, offset: 33847},
+							pos:        position{line: 1367, col: 38, offset: 33858},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1368, col: 9, offset: 33863},
+							pos:        position{line: 1368, col: 9, offset: 33874},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1368, col: 21, offset: 33875},
+							pos:        position{line: 1368, col: 21, offset: 33886},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1368, col: 33, offset: 33887},
+							pos:        position{line: 1368, col: 33, offset: 33898},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1369, col: 9, offset: 33905},
+							pos:        position{line: 1369, col: 9, offset: 33916},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1369, col: 18, offset: 33914},
+							pos:        position{line: 1369, col: 18, offset: 33925},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1370, col: 9, offset: 33931},
+							pos:        position{line: 1370, col: 9, offset: 33942},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1370, col: 22, offset: 33944},
+							pos:        position{line: 1370, col: 22, offset: 33955},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1371, col: 9, offset: 33959},
+							pos:        position{line: 1371, col: 9, offset: 33970},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1372, col: 9, offset: 33975},
+							pos:        position{line: 1372, col: 9, offset: 33986},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1372, col: 16, offset: 33982},
+							pos:        position{line: 1372, col: 16, offset: 33993},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1373, col: 9, offset: 33996},
+							pos:        position{line: 1373, col: 9, offset: 34007},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1373, col: 18, offset: 34005},
+							pos:        position{line: 1373, col: 18, offset: 34016},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9407,31 +9415,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1381, col: 1, offset: 34203},
+			pos:  position{line: 1381, col: 1, offset: 34214},
 			expr: &choiceExpr{
-				pos: position{line: 1382, col: 5, offset: 34221},
+				pos: position{line: 1382, col: 5, offset: 34232},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1382, col: 5, offset: 34221},
+						pos: position{line: 1382, col: 5, offset: 34232},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1382, col: 5, offset: 34221},
+							pos: position{line: 1382, col: 5, offset: 34232},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1382, col: 5, offset: 34221},
+									pos:   position{line: 1382, col: 5, offset: 34232},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1382, col: 11, offset: 34227},
+										pos:  position{line: 1382, col: 11, offset: 34238},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1382, col: 21, offset: 34237},
+									pos:   position{line: 1382, col: 21, offset: 34248},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1382, col: 26, offset: 34242},
+										pos: position{line: 1382, col: 26, offset: 34253},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1382, col: 26, offset: 34242},
+											pos:  position{line: 1382, col: 26, offset: 34253},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9440,10 +9448,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1385, col: 5, offset: 34308},
+						pos: position{line: 1385, col: 5, offset: 34319},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1385, col: 5, offset: 34308},
+							pos:        position{line: 1385, col: 5, offset: 34319},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9456,32 +9464,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1387, col: 1, offset: 34332},
+			pos:  position{line: 1387, col: 1, offset: 34343},
 			expr: &actionExpr{
-				pos: position{line: 1387, col: 21, offset: 34352},
+				pos: position{line: 1387, col: 21, offset: 34363},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1387, col: 21, offset: 34352},
+					pos: position{line: 1387, col: 21, offset: 34363},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1387, col: 21, offset: 34352},
+							pos:  position{line: 1387, col: 21, offset: 34363},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1387, col: 24, offset: 34355},
+							pos:        position{line: 1387, col: 24, offset: 34366},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1387, col: 28, offset: 34359},
+							pos:  position{line: 1387, col: 28, offset: 34370},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1387, col: 31, offset: 34362},
+							pos:   position{line: 1387, col: 31, offset: 34373},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1387, col: 35, offset: 34366},
+								pos:  position{line: 1387, col: 35, offset: 34377},
 								name: "TypeField",
 							},
 						},
@@ -9493,40 +9501,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1389, col: 1, offset: 34397},
+			pos:  position{line: 1389, col: 1, offset: 34408},
 			expr: &actionExpr{
-				pos: position{line: 1390, col: 5, offset: 34411},
+				pos: position{line: 1390, col: 5, offset: 34422},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1390, col: 5, offset: 34411},
+					pos: position{line: 1390, col: 5, offset: 34422},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1390, col: 5, offset: 34411},
+							pos:   position{line: 1390, col: 5, offset: 34422},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1390, col: 10, offset: 34416},
+								pos:  position{line: 1390, col: 10, offset: 34427},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1390, col: 20, offset: 34426},
+							pos:  position{line: 1390, col: 20, offset: 34437},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1390, col: 23, offset: 34429},
+							pos:        position{line: 1390, col: 23, offset: 34440},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1390, col: 27, offset: 34433},
+							pos:  position{line: 1390, col: 27, offset: 34444},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1390, col: 30, offset: 34436},
+							pos:   position{line: 1390, col: 30, offset: 34447},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1390, col: 34, offset: 34440},
+								pos:  position{line: 1390, col: 34, offset: 34451},
 								name: "Type",
 							},
 						},
@@ -9538,16 +9546,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1397, col: 1, offset: 34564},
+			pos:  position{line: 1397, col: 1, offset: 34575},
 			expr: &choiceExpr{
-				pos: position{line: 1398, col: 5, offset: 34578},
+				pos: position{line: 1398, col: 5, offset: 34589},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1398, col: 5, offset: 34578},
+						pos:  position{line: 1398, col: 5, offset: 34589},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1399, col: 5, offset: 34597},
+						pos:  position{line: 1399, col: 5, offset: 34608},
 						name: "QuotedString",
 					},
 				},
@@ -9557,24 +9565,24 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1401, col: 1, offset: 34611},
+			pos:  position{line: 1401, col: 1, offset: 34622},
 			expr: &actionExpr{
-				pos: position{line: 1401, col: 12, offset: 34622},
+				pos: position{line: 1401, col: 12, offset: 34633},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1401, col: 12, offset: 34622},
+					pos: position{line: 1401, col: 12, offset: 34633},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1401, col: 13, offset: 34623},
+							pos: position{line: 1401, col: 13, offset: 34634},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1401, col: 13, offset: 34623},
+									pos:        position{line: 1401, col: 13, offset: 34634},
 									val:        "and",
 									ignoreCase: false,
 									want:       "\"and\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1401, col: 21, offset: 34631},
+									pos:        position{line: 1401, col: 21, offset: 34642},
 									val:        "AND",
 									ignoreCase: false,
 									want:       "\"AND\"",
@@ -9582,9 +9590,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1401, col: 28, offset: 34638},
+							pos: position{line: 1401, col: 28, offset: 34649},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1401, col: 29, offset: 34639},
+								pos:  position{line: 1401, col: 29, offset: 34650},
 								name: "IdentifierRest",
 							},
 						},
@@ -9596,20 +9604,20 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1402, col: 1, offset: 34676},
+			pos:  position{line: 1402, col: 1, offset: 34687},
 			expr: &seqExpr{
-				pos: position{line: 1402, col: 11, offset: 34686},
+				pos: position{line: 1402, col: 11, offset: 34697},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1402, col: 11, offset: 34686},
+						pos:        position{line: 1402, col: 11, offset: 34697},
 						val:        "by",
 						ignoreCase: false,
 						want:       "\"by\"",
 					},
 					&notExpr{
-						pos: position{line: 1402, col: 16, offset: 34691},
+						pos: position{line: 1402, col: 16, offset: 34702},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1402, col: 17, offset: 34692},
+							pos:  position{line: 1402, col: 17, offset: 34703},
 							name: "IdentifierRest",
 						},
 					},
@@ -9620,20 +9628,20 @@ var g = &grammar{
 		},
 		{
 			name: "FalseToken",
-			pos:  position{line: 1403, col: 1, offset: 34707},
+			pos:  position{line: 1403, col: 1, offset: 34718},
 			expr: &seqExpr{
-				pos: position{line: 1403, col: 14, offset: 34720},
+				pos: position{line: 1403, col: 14, offset: 34731},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1403, col: 14, offset: 34720},
+						pos:        position{line: 1403, col: 14, offset: 34731},
 						val:        "false",
 						ignoreCase: false,
 						want:       "\"false\"",
 					},
 					&notExpr{
-						pos: position{line: 1403, col: 22, offset: 34728},
+						pos: position{line: 1403, col: 22, offset: 34739},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1403, col: 23, offset: 34729},
+							pos:  position{line: 1403, col: 23, offset: 34740},
 							name: "IdentifierRest",
 						},
 					},
@@ -9644,20 +9652,20 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1404, col: 1, offset: 34744},
+			pos:  position{line: 1404, col: 1, offset: 34755},
 			expr: &seqExpr{
-				pos: position{line: 1404, col: 11, offset: 34754},
+				pos: position{line: 1404, col: 11, offset: 34765},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1404, col: 11, offset: 34754},
+						pos:        position{line: 1404, col: 11, offset: 34765},
 						val:        "in",
 						ignoreCase: false,
 						want:       "\"in\"",
 					},
 					&notExpr{
-						pos: position{line: 1404, col: 16, offset: 34759},
+						pos: position{line: 1404, col: 16, offset: 34770},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1404, col: 17, offset: 34760},
+							pos:  position{line: 1404, col: 17, offset: 34771},
 							name: "IdentifierRest",
 						},
 					},
@@ -9668,24 +9676,24 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1405, col: 1, offset: 34775},
+			pos:  position{line: 1405, col: 1, offset: 34786},
 			expr: &actionExpr{
-				pos: position{line: 1405, col: 12, offset: 34786},
+				pos: position{line: 1405, col: 12, offset: 34797},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1405, col: 12, offset: 34786},
+					pos: position{line: 1405, col: 12, offset: 34797},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1405, col: 13, offset: 34787},
+							pos: position{line: 1405, col: 13, offset: 34798},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1405, col: 13, offset: 34787},
+									pos:        position{line: 1405, col: 13, offset: 34798},
 									val:        "not",
 									ignoreCase: false,
 									want:       "\"not\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1405, col: 21, offset: 34795},
+									pos:        position{line: 1405, col: 21, offset: 34806},
 									val:        "NOT",
 									ignoreCase: false,
 									want:       "\"NOT\"",
@@ -9693,9 +9701,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1405, col: 28, offset: 34802},
+							pos: position{line: 1405, col: 28, offset: 34813},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1405, col: 29, offset: 34803},
+								pos:  position{line: 1405, col: 29, offset: 34814},
 								name: "IdentifierRest",
 							},
 						},
@@ -9707,20 +9715,20 @@ var g = &grammar{
 		},
 		{
 			name: "NullToken",
-			pos:  position{line: 1406, col: 1, offset: 34840},
+			pos:  position{line: 1406, col: 1, offset: 34851},
 			expr: &seqExpr{
-				pos: position{line: 1406, col: 13, offset: 34852},
+				pos: position{line: 1406, col: 13, offset: 34863},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1406, col: 13, offset: 34852},
+						pos:        position{line: 1406, col: 13, offset: 34863},
 						val:        "null",
 						ignoreCase: false,
 						want:       "\"null\"",
 					},
 					&notExpr{
-						pos: position{line: 1406, col: 20, offset: 34859},
+						pos: position{line: 1406, col: 20, offset: 34870},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1406, col: 21, offset: 34860},
+							pos:  position{line: 1406, col: 21, offset: 34871},
 							name: "IdentifierRest",
 						},
 					},
@@ -9731,24 +9739,24 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1407, col: 1, offset: 34875},
+			pos:  position{line: 1407, col: 1, offset: 34886},
 			expr: &actionExpr{
-				pos: position{line: 1407, col: 11, offset: 34885},
+				pos: position{line: 1407, col: 11, offset: 34896},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1407, col: 11, offset: 34885},
+					pos: position{line: 1407, col: 11, offset: 34896},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1407, col: 12, offset: 34886},
+							pos: position{line: 1407, col: 12, offset: 34897},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1407, col: 12, offset: 34886},
+									pos:        position{line: 1407, col: 12, offset: 34897},
 									val:        "or",
 									ignoreCase: false,
 									want:       "\"or\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1407, col: 19, offset: 34893},
+									pos:        position{line: 1407, col: 19, offset: 34904},
 									val:        "OR",
 									ignoreCase: false,
 									want:       "\"OR\"",
@@ -9756,9 +9764,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1407, col: 25, offset: 34899},
+							pos: position{line: 1407, col: 25, offset: 34910},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1407, col: 26, offset: 34900},
+								pos:  position{line: 1407, col: 26, offset: 34911},
 								name: "IdentifierRest",
 							},
 						},
@@ -9770,20 +9778,20 @@ var g = &grammar{
 		},
 		{
 			name: "TrueToken",
-			pos:  position{line: 1408, col: 1, offset: 34936},
+			pos:  position{line: 1408, col: 1, offset: 34947},
 			expr: &seqExpr{
-				pos: position{line: 1408, col: 13, offset: 34948},
+				pos: position{line: 1408, col: 13, offset: 34959},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1408, col: 13, offset: 34948},
+						pos:        position{line: 1408, col: 13, offset: 34959},
 						val:        "true",
 						ignoreCase: false,
 						want:       "\"true\"",
 					},
 					&notExpr{
-						pos: position{line: 1408, col: 20, offset: 34955},
+						pos: position{line: 1408, col: 20, offset: 34966},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1408, col: 21, offset: 34956},
+							pos:  position{line: 1408, col: 21, offset: 34967},
 							name: "IdentifierRest",
 						},
 					},
@@ -9794,15 +9802,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1410, col: 1, offset: 34972},
+			pos:  position{line: 1410, col: 1, offset: 34983},
 			expr: &actionExpr{
-				pos: position{line: 1411, col: 5, offset: 34987},
+				pos: position{line: 1411, col: 5, offset: 34998},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1411, col: 5, offset: 34987},
+					pos:   position{line: 1411, col: 5, offset: 34998},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1411, col: 8, offset: 34990},
+						pos:  position{line: 1411, col: 8, offset: 35001},
 						name: "IdentifierName",
 					},
 				},
@@ -9812,51 +9820,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1419, col: 1, offset: 35133},
+			pos:  position{line: 1419, col: 1, offset: 35144},
 			expr: &actionExpr{
-				pos: position{line: 1420, col: 5, offset: 35149},
+				pos: position{line: 1420, col: 5, offset: 35160},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1420, col: 5, offset: 35149},
+					pos: position{line: 1420, col: 5, offset: 35160},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1420, col: 5, offset: 35149},
+							pos:   position{line: 1420, col: 5, offset: 35160},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1420, col: 11, offset: 35155},
+								pos:  position{line: 1420, col: 11, offset: 35166},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1420, col: 22, offset: 35166},
+							pos:   position{line: 1420, col: 22, offset: 35177},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1420, col: 27, offset: 35171},
+								pos: position{line: 1420, col: 27, offset: 35182},
 								expr: &actionExpr{
-									pos: position{line: 1420, col: 28, offset: 35172},
+									pos: position{line: 1420, col: 28, offset: 35183},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1420, col: 28, offset: 35172},
+										pos: position{line: 1420, col: 28, offset: 35183},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1420, col: 28, offset: 35172},
+												pos:  position{line: 1420, col: 28, offset: 35183},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1420, col: 31, offset: 35175},
+												pos:        position{line: 1420, col: 31, offset: 35186},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1420, col: 35, offset: 35179},
+												pos:  position{line: 1420, col: 35, offset: 35190},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1420, col: 38, offset: 35182},
+												pos:   position{line: 1420, col: 38, offset: 35193},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1420, col: 43, offset: 35187},
+													pos:  position{line: 1420, col: 43, offset: 35198},
 													name: "Identifier",
 												},
 											},
@@ -9873,29 +9881,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1424, col: 1, offset: 35265},
+			pos:  position{line: 1424, col: 1, offset: 35276},
 			expr: &choiceExpr{
-				pos: position{line: 1425, col: 5, offset: 35284},
+				pos: position{line: 1425, col: 5, offset: 35295},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1425, col: 5, offset: 35284},
+						pos: position{line: 1425, col: 5, offset: 35295},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1425, col: 5, offset: 35284},
+							pos: position{line: 1425, col: 5, offset: 35295},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1425, col: 5, offset: 35284},
+									pos: position{line: 1425, col: 5, offset: 35295},
 									expr: &seqExpr{
-										pos: position{line: 1425, col: 7, offset: 35286},
+										pos: position{line: 1425, col: 7, offset: 35297},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1425, col: 7, offset: 35286},
+												pos:  position{line: 1425, col: 7, offset: 35297},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1425, col: 15, offset: 35294},
+												pos: position{line: 1425, col: 15, offset: 35305},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1425, col: 16, offset: 35295},
+													pos:  position{line: 1425, col: 16, offset: 35306},
 													name: "IdentifierRest",
 												},
 											},
@@ -9903,13 +9911,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1425, col: 32, offset: 35311},
+									pos:  position{line: 1425, col: 32, offset: 35322},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1425, col: 48, offset: 35327},
+									pos: position{line: 1425, col: 48, offset: 35338},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1425, col: 48, offset: 35327},
+										pos:  position{line: 1425, col: 48, offset: 35338},
 										name: "IdentifierRest",
 									},
 								},
@@ -9917,32 +9925,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1426, col: 5, offset: 35378},
+						pos: position{line: 1426, col: 5, offset: 35389},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1426, col: 5, offset: 35378},
+							pos:        position{line: 1426, col: 5, offset: 35389},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1427, col: 5, offset: 35417},
+						pos: position{line: 1427, col: 5, offset: 35428},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1427, col: 5, offset: 35417},
+							pos: position{line: 1427, col: 5, offset: 35428},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1427, col: 5, offset: 35417},
+									pos:        position{line: 1427, col: 5, offset: 35428},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1427, col: 10, offset: 35422},
+									pos:   position{line: 1427, col: 10, offset: 35433},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1427, col: 13, offset: 35425},
+										pos:  position{line: 1427, col: 13, offset: 35436},
 										name: "IDGuard",
 									},
 								},
@@ -9950,10 +9958,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1429, col: 5, offset: 35516},
+						pos: position{line: 1429, col: 5, offset: 35527},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1429, col: 5, offset: 35516},
+							pos:        position{line: 1429, col: 5, offset: 35527},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
@@ -9966,22 +9974,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1431, col: 1, offset: 35555},
+			pos:  position{line: 1431, col: 1, offset: 35566},
 			expr: &choiceExpr{
-				pos: position{line: 1432, col: 5, offset: 35575},
+				pos: position{line: 1432, col: 5, offset: 35586},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1432, col: 5, offset: 35575},
+						pos:  position{line: 1432, col: 5, offset: 35586},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1433, col: 5, offset: 35593},
+						pos:        position{line: 1433, col: 5, offset: 35604},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1434, col: 5, offset: 35601},
+						pos:        position{line: 1434, col: 5, offset: 35612},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -9993,24 +10001,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1436, col: 1, offset: 35606},
+			pos:  position{line: 1436, col: 1, offset: 35617},
 			expr: &choiceExpr{
-				pos: position{line: 1437, col: 5, offset: 35625},
+				pos: position{line: 1437, col: 5, offset: 35636},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1437, col: 5, offset: 35625},
+						pos:  position{line: 1437, col: 5, offset: 35636},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1438, col: 5, offset: 35645},
+						pos:  position{line: 1438, col: 5, offset: 35656},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1439, col: 5, offset: 35670},
+						pos:  position{line: 1439, col: 5, offset: 35681},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1440, col: 5, offset: 35687},
+						pos:  position{line: 1440, col: 5, offset: 35698},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10020,24 +10028,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1442, col: 1, offset: 35716},
+			pos:  position{line: 1442, col: 1, offset: 35727},
 			expr: &choiceExpr{
-				pos: position{line: 1443, col: 5, offset: 35728},
+				pos: position{line: 1443, col: 5, offset: 35739},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1443, col: 5, offset: 35728},
+						pos:  position{line: 1443, col: 5, offset: 35739},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1444, col: 5, offset: 35747},
+						pos:  position{line: 1444, col: 5, offset: 35758},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1445, col: 5, offset: 35763},
+						pos:  position{line: 1445, col: 5, offset: 35774},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1446, col: 5, offset: 35771},
+						pos:  position{line: 1446, col: 5, offset: 35782},
 						name: "Infinity",
 					},
 				},
@@ -10047,25 +10055,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1448, col: 1, offset: 35781},
+			pos:  position{line: 1448, col: 1, offset: 35792},
 			expr: &actionExpr{
-				pos: position{line: 1449, col: 5, offset: 35790},
+				pos: position{line: 1449, col: 5, offset: 35801},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1449, col: 5, offset: 35790},
+					pos: position{line: 1449, col: 5, offset: 35801},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1449, col: 5, offset: 35790},
+							pos:  position{line: 1449, col: 5, offset: 35801},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 14, offset: 35799},
+							pos:        position{line: 1449, col: 14, offset: 35810},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1449, col: 18, offset: 35803},
+							pos:  position{line: 1449, col: 18, offset: 35814},
 							name: "FullTime",
 						},
 					},
@@ -10076,32 +10084,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1453, col: 1, offset: 35879},
+			pos:  position{line: 1453, col: 1, offset: 35890},
 			expr: &seqExpr{
-				pos: position{line: 1453, col: 12, offset: 35890},
+				pos: position{line: 1453, col: 12, offset: 35901},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1453, col: 12, offset: 35890},
+						pos:  position{line: 1453, col: 12, offset: 35901},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1453, col: 15, offset: 35893},
+						pos:        position{line: 1453, col: 15, offset: 35904},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1453, col: 19, offset: 35897},
+						pos:  position{line: 1453, col: 19, offset: 35908},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1453, col: 22, offset: 35900},
+						pos:        position{line: 1453, col: 22, offset: 35911},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1453, col: 26, offset: 35904},
+						pos:  position{line: 1453, col: 26, offset: 35915},
 						name: "D2",
 					},
 				},
@@ -10111,33 +10119,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1455, col: 1, offset: 35908},
+			pos:  position{line: 1455, col: 1, offset: 35919},
 			expr: &seqExpr{
-				pos: position{line: 1455, col: 6, offset: 35913},
+				pos: position{line: 1455, col: 6, offset: 35924},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1455, col: 6, offset: 35913},
+						pos:        position{line: 1455, col: 6, offset: 35924},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1455, col: 11, offset: 35918},
+						pos:        position{line: 1455, col: 11, offset: 35929},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1455, col: 16, offset: 35923},
+						pos:        position{line: 1455, col: 16, offset: 35934},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1455, col: 21, offset: 35928},
+						pos:        position{line: 1455, col: 21, offset: 35939},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10150,19 +10158,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1456, col: 1, offset: 35934},
+			pos:  position{line: 1456, col: 1, offset: 35945},
 			expr: &seqExpr{
-				pos: position{line: 1456, col: 6, offset: 35939},
+				pos: position{line: 1456, col: 6, offset: 35950},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1456, col: 6, offset: 35939},
+						pos:        position{line: 1456, col: 6, offset: 35950},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1456, col: 11, offset: 35944},
+						pos:        position{line: 1456, col: 11, offset: 35955},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10175,16 +10183,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1458, col: 1, offset: 35951},
+			pos:  position{line: 1458, col: 1, offset: 35962},
 			expr: &seqExpr{
-				pos: position{line: 1458, col: 12, offset: 35962},
+				pos: position{line: 1458, col: 12, offset: 35973},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1458, col: 12, offset: 35962},
+						pos:  position{line: 1458, col: 12, offset: 35973},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1458, col: 24, offset: 35974},
+						pos:  position{line: 1458, col: 24, offset: 35985},
 						name: "TimeOffset",
 					},
 				},
@@ -10194,49 +10202,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1460, col: 1, offset: 35986},
+			pos:  position{line: 1460, col: 1, offset: 35997},
 			expr: &seqExpr{
-				pos: position{line: 1460, col: 15, offset: 36000},
+				pos: position{line: 1460, col: 15, offset: 36011},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1460, col: 15, offset: 36000},
+						pos:  position{line: 1460, col: 15, offset: 36011},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1460, col: 18, offset: 36003},
+						pos:        position{line: 1460, col: 18, offset: 36014},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1460, col: 22, offset: 36007},
+						pos:  position{line: 1460, col: 22, offset: 36018},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1460, col: 25, offset: 36010},
+						pos:        position{line: 1460, col: 25, offset: 36021},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1460, col: 29, offset: 36014},
+						pos:  position{line: 1460, col: 29, offset: 36025},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1460, col: 32, offset: 36017},
+						pos: position{line: 1460, col: 32, offset: 36028},
 						expr: &seqExpr{
-							pos: position{line: 1460, col: 33, offset: 36018},
+							pos: position{line: 1460, col: 33, offset: 36029},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1460, col: 33, offset: 36018},
+									pos:        position{line: 1460, col: 33, offset: 36029},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1460, col: 37, offset: 36022},
+									pos: position{line: 1460, col: 37, offset: 36033},
 									expr: &charClassMatcher{
-										pos:        position{line: 1460, col: 37, offset: 36022},
+										pos:        position{line: 1460, col: 37, offset: 36033},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10253,30 +10261,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1462, col: 1, offset: 36032},
+			pos:  position{line: 1462, col: 1, offset: 36043},
 			expr: &choiceExpr{
-				pos: position{line: 1463, col: 5, offset: 36047},
+				pos: position{line: 1463, col: 5, offset: 36058},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1463, col: 5, offset: 36047},
+						pos:        position{line: 1463, col: 5, offset: 36058},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1464, col: 5, offset: 36055},
+						pos: position{line: 1464, col: 5, offset: 36066},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1464, col: 6, offset: 36056},
+								pos: position{line: 1464, col: 6, offset: 36067},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1464, col: 6, offset: 36056},
+										pos:        position{line: 1464, col: 6, offset: 36067},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1464, col: 12, offset: 36062},
+										pos:        position{line: 1464, col: 12, offset: 36073},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10284,34 +10292,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1464, col: 17, offset: 36067},
+								pos:  position{line: 1464, col: 17, offset: 36078},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1464, col: 20, offset: 36070},
+								pos:        position{line: 1464, col: 20, offset: 36081},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1464, col: 24, offset: 36074},
+								pos:  position{line: 1464, col: 24, offset: 36085},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1464, col: 27, offset: 36077},
+								pos: position{line: 1464, col: 27, offset: 36088},
 								expr: &seqExpr{
-									pos: position{line: 1464, col: 28, offset: 36078},
+									pos: position{line: 1464, col: 28, offset: 36089},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1464, col: 28, offset: 36078},
+											pos:        position{line: 1464, col: 28, offset: 36089},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1464, col: 32, offset: 36082},
+											pos: position{line: 1464, col: 32, offset: 36093},
 											expr: &charClassMatcher{
-												pos:        position{line: 1464, col: 32, offset: 36082},
+												pos:        position{line: 1464, col: 32, offset: 36093},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10330,33 +10338,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1466, col: 1, offset: 36092},
+			pos:  position{line: 1466, col: 1, offset: 36103},
 			expr: &actionExpr{
-				pos: position{line: 1467, col: 5, offset: 36105},
+				pos: position{line: 1467, col: 5, offset: 36116},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1467, col: 5, offset: 36105},
+					pos: position{line: 1467, col: 5, offset: 36116},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1467, col: 5, offset: 36105},
+							pos: position{line: 1467, col: 5, offset: 36116},
 							expr: &litMatcher{
-								pos:        position{line: 1467, col: 5, offset: 36105},
+								pos:        position{line: 1467, col: 5, offset: 36116},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1467, col: 10, offset: 36110},
+							pos: position{line: 1467, col: 10, offset: 36121},
 							expr: &seqExpr{
-								pos: position{line: 1467, col: 11, offset: 36111},
+								pos: position{line: 1467, col: 11, offset: 36122},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1467, col: 11, offset: 36111},
+										pos:  position{line: 1467, col: 11, offset: 36122},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1467, col: 19, offset: 36119},
+										pos:  position{line: 1467, col: 19, offset: 36130},
 										name: "TimeUnit",
 									},
 								},
@@ -10370,27 +10378,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1471, col: 1, offset: 36201},
+			pos:  position{line: 1471, col: 1, offset: 36212},
 			expr: &seqExpr{
-				pos: position{line: 1471, col: 11, offset: 36211},
+				pos: position{line: 1471, col: 11, offset: 36222},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1471, col: 11, offset: 36211},
+						pos:  position{line: 1471, col: 11, offset: 36222},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1471, col: 16, offset: 36216},
+						pos: position{line: 1471, col: 16, offset: 36227},
 						expr: &seqExpr{
-							pos: position{line: 1471, col: 17, offset: 36217},
+							pos: position{line: 1471, col: 17, offset: 36228},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1471, col: 17, offset: 36217},
+									pos:        position{line: 1471, col: 17, offset: 36228},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1471, col: 21, offset: 36221},
+									pos:  position{line: 1471, col: 21, offset: 36232},
 									name: "UInt",
 								},
 							},
@@ -10403,60 +10411,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1473, col: 1, offset: 36229},
+			pos:  position{line: 1473, col: 1, offset: 36240},
 			expr: &choiceExpr{
-				pos: position{line: 1474, col: 5, offset: 36242},
+				pos: position{line: 1474, col: 5, offset: 36253},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1474, col: 5, offset: 36242},
+						pos:        position{line: 1474, col: 5, offset: 36253},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1475, col: 5, offset: 36251},
+						pos:        position{line: 1475, col: 5, offset: 36262},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1476, col: 5, offset: 36260},
+						pos:        position{line: 1476, col: 5, offset: 36271},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1477, col: 5, offset: 36269},
+						pos:        position{line: 1477, col: 5, offset: 36280},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1478, col: 5, offset: 36277},
+						pos:        position{line: 1478, col: 5, offset: 36288},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1479, col: 5, offset: 36285},
+						pos:        position{line: 1479, col: 5, offset: 36296},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1480, col: 5, offset: 36293},
+						pos:        position{line: 1480, col: 5, offset: 36304},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1481, col: 5, offset: 36301},
+						pos:        position{line: 1481, col: 5, offset: 36312},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1482, col: 5, offset: 36309},
+						pos:        position{line: 1482, col: 5, offset: 36320},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10468,45 +10476,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1484, col: 1, offset: 36314},
+			pos:  position{line: 1484, col: 1, offset: 36325},
 			expr: &actionExpr{
-				pos: position{line: 1485, col: 5, offset: 36321},
+				pos: position{line: 1485, col: 5, offset: 36332},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1485, col: 5, offset: 36321},
+					pos: position{line: 1485, col: 5, offset: 36332},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1485, col: 5, offset: 36321},
+							pos:  position{line: 1485, col: 5, offset: 36332},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1485, col: 10, offset: 36326},
+							pos:        position{line: 1485, col: 10, offset: 36337},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1485, col: 14, offset: 36330},
+							pos:  position{line: 1485, col: 14, offset: 36341},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1485, col: 19, offset: 36335},
+							pos:        position{line: 1485, col: 19, offset: 36346},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1485, col: 23, offset: 36339},
+							pos:  position{line: 1485, col: 23, offset: 36350},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1485, col: 28, offset: 36344},
+							pos:        position{line: 1485, col: 28, offset: 36355},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1485, col: 32, offset: 36348},
+							pos:  position{line: 1485, col: 32, offset: 36359},
 							name: "UInt",
 						},
 					},
@@ -10517,43 +10525,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1487, col: 1, offset: 36385},
+			pos:  position{line: 1487, col: 1, offset: 36396},
 			expr: &actionExpr{
-				pos: position{line: 1488, col: 5, offset: 36393},
+				pos: position{line: 1488, col: 5, offset: 36404},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1488, col: 5, offset: 36393},
+					pos: position{line: 1488, col: 5, offset: 36404},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1488, col: 5, offset: 36393},
+							pos: position{line: 1488, col: 5, offset: 36404},
 							expr: &seqExpr{
-								pos: position{line: 1488, col: 7, offset: 36395},
+								pos: position{line: 1488, col: 7, offset: 36406},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1488, col: 7, offset: 36395},
+										pos:  position{line: 1488, col: 7, offset: 36406},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1488, col: 11, offset: 36399},
+										pos:        position{line: 1488, col: 11, offset: 36410},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1488, col: 15, offset: 36403},
+										pos:  position{line: 1488, col: 15, offset: 36414},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1488, col: 19, offset: 36407},
+										pos: position{line: 1488, col: 19, offset: 36418},
 										expr: &choiceExpr{
-											pos: position{line: 1488, col: 21, offset: 36409},
+											pos: position{line: 1488, col: 21, offset: 36420},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1488, col: 21, offset: 36409},
+													pos:  position{line: 1488, col: 21, offset: 36420},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1488, col: 32, offset: 36420},
+													pos:        position{line: 1488, col: 32, offset: 36431},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10565,10 +10573,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1488, col: 38, offset: 36426},
+							pos:   position{line: 1488, col: 38, offset: 36437},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1488, col: 40, offset: 36428},
+								pos:  position{line: 1488, col: 40, offset: 36439},
 								name: "IP6Variations",
 							},
 						},
@@ -10580,32 +10588,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1492, col: 1, offset: 36592},
+			pos:  position{line: 1492, col: 1, offset: 36603},
 			expr: &choiceExpr{
-				pos: position{line: 1493, col: 5, offset: 36610},
+				pos: position{line: 1493, col: 5, offset: 36621},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1493, col: 5, offset: 36610},
+						pos: position{line: 1493, col: 5, offset: 36621},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1493, col: 5, offset: 36610},
+							pos: position{line: 1493, col: 5, offset: 36621},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1493, col: 5, offset: 36610},
+									pos:   position{line: 1493, col: 5, offset: 36621},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1493, col: 7, offset: 36612},
+										pos: position{line: 1493, col: 7, offset: 36623},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1493, col: 7, offset: 36612},
+											pos:  position{line: 1493, col: 7, offset: 36623},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1493, col: 17, offset: 36622},
+									pos:   position{line: 1493, col: 17, offset: 36633},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1493, col: 19, offset: 36624},
+										pos:  position{line: 1493, col: 19, offset: 36635},
 										name: "IP6Tail",
 									},
 								},
@@ -10613,52 +10621,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1496, col: 5, offset: 36688},
+						pos: position{line: 1496, col: 5, offset: 36699},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1496, col: 5, offset: 36688},
+							pos: position{line: 1496, col: 5, offset: 36699},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1496, col: 5, offset: 36688},
+									pos:   position{line: 1496, col: 5, offset: 36699},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1496, col: 7, offset: 36690},
+										pos:  position{line: 1496, col: 7, offset: 36701},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1496, col: 11, offset: 36694},
+									pos:   position{line: 1496, col: 11, offset: 36705},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1496, col: 13, offset: 36696},
+										pos: position{line: 1496, col: 13, offset: 36707},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1496, col: 13, offset: 36696},
+											pos:  position{line: 1496, col: 13, offset: 36707},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1496, col: 23, offset: 36706},
+									pos:        position{line: 1496, col: 23, offset: 36717},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1496, col: 28, offset: 36711},
+									pos:   position{line: 1496, col: 28, offset: 36722},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1496, col: 30, offset: 36713},
+										pos: position{line: 1496, col: 30, offset: 36724},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1496, col: 30, offset: 36713},
+											pos:  position{line: 1496, col: 30, offset: 36724},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1496, col: 40, offset: 36723},
+									pos:   position{line: 1496, col: 40, offset: 36734},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1496, col: 42, offset: 36725},
+										pos:  position{line: 1496, col: 42, offset: 36736},
 										name: "IP6Tail",
 									},
 								},
@@ -10666,33 +10674,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1499, col: 5, offset: 36824},
+						pos: position{line: 1499, col: 5, offset: 36835},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1499, col: 5, offset: 36824},
+							pos: position{line: 1499, col: 5, offset: 36835},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1499, col: 5, offset: 36824},
+									pos:        position{line: 1499, col: 5, offset: 36835},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1499, col: 10, offset: 36829},
+									pos:   position{line: 1499, col: 10, offset: 36840},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1499, col: 12, offset: 36831},
+										pos: position{line: 1499, col: 12, offset: 36842},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1499, col: 12, offset: 36831},
+											pos:  position{line: 1499, col: 12, offset: 36842},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1499, col: 22, offset: 36841},
+									pos:   position{line: 1499, col: 22, offset: 36852},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1499, col: 24, offset: 36843},
+										pos:  position{line: 1499, col: 24, offset: 36854},
 										name: "IP6Tail",
 									},
 								},
@@ -10700,32 +10708,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1502, col: 5, offset: 36914},
+						pos: position{line: 1502, col: 5, offset: 36925},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1502, col: 5, offset: 36914},
+							pos: position{line: 1502, col: 5, offset: 36925},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1502, col: 5, offset: 36914},
+									pos:   position{line: 1502, col: 5, offset: 36925},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1502, col: 7, offset: 36916},
+										pos:  position{line: 1502, col: 7, offset: 36927},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1502, col: 11, offset: 36920},
+									pos:   position{line: 1502, col: 11, offset: 36931},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1502, col: 13, offset: 36922},
+										pos: position{line: 1502, col: 13, offset: 36933},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1502, col: 13, offset: 36922},
+											pos:  position{line: 1502, col: 13, offset: 36933},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1502, col: 23, offset: 36932},
+									pos:        position{line: 1502, col: 23, offset: 36943},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -10734,10 +10742,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1505, col: 5, offset: 37000},
+						pos: position{line: 1505, col: 5, offset: 37011},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1505, col: 5, offset: 37000},
+							pos:        position{line: 1505, col: 5, offset: 37011},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10750,16 +10758,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1509, col: 1, offset: 37037},
+			pos:  position{line: 1509, col: 1, offset: 37048},
 			expr: &choiceExpr{
-				pos: position{line: 1510, col: 5, offset: 37049},
+				pos: position{line: 1510, col: 5, offset: 37060},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1510, col: 5, offset: 37049},
+						pos:  position{line: 1510, col: 5, offset: 37060},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1511, col: 5, offset: 37056},
+						pos:  position{line: 1511, col: 5, offset: 37067},
 						name: "Hex",
 					},
 				},
@@ -10769,24 +10777,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1513, col: 1, offset: 37061},
+			pos:  position{line: 1513, col: 1, offset: 37072},
 			expr: &actionExpr{
-				pos: position{line: 1513, col: 12, offset: 37072},
+				pos: position{line: 1513, col: 12, offset: 37083},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1513, col: 12, offset: 37072},
+					pos: position{line: 1513, col: 12, offset: 37083},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1513, col: 12, offset: 37072},
+							pos:        position{line: 1513, col: 12, offset: 37083},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1513, col: 16, offset: 37076},
+							pos:   position{line: 1513, col: 16, offset: 37087},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 18, offset: 37078},
+								pos:  position{line: 1513, col: 18, offset: 37089},
 								name: "Hex",
 							},
 						},
@@ -10798,23 +10806,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1515, col: 1, offset: 37116},
+			pos:  position{line: 1515, col: 1, offset: 37127},
 			expr: &actionExpr{
-				pos: position{line: 1515, col: 12, offset: 37127},
+				pos: position{line: 1515, col: 12, offset: 37138},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1515, col: 12, offset: 37127},
+					pos: position{line: 1515, col: 12, offset: 37138},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1515, col: 12, offset: 37127},
+							pos:   position{line: 1515, col: 12, offset: 37138},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1515, col: 14, offset: 37129},
+								pos:  position{line: 1515, col: 14, offset: 37140},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1515, col: 18, offset: 37133},
+							pos:        position{line: 1515, col: 18, offset: 37144},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10827,32 +10835,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1517, col: 1, offset: 37171},
+			pos:  position{line: 1517, col: 1, offset: 37182},
 			expr: &actionExpr{
-				pos: position{line: 1518, col: 5, offset: 37182},
+				pos: position{line: 1518, col: 5, offset: 37193},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1518, col: 5, offset: 37182},
+					pos: position{line: 1518, col: 5, offset: 37193},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1518, col: 5, offset: 37182},
+							pos:   position{line: 1518, col: 5, offset: 37193},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1518, col: 7, offset: 37184},
+								pos:  position{line: 1518, col: 7, offset: 37195},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1518, col: 10, offset: 37187},
+							pos:        position{line: 1518, col: 10, offset: 37198},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1518, col: 14, offset: 37191},
+							pos:   position{line: 1518, col: 14, offset: 37202},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1518, col: 16, offset: 37193},
+								pos:  position{line: 1518, col: 16, offset: 37204},
 								name: "UIntString",
 							},
 						},
@@ -10864,32 +10872,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1522, col: 1, offset: 37261},
+			pos:  position{line: 1522, col: 1, offset: 37272},
 			expr: &actionExpr{
-				pos: position{line: 1523, col: 5, offset: 37272},
+				pos: position{line: 1523, col: 5, offset: 37283},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1523, col: 5, offset: 37272},
+					pos: position{line: 1523, col: 5, offset: 37283},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1523, col: 5, offset: 37272},
+							pos:   position{line: 1523, col: 5, offset: 37283},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1523, col: 7, offset: 37274},
+								pos:  position{line: 1523, col: 7, offset: 37285},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1523, col: 11, offset: 37278},
+							pos:        position{line: 1523, col: 11, offset: 37289},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1523, col: 15, offset: 37282},
+							pos:   position{line: 1523, col: 15, offset: 37293},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1523, col: 17, offset: 37284},
+								pos:  position{line: 1523, col: 17, offset: 37295},
 								name: "UIntString",
 							},
 						},
@@ -10901,15 +10909,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1527, col: 1, offset: 37352},
+			pos:  position{line: 1527, col: 1, offset: 37363},
 			expr: &actionExpr{
-				pos: position{line: 1528, col: 4, offset: 37360},
+				pos: position{line: 1528, col: 4, offset: 37371},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1528, col: 4, offset: 37360},
+					pos:   position{line: 1528, col: 4, offset: 37371},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1528, col: 6, offset: 37362},
+						pos:  position{line: 1528, col: 6, offset: 37373},
 						name: "UIntString",
 					},
 				},
@@ -10919,16 +10927,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1530, col: 1, offset: 37402},
+			pos:  position{line: 1530, col: 1, offset: 37413},
 			expr: &choiceExpr{
-				pos: position{line: 1531, col: 5, offset: 37416},
+				pos: position{line: 1531, col: 5, offset: 37427},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1531, col: 5, offset: 37416},
+						pos:  position{line: 1531, col: 5, offset: 37427},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1532, col: 5, offset: 37431},
+						pos:  position{line: 1532, col: 5, offset: 37442},
 						name: "MinusIntString",
 					},
 				},
@@ -10938,14 +10946,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1534, col: 1, offset: 37447},
+			pos:  position{line: 1534, col: 1, offset: 37458},
 			expr: &actionExpr{
-				pos: position{line: 1534, col: 14, offset: 37460},
+				pos: position{line: 1534, col: 14, offset: 37471},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1534, col: 14, offset: 37460},
+					pos: position{line: 1534, col: 14, offset: 37471},
 					expr: &charClassMatcher{
-						pos:        position{line: 1534, col: 14, offset: 37460},
+						pos:        position{line: 1534, col: 14, offset: 37471},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10958,21 +10966,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1536, col: 1, offset: 37499},
+			pos:  position{line: 1536, col: 1, offset: 37510},
 			expr: &actionExpr{
-				pos: position{line: 1537, col: 5, offset: 37518},
+				pos: position{line: 1537, col: 5, offset: 37529},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1537, col: 5, offset: 37518},
+					pos: position{line: 1537, col: 5, offset: 37529},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1537, col: 5, offset: 37518},
+							pos:        position{line: 1537, col: 5, offset: 37529},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1537, col: 9, offset: 37522},
+							pos:  position{line: 1537, col: 9, offset: 37533},
 							name: "UIntString",
 						},
 					},
@@ -10983,29 +10991,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1539, col: 1, offset: 37565},
+			pos:  position{line: 1539, col: 1, offset: 37576},
 			expr: &choiceExpr{
-				pos: position{line: 1540, col: 5, offset: 37581},
+				pos: position{line: 1540, col: 5, offset: 37592},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1540, col: 5, offset: 37581},
+						pos: position{line: 1540, col: 5, offset: 37592},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1540, col: 5, offset: 37581},
+							pos: position{line: 1540, col: 5, offset: 37592},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1540, col: 5, offset: 37581},
+									pos: position{line: 1540, col: 5, offset: 37592},
 									expr: &litMatcher{
-										pos:        position{line: 1540, col: 5, offset: 37581},
+										pos:        position{line: 1540, col: 5, offset: 37592},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1540, col: 10, offset: 37586},
+									pos: position{line: 1540, col: 10, offset: 37597},
 									expr: &charClassMatcher{
-										pos:        position{line: 1540, col: 10, offset: 37586},
+										pos:        position{line: 1540, col: 10, offset: 37597},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11013,15 +11021,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1540, col: 17, offset: 37593},
+									pos:        position{line: 1540, col: 17, offset: 37604},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1540, col: 21, offset: 37597},
+									pos: position{line: 1540, col: 21, offset: 37608},
 									expr: &charClassMatcher{
-										pos:        position{line: 1540, col: 21, offset: 37597},
+										pos:        position{line: 1540, col: 21, offset: 37608},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11029,9 +11037,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1540, col: 28, offset: 37604},
+									pos: position{line: 1540, col: 28, offset: 37615},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1540, col: 28, offset: 37604},
+										pos:  position{line: 1540, col: 28, offset: 37615},
 										name: "ExponentPart",
 									},
 								},
@@ -11039,30 +11047,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1541, col: 5, offset: 37653},
+						pos: position{line: 1541, col: 5, offset: 37664},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1541, col: 5, offset: 37653},
+							pos: position{line: 1541, col: 5, offset: 37664},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1541, col: 5, offset: 37653},
+									pos: position{line: 1541, col: 5, offset: 37664},
 									expr: &litMatcher{
-										pos:        position{line: 1541, col: 5, offset: 37653},
+										pos:        position{line: 1541, col: 5, offset: 37664},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1541, col: 10, offset: 37658},
+									pos:        position{line: 1541, col: 10, offset: 37669},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1541, col: 14, offset: 37662},
+									pos: position{line: 1541, col: 14, offset: 37673},
 									expr: &charClassMatcher{
-										pos:        position{line: 1541, col: 14, offset: 37662},
+										pos:        position{line: 1541, col: 14, offset: 37673},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11070,9 +11078,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1541, col: 21, offset: 37669},
+									pos: position{line: 1541, col: 21, offset: 37680},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1541, col: 21, offset: 37669},
+										pos:  position{line: 1541, col: 21, offset: 37680},
 										name: "ExponentPart",
 									},
 								},
@@ -11080,17 +11088,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1542, col: 5, offset: 37718},
+						pos: position{line: 1542, col: 5, offset: 37729},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1542, col: 6, offset: 37719},
+							pos: position{line: 1542, col: 6, offset: 37730},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1542, col: 6, offset: 37719},
+									pos:  position{line: 1542, col: 6, offset: 37730},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1542, col: 12, offset: 37725},
+									pos:  position{line: 1542, col: 12, offset: 37736},
 									name: "Infinity",
 								},
 							},
@@ -11103,20 +11111,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1545, col: 1, offset: 37768},
+			pos:  position{line: 1545, col: 1, offset: 37779},
 			expr: &seqExpr{
-				pos: position{line: 1545, col: 16, offset: 37783},
+				pos: position{line: 1545, col: 16, offset: 37794},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1545, col: 16, offset: 37783},
+						pos:        position{line: 1545, col: 16, offset: 37794},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1545, col: 21, offset: 37788},
+						pos: position{line: 1545, col: 21, offset: 37799},
 						expr: &charClassMatcher{
-							pos:        position{line: 1545, col: 21, offset: 37788},
+							pos:        position{line: 1545, col: 21, offset: 37799},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11124,7 +11132,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1545, col: 27, offset: 37794},
+						pos:  position{line: 1545, col: 27, offset: 37805},
 						name: "UIntString",
 					},
 				},
@@ -11134,9 +11142,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1547, col: 1, offset: 37806},
+			pos:  position{line: 1547, col: 1, offset: 37817},
 			expr: &litMatcher{
-				pos:        position{line: 1547, col: 7, offset: 37812},
+				pos:        position{line: 1547, col: 7, offset: 37823},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11146,23 +11154,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1549, col: 1, offset: 37819},
+			pos:  position{line: 1549, col: 1, offset: 37830},
 			expr: &seqExpr{
-				pos: position{line: 1549, col: 12, offset: 37830},
+				pos: position{line: 1549, col: 12, offset: 37841},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1549, col: 12, offset: 37830},
+						pos: position{line: 1549, col: 12, offset: 37841},
 						expr: &choiceExpr{
-							pos: position{line: 1549, col: 13, offset: 37831},
+							pos: position{line: 1549, col: 13, offset: 37842},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1549, col: 13, offset: 37831},
+									pos:        position{line: 1549, col: 13, offset: 37842},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1549, col: 19, offset: 37837},
+									pos:        position{line: 1549, col: 19, offset: 37848},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11171,7 +11179,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1549, col: 25, offset: 37843},
+						pos:        position{line: 1549, col: 25, offset: 37854},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11183,14 +11191,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1551, col: 1, offset: 37850},
+			pos:  position{line: 1551, col: 1, offset: 37861},
 			expr: &actionExpr{
-				pos: position{line: 1551, col: 7, offset: 37856},
+				pos: position{line: 1551, col: 7, offset: 37867},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1551, col: 7, offset: 37856},
+					pos: position{line: 1551, col: 7, offset: 37867},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1551, col: 7, offset: 37856},
+						pos:  position{line: 1551, col: 7, offset: 37867},
 						name: "HexDigit",
 					},
 				},
@@ -11200,9 +11208,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1553, col: 1, offset: 37898},
+			pos:  position{line: 1553, col: 1, offset: 37909},
 			expr: &charClassMatcher{
-				pos:        position{line: 1553, col: 12, offset: 37909},
+				pos:        position{line: 1553, col: 12, offset: 37920},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11213,35 +11221,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1555, col: 1, offset: 37922},
+			pos:  position{line: 1555, col: 1, offset: 37933},
 			expr: &choiceExpr{
-				pos: position{line: 1556, col: 5, offset: 37939},
+				pos: position{line: 1556, col: 5, offset: 37950},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1556, col: 5, offset: 37939},
+						pos: position{line: 1556, col: 5, offset: 37950},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1556, col: 5, offset: 37939},
+							pos: position{line: 1556, col: 5, offset: 37950},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1556, col: 5, offset: 37939},
+									pos:        position{line: 1556, col: 5, offset: 37950},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1556, col: 9, offset: 37943},
+									pos:   position{line: 1556, col: 9, offset: 37954},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1556, col: 11, offset: 37945},
+										pos: position{line: 1556, col: 11, offset: 37956},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1556, col: 11, offset: 37945},
+											pos:  position{line: 1556, col: 11, offset: 37956},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1556, col: 29, offset: 37963},
+									pos:        position{line: 1556, col: 29, offset: 37974},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11250,30 +11258,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1557, col: 5, offset: 38000},
+						pos: position{line: 1557, col: 5, offset: 38011},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1557, col: 5, offset: 38000},
+							pos: position{line: 1557, col: 5, offset: 38011},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1557, col: 5, offset: 38000},
+									pos:        position{line: 1557, col: 5, offset: 38011},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1557, col: 9, offset: 38004},
+									pos:   position{line: 1557, col: 9, offset: 38015},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1557, col: 11, offset: 38006},
+										pos: position{line: 1557, col: 11, offset: 38017},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1557, col: 11, offset: 38006},
+											pos:  position{line: 1557, col: 11, offset: 38017},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1557, col: 29, offset: 38024},
+									pos:        position{line: 1557, col: 29, offset: 38035},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11288,57 +11296,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1559, col: 1, offset: 38058},
+			pos:  position{line: 1559, col: 1, offset: 38069},
 			expr: &choiceExpr{
-				pos: position{line: 1560, col: 5, offset: 38079},
+				pos: position{line: 1560, col: 5, offset: 38090},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1560, col: 5, offset: 38079},
+						pos: position{line: 1560, col: 5, offset: 38090},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1560, col: 5, offset: 38079},
+							pos: position{line: 1560, col: 5, offset: 38090},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1560, col: 5, offset: 38079},
+									pos: position{line: 1560, col: 5, offset: 38090},
 									expr: &choiceExpr{
-										pos: position{line: 1560, col: 7, offset: 38081},
+										pos: position{line: 1560, col: 7, offset: 38092},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1560, col: 7, offset: 38081},
+												pos:        position{line: 1560, col: 7, offset: 38092},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1560, col: 13, offset: 38087},
+												pos:  position{line: 1560, col: 13, offset: 38098},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1560, col: 26, offset: 38100,
+									line: 1560, col: 26, offset: 38111,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1561, col: 5, offset: 38137},
+						pos: position{line: 1561, col: 5, offset: 38148},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1561, col: 5, offset: 38137},
+							pos: position{line: 1561, col: 5, offset: 38148},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1561, col: 5, offset: 38137},
+									pos:        position{line: 1561, col: 5, offset: 38148},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1561, col: 10, offset: 38142},
+									pos:   position{line: 1561, col: 10, offset: 38153},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1561, col: 12, offset: 38144},
+										pos:  position{line: 1561, col: 12, offset: 38155},
 										name: "EscapeSequence",
 									},
 								},
@@ -11352,28 +11360,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1563, col: 1, offset: 38178},
+			pos:  position{line: 1563, col: 1, offset: 38189},
 			expr: &actionExpr{
-				pos: position{line: 1564, col: 5, offset: 38190},
+				pos: position{line: 1564, col: 5, offset: 38201},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1564, col: 5, offset: 38190},
+					pos: position{line: 1564, col: 5, offset: 38201},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1564, col: 5, offset: 38190},
+							pos:   position{line: 1564, col: 5, offset: 38201},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1564, col: 10, offset: 38195},
+								pos:  position{line: 1564, col: 10, offset: 38206},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1564, col: 23, offset: 38208},
+							pos:   position{line: 1564, col: 23, offset: 38219},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1564, col: 28, offset: 38213},
+								pos: position{line: 1564, col: 28, offset: 38224},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1564, col: 28, offset: 38213},
+									pos:  position{line: 1564, col: 28, offset: 38224},
 									name: "KeyWordRest",
 								},
 							},
@@ -11386,16 +11394,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1566, col: 1, offset: 38275},
+			pos:  position{line: 1566, col: 1, offset: 38286},
 			expr: &choiceExpr{
-				pos: position{line: 1567, col: 5, offset: 38292},
+				pos: position{line: 1567, col: 5, offset: 38303},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1567, col: 5, offset: 38292},
+						pos:  position{line: 1567, col: 5, offset: 38303},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1568, col: 5, offset: 38309},
+						pos:  position{line: 1568, col: 5, offset: 38320},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11405,16 +11413,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1570, col: 1, offset: 38321},
+			pos:  position{line: 1570, col: 1, offset: 38332},
 			expr: &choiceExpr{
-				pos: position{line: 1571, col: 5, offset: 38337},
+				pos: position{line: 1571, col: 5, offset: 38348},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1571, col: 5, offset: 38337},
+						pos:  position{line: 1571, col: 5, offset: 38348},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1572, col: 5, offset: 38354},
+						pos:        position{line: 1572, col: 5, offset: 38365},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11427,19 +11435,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1574, col: 1, offset: 38361},
+			pos:  position{line: 1574, col: 1, offset: 38372},
 			expr: &actionExpr{
-				pos: position{line: 1574, col: 16, offset: 38376},
+				pos: position{line: 1574, col: 16, offset: 38387},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1574, col: 17, offset: 38377},
+					pos: position{line: 1574, col: 17, offset: 38388},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1574, col: 17, offset: 38377},
+							pos:  position{line: 1574, col: 17, offset: 38388},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1574, col: 33, offset: 38393},
+							pos:        position{line: 1574, col: 33, offset: 38404},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11453,31 +11461,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1576, col: 1, offset: 38437},
+			pos:  position{line: 1576, col: 1, offset: 38448},
 			expr: &actionExpr{
-				pos: position{line: 1576, col: 14, offset: 38450},
+				pos: position{line: 1576, col: 14, offset: 38461},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1576, col: 14, offset: 38450},
+					pos: position{line: 1576, col: 14, offset: 38461},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1576, col: 14, offset: 38450},
+							pos:        position{line: 1576, col: 14, offset: 38461},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1576, col: 19, offset: 38455},
+							pos:   position{line: 1576, col: 19, offset: 38466},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1576, col: 22, offset: 38458},
+								pos: position{line: 1576, col: 22, offset: 38469},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1576, col: 22, offset: 38458},
+										pos:  position{line: 1576, col: 22, offset: 38469},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1576, col: 38, offset: 38474},
+										pos:  position{line: 1576, col: 38, offset: 38485},
 										name: "EscapeSequence",
 									},
 								},
@@ -11491,42 +11499,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1578, col: 1, offset: 38509},
+			pos:  position{line: 1578, col: 1, offset: 38520},
 			expr: &actionExpr{
-				pos: position{line: 1579, col: 5, offset: 38525},
+				pos: position{line: 1579, col: 5, offset: 38536},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1579, col: 5, offset: 38525},
+					pos: position{line: 1579, col: 5, offset: 38536},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1579, col: 5, offset: 38525},
+							pos: position{line: 1579, col: 5, offset: 38536},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1579, col: 6, offset: 38526},
+								pos:  position{line: 1579, col: 6, offset: 38537},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1579, col: 22, offset: 38542},
+							pos: position{line: 1579, col: 22, offset: 38553},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1579, col: 23, offset: 38543},
+								pos:  position{line: 1579, col: 23, offset: 38554},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1579, col: 35, offset: 38555},
+							pos:   position{line: 1579, col: 35, offset: 38566},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1579, col: 40, offset: 38560},
+								pos:  position{line: 1579, col: 40, offset: 38571},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1579, col: 50, offset: 38570},
+							pos:   position{line: 1579, col: 50, offset: 38581},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1579, col: 55, offset: 38575},
+								pos: position{line: 1579, col: 55, offset: 38586},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1579, col: 55, offset: 38575},
+									pos:  position{line: 1579, col: 55, offset: 38586},
 									name: "GlobRest",
 								},
 							},
@@ -11539,28 +11547,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1583, col: 1, offset: 38644},
+			pos:  position{line: 1583, col: 1, offset: 38655},
 			expr: &choiceExpr{
-				pos: position{line: 1583, col: 19, offset: 38662},
+				pos: position{line: 1583, col: 19, offset: 38673},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 19, offset: 38662},
+						pos:  position{line: 1583, col: 19, offset: 38673},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1583, col: 34, offset: 38677},
+						pos: position{line: 1583, col: 34, offset: 38688},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1583, col: 34, offset: 38677},
+								pos: position{line: 1583, col: 34, offset: 38688},
 								expr: &litMatcher{
-									pos:        position{line: 1583, col: 34, offset: 38677},
+									pos:        position{line: 1583, col: 34, offset: 38688},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1583, col: 39, offset: 38682},
+								pos:  position{line: 1583, col: 39, offset: 38693},
 								name: "KeyWordRest",
 							},
 						},
@@ -11572,19 +11580,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1584, col: 1, offset: 38694},
+			pos:  position{line: 1584, col: 1, offset: 38705},
 			expr: &seqExpr{
-				pos: position{line: 1584, col: 15, offset: 38708},
+				pos: position{line: 1584, col: 15, offset: 38719},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1584, col: 15, offset: 38708},
+						pos: position{line: 1584, col: 15, offset: 38719},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1584, col: 15, offset: 38708},
+							pos:  position{line: 1584, col: 15, offset: 38719},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1584, col: 28, offset: 38721},
+						pos:        position{line: 1584, col: 28, offset: 38732},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11596,23 +11604,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1586, col: 1, offset: 38726},
+			pos:  position{line: 1586, col: 1, offset: 38737},
 			expr: &choiceExpr{
-				pos: position{line: 1587, col: 5, offset: 38740},
+				pos: position{line: 1587, col: 5, offset: 38751},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1587, col: 5, offset: 38740},
+						pos:  position{line: 1587, col: 5, offset: 38751},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1588, col: 5, offset: 38757},
+						pos:  position{line: 1588, col: 5, offset: 38768},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1589, col: 5, offset: 38769},
+						pos: position{line: 1589, col: 5, offset: 38780},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1589, col: 5, offset: 38769},
+							pos:        position{line: 1589, col: 5, offset: 38780},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -11625,16 +11633,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1591, col: 1, offset: 38794},
+			pos:  position{line: 1591, col: 1, offset: 38805},
 			expr: &choiceExpr{
-				pos: position{line: 1592, col: 5, offset: 38807},
+				pos: position{line: 1592, col: 5, offset: 38818},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1592, col: 5, offset: 38807},
+						pos:  position{line: 1592, col: 5, offset: 38818},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1593, col: 5, offset: 38821},
+						pos:        position{line: 1593, col: 5, offset: 38832},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11647,31 +11655,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1595, col: 1, offset: 38828},
+			pos:  position{line: 1595, col: 1, offset: 38839},
 			expr: &actionExpr{
-				pos: position{line: 1595, col: 11, offset: 38838},
+				pos: position{line: 1595, col: 11, offset: 38849},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1595, col: 11, offset: 38838},
+					pos: position{line: 1595, col: 11, offset: 38849},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1595, col: 11, offset: 38838},
+							pos:        position{line: 1595, col: 11, offset: 38849},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1595, col: 16, offset: 38843},
+							pos:   position{line: 1595, col: 16, offset: 38854},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1595, col: 19, offset: 38846},
+								pos: position{line: 1595, col: 19, offset: 38857},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1595, col: 19, offset: 38846},
+										pos:  position{line: 1595, col: 19, offset: 38857},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1595, col: 32, offset: 38859},
+										pos:  position{line: 1595, col: 32, offset: 38870},
 										name: "EscapeSequence",
 									},
 								},
@@ -11685,32 +11693,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1597, col: 1, offset: 38894},
+			pos:  position{line: 1597, col: 1, offset: 38905},
 			expr: &choiceExpr{
-				pos: position{line: 1598, col: 5, offset: 38909},
+				pos: position{line: 1598, col: 5, offset: 38920},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1598, col: 5, offset: 38909},
+						pos: position{line: 1598, col: 5, offset: 38920},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1598, col: 5, offset: 38909},
+							pos:        position{line: 1598, col: 5, offset: 38920},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1599, col: 5, offset: 38937},
+						pos: position{line: 1599, col: 5, offset: 38948},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1599, col: 5, offset: 38937},
+							pos:        position{line: 1599, col: 5, offset: 38948},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 5, offset: 38967},
+						pos:        position{line: 1600, col: 5, offset: 38978},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11723,57 +11731,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1602, col: 1, offset: 38973},
+			pos:  position{line: 1602, col: 1, offset: 38984},
 			expr: &choiceExpr{
-				pos: position{line: 1603, col: 5, offset: 38994},
+				pos: position{line: 1603, col: 5, offset: 39005},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1603, col: 5, offset: 38994},
+						pos: position{line: 1603, col: 5, offset: 39005},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1603, col: 5, offset: 38994},
+							pos: position{line: 1603, col: 5, offset: 39005},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1603, col: 5, offset: 38994},
+									pos: position{line: 1603, col: 5, offset: 39005},
 									expr: &choiceExpr{
-										pos: position{line: 1603, col: 7, offset: 38996},
+										pos: position{line: 1603, col: 7, offset: 39007},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1603, col: 7, offset: 38996},
+												pos:        position{line: 1603, col: 7, offset: 39007},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 13, offset: 39002},
+												pos:  position{line: 1603, col: 13, offset: 39013},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1603, col: 26, offset: 39015,
+									line: 1603, col: 26, offset: 39026,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1604, col: 5, offset: 39052},
+						pos: position{line: 1604, col: 5, offset: 39063},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1604, col: 5, offset: 39052},
+							pos: position{line: 1604, col: 5, offset: 39063},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1604, col: 5, offset: 39052},
+									pos:        position{line: 1604, col: 5, offset: 39063},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1604, col: 10, offset: 39057},
+									pos:   position{line: 1604, col: 10, offset: 39068},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1604, col: 12, offset: 39059},
+										pos:  position{line: 1604, col: 12, offset: 39070},
 										name: "EscapeSequence",
 									},
 								},
@@ -11787,16 +11795,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1606, col: 1, offset: 39093},
+			pos:  position{line: 1606, col: 1, offset: 39104},
 			expr: &choiceExpr{
-				pos: position{line: 1607, col: 5, offset: 39112},
+				pos: position{line: 1607, col: 5, offset: 39123},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1607, col: 5, offset: 39112},
+						pos:  position{line: 1607, col: 5, offset: 39123},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1608, col: 5, offset: 39133},
+						pos:  position{line: 1608, col: 5, offset: 39144},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11806,87 +11814,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1610, col: 1, offset: 39148},
+			pos:  position{line: 1610, col: 1, offset: 39159},
 			expr: &choiceExpr{
-				pos: position{line: 1611, col: 5, offset: 39169},
+				pos: position{line: 1611, col: 5, offset: 39180},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1611, col: 5, offset: 39169},
+						pos:        position{line: 1611, col: 5, offset: 39180},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1612, col: 5, offset: 39177},
+						pos: position{line: 1612, col: 5, offset: 39188},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1612, col: 5, offset: 39177},
+							pos:        position{line: 1612, col: 5, offset: 39188},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1613, col: 5, offset: 39217},
+						pos:        position{line: 1613, col: 5, offset: 39228},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1614, col: 5, offset: 39226},
+						pos: position{line: 1614, col: 5, offset: 39237},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1614, col: 5, offset: 39226},
+							pos:        position{line: 1614, col: 5, offset: 39237},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1615, col: 5, offset: 39255},
+						pos: position{line: 1615, col: 5, offset: 39266},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1615, col: 5, offset: 39255},
+							pos:        position{line: 1615, col: 5, offset: 39266},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1616, col: 5, offset: 39284},
+						pos: position{line: 1616, col: 5, offset: 39295},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1616, col: 5, offset: 39284},
+							pos:        position{line: 1616, col: 5, offset: 39295},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1617, col: 5, offset: 39313},
+						pos: position{line: 1617, col: 5, offset: 39324},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1617, col: 5, offset: 39313},
+							pos:        position{line: 1617, col: 5, offset: 39324},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1618, col: 5, offset: 39342},
+						pos: position{line: 1618, col: 5, offset: 39353},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1618, col: 5, offset: 39342},
+							pos:        position{line: 1618, col: 5, offset: 39353},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1619, col: 5, offset: 39371},
+						pos: position{line: 1619, col: 5, offset: 39382},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1619, col: 5, offset: 39371},
+							pos:        position{line: 1619, col: 5, offset: 39382},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -11899,32 +11907,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1621, col: 1, offset: 39397},
+			pos:  position{line: 1621, col: 1, offset: 39408},
 			expr: &choiceExpr{
-				pos: position{line: 1622, col: 5, offset: 39415},
+				pos: position{line: 1622, col: 5, offset: 39426},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1622, col: 5, offset: 39415},
+						pos: position{line: 1622, col: 5, offset: 39426},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1622, col: 5, offset: 39415},
+							pos:        position{line: 1622, col: 5, offset: 39426},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1623, col: 5, offset: 39443},
+						pos: position{line: 1623, col: 5, offset: 39454},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1623, col: 5, offset: 39443},
+							pos:        position{line: 1623, col: 5, offset: 39454},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1624, col: 5, offset: 39471},
+						pos:        position{line: 1624, col: 5, offset: 39482},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11937,42 +11945,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1626, col: 1, offset: 39477},
+			pos:  position{line: 1626, col: 1, offset: 39488},
 			expr: &choiceExpr{
-				pos: position{line: 1627, col: 5, offset: 39495},
+				pos: position{line: 1627, col: 5, offset: 39506},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1627, col: 5, offset: 39495},
+						pos: position{line: 1627, col: 5, offset: 39506},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1627, col: 5, offset: 39495},
+							pos: position{line: 1627, col: 5, offset: 39506},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1627, col: 5, offset: 39495},
+									pos:        position{line: 1627, col: 5, offset: 39506},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1627, col: 9, offset: 39499},
+									pos:   position{line: 1627, col: 9, offset: 39510},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1627, col: 16, offset: 39506},
+										pos: position{line: 1627, col: 16, offset: 39517},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1627, col: 16, offset: 39506},
+												pos:  position{line: 1627, col: 16, offset: 39517},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1627, col: 25, offset: 39515},
+												pos:  position{line: 1627, col: 25, offset: 39526},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1627, col: 34, offset: 39524},
+												pos:  position{line: 1627, col: 34, offset: 39535},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1627, col: 43, offset: 39533},
+												pos:  position{line: 1627, col: 43, offset: 39544},
 												name: "HexDigit",
 											},
 										},
@@ -11982,65 +11990,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1630, col: 5, offset: 39596},
+						pos: position{line: 1630, col: 5, offset: 39607},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1630, col: 5, offset: 39596},
+							pos: position{line: 1630, col: 5, offset: 39607},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1630, col: 5, offset: 39596},
+									pos:        position{line: 1630, col: 5, offset: 39607},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1630, col: 9, offset: 39600},
+									pos:        position{line: 1630, col: 9, offset: 39611},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 13, offset: 39604},
+									pos:   position{line: 1630, col: 13, offset: 39615},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1630, col: 20, offset: 39611},
+										pos: position{line: 1630, col: 20, offset: 39622},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1630, col: 20, offset: 39611},
+												pos:  position{line: 1630, col: 20, offset: 39622},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1630, col: 29, offset: 39620},
+												pos: position{line: 1630, col: 29, offset: 39631},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1630, col: 29, offset: 39620},
+													pos:  position{line: 1630, col: 29, offset: 39631},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1630, col: 39, offset: 39630},
+												pos: position{line: 1630, col: 39, offset: 39641},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1630, col: 39, offset: 39630},
+													pos:  position{line: 1630, col: 39, offset: 39641},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1630, col: 49, offset: 39640},
+												pos: position{line: 1630, col: 49, offset: 39651},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1630, col: 49, offset: 39640},
+													pos:  position{line: 1630, col: 49, offset: 39651},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1630, col: 59, offset: 39650},
+												pos: position{line: 1630, col: 59, offset: 39661},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1630, col: 59, offset: 39650},
+													pos:  position{line: 1630, col: 59, offset: 39661},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1630, col: 69, offset: 39660},
+												pos: position{line: 1630, col: 69, offset: 39671},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1630, col: 69, offset: 39660},
+													pos:  position{line: 1630, col: 69, offset: 39671},
 													name: "HexDigit",
 												},
 											},
@@ -12048,7 +12056,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1630, col: 80, offset: 39671},
+									pos:        position{line: 1630, col: 80, offset: 39682},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12063,37 +12071,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1634, col: 1, offset: 39725},
+			pos:  position{line: 1634, col: 1, offset: 39736},
 			expr: &actionExpr{
-				pos: position{line: 1635, col: 5, offset: 39743},
+				pos: position{line: 1635, col: 5, offset: 39754},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1635, col: 5, offset: 39743},
+					pos: position{line: 1635, col: 5, offset: 39754},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1635, col: 5, offset: 39743},
+							pos:        position{line: 1635, col: 5, offset: 39754},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1635, col: 9, offset: 39747},
+							pos:   position{line: 1635, col: 9, offset: 39758},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1635, col: 14, offset: 39752},
+								pos:  position{line: 1635, col: 14, offset: 39763},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1635, col: 25, offset: 39763},
+							pos:        position{line: 1635, col: 25, offset: 39774},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1635, col: 29, offset: 39767},
+							pos: position{line: 1635, col: 29, offset: 39778},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1635, col: 30, offset: 39768},
+								pos:  position{line: 1635, col: 30, offset: 39779},
 								name: "KeyWordStart",
 							},
 						},
@@ -12105,33 +12113,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1637, col: 1, offset: 39803},
+			pos:  position{line: 1637, col: 1, offset: 39814},
 			expr: &actionExpr{
-				pos: position{line: 1638, col: 5, offset: 39818},
+				pos: position{line: 1638, col: 5, offset: 39829},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1638, col: 5, offset: 39818},
+					pos: position{line: 1638, col: 5, offset: 39829},
 					expr: &choiceExpr{
-						pos: position{line: 1638, col: 6, offset: 39819},
+						pos: position{line: 1638, col: 6, offset: 39830},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1638, col: 6, offset: 39819},
+								pos:        position{line: 1638, col: 6, offset: 39830},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1638, col: 15, offset: 39828},
+								pos: position{line: 1638, col: 15, offset: 39839},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1638, col: 15, offset: 39828},
+										pos:        position{line: 1638, col: 15, offset: 39839},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1638, col: 20, offset: 39833,
+										line: 1638, col: 20, offset: 39844,
 									},
 								},
 							},
@@ -12144,9 +12152,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1640, col: 1, offset: 39869},
+			pos:  position{line: 1640, col: 1, offset: 39880},
 			expr: &charClassMatcher{
-				pos:        position{line: 1641, col: 5, offset: 39885},
+				pos:        position{line: 1641, col: 5, offset: 39896},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12158,11 +12166,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1643, col: 1, offset: 39900},
+			pos:  position{line: 1643, col: 1, offset: 39911},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1643, col: 5, offset: 39904},
+				pos: position{line: 1643, col: 5, offset: 39915},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1643, col: 5, offset: 39904},
+					pos:  position{line: 1643, col: 5, offset: 39915},
 					name: "AnySpace",
 				},
 			},
@@ -12171,11 +12179,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1645, col: 1, offset: 39915},
+			pos:  position{line: 1645, col: 1, offset: 39926},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1645, col: 6, offset: 39920},
+				pos: position{line: 1645, col: 6, offset: 39931},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1645, col: 6, offset: 39920},
+					pos:  position{line: 1645, col: 6, offset: 39931},
 					name: "AnySpace",
 				},
 			},
@@ -12184,20 +12192,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1647, col: 1, offset: 39931},
+			pos:  position{line: 1647, col: 1, offset: 39942},
 			expr: &choiceExpr{
-				pos: position{line: 1648, col: 5, offset: 39944},
+				pos: position{line: 1648, col: 5, offset: 39955},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1648, col: 5, offset: 39944},
+						pos:  position{line: 1648, col: 5, offset: 39955},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1649, col: 5, offset: 39959},
+						pos:  position{line: 1649, col: 5, offset: 39970},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1650, col: 5, offset: 39978},
+						pos:  position{line: 1650, col: 5, offset: 39989},
 						name: "Comment",
 					},
 				},
@@ -12207,32 +12215,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1652, col: 1, offset: 39987},
+			pos:  position{line: 1652, col: 1, offset: 39998},
 			expr: &choiceExpr{
-				pos: position{line: 1653, col: 5, offset: 40005},
+				pos: position{line: 1653, col: 5, offset: 40016},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1653, col: 5, offset: 40005},
+						pos:  position{line: 1653, col: 5, offset: 40016},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1654, col: 5, offset: 40012},
+						pos:  position{line: 1654, col: 5, offset: 40023},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1655, col: 5, offset: 40019},
+						pos:  position{line: 1655, col: 5, offset: 40030},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1656, col: 5, offset: 40026},
+						pos:  position{line: 1656, col: 5, offset: 40037},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1657, col: 5, offset: 40033},
+						pos:  position{line: 1657, col: 5, offset: 40044},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1658, col: 5, offset: 40040},
+						pos:  position{line: 1658, col: 5, offset: 40051},
 						name: "Nl",
 					},
 				},
@@ -12242,16 +12250,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1660, col: 1, offset: 40044},
+			pos:  position{line: 1660, col: 1, offset: 40055},
 			expr: &choiceExpr{
-				pos: position{line: 1661, col: 5, offset: 40069},
+				pos: position{line: 1661, col: 5, offset: 40080},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1661, col: 5, offset: 40069},
+						pos:  position{line: 1661, col: 5, offset: 40080},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1662, col: 5, offset: 40076},
+						pos:  position{line: 1662, col: 5, offset: 40087},
 						name: "Mc",
 					},
 				},
@@ -12261,9 +12269,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1664, col: 1, offset: 40080},
+			pos:  position{line: 1664, col: 1, offset: 40091},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1665, col: 5, offset: 40097},
+				pos:  position{line: 1665, col: 5, offset: 40108},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12271,9 +12279,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1667, col: 1, offset: 40101},
+			pos:  position{line: 1667, col: 1, offset: 40112},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1668, col: 5, offset: 40133},
+				pos:  position{line: 1668, col: 5, offset: 40144},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12281,9 +12289,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1674, col: 1, offset: 40314},
+			pos:  position{line: 1674, col: 1, offset: 40325},
 			expr: &charClassMatcher{
-				pos:        position{line: 1674, col: 6, offset: 40319},
+				pos:        position{line: 1674, col: 6, offset: 40330},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12295,9 +12303,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1677, col: 1, offset: 44471},
+			pos:  position{line: 1677, col: 1, offset: 44482},
 			expr: &charClassMatcher{
-				pos:        position{line: 1677, col: 6, offset: 44476},
+				pos:        position{line: 1677, col: 6, offset: 44487},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12309,9 +12317,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1680, col: 1, offset: 44961},
+			pos:  position{line: 1680, col: 1, offset: 44972},
 			expr: &charClassMatcher{
-				pos:        position{line: 1680, col: 6, offset: 44966},
+				pos:        position{line: 1680, col: 6, offset: 44977},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12323,9 +12331,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1683, col: 1, offset: 48413},
+			pos:  position{line: 1683, col: 1, offset: 48424},
 			expr: &charClassMatcher{
-				pos:        position{line: 1683, col: 6, offset: 48418},
+				pos:        position{line: 1683, col: 6, offset: 48429},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12337,9 +12345,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1686, col: 1, offset: 48524},
+			pos:  position{line: 1686, col: 1, offset: 48535},
 			expr: &charClassMatcher{
-				pos:        position{line: 1686, col: 6, offset: 48529},
+				pos:        position{line: 1686, col: 6, offset: 48540},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12351,9 +12359,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1689, col: 1, offset: 52530},
+			pos:  position{line: 1689, col: 1, offset: 52541},
 			expr: &charClassMatcher{
-				pos:        position{line: 1689, col: 6, offset: 52535},
+				pos:        position{line: 1689, col: 6, offset: 52546},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12365,9 +12373,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1692, col: 1, offset: 53723},
+			pos:  position{line: 1692, col: 1, offset: 53734},
 			expr: &charClassMatcher{
-				pos:        position{line: 1692, col: 6, offset: 53728},
+				pos:        position{line: 1692, col: 6, offset: 53739},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12379,9 +12387,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1695, col: 1, offset: 55908},
+			pos:  position{line: 1695, col: 1, offset: 55919},
 			expr: &charClassMatcher{
-				pos:        position{line: 1695, col: 6, offset: 55913},
+				pos:        position{line: 1695, col: 6, offset: 55924},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12392,9 +12400,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1698, col: 1, offset: 56416},
+			pos:  position{line: 1698, col: 1, offset: 56427},
 			expr: &charClassMatcher{
-				pos:        position{line: 1698, col: 6, offset: 56421},
+				pos:        position{line: 1698, col: 6, offset: 56432},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12406,9 +12414,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1701, col: 1, offset: 56535},
+			pos:  position{line: 1701, col: 1, offset: 56546},
 			expr: &charClassMatcher{
-				pos:        position{line: 1701, col: 6, offset: 56540},
+				pos:        position{line: 1701, col: 6, offset: 56551},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12420,9 +12428,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1704, col: 1, offset: 56621},
+			pos:  position{line: 1704, col: 1, offset: 56632},
 			expr: &charClassMatcher{
-				pos:        position{line: 1704, col: 6, offset: 56626},
+				pos:        position{line: 1704, col: 6, offset: 56637},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12434,9 +12442,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1706, col: 1, offset: 56679},
+			pos:  position{line: 1706, col: 1, offset: 56690},
 			expr: &anyMatcher{
-				line: 1707, col: 5, offset: 56699,
+				line: 1707, col: 5, offset: 56710,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12444,48 +12452,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1709, col: 1, offset: 56702},
+			pos:         position{line: 1709, col: 1, offset: 56713},
 			expr: &choiceExpr{
-				pos: position{line: 1710, col: 5, offset: 56730},
+				pos: position{line: 1710, col: 5, offset: 56741},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1710, col: 5, offset: 56730},
+						pos:        position{line: 1710, col: 5, offset: 56741},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1711, col: 5, offset: 56739},
+						pos:        position{line: 1711, col: 5, offset: 56750},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1712, col: 5, offset: 56748},
+						pos:        position{line: 1712, col: 5, offset: 56759},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1713, col: 5, offset: 56757},
+						pos:        position{line: 1713, col: 5, offset: 56768},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1714, col: 5, offset: 56765},
+						pos:        position{line: 1714, col: 5, offset: 56776},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1715, col: 5, offset: 56778},
+						pos:        position{line: 1715, col: 5, offset: 56789},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1716, col: 5, offset: 56791},
+						pos:  position{line: 1716, col: 5, offset: 56802},
 						name: "Zs",
 					},
 				},
@@ -12495,9 +12503,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1718, col: 1, offset: 56795},
+			pos:  position{line: 1718, col: 1, offset: 56806},
 			expr: &charClassMatcher{
-				pos:        position{line: 1719, col: 5, offset: 56814},
+				pos:        position{line: 1719, col: 5, offset: 56825},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12509,9 +12517,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1725, col: 1, offset: 57144},
+			pos:         position{line: 1725, col: 1, offset: 57155},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1728, col: 5, offset: 57215},
+				pos:  position{line: 1728, col: 5, offset: 57226},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -12519,39 +12527,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1730, col: 1, offset: 57234},
+			pos:  position{line: 1730, col: 1, offset: 57245},
 			expr: &seqExpr{
-				pos: position{line: 1731, col: 5, offset: 57255},
+				pos: position{line: 1731, col: 5, offset: 57266},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1731, col: 5, offset: 57255},
+						pos:        position{line: 1731, col: 5, offset: 57266},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1731, col: 10, offset: 57260},
+						pos: position{line: 1731, col: 10, offset: 57271},
 						expr: &seqExpr{
-							pos: position{line: 1731, col: 11, offset: 57261},
+							pos: position{line: 1731, col: 11, offset: 57272},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1731, col: 11, offset: 57261},
+									pos: position{line: 1731, col: 11, offset: 57272},
 									expr: &litMatcher{
-										pos:        position{line: 1731, col: 12, offset: 57262},
+										pos:        position{line: 1731, col: 12, offset: 57273},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1731, col: 17, offset: 57267},
+									pos:  position{line: 1731, col: 17, offset: 57278},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1731, col: 35, offset: 57285},
+						pos:        position{line: 1731, col: 35, offset: 57296},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12563,30 +12571,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1733, col: 1, offset: 57291},
+			pos:  position{line: 1733, col: 1, offset: 57302},
 			expr: &seqExpr{
-				pos: position{line: 1734, col: 5, offset: 57313},
+				pos: position{line: 1734, col: 5, offset: 57324},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1734, col: 5, offset: 57313},
+						pos:        position{line: 1734, col: 5, offset: 57324},
 						val:        "//",
 						ignoreCase: false,
 						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1734, col: 10, offset: 57318},
+						pos: position{line: 1734, col: 10, offset: 57329},
 						expr: &seqExpr{
-							pos: position{line: 1734, col: 11, offset: 57319},
+							pos: position{line: 1734, col: 11, offset: 57330},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1734, col: 11, offset: 57319},
+									pos: position{line: 1734, col: 11, offset: 57330},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1734, col: 12, offset: 57320},
+										pos:  position{line: 1734, col: 12, offset: 57331},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1734, col: 27, offset: 57335},
+									pos:  position{line: 1734, col: 27, offset: 57346},
 									name: "SourceCharacter",
 								},
 							},
@@ -12599,19 +12607,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1736, col: 1, offset: 57354},
+			pos:  position{line: 1736, col: 1, offset: 57365},
 			expr: &seqExpr{
-				pos: position{line: 1736, col: 7, offset: 57360},
+				pos: position{line: 1736, col: 7, offset: 57371},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1736, col: 7, offset: 57360},
+						pos: position{line: 1736, col: 7, offset: 57371},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1736, col: 7, offset: 57360},
+							pos:  position{line: 1736, col: 7, offset: 57371},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1736, col: 19, offset: 57372},
+						pos:  position{line: 1736, col: 19, offset: 57383},
 						name: "LineTerminator",
 					},
 				},
@@ -12621,16 +12629,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1738, col: 1, offset: 57388},
+			pos:  position{line: 1738, col: 1, offset: 57399},
 			expr: &choiceExpr{
-				pos: position{line: 1738, col: 7, offset: 57394},
+				pos: position{line: 1738, col: 7, offset: 57405},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1738, col: 7, offset: 57394},
+						pos:  position{line: 1738, col: 7, offset: 57405},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1738, col: 11, offset: 57398},
+						pos:  position{line: 1738, col: 11, offset: 57409},
 						name: "EOF",
 					},
 				},
@@ -12640,11 +12648,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1740, col: 1, offset: 57403},
+			pos:  position{line: 1740, col: 1, offset: 57414},
 			expr: &notExpr{
-				pos: position{line: 1740, col: 7, offset: 57409},
+				pos: position{line: 1740, col: 7, offset: 57420},
 				expr: &anyMatcher{
-					line: 1740, col: 8, offset: 57410,
+					line: 1740, col: 8, offset: 57421,
 				},
 			},
 			leader:        false,
@@ -12652,11 +12660,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1742, col: 1, offset: 57413},
+			pos:  position{line: 1742, col: 1, offset: 57424},
 			expr: &notExpr{
-				pos: position{line: 1742, col: 8, offset: 57420},
+				pos: position{line: 1742, col: 8, offset: 57431},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1742, col: 9, offset: 57421},
+					pos:  position{line: 1742, col: 9, offset: 57432},
 					name: "KeyWordChars",
 				},
 			},
@@ -12876,7 +12884,7 @@ func (p *parser) callonOperation25() (any, error) {
 func (c *current) onOperation35(trunks any) (any, error) {
 	return &ast.From{
 		Kind:       "From",
-		Trunks:     sliceOf[ast.Trunk](trunks),
+		Trunks:     sliceOf[ast.Seq](trunks),
 		KeywordPos: c.pos.offset,
 		Rparen:     lastPos(c, ")"),
 	}, nil
@@ -13008,19 +13016,29 @@ func (p *parser) callonCase8() (any, error) {
 	return p.cur.onCase8()
 }
 
-func (c *current) onFromLeg1(source, opt any) (any, error) {
-	t := ast.Trunk{Kind: "Trunk", Source: source.(ast.Source)}
-	if opt != nil {
-		t.Seq = sliceOf[ast.Op](opt.([]any)[3])
+func (c *current) onFromLeg8(s any) (any, error) {
+	return s, nil
+}
+
+func (p *parser) callonFromLeg8() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onFromLeg8(stack["s"])
+}
+
+func (c *current) onFromLeg1(source, seq any) (any, error) {
+	ops := []any{source}
+	if seq != nil {
+		ops = append(ops, seq.([]any)...)
 	}
-	return t, nil
+	return ast.Seq(sliceOf[ast.Op](ops)), nil
 
 }
 
 func (p *parser) callonFromLeg1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFromLeg1(stack["source"], stack["opt"])
+	return p.cur.onFromLeg1(stack["source"], stack["seq"])
 }
 
 func (c *current) onComparator1() (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -112,7 +112,7 @@ Operation
   / "from" __ "(" trunks:FromLeg+ __ ")" {
       return &ast.From{
           Kind: "From",
-          Trunks: sliceOf[ast.Trunk](trunks),
+          Trunks: sliceOf[ast.Seq](trunks),
           KeywordPos: c.pos.offset,
           Rparen: lastPos(c, ")"),
       }, nil
@@ -153,12 +153,12 @@ Case
   / "default" { return nil, nil }
 
 FromLeg
-  = __ source:FromSource opt:(__ "=>" __ Seq)? {
-      t := ast.Trunk{Kind:"Trunk",Source:source.(ast.Source)}
-      if opt != nil {
-        t.Seq = sliceOf[ast.Op](opt.([]any)[3])
+  = __ source:FromSource seq:(__ "=>" __ s:Seq { return s, nil })? {
+      ops := []any{source}
+      if seq != nil {
+        ops = append(ops, seq.([]any)...)
       }
-      return t, nil
+      return ast.Seq(sliceOf[ast.Op](ops)), nil
     }
 
 FromSource

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -52,16 +52,17 @@ func (a *analyzer) semFrom(from *ast.From, seq dag.Seq) dag.Seq {
 	}
 }
 
-func (a *analyzer) semTrunk(trunk ast.Trunk, out dag.Seq) dag.Seq {
-	if pool, ok := trunk.Source.(*ast.Pool); ok && trunk.Seq != nil {
+func (a *analyzer) semTrunk(trunk ast.Seq, out dag.Seq) dag.Seq {
+	src := trunk[0].(ast.Source)
+	if pool, ok := src.(*ast.Pool); ok && len(trunk) > 1 {
 		switch pool.Spec.Pool.(type) {
 		case *ast.Glob, *ast.Regexp:
-			a.error(&trunk, errors.New("=> not allowed after pool pattern in 'from' operator"))
+			a.error(src, errors.New("=> not allowed after pool pattern in 'from' operator"))
 			return append(out, badOp())
 		}
 	}
-	sources := a.semSource(trunk.Source)
-	seq := a.semSeq(trunk.Seq)
+	sources := a.semSource(src)
+	seq := a.semSeq(trunk[1:])
 	if len(sources) == 1 {
 		return append(out, append(dag.Seq{sources[0]}, seq...)...)
 	}

--- a/compiler/ztests/from-error.yaml
+++ b/compiler/ztests/from-error.yaml
@@ -33,4 +33,4 @@ outputs:
       ===
       => not allowed after pool pattern in 'from' operator at line 1, column 7:
       from (pool * => count())
-            ~~~~~~~~~~~~~~~~~
+            ~~~~~~

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -428,14 +428,14 @@ func (c *canon) op(p ast.Op) {
 	case *ast.From:
 		c.next()
 		c.open("from (")
-		for _, trunk := range p.Trunks {
+		for _, seq := range p.Trunks {
 			c.ret()
-			c.source(trunk.Source)
-			if trunk.Seq != nil {
+			c.source(seq[0].(ast.Source))
+			if len(seq) > 1 {
 				c.write(" =>")
 				c.open()
 				c.head = true
-				c.seq(trunk.Seq)
+				c.seq(seq[1:])
 				c.close()
 			}
 		}


### PR DESCRIPTION
This commit simplifies the AST by removing the ast.Trunk object and replacing it with ast.Seq.  This is in preparation for unifying the SuperPipe and SQL from semantics.