### PR TITLE
bump vng/supc version number

### DIFF
--- a/vng/header.go
+++ b/vng/header.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Version     = 4
+	Version     = 5
 	HeaderSize  = 24
 	MaxMetaSize = 100 * 1024 * 1024
 	MaxDataSize = 2 * 1024 * 1024 * 1024

--- a/vng/ztests/const.yaml
+++ b/vng/ztests/const.yaml
@@ -12,5 +12,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {Version:4(uint32),MetaSize:35(uint64),DataSize:0(uint64)}
+      {Version:5(uint32),MetaSize:35(uint64),DataSize:0(uint64)}
       {Value:1,Count:3(uint32)}(=Const)


### PR DESCRIPTION
We made a breaking change to the vng/supc format in #5302 but we neglected to change the file format version number.  This commit changes the version number to provide a version mismatch error instead of strange sanity-check failure.