### PR TITLE
Add count() docs examples about absent/zero output

### DIFF
--- a/docs/language/aggregates/count.md
+++ b/docs/language/aggregates/count.md
@@ -54,6 +54,23 @@ echo '{a:1,k:1} {a:2,k:1} {a:3,k:2}' | super query -z -c 'count() by k | sort' -
 {k:2,count:1(uint64)}
 ```
 
+A simple count with no input values returns no output:
+```mdtest-command
+echo '1 "foo" 10.0.0.1' | super query -z -c 'where grep("bar") | count()' -
+```
+=>
+```mdtest-output
+```
+
+Count can return an explicit zero when using a `where` clause in the aggregation:
+```mdtest-command
+echo '1 "foo" 10.0.0.1' | super query -z -c 'count() where grep("bar")' -
+```
+=>
+```mdtest-output
+0(uint64)
+```
+
 Note that the number of input values are counted, unlike the [`len` function](../functions/len.md) which counts the number of elements in a given value:
 ```mdtest-command
 echo '[1,2,3]' | super query -z -c 'count()' -


### PR DESCRIPTION
## What's Changing

This adds some examples to the `count()` doc to show when it returns no output and how it can be made to show an explicit count of `0` in some cases.

## Why

We haven't shown this to date in the `count()` docs. Similar to the changes I made in #5316, some users may need help to see the subtle change in behavior based on the location of a `where`.

## Details

In a [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1729205820795209) a user recently asked:

>```
>❯ echo '1 2' | zq -z 'where this == 3 | count()' -
>```
> I can’t figure out a way to get a 0 count in any case where where has no matches. Is there a way to do that?

At the time I pointed them to #4708 because it contains an (admittedly somewhat hacky) approach shown [here](https://github.com/brimdata/super/issues/4708#issuecomment-2225851732) that gets the job done for the general case of "showing a zero in a place that would otherwise show nothing", e.g.:

```
$ super -version
Version: v1.18.0-46-gfa1fc3b1

$ echo '1 2' | super query -c '
fork (
  => where this == 3 | c:=count() | yield {k:0,count:c}
  => yield {k:1,count:uint64(0)}
)
| sort k
| head 1
| yield count
' -
0(uint64)

$ echo '1 2 3' | super query -c '
fork (
  => where this == 3 | c:=count() | yield {k:0,count:c}
  => yield {k:1,count:uint64(0)}
)
| sort k
| head 1
| yield count
' -
1(uint64)
```

However, @nwt also spotted that for the user's particular example, using the `where` clause in the aggregation would give the result in a more direct/intuitive way, so it seems worth calling out in the docs.