### PR TITLE
add support for SQL-style case expressions

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -81,6 +81,21 @@ type Conditional struct {
 	Loc  `json:"loc"`
 }
 
+type CaseExpr struct {
+	Kind  string `json:"kind" unpack:""`
+	Expr  Expr   `json:"expr"`
+	Whens []When `json:"whens"`
+	Else  Expr   `json:"else"`
+	Loc   `json:"loc"`
+}
+
+type When struct {
+	Kind string `json:"kind" unpack:""`
+	Cond Expr   `json:"expr"`
+	Then Expr   `json:"else"`
+	Loc  `json:"loc"`
+}
+
 // A Call represents different things dependending on its context.
 // As a operator, it is either a group-by with no group-by keys and no duration,
 // or a filter with a function that is boolean valued.  This is determined
@@ -264,6 +279,7 @@ func (*UnaryExpr) ExprAST()   {}
 func (*BinaryExpr) ExprAST()  {}
 func (*Conditional) ExprAST() {}
 func (*Call) ExprAST()        {}
+func (*CaseExpr) ExprAST()    {}
 func (*Cast) ExprAST()        {}
 func (*ID) ExprAST()          {}
 func (*IndexExpr) ExprAST()   {}

--- a/compiler/ast/unpack.go
+++ b/compiler/ast/unpack.go
@@ -16,6 +16,7 @@ var unpacker = unpack.New(
 	OpExpr{},
 	BinaryExpr{},
 	Call{},
+	CaseExpr{},
 	Cast{},
 	CastValue{},
 	Conditional{},

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -7084,64 +7084,64 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1044, col: 5, offset: 25291},
+						pos: position{line: 1044, col: 5, offset: 25293},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1044, col: 5, offset: 25291},
+							pos: position{line: 1044, col: 5, offset: 25293},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1044, col: 5, offset: 25291},
+									pos:        position{line: 1044, col: 5, offset: 25293},
 									val:        "case",
 									ignoreCase: true,
 									want:       "\"case\"i",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1044, col: 13, offset: 25299},
+									pos:  position{line: 1044, col: 13, offset: 25301},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1044, col: 15, offset: 25301},
+									pos:   position{line: 1044, col: 15, offset: 25303},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1044, col: 20, offset: 25306},
+										pos:  position{line: 1044, col: 20, offset: 25308},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1044, col: 25, offset: 25311},
+									pos:   position{line: 1044, col: 25, offset: 25313},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1044, col: 31, offset: 25317},
+										pos: position{line: 1044, col: 31, offset: 25319},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1044, col: 31, offset: 25317},
+											pos:  position{line: 1044, col: 31, offset: 25319},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1044, col: 37, offset: 25323},
+									pos:   position{line: 1044, col: 37, offset: 25325},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1044, col: 43, offset: 25329},
+										pos: position{line: 1044, col: 43, offset: 25331},
 										expr: &seqExpr{
-											pos: position{line: 1044, col: 44, offset: 25330},
+											pos: position{line: 1044, col: 44, offset: 25332},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1044, col: 44, offset: 25330},
+													pos:  position{line: 1044, col: 44, offset: 25332},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 1044, col: 46, offset: 25332},
+													pos:        position{line: 1044, col: 46, offset: 25334},
 													val:        "else",
 													ignoreCase: false,
 													want:       "\"else\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1044, col: 53, offset: 25339},
+													pos:  position{line: 1044, col: 53, offset: 25341},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1044, col: 55, offset: 25341},
+													pos:  position{line: 1044, col: 55, offset: 25343},
 													name: "Expr",
 												},
 											},
@@ -7149,26 +7149,26 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1044, col: 62, offset: 25348},
+									pos:  position{line: 1044, col: 62, offset: 25350},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 1044, col: 64, offset: 25350},
+									pos:        position{line: 1044, col: 64, offset: 25352},
 									val:        "end",
 									ignoreCase: true,
 									want:       "\"end\"i",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1044, col: 71, offset: 25357},
+									pos: position{line: 1044, col: 71, offset: 25359},
 									expr: &seqExpr{
-										pos: position{line: 1044, col: 72, offset: 25358},
+										pos: position{line: 1044, col: 72, offset: 25360},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1044, col: 72, offset: 25358},
+												pos:  position{line: 1044, col: 72, offset: 25360},
 												name: "_",
 											},
 											&litMatcher{
-												pos:        position{line: 1044, col: 74, offset: 25360},
+												pos:        position{line: 1044, col: 74, offset: 25362},
 												val:        "case",
 												ignoreCase: true,
 												want:       "\"case\"i",
@@ -7186,54 +7186,54 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1057, col: 1, offset: 25668},
+			pos:  position{line: 1057, col: 1, offset: 25670},
 			expr: &actionExpr{
-				pos: position{line: 1058, col: 5, offset: 25677},
+				pos: position{line: 1058, col: 5, offset: 25679},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1058, col: 5, offset: 25677},
+					pos: position{line: 1058, col: 5, offset: 25679},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1058, col: 5, offset: 25677},
+							pos:  position{line: 1058, col: 5, offset: 25679},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 1058, col: 7, offset: 25679},
+							pos:        position{line: 1058, col: 7, offset: 25681},
 							val:        "when",
 							ignoreCase: true,
 							want:       "\"when\"i",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1058, col: 15, offset: 25687},
+							pos:  position{line: 1058, col: 15, offset: 25689},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1058, col: 18, offset: 25690},
+							pos:   position{line: 1058, col: 18, offset: 25692},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1058, col: 23, offset: 25695},
+								pos:  position{line: 1058, col: 23, offset: 25697},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1058, col: 28, offset: 25700},
+							pos:  position{line: 1058, col: 28, offset: 25702},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 1058, col: 30, offset: 25702},
+							pos:        position{line: 1058, col: 30, offset: 25704},
 							val:        "then",
 							ignoreCase: true,
 							want:       "\"then\"i",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1058, col: 38, offset: 25710},
+							pos:  position{line: 1058, col: 38, offset: 25712},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1058, col: 40, offset: 25712},
+							pos:   position{line: 1058, col: 40, offset: 25714},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1058, col: 45, offset: 25717},
+								pos:  position{line: 1058, col: 45, offset: 25719},
 								name: "Expr",
 							},
 						},
@@ -7245,15 +7245,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1066, col: 1, offset: 25851},
+			pos:  position{line: 1067, col: 1, offset: 25874},
 			expr: &actionExpr{
-				pos: position{line: 1067, col: 5, offset: 25871},
+				pos: position{line: 1068, col: 5, offset: 25894},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1067, col: 5, offset: 25871},
+					pos:   position{line: 1068, col: 5, offset: 25894},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1067, col: 9, offset: 25875},
+						pos:  position{line: 1068, col: 9, offset: 25898},
 						name: "RegexpPattern",
 					},
 				},
@@ -7263,24 +7263,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1069, col: 1, offset: 25946},
+			pos:  position{line: 1070, col: 1, offset: 25969},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 5, offset: 25963},
+				pos: position{line: 1071, col: 5, offset: 25986},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 25963},
+						pos: position{line: 1071, col: 5, offset: 25986},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1070, col: 5, offset: 25963},
+							pos:   position{line: 1071, col: 5, offset: 25986},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1070, col: 7, offset: 25965},
+								pos:  position{line: 1071, col: 7, offset: 25988},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1071, col: 5, offset: 26003},
+						pos:  position{line: 1072, col: 5, offset: 26026},
 						name: "OptionalExprs",
 					},
 				},
@@ -7290,98 +7290,98 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1073, col: 1, offset: 26018},
+			pos:  position{line: 1074, col: 1, offset: 26041},
 			expr: &actionExpr{
-				pos: position{line: 1074, col: 5, offset: 26027},
+				pos: position{line: 1075, col: 5, offset: 26050},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1074, col: 5, offset: 26027},
+					pos: position{line: 1075, col: 5, offset: 26050},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1074, col: 5, offset: 26027},
+							pos:        position{line: 1075, col: 5, offset: 26050},
 							val:        "grep",
 							ignoreCase: false,
 							want:       "\"grep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1074, col: 12, offset: 26034},
+							pos:  position{line: 1075, col: 12, offset: 26057},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1074, col: 15, offset: 26037},
+							pos:        position{line: 1075, col: 15, offset: 26060},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1074, col: 19, offset: 26041},
+							pos:  position{line: 1075, col: 19, offset: 26064},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1074, col: 22, offset: 26044},
+							pos:   position{line: 1075, col: 22, offset: 26067},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1074, col: 31, offset: 26053},
+								pos: position{line: 1075, col: 31, offset: 26076},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1074, col: 31, offset: 26053},
+										pos:  position{line: 1075, col: 31, offset: 26076},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1074, col: 40, offset: 26062},
+										pos:  position{line: 1075, col: 40, offset: 26085},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1074, col: 47, offset: 26069},
+										pos:  position{line: 1075, col: 47, offset: 26092},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1074, col: 53, offset: 26075},
+							pos:  position{line: 1075, col: 53, offset: 26098},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1074, col: 56, offset: 26078},
+							pos:   position{line: 1075, col: 56, offset: 26101},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1074, col: 60, offset: 26082},
+								pos: position{line: 1075, col: 60, offset: 26105},
 								expr: &actionExpr{
-									pos: position{line: 1074, col: 61, offset: 26083},
+									pos: position{line: 1075, col: 61, offset: 26106},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1074, col: 61, offset: 26083},
+										pos: position{line: 1075, col: 61, offset: 26106},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1074, col: 61, offset: 26083},
+												pos:        position{line: 1075, col: 61, offset: 26106},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1074, col: 65, offset: 26087},
+												pos:  position{line: 1075, col: 65, offset: 26110},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1074, col: 68, offset: 26090},
+												pos:   position{line: 1075, col: 68, offset: 26113},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1074, col: 71, offset: 26093},
+													pos: position{line: 1075, col: 71, offset: 26116},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1074, col: 71, offset: 26093},
+															pos:  position{line: 1075, col: 71, offset: 26116},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1074, col: 82, offset: 26104},
+															pos:  position{line: 1075, col: 82, offset: 26127},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1074, col: 88, offset: 26110},
+												pos:  position{line: 1075, col: 88, offset: 26133},
 												name: "__",
 											},
 										},
@@ -7390,7 +7390,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1074, col: 111, offset: 26133},
+							pos:        position{line: 1075, col: 111, offset: 26156},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7403,19 +7403,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1086, col: 1, offset: 26346},
+			pos:  position{line: 1087, col: 1, offset: 26369},
 			expr: &choiceExpr{
-				pos: position{line: 1087, col: 5, offset: 26364},
+				pos: position{line: 1088, col: 5, offset: 26387},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1087, col: 5, offset: 26364},
+						pos:  position{line: 1088, col: 5, offset: 26387},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1088, col: 5, offset: 26374},
+						pos: position{line: 1089, col: 5, offset: 26397},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1088, col: 5, offset: 26374},
+							pos:  position{line: 1089, col: 5, offset: 26397},
 							name: "__",
 						},
 					},
@@ -7426,51 +7426,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1090, col: 1, offset: 26402},
+			pos:  position{line: 1091, col: 1, offset: 26425},
 			expr: &actionExpr{
-				pos: position{line: 1091, col: 5, offset: 26412},
+				pos: position{line: 1092, col: 5, offset: 26435},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1091, col: 5, offset: 26412},
+					pos: position{line: 1092, col: 5, offset: 26435},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1091, col: 5, offset: 26412},
+							pos:   position{line: 1092, col: 5, offset: 26435},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1091, col: 11, offset: 26418},
+								pos:  position{line: 1092, col: 11, offset: 26441},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1091, col: 16, offset: 26423},
+							pos:   position{line: 1092, col: 16, offset: 26446},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1091, col: 21, offset: 26428},
+								pos: position{line: 1092, col: 21, offset: 26451},
 								expr: &actionExpr{
-									pos: position{line: 1091, col: 22, offset: 26429},
+									pos: position{line: 1092, col: 22, offset: 26452},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1091, col: 22, offset: 26429},
+										pos: position{line: 1092, col: 22, offset: 26452},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1091, col: 22, offset: 26429},
+												pos:  position{line: 1092, col: 22, offset: 26452},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1091, col: 25, offset: 26432},
+												pos:        position{line: 1092, col: 25, offset: 26455},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1091, col: 29, offset: 26436},
+												pos:  position{line: 1092, col: 29, offset: 26459},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1091, col: 32, offset: 26439},
+												pos:   position{line: 1092, col: 32, offset: 26462},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1091, col: 34, offset: 26441},
+													pos:  position{line: 1092, col: 34, offset: 26464},
 													name: "Expr",
 												},
 											},
@@ -7487,64 +7487,64 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1095, col: 1, offset: 26514},
+			pos:  position{line: 1096, col: 1, offset: 26537},
 			expr: &choiceExpr{
-				pos: position{line: 1096, col: 5, offset: 26526},
+				pos: position{line: 1097, col: 5, offset: 26549},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1096, col: 5, offset: 26526},
+						pos:  position{line: 1097, col: 5, offset: 26549},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1097, col: 5, offset: 26537},
+						pos:  position{line: 1098, col: 5, offset: 26560},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1098, col: 5, offset: 26547},
+						pos:  position{line: 1099, col: 5, offset: 26570},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1099, col: 5, offset: 26555},
+						pos:  position{line: 1100, col: 5, offset: 26578},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 26563},
+						pos:  position{line: 1101, col: 5, offset: 26586},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1101, col: 5, offset: 26575},
+						pos:  position{line: 1102, col: 5, offset: 26598},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1102, col: 5, offset: 26590},
+						pos: position{line: 1103, col: 5, offset: 26613},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1102, col: 5, offset: 26590},
+							pos: position{line: 1103, col: 5, offset: 26613},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1102, col: 5, offset: 26590},
+									pos:        position{line: 1103, col: 5, offset: 26613},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 9, offset: 26594},
+									pos:  position{line: 1103, col: 9, offset: 26617},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 12, offset: 26597},
+									pos:   position{line: 1103, col: 12, offset: 26620},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1102, col: 17, offset: 26602},
+										pos:  position{line: 1103, col: 17, offset: 26625},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 26, offset: 26611},
+									pos:  position{line: 1103, col: 26, offset: 26634},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1102, col: 29, offset: 26614},
+									pos:        position{line: 1103, col: 29, offset: 26637},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7553,35 +7553,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1103, col: 5, offset: 26643},
+						pos: position{line: 1104, col: 5, offset: 26666},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1103, col: 5, offset: 26643},
+							pos: position{line: 1104, col: 5, offset: 26666},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1103, col: 5, offset: 26643},
+									pos:        position{line: 1104, col: 5, offset: 26666},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 9, offset: 26647},
+									pos:  position{line: 1104, col: 9, offset: 26670},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 12, offset: 26650},
+									pos:   position{line: 1104, col: 12, offset: 26673},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 17, offset: 26655},
+										pos:  position{line: 1104, col: 17, offset: 26678},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 22, offset: 26660},
+									pos:  position{line: 1104, col: 22, offset: 26683},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 25, offset: 26663},
+									pos:        position{line: 1104, col: 25, offset: 26686},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7596,61 +7596,61 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1105, col: 1, offset: 26689},
+			pos:  position{line: 1106, col: 1, offset: 26712},
 			expr: &actionExpr{
-				pos: position{line: 1106, col: 5, offset: 26702},
+				pos: position{line: 1107, col: 5, offset: 26725},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1106, col: 5, offset: 26702},
+					pos: position{line: 1107, col: 5, offset: 26725},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1106, col: 5, offset: 26702},
+							pos:        position{line: 1107, col: 5, offset: 26725},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1106, col: 12, offset: 26709},
+							pos:  position{line: 1107, col: 12, offset: 26732},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1106, col: 14, offset: 26711},
+							pos:   position{line: 1107, col: 14, offset: 26734},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1106, col: 20, offset: 26717},
+								pos:  position{line: 1107, col: 20, offset: 26740},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1106, col: 26, offset: 26723},
+							pos:   position{line: 1107, col: 26, offset: 26746},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1106, col: 33, offset: 26730},
+								pos: position{line: 1107, col: 33, offset: 26753},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1106, col: 33, offset: 26730},
+									pos:  position{line: 1107, col: 33, offset: 26753},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1106, col: 41, offset: 26738},
+							pos:  position{line: 1107, col: 41, offset: 26761},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1106, col: 44, offset: 26741},
+							pos:        position{line: 1107, col: 44, offset: 26764},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1106, col: 48, offset: 26745},
+							pos:  position{line: 1107, col: 48, offset: 26768},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1106, col: 51, offset: 26748},
+							pos:   position{line: 1107, col: 51, offset: 26771},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1106, col: 56, offset: 26753},
+								pos:  position{line: 1107, col: 56, offset: 26776},
 								name: "Seq",
 							},
 						},
@@ -7662,37 +7662,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1116, col: 1, offset: 26984},
+			pos:  position{line: 1117, col: 1, offset: 27007},
 			expr: &actionExpr{
-				pos: position{line: 1117, col: 5, offset: 26995},
+				pos: position{line: 1118, col: 5, offset: 27018},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1117, col: 5, offset: 26995},
+					pos: position{line: 1118, col: 5, offset: 27018},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1117, col: 5, offset: 26995},
+							pos:        position{line: 1118, col: 5, offset: 27018},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1117, col: 9, offset: 26999},
+							pos:  position{line: 1118, col: 9, offset: 27022},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1117, col: 12, offset: 27002},
+							pos:   position{line: 1118, col: 12, offset: 27025},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1117, col: 18, offset: 27008},
+								pos:  position{line: 1118, col: 18, offset: 27031},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1117, col: 30, offset: 27020},
+							pos:  position{line: 1118, col: 30, offset: 27043},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1117, col: 33, offset: 27023},
+							pos:        position{line: 1118, col: 33, offset: 27046},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7705,31 +7705,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1125, col: 1, offset: 27181},
+			pos:  position{line: 1126, col: 1, offset: 27204},
 			expr: &choiceExpr{
-				pos: position{line: 1126, col: 5, offset: 27197},
+				pos: position{line: 1127, col: 5, offset: 27220},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1126, col: 5, offset: 27197},
+						pos: position{line: 1127, col: 5, offset: 27220},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1126, col: 5, offset: 27197},
+							pos: position{line: 1127, col: 5, offset: 27220},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1126, col: 5, offset: 27197},
+									pos:   position{line: 1127, col: 5, offset: 27220},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 11, offset: 27203},
+										pos:  position{line: 1127, col: 11, offset: 27226},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 22, offset: 27214},
+									pos:   position{line: 1127, col: 22, offset: 27237},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1126, col: 27, offset: 27219},
+										pos: position{line: 1127, col: 27, offset: 27242},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1126, col: 27, offset: 27219},
+											pos:  position{line: 1127, col: 27, offset: 27242},
 											name: "RecordElemTail",
 										},
 									},
@@ -7738,10 +7738,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1129, col: 5, offset: 27282},
+						pos: position{line: 1130, col: 5, offset: 27305},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1129, col: 5, offset: 27282},
+							pos:  position{line: 1130, col: 5, offset: 27305},
 							name: "__",
 						},
 					},
@@ -7752,32 +7752,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1131, col: 1, offset: 27306},
+			pos:  position{line: 1132, col: 1, offset: 27329},
 			expr: &actionExpr{
-				pos: position{line: 1131, col: 18, offset: 27323},
+				pos: position{line: 1132, col: 18, offset: 27346},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1131, col: 18, offset: 27323},
+					pos: position{line: 1132, col: 18, offset: 27346},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1131, col: 18, offset: 27323},
+							pos:  position{line: 1132, col: 18, offset: 27346},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1131, col: 21, offset: 27326},
+							pos:        position{line: 1132, col: 21, offset: 27349},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1131, col: 25, offset: 27330},
+							pos:  position{line: 1132, col: 25, offset: 27353},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1131, col: 28, offset: 27333},
+							pos:   position{line: 1132, col: 28, offset: 27356},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1131, col: 33, offset: 27338},
+								pos:  position{line: 1132, col: 33, offset: 27361},
 								name: "RecordElem",
 							},
 						},
@@ -7789,20 +7789,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1133, col: 1, offset: 27371},
+			pos:  position{line: 1134, col: 1, offset: 27394},
 			expr: &choiceExpr{
-				pos: position{line: 1134, col: 5, offset: 27386},
+				pos: position{line: 1135, col: 5, offset: 27409},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 5, offset: 27386},
+						pos:  position{line: 1135, col: 5, offset: 27409},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1135, col: 5, offset: 27397},
+						pos:  position{line: 1136, col: 5, offset: 27420},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1136, col: 5, offset: 27411},
+						pos:  position{line: 1137, col: 5, offset: 27434},
 						name: "Identifier",
 					},
 				},
@@ -7812,28 +7812,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1138, col: 1, offset: 27423},
+			pos:  position{line: 1139, col: 1, offset: 27446},
 			expr: &actionExpr{
-				pos: position{line: 1139, col: 5, offset: 27434},
+				pos: position{line: 1140, col: 5, offset: 27457},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1139, col: 5, offset: 27434},
+					pos: position{line: 1140, col: 5, offset: 27457},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1139, col: 5, offset: 27434},
+							pos:        position{line: 1140, col: 5, offset: 27457},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1139, col: 11, offset: 27440},
+							pos:  position{line: 1140, col: 11, offset: 27463},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1139, col: 14, offset: 27443},
+							pos:   position{line: 1140, col: 14, offset: 27466},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1139, col: 19, offset: 27448},
+								pos:  position{line: 1140, col: 19, offset: 27471},
 								name: "Expr",
 							},
 						},
@@ -7845,40 +7845,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1143, col: 1, offset: 27544},
+			pos:  position{line: 1144, col: 1, offset: 27567},
 			expr: &actionExpr{
-				pos: position{line: 1144, col: 5, offset: 27558},
+				pos: position{line: 1145, col: 5, offset: 27581},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1144, col: 5, offset: 27558},
+					pos: position{line: 1145, col: 5, offset: 27581},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1144, col: 5, offset: 27558},
+							pos:   position{line: 1145, col: 5, offset: 27581},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1144, col: 10, offset: 27563},
+								pos:  position{line: 1145, col: 10, offset: 27586},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1144, col: 15, offset: 27568},
+							pos:  position{line: 1145, col: 15, offset: 27591},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1144, col: 18, offset: 27571},
+							pos:        position{line: 1145, col: 18, offset: 27594},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1144, col: 22, offset: 27575},
+							pos:  position{line: 1145, col: 22, offset: 27598},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1144, col: 25, offset: 27578},
+							pos:   position{line: 1145, col: 25, offset: 27601},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1144, col: 31, offset: 27584},
+								pos:  position{line: 1145, col: 31, offset: 27607},
 								name: "Expr",
 							},
 						},
@@ -7890,37 +7890,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1153, col: 1, offset: 27753},
+			pos:  position{line: 1154, col: 1, offset: 27776},
 			expr: &actionExpr{
-				pos: position{line: 1154, col: 5, offset: 27763},
+				pos: position{line: 1155, col: 5, offset: 27786},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1154, col: 5, offset: 27763},
+					pos: position{line: 1155, col: 5, offset: 27786},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1154, col: 5, offset: 27763},
+							pos:        position{line: 1155, col: 5, offset: 27786},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1154, col: 9, offset: 27767},
+							pos:  position{line: 1155, col: 9, offset: 27790},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1154, col: 12, offset: 27770},
+							pos:   position{line: 1155, col: 12, offset: 27793},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1154, col: 18, offset: 27776},
+								pos:  position{line: 1155, col: 18, offset: 27799},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1154, col: 30, offset: 27788},
+							pos:  position{line: 1155, col: 30, offset: 27811},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1154, col: 33, offset: 27791},
+							pos:        position{line: 1155, col: 33, offset: 27814},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -7933,37 +7933,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1162, col: 1, offset: 27947},
+			pos:  position{line: 1163, col: 1, offset: 27970},
 			expr: &actionExpr{
-				pos: position{line: 1163, col: 5, offset: 27955},
+				pos: position{line: 1164, col: 5, offset: 27978},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1163, col: 5, offset: 27955},
+					pos: position{line: 1164, col: 5, offset: 27978},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1163, col: 5, offset: 27955},
+							pos:        position{line: 1164, col: 5, offset: 27978},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1163, col: 10, offset: 27960},
+							pos:  position{line: 1164, col: 10, offset: 27983},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1163, col: 13, offset: 27963},
+							pos:   position{line: 1164, col: 13, offset: 27986},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1163, col: 19, offset: 27969},
+								pos:  position{line: 1164, col: 19, offset: 27992},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1163, col: 31, offset: 27981},
+							pos:  position{line: 1164, col: 31, offset: 28004},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1163, col: 34, offset: 27984},
+							pos:        position{line: 1164, col: 34, offset: 28007},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -7976,54 +7976,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1171, col: 1, offset: 28137},
+			pos:  position{line: 1172, col: 1, offset: 28160},
 			expr: &choiceExpr{
-				pos: position{line: 1172, col: 5, offset: 28153},
+				pos: position{line: 1173, col: 5, offset: 28176},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1172, col: 5, offset: 28153},
+						pos: position{line: 1173, col: 5, offset: 28176},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1172, col: 5, offset: 28153},
+							pos: position{line: 1173, col: 5, offset: 28176},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1172, col: 5, offset: 28153},
+									pos:   position{line: 1173, col: 5, offset: 28176},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1172, col: 11, offset: 28159},
+										pos:  position{line: 1173, col: 11, offset: 28182},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1172, col: 22, offset: 28170},
+									pos:   position{line: 1173, col: 22, offset: 28193},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1172, col: 27, offset: 28175},
+										pos: position{line: 1173, col: 27, offset: 28198},
 										expr: &actionExpr{
-											pos: position{line: 1172, col: 28, offset: 28176},
+											pos: position{line: 1173, col: 28, offset: 28199},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1172, col: 28, offset: 28176},
+												pos: position{line: 1173, col: 28, offset: 28199},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1172, col: 28, offset: 28176},
+														pos:  position{line: 1173, col: 28, offset: 28199},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1172, col: 31, offset: 28179},
+														pos:        position{line: 1173, col: 31, offset: 28202},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1172, col: 35, offset: 28183},
+														pos:  position{line: 1173, col: 35, offset: 28206},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1172, col: 38, offset: 28186},
+														pos:   position{line: 1173, col: 38, offset: 28209},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1172, col: 40, offset: 28188},
+															pos:  position{line: 1173, col: 40, offset: 28211},
 															name: "VectorElem",
 														},
 													},
@@ -8036,10 +8036,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1175, col: 5, offset: 28270},
+						pos: position{line: 1176, col: 5, offset: 28293},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1175, col: 5, offset: 28270},
+							pos:  position{line: 1176, col: 5, offset: 28293},
 							name: "__",
 						},
 					},
@@ -8050,22 +8050,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1177, col: 1, offset: 28294},
+			pos:  position{line: 1178, col: 1, offset: 28317},
 			expr: &choiceExpr{
-				pos: position{line: 1178, col: 5, offset: 28309},
+				pos: position{line: 1179, col: 5, offset: 28332},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1178, col: 5, offset: 28309},
+						pos:  position{line: 1179, col: 5, offset: 28332},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1179, col: 5, offset: 28320},
+						pos: position{line: 1180, col: 5, offset: 28343},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1179, col: 5, offset: 28320},
+							pos:   position{line: 1180, col: 5, offset: 28343},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1179, col: 7, offset: 28322},
+								pos:  position{line: 1180, col: 7, offset: 28345},
 								name: "Expr",
 							},
 						},
@@ -8077,37 +8077,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1181, col: 1, offset: 28413},
+			pos:  position{line: 1182, col: 1, offset: 28436},
 			expr: &actionExpr{
-				pos: position{line: 1182, col: 5, offset: 28421},
+				pos: position{line: 1183, col: 5, offset: 28444},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1182, col: 5, offset: 28421},
+					pos: position{line: 1183, col: 5, offset: 28444},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1182, col: 5, offset: 28421},
+							pos:        position{line: 1183, col: 5, offset: 28444},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1182, col: 10, offset: 28426},
+							pos:  position{line: 1183, col: 10, offset: 28449},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1182, col: 13, offset: 28429},
+							pos:   position{line: 1183, col: 13, offset: 28452},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1182, col: 19, offset: 28435},
+								pos:  position{line: 1183, col: 19, offset: 28458},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1182, col: 27, offset: 28443},
+							pos:  position{line: 1183, col: 27, offset: 28466},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1182, col: 30, offset: 28446},
+							pos:        position{line: 1183, col: 30, offset: 28469},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8120,31 +8120,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1190, col: 1, offset: 28600},
+			pos:  position{line: 1191, col: 1, offset: 28623},
 			expr: &choiceExpr{
-				pos: position{line: 1191, col: 5, offset: 28612},
+				pos: position{line: 1192, col: 5, offset: 28635},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1191, col: 5, offset: 28612},
+						pos: position{line: 1192, col: 5, offset: 28635},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1191, col: 5, offset: 28612},
+							pos: position{line: 1192, col: 5, offset: 28635},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1191, col: 5, offset: 28612},
+									pos:   position{line: 1192, col: 5, offset: 28635},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1191, col: 11, offset: 28618},
+										pos:  position{line: 1192, col: 11, offset: 28641},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1191, col: 17, offset: 28624},
+									pos:   position{line: 1192, col: 17, offset: 28647},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1191, col: 22, offset: 28629},
+										pos: position{line: 1192, col: 22, offset: 28652},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1191, col: 22, offset: 28629},
+											pos:  position{line: 1192, col: 22, offset: 28652},
 											name: "EntryTail",
 										},
 									},
@@ -8153,10 +8153,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1194, col: 5, offset: 28687},
+						pos: position{line: 1195, col: 5, offset: 28710},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1194, col: 5, offset: 28687},
+							pos:  position{line: 1195, col: 5, offset: 28710},
 							name: "__",
 						},
 					},
@@ -8167,32 +8167,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1197, col: 1, offset: 28712},
+			pos:  position{line: 1198, col: 1, offset: 28735},
 			expr: &actionExpr{
-				pos: position{line: 1197, col: 13, offset: 28724},
+				pos: position{line: 1198, col: 13, offset: 28747},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1197, col: 13, offset: 28724},
+					pos: position{line: 1198, col: 13, offset: 28747},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1197, col: 13, offset: 28724},
+							pos:  position{line: 1198, col: 13, offset: 28747},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1197, col: 16, offset: 28727},
+							pos:        position{line: 1198, col: 16, offset: 28750},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1197, col: 20, offset: 28731},
+							pos:  position{line: 1198, col: 20, offset: 28754},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1197, col: 23, offset: 28734},
+							pos:   position{line: 1198, col: 23, offset: 28757},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1197, col: 25, offset: 28736},
+								pos:  position{line: 1198, col: 25, offset: 28759},
 								name: "Entry",
 							},
 						},
@@ -8204,40 +8204,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1199, col: 1, offset: 28761},
+			pos:  position{line: 1200, col: 1, offset: 28784},
 			expr: &actionExpr{
-				pos: position{line: 1200, col: 5, offset: 28771},
+				pos: position{line: 1201, col: 5, offset: 28794},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1200, col: 5, offset: 28771},
+					pos: position{line: 1201, col: 5, offset: 28794},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1200, col: 5, offset: 28771},
+							pos:   position{line: 1201, col: 5, offset: 28794},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1200, col: 9, offset: 28775},
+								pos:  position{line: 1201, col: 9, offset: 28798},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1200, col: 14, offset: 28780},
+							pos:  position{line: 1201, col: 14, offset: 28803},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1200, col: 17, offset: 28783},
+							pos:        position{line: 1201, col: 17, offset: 28806},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1200, col: 21, offset: 28787},
+							pos:  position{line: 1201, col: 21, offset: 28810},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1200, col: 24, offset: 28790},
+							pos:   position{line: 1201, col: 24, offset: 28813},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1200, col: 30, offset: 28796},
+								pos:  position{line: 1201, col: 30, offset: 28819},
 								name: "Expr",
 							},
 						},
@@ -8249,56 +8249,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1206, col: 1, offset: 28921},
+			pos:  position{line: 1207, col: 1, offset: 28944},
 			expr: &choiceExpr{
-				pos: position{line: 1207, col: 5, offset: 28933},
+				pos: position{line: 1208, col: 5, offset: 28956},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1207, col: 5, offset: 28933},
+						pos:  position{line: 1208, col: 5, offset: 28956},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1208, col: 5, offset: 28949},
+						pos:  position{line: 1209, col: 5, offset: 28972},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1209, col: 5, offset: 28967},
+						pos:  position{line: 1210, col: 5, offset: 28990},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1210, col: 5, offset: 28979},
+						pos:  position{line: 1211, col: 5, offset: 29002},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1211, col: 5, offset: 28997},
+						pos:  position{line: 1212, col: 5, offset: 29020},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1212, col: 5, offset: 29016},
+						pos:  position{line: 1213, col: 5, offset: 29039},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1213, col: 5, offset: 29033},
+						pos:  position{line: 1214, col: 5, offset: 29056},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1214, col: 5, offset: 29046},
+						pos:  position{line: 1215, col: 5, offset: 29069},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 5, offset: 29055},
+						pos:  position{line: 1216, col: 5, offset: 29078},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1216, col: 5, offset: 29072},
+						pos:  position{line: 1217, col: 5, offset: 29095},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 5, offset: 29091},
+						pos:  position{line: 1218, col: 5, offset: 29114},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1218, col: 5, offset: 29110},
+						pos:  position{line: 1219, col: 5, offset: 29133},
 						name: "NullLiteral",
 					},
 				},
@@ -8308,28 +8308,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1220, col: 1, offset: 29123},
+			pos:  position{line: 1221, col: 1, offset: 29146},
 			expr: &choiceExpr{
-				pos: position{line: 1221, col: 5, offset: 29141},
+				pos: position{line: 1222, col: 5, offset: 29164},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1221, col: 5, offset: 29141},
+						pos: position{line: 1222, col: 5, offset: 29164},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1221, col: 5, offset: 29141},
+							pos: position{line: 1222, col: 5, offset: 29164},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1221, col: 5, offset: 29141},
+									pos:   position{line: 1222, col: 5, offset: 29164},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1221, col: 7, offset: 29143},
+										pos:  position{line: 1222, col: 7, offset: 29166},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1221, col: 14, offset: 29150},
+									pos: position{line: 1222, col: 14, offset: 29173},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1221, col: 15, offset: 29151},
+										pos:  position{line: 1222, col: 15, offset: 29174},
 										name: "IdentifierRest",
 									},
 								},
@@ -8337,13 +8337,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1224, col: 5, offset: 29231},
+						pos: position{line: 1225, col: 5, offset: 29254},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1224, col: 5, offset: 29231},
+							pos:   position{line: 1225, col: 5, offset: 29254},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1224, col: 7, offset: 29233},
+								pos:  position{line: 1225, col: 7, offset: 29256},
 								name: "IP4Net",
 							},
 						},
@@ -8355,28 +8355,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1228, col: 1, offset: 29302},
+			pos:  position{line: 1229, col: 1, offset: 29325},
 			expr: &choiceExpr{
-				pos: position{line: 1229, col: 5, offset: 29321},
+				pos: position{line: 1230, col: 5, offset: 29344},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1229, col: 5, offset: 29321},
+						pos: position{line: 1230, col: 5, offset: 29344},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1229, col: 5, offset: 29321},
+							pos: position{line: 1230, col: 5, offset: 29344},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1229, col: 5, offset: 29321},
+									pos:   position{line: 1230, col: 5, offset: 29344},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1229, col: 7, offset: 29323},
+										pos:  position{line: 1230, col: 7, offset: 29346},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1229, col: 11, offset: 29327},
+									pos: position{line: 1230, col: 11, offset: 29350},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1229, col: 12, offset: 29328},
+										pos:  position{line: 1230, col: 12, offset: 29351},
 										name: "IdentifierRest",
 									},
 								},
@@ -8384,13 +8384,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1232, col: 5, offset: 29407},
+						pos: position{line: 1233, col: 5, offset: 29430},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1232, col: 5, offset: 29407},
+							pos:   position{line: 1233, col: 5, offset: 29430},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1232, col: 7, offset: 29409},
+								pos:  position{line: 1233, col: 7, offset: 29432},
 								name: "IP",
 							},
 						},
@@ -8402,15 +8402,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1236, col: 1, offset: 29473},
+			pos:  position{line: 1237, col: 1, offset: 29496},
 			expr: &actionExpr{
-				pos: position{line: 1237, col: 5, offset: 29490},
+				pos: position{line: 1238, col: 5, offset: 29513},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1237, col: 5, offset: 29490},
+					pos:   position{line: 1238, col: 5, offset: 29513},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1237, col: 7, offset: 29492},
+						pos:  position{line: 1238, col: 7, offset: 29515},
 						name: "FloatString",
 					},
 				},
@@ -8420,15 +8420,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1241, col: 1, offset: 29570},
+			pos:  position{line: 1242, col: 1, offset: 29593},
 			expr: &actionExpr{
-				pos: position{line: 1242, col: 5, offset: 29589},
+				pos: position{line: 1243, col: 5, offset: 29612},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1242, col: 5, offset: 29589},
+					pos:   position{line: 1243, col: 5, offset: 29612},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1242, col: 7, offset: 29591},
+						pos:  position{line: 1243, col: 7, offset: 29614},
 						name: "IntString",
 					},
 				},
@@ -8438,23 +8438,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1246, col: 1, offset: 29665},
+			pos:  position{line: 1247, col: 1, offset: 29688},
 			expr: &choiceExpr{
-				pos: position{line: 1247, col: 5, offset: 29684},
+				pos: position{line: 1248, col: 5, offset: 29707},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1247, col: 5, offset: 29684},
+						pos: position{line: 1248, col: 5, offset: 29707},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1247, col: 5, offset: 29684},
+							pos:  position{line: 1248, col: 5, offset: 29707},
 							name: "TrueToken",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1248, col: 5, offset: 29747},
+						pos: position{line: 1249, col: 5, offset: 29770},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1248, col: 5, offset: 29747},
+							pos:  position{line: 1249, col: 5, offset: 29770},
 							name: "FalseToken",
 						},
 					},
@@ -8465,12 +8465,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1250, col: 1, offset: 29808},
+			pos:  position{line: 1251, col: 1, offset: 29831},
 			expr: &actionExpr{
-				pos: position{line: 1251, col: 5, offset: 29824},
+				pos: position{line: 1252, col: 5, offset: 29847},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1251, col: 5, offset: 29824},
+					pos:  position{line: 1252, col: 5, offset: 29847},
 					name: "NullToken",
 				},
 			},
@@ -8479,23 +8479,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1253, col: 1, offset: 29879},
+			pos:  position{line: 1254, col: 1, offset: 29902},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 5, offset: 29896},
+				pos: position{line: 1255, col: 5, offset: 29919},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1254, col: 5, offset: 29896},
+					pos: position{line: 1255, col: 5, offset: 29919},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1254, col: 5, offset: 29896},
+							pos:        position{line: 1255, col: 5, offset: 29919},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1254, col: 10, offset: 29901},
+							pos: position{line: 1255, col: 10, offset: 29924},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1254, col: 10, offset: 29901},
+								pos:  position{line: 1255, col: 10, offset: 29924},
 								name: "HexDigit",
 							},
 						},
@@ -8507,29 +8507,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1258, col: 1, offset: 29975},
+			pos:  position{line: 1259, col: 1, offset: 29998},
 			expr: &actionExpr{
-				pos: position{line: 1259, col: 5, offset: 29991},
+				pos: position{line: 1260, col: 5, offset: 30014},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1259, col: 5, offset: 29991},
+					pos: position{line: 1260, col: 5, offset: 30014},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1259, col: 5, offset: 29991},
+							pos:        position{line: 1260, col: 5, offset: 30014},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1259, col: 9, offset: 29995},
+							pos:   position{line: 1260, col: 9, offset: 30018},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1259, col: 13, offset: 29999},
+								pos:  position{line: 1260, col: 13, offset: 30022},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1259, col: 18, offset: 30004},
+							pos:        position{line: 1260, col: 18, offset: 30027},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8542,16 +8542,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1267, col: 1, offset: 30137},
+			pos:  position{line: 1268, col: 1, offset: 30160},
 			expr: &choiceExpr{
-				pos: position{line: 1268, col: 5, offset: 30146},
+				pos: position{line: 1269, col: 5, offset: 30169},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1268, col: 5, offset: 30146},
+						pos:  position{line: 1269, col: 5, offset: 30169},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1269, col: 5, offset: 30164},
+						pos:  position{line: 1270, col: 5, offset: 30187},
 						name: "ComplexType",
 					},
 				},
@@ -8561,28 +8561,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1271, col: 1, offset: 30177},
+			pos:  position{line: 1272, col: 1, offset: 30200},
 			expr: &choiceExpr{
-				pos: position{line: 1272, col: 5, offset: 30195},
+				pos: position{line: 1273, col: 5, offset: 30218},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1272, col: 5, offset: 30195},
+						pos: position{line: 1273, col: 5, offset: 30218},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1272, col: 5, offset: 30195},
+							pos: position{line: 1273, col: 5, offset: 30218},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1272, col: 5, offset: 30195},
+									pos:   position{line: 1273, col: 5, offset: 30218},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1272, col: 10, offset: 30200},
+										pos:  position{line: 1273, col: 10, offset: 30223},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1272, col: 24, offset: 30214},
+									pos: position{line: 1273, col: 24, offset: 30237},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1272, col: 25, offset: 30215},
+										pos:  position{line: 1273, col: 25, offset: 30238},
 										name: "IdentifierRest",
 									},
 								},
@@ -8590,45 +8590,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1273, col: 5, offset: 30255},
+						pos: position{line: 1274, col: 5, offset: 30278},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1273, col: 5, offset: 30255},
+							pos: position{line: 1274, col: 5, offset: 30278},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1273, col: 5, offset: 30255},
+									pos:        position{line: 1274, col: 5, offset: 30278},
 									val:        "error",
 									ignoreCase: false,
 									want:       "\"error\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 13, offset: 30263},
+									pos:  position{line: 1274, col: 13, offset: 30286},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1273, col: 16, offset: 30266},
+									pos:        position{line: 1274, col: 16, offset: 30289},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 20, offset: 30270},
+									pos:  position{line: 1274, col: 20, offset: 30293},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1273, col: 23, offset: 30273},
+									pos:   position{line: 1274, col: 23, offset: 30296},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1273, col: 25, offset: 30275},
+										pos:  position{line: 1274, col: 25, offset: 30298},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 30, offset: 30280},
+									pos:  position{line: 1274, col: 30, offset: 30303},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1273, col: 33, offset: 30283},
+									pos:        position{line: 1274, col: 33, offset: 30306},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8637,43 +8637,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1280, col: 5, offset: 30423},
+						pos: position{line: 1281, col: 5, offset: 30446},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1280, col: 5, offset: 30423},
+							pos: position{line: 1281, col: 5, offset: 30446},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1280, col: 5, offset: 30423},
+									pos:   position{line: 1281, col: 5, offset: 30446},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1280, col: 10, offset: 30428},
+										pos:  position{line: 1281, col: 10, offset: 30451},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1280, col: 15, offset: 30433},
+									pos:   position{line: 1281, col: 15, offset: 30456},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1280, col: 19, offset: 30437},
+										pos: position{line: 1281, col: 19, offset: 30460},
 										expr: &seqExpr{
-											pos: position{line: 1280, col: 20, offset: 30438},
+											pos: position{line: 1281, col: 20, offset: 30461},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1280, col: 20, offset: 30438},
+													pos:  position{line: 1281, col: 20, offset: 30461},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1280, col: 23, offset: 30441},
+													pos:        position{line: 1281, col: 23, offset: 30464},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1280, col: 27, offset: 30445},
+													pos:  position{line: 1281, col: 27, offset: 30468},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1280, col: 30, offset: 30448},
+													pos:  position{line: 1281, col: 30, offset: 30471},
 													name: "Type",
 												},
 											},
@@ -8684,31 +8684,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1291, col: 5, offset: 30773},
+						pos: position{line: 1292, col: 5, offset: 30796},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1291, col: 5, offset: 30773},
+							pos: position{line: 1292, col: 5, offset: 30796},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1291, col: 5, offset: 30773},
+									pos:        position{line: 1292, col: 5, offset: 30796},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1291, col: 9, offset: 30777},
+									pos:  position{line: 1292, col: 9, offset: 30800},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1291, col: 12, offset: 30780},
+									pos:   position{line: 1292, col: 12, offset: 30803},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1291, col: 18, offset: 30786},
+										pos:  position{line: 1292, col: 18, offset: 30809},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1291, col: 27, offset: 30795},
+									pos:        position{line: 1292, col: 27, offset: 30818},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8723,28 +8723,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1299, col: 1, offset: 30939},
+			pos:  position{line: 1300, col: 1, offset: 30962},
 			expr: &actionExpr{
-				pos: position{line: 1300, col: 5, offset: 30952},
+				pos: position{line: 1301, col: 5, offset: 30975},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1300, col: 5, offset: 30952},
+					pos: position{line: 1301, col: 5, offset: 30975},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1300, col: 5, offset: 30952},
+							pos:   position{line: 1301, col: 5, offset: 30975},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1300, col: 11, offset: 30958},
+								pos:  position{line: 1301, col: 11, offset: 30981},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1300, col: 16, offset: 30963},
+							pos:   position{line: 1301, col: 16, offset: 30986},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1300, col: 21, offset: 30968},
+								pos: position{line: 1301, col: 21, offset: 30991},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1300, col: 21, offset: 30968},
+									pos:  position{line: 1301, col: 21, offset: 30991},
 									name: "TypeListTail",
 								},
 							},
@@ -8757,32 +8757,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1304, col: 1, offset: 31026},
+			pos:  position{line: 1305, col: 1, offset: 31049},
 			expr: &actionExpr{
-				pos: position{line: 1304, col: 16, offset: 31041},
+				pos: position{line: 1305, col: 16, offset: 31064},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1304, col: 16, offset: 31041},
+					pos: position{line: 1305, col: 16, offset: 31064},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1304, col: 16, offset: 31041},
+							pos:  position{line: 1305, col: 16, offset: 31064},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1304, col: 19, offset: 31044},
+							pos:        position{line: 1305, col: 19, offset: 31067},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1304, col: 23, offset: 31048},
+							pos:  position{line: 1305, col: 23, offset: 31071},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1304, col: 26, offset: 31051},
+							pos:   position{line: 1305, col: 26, offset: 31074},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1304, col: 30, offset: 31055},
+								pos:  position{line: 1305, col: 30, offset: 31078},
 								name: "Type",
 							},
 						},
@@ -8794,40 +8794,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1306, col: 1, offset: 31081},
+			pos:  position{line: 1307, col: 1, offset: 31104},
 			expr: &choiceExpr{
-				pos: position{line: 1307, col: 5, offset: 31097},
+				pos: position{line: 1308, col: 5, offset: 31120},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1307, col: 5, offset: 31097},
+						pos: position{line: 1308, col: 5, offset: 31120},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1307, col: 5, offset: 31097},
+							pos: position{line: 1308, col: 5, offset: 31120},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1307, col: 5, offset: 31097},
+									pos:        position{line: 1308, col: 5, offset: 31120},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1307, col: 9, offset: 31101},
+									pos:  position{line: 1308, col: 9, offset: 31124},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1307, col: 12, offset: 31104},
+									pos:   position{line: 1308, col: 12, offset: 31127},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1307, col: 19, offset: 31111},
+										pos:  position{line: 1308, col: 19, offset: 31134},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1307, col: 33, offset: 31125},
+									pos:  position{line: 1308, col: 33, offset: 31148},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1307, col: 36, offset: 31128},
+									pos:        position{line: 1308, col: 36, offset: 31151},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -8836,35 +8836,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 31290},
+						pos: position{line: 1315, col: 5, offset: 31313},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1314, col: 5, offset: 31290},
+							pos: position{line: 1315, col: 5, offset: 31313},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1314, col: 5, offset: 31290},
+									pos:        position{line: 1315, col: 5, offset: 31313},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1314, col: 9, offset: 31294},
+									pos:  position{line: 1315, col: 9, offset: 31317},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1314, col: 12, offset: 31297},
+									pos:   position{line: 1315, col: 12, offset: 31320},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1314, col: 16, offset: 31301},
+										pos:  position{line: 1315, col: 16, offset: 31324},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1314, col: 21, offset: 31306},
+									pos:  position{line: 1315, col: 21, offset: 31329},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1314, col: 24, offset: 31309},
+									pos:        position{line: 1315, col: 24, offset: 31332},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -8873,35 +8873,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1321, col: 5, offset: 31451},
+						pos: position{line: 1322, col: 5, offset: 31474},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1321, col: 5, offset: 31451},
+							pos: position{line: 1322, col: 5, offset: 31474},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1321, col: 5, offset: 31451},
+									pos:        position{line: 1322, col: 5, offset: 31474},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1321, col: 10, offset: 31456},
+									pos:  position{line: 1322, col: 10, offset: 31479},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1321, col: 13, offset: 31459},
+									pos:   position{line: 1322, col: 13, offset: 31482},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1321, col: 17, offset: 31463},
+										pos:  position{line: 1322, col: 17, offset: 31486},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1321, col: 22, offset: 31468},
+									pos:  position{line: 1322, col: 22, offset: 31491},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1321, col: 25, offset: 31471},
+									pos:        position{line: 1322, col: 25, offset: 31494},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -8910,57 +8910,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1328, col: 5, offset: 31610},
+						pos: position{line: 1329, col: 5, offset: 31633},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1328, col: 5, offset: 31610},
+							pos: position{line: 1329, col: 5, offset: 31633},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1328, col: 5, offset: 31610},
+									pos:        position{line: 1329, col: 5, offset: 31633},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1328, col: 10, offset: 31615},
+									pos:  position{line: 1329, col: 10, offset: 31638},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1328, col: 13, offset: 31618},
+									pos:   position{line: 1329, col: 13, offset: 31641},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1328, col: 21, offset: 31626},
+										pos:  position{line: 1329, col: 21, offset: 31649},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1328, col: 26, offset: 31631},
+									pos:  position{line: 1329, col: 26, offset: 31654},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1328, col: 29, offset: 31634},
+									pos:        position{line: 1329, col: 29, offset: 31657},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1328, col: 33, offset: 31638},
+									pos:  position{line: 1329, col: 33, offset: 31661},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1328, col: 36, offset: 31641},
+									pos:   position{line: 1329, col: 36, offset: 31664},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1328, col: 44, offset: 31649},
+										pos:  position{line: 1329, col: 44, offset: 31672},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1328, col: 49, offset: 31654},
+									pos:  position{line: 1329, col: 49, offset: 31677},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1328, col: 52, offset: 31657},
+									pos:        position{line: 1329, col: 52, offset: 31680},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -8975,35 +8975,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1337, col: 1, offset: 31831},
+			pos:  position{line: 1338, col: 1, offset: 31854},
 			expr: &choiceExpr{
-				pos: position{line: 1338, col: 5, offset: 31849},
+				pos: position{line: 1339, col: 5, offset: 31872},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1338, col: 5, offset: 31849},
+						pos: position{line: 1339, col: 5, offset: 31872},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1338, col: 5, offset: 31849},
+							pos: position{line: 1339, col: 5, offset: 31872},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1338, col: 5, offset: 31849},
+									pos:        position{line: 1339, col: 5, offset: 31872},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1338, col: 9, offset: 31853},
+									pos:   position{line: 1339, col: 9, offset: 31876},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1338, col: 11, offset: 31855},
+										pos: position{line: 1339, col: 11, offset: 31878},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1338, col: 11, offset: 31855},
+											pos:  position{line: 1339, col: 11, offset: 31878},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1338, col: 29, offset: 31873},
+									pos:        position{line: 1339, col: 29, offset: 31896},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9012,30 +9012,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1339, col: 5, offset: 31937},
+						pos: position{line: 1340, col: 5, offset: 31960},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1339, col: 5, offset: 31937},
+							pos: position{line: 1340, col: 5, offset: 31960},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1339, col: 5, offset: 31937},
+									pos:        position{line: 1340, col: 5, offset: 31960},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1339, col: 9, offset: 31941},
+									pos:   position{line: 1340, col: 9, offset: 31964},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1339, col: 11, offset: 31943},
+										pos: position{line: 1340, col: 11, offset: 31966},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1339, col: 11, offset: 31943},
+											pos:  position{line: 1340, col: 11, offset: 31966},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1339, col: 29, offset: 31961},
+									pos:        position{line: 1340, col: 29, offset: 31984},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9050,35 +9050,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1341, col: 1, offset: 32022},
+			pos:  position{line: 1342, col: 1, offset: 32045},
 			expr: &choiceExpr{
-				pos: position{line: 1342, col: 5, offset: 32034},
+				pos: position{line: 1343, col: 5, offset: 32057},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 32034},
+						pos: position{line: 1343, col: 5, offset: 32057},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1342, col: 5, offset: 32034},
+							pos: position{line: 1343, col: 5, offset: 32057},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1342, col: 5, offset: 32034},
+									pos:        position{line: 1343, col: 5, offset: 32057},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1342, col: 11, offset: 32040},
+									pos:   position{line: 1343, col: 11, offset: 32063},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1342, col: 13, offset: 32042},
+										pos: position{line: 1343, col: 13, offset: 32065},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1342, col: 13, offset: 32042},
+											pos:  position{line: 1343, col: 13, offset: 32065},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1342, col: 38, offset: 32067},
+									pos:        position{line: 1343, col: 38, offset: 32090},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9087,30 +9087,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1349, col: 5, offset: 32213},
+						pos: position{line: 1350, col: 5, offset: 32236},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1349, col: 5, offset: 32213},
+							pos: position{line: 1350, col: 5, offset: 32236},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1349, col: 5, offset: 32213},
+									pos:        position{line: 1350, col: 5, offset: 32236},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1349, col: 10, offset: 32218},
+									pos:   position{line: 1350, col: 10, offset: 32241},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1349, col: 12, offset: 32220},
+										pos: position{line: 1350, col: 12, offset: 32243},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1349, col: 12, offset: 32220},
+											pos:  position{line: 1350, col: 12, offset: 32243},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1349, col: 37, offset: 32245},
+									pos:        position{line: 1350, col: 37, offset: 32268},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9125,24 +9125,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1357, col: 1, offset: 32388},
+			pos:  position{line: 1358, col: 1, offset: 32411},
 			expr: &choiceExpr{
-				pos: position{line: 1358, col: 5, offset: 32416},
+				pos: position{line: 1359, col: 5, offset: 32439},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1358, col: 5, offset: 32416},
+						pos:  position{line: 1359, col: 5, offset: 32439},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1359, col: 5, offset: 32432},
+						pos: position{line: 1360, col: 5, offset: 32455},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1359, col: 5, offset: 32432},
+							pos:   position{line: 1360, col: 5, offset: 32455},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1359, col: 7, offset: 32434},
+								pos: position{line: 1360, col: 7, offset: 32457},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1359, col: 7, offset: 32434},
+									pos:  position{line: 1360, col: 7, offset: 32457},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9155,27 +9155,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1363, col: 1, offset: 32557},
+			pos:  position{line: 1364, col: 1, offset: 32580},
 			expr: &choiceExpr{
-				pos: position{line: 1364, col: 5, offset: 32585},
+				pos: position{line: 1365, col: 5, offset: 32608},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1364, col: 5, offset: 32585},
+						pos: position{line: 1365, col: 5, offset: 32608},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1364, col: 5, offset: 32585},
+							pos: position{line: 1365, col: 5, offset: 32608},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1364, col: 5, offset: 32585},
+									pos:        position{line: 1365, col: 5, offset: 32608},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1364, col: 10, offset: 32590},
+									pos:   position{line: 1365, col: 10, offset: 32613},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1364, col: 12, offset: 32592},
+										pos:        position{line: 1365, col: 12, offset: 32615},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9185,25 +9185,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1365, col: 5, offset: 32618},
+						pos: position{line: 1366, col: 5, offset: 32641},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1365, col: 5, offset: 32618},
+							pos: position{line: 1366, col: 5, offset: 32641},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1365, col: 5, offset: 32618},
+									pos: position{line: 1366, col: 5, offset: 32641},
 									expr: &litMatcher{
-										pos:        position{line: 1365, col: 7, offset: 32620},
+										pos:        position{line: 1366, col: 7, offset: 32643},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1365, col: 12, offset: 32625},
+									pos:   position{line: 1366, col: 12, offset: 32648},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1365, col: 14, offset: 32627},
+										pos:  position{line: 1366, col: 14, offset: 32650},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9217,24 +9217,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1367, col: 1, offset: 32663},
+			pos:  position{line: 1368, col: 1, offset: 32686},
 			expr: &choiceExpr{
-				pos: position{line: 1368, col: 5, offset: 32691},
+				pos: position{line: 1369, col: 5, offset: 32714},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 5, offset: 32691},
+						pos:  position{line: 1369, col: 5, offset: 32714},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 32707},
+						pos: position{line: 1370, col: 5, offset: 32730},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1369, col: 5, offset: 32707},
+							pos:   position{line: 1370, col: 5, offset: 32730},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1369, col: 7, offset: 32709},
+								pos: position{line: 1370, col: 7, offset: 32732},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1369, col: 7, offset: 32709},
+									pos:  position{line: 1370, col: 7, offset: 32732},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9247,27 +9247,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1373, col: 1, offset: 32832},
+			pos:  position{line: 1374, col: 1, offset: 32855},
 			expr: &choiceExpr{
-				pos: position{line: 1374, col: 5, offset: 32860},
+				pos: position{line: 1375, col: 5, offset: 32883},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1374, col: 5, offset: 32860},
+						pos: position{line: 1375, col: 5, offset: 32883},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1374, col: 5, offset: 32860},
+							pos: position{line: 1375, col: 5, offset: 32883},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1374, col: 5, offset: 32860},
+									pos:        position{line: 1375, col: 5, offset: 32883},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1374, col: 10, offset: 32865},
+									pos:   position{line: 1375, col: 10, offset: 32888},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1374, col: 12, offset: 32867},
+										pos:        position{line: 1375, col: 12, offset: 32890},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9277,25 +9277,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1375, col: 5, offset: 32893},
+						pos: position{line: 1376, col: 5, offset: 32916},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1375, col: 5, offset: 32893},
+							pos: position{line: 1376, col: 5, offset: 32916},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1375, col: 5, offset: 32893},
+									pos: position{line: 1376, col: 5, offset: 32916},
 									expr: &litMatcher{
-										pos:        position{line: 1375, col: 7, offset: 32895},
+										pos:        position{line: 1376, col: 7, offset: 32918},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1375, col: 12, offset: 32900},
+									pos:   position{line: 1376, col: 12, offset: 32923},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1375, col: 14, offset: 32902},
+										pos:  position{line: 1376, col: 14, offset: 32925},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9309,37 +9309,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1377, col: 1, offset: 32938},
+			pos:  position{line: 1378, col: 1, offset: 32961},
 			expr: &actionExpr{
-				pos: position{line: 1378, col: 5, offset: 32954},
+				pos: position{line: 1379, col: 5, offset: 32977},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1378, col: 5, offset: 32954},
+					pos: position{line: 1379, col: 5, offset: 32977},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1378, col: 5, offset: 32954},
+							pos:        position{line: 1379, col: 5, offset: 32977},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1378, col: 9, offset: 32958},
+							pos:  position{line: 1379, col: 9, offset: 32981},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1378, col: 12, offset: 32961},
+							pos:   position{line: 1379, col: 12, offset: 32984},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1378, col: 14, offset: 32963},
+								pos:  position{line: 1379, col: 14, offset: 32986},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1378, col: 19, offset: 32968},
+							pos:  position{line: 1379, col: 19, offset: 32991},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1378, col: 22, offset: 32971},
+							pos:        position{line: 1379, col: 22, offset: 32994},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9352,129 +9352,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1386, col: 1, offset: 33106},
+			pos:  position{line: 1387, col: 1, offset: 33129},
 			expr: &actionExpr{
-				pos: position{line: 1387, col: 5, offset: 33124},
+				pos: position{line: 1388, col: 5, offset: 33147},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1387, col: 9, offset: 33128},
+					pos: position{line: 1388, col: 9, offset: 33151},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1387, col: 9, offset: 33128},
+							pos:        position{line: 1388, col: 9, offset: 33151},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1387, col: 19, offset: 33138},
+							pos:        position{line: 1388, col: 19, offset: 33161},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1387, col: 30, offset: 33149},
+							pos:        position{line: 1388, col: 30, offset: 33172},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1387, col: 41, offset: 33160},
+							pos:        position{line: 1388, col: 41, offset: 33183},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1388, col: 9, offset: 33177},
+							pos:        position{line: 1389, col: 9, offset: 33200},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1388, col: 18, offset: 33186},
+							pos:        position{line: 1389, col: 18, offset: 33209},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1388, col: 28, offset: 33196},
+							pos:        position{line: 1389, col: 28, offset: 33219},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1388, col: 38, offset: 33206},
+							pos:        position{line: 1389, col: 38, offset: 33229},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1389, col: 9, offset: 33222},
+							pos:        position{line: 1390, col: 9, offset: 33245},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1389, col: 21, offset: 33234},
+							pos:        position{line: 1390, col: 21, offset: 33257},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1389, col: 33, offset: 33246},
+							pos:        position{line: 1390, col: 33, offset: 33269},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1390, col: 9, offset: 33264},
+							pos:        position{line: 1391, col: 9, offset: 33287},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1390, col: 18, offset: 33273},
+							pos:        position{line: 1391, col: 18, offset: 33296},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1391, col: 9, offset: 33290},
+							pos:        position{line: 1392, col: 9, offset: 33313},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1391, col: 22, offset: 33303},
+							pos:        position{line: 1392, col: 22, offset: 33326},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1392, col: 9, offset: 33318},
+							pos:        position{line: 1393, col: 9, offset: 33341},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1393, col: 9, offset: 33334},
+							pos:        position{line: 1394, col: 9, offset: 33357},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1393, col: 16, offset: 33341},
+							pos:        position{line: 1394, col: 16, offset: 33364},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1394, col: 9, offset: 33355},
+							pos:        position{line: 1395, col: 9, offset: 33378},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1394, col: 18, offset: 33364},
+							pos:        position{line: 1395, col: 18, offset: 33387},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9487,31 +9487,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1402, col: 1, offset: 33549},
+			pos:  position{line: 1403, col: 1, offset: 33572},
 			expr: &choiceExpr{
-				pos: position{line: 1403, col: 5, offset: 33567},
+				pos: position{line: 1404, col: 5, offset: 33590},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1403, col: 5, offset: 33567},
+						pos: position{line: 1404, col: 5, offset: 33590},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1403, col: 5, offset: 33567},
+							pos: position{line: 1404, col: 5, offset: 33590},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1403, col: 5, offset: 33567},
+									pos:   position{line: 1404, col: 5, offset: 33590},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1403, col: 11, offset: 33573},
+										pos:  position{line: 1404, col: 11, offset: 33596},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1403, col: 21, offset: 33583},
+									pos:   position{line: 1404, col: 21, offset: 33606},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1403, col: 26, offset: 33588},
+										pos: position{line: 1404, col: 26, offset: 33611},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1403, col: 26, offset: 33588},
+											pos:  position{line: 1404, col: 26, offset: 33611},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9520,10 +9520,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1406, col: 5, offset: 33654},
+						pos: position{line: 1407, col: 5, offset: 33677},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1406, col: 5, offset: 33654},
+							pos:        position{line: 1407, col: 5, offset: 33677},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9536,32 +9536,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1408, col: 1, offset: 33678},
+			pos:  position{line: 1409, col: 1, offset: 33701},
 			expr: &actionExpr{
-				pos: position{line: 1408, col: 21, offset: 33698},
+				pos: position{line: 1409, col: 21, offset: 33721},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1408, col: 21, offset: 33698},
+					pos: position{line: 1409, col: 21, offset: 33721},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1408, col: 21, offset: 33698},
+							pos:  position{line: 1409, col: 21, offset: 33721},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1408, col: 24, offset: 33701},
+							pos:        position{line: 1409, col: 24, offset: 33724},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1408, col: 28, offset: 33705},
+							pos:  position{line: 1409, col: 28, offset: 33728},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1408, col: 31, offset: 33708},
+							pos:   position{line: 1409, col: 31, offset: 33731},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1408, col: 35, offset: 33712},
+								pos:  position{line: 1409, col: 35, offset: 33735},
 								name: "TypeField",
 							},
 						},
@@ -9573,40 +9573,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1410, col: 1, offset: 33743},
+			pos:  position{line: 1411, col: 1, offset: 33766},
 			expr: &actionExpr{
-				pos: position{line: 1411, col: 5, offset: 33757},
+				pos: position{line: 1412, col: 5, offset: 33780},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1411, col: 5, offset: 33757},
+					pos: position{line: 1412, col: 5, offset: 33780},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1411, col: 5, offset: 33757},
+							pos:   position{line: 1412, col: 5, offset: 33780},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 10, offset: 33762},
+								pos:  position{line: 1412, col: 10, offset: 33785},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1411, col: 15, offset: 33767},
+							pos:  position{line: 1412, col: 15, offset: 33790},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1411, col: 18, offset: 33770},
+							pos:        position{line: 1412, col: 18, offset: 33793},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1411, col: 22, offset: 33774},
+							pos:  position{line: 1412, col: 22, offset: 33797},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1411, col: 25, offset: 33777},
+							pos:   position{line: 1412, col: 25, offset: 33800},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 29, offset: 33781},
+								pos:  position{line: 1412, col: 29, offset: 33804},
 								name: "Type",
 							},
 						},
@@ -9618,54 +9618,54 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1419, col: 1, offset: 33930},
+			pos:  position{line: 1420, col: 1, offset: 33953},
 			expr: &choiceExpr{
-				pos: position{line: 1420, col: 5, offset: 33939},
+				pos: position{line: 1421, col: 5, offset: 33962},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1420, col: 5, offset: 33939},
+						pos: position{line: 1421, col: 5, offset: 33962},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1420, col: 5, offset: 33939},
+							pos:   position{line: 1421, col: 5, offset: 33962},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1420, col: 7, offset: 33941},
+								pos:  position{line: 1421, col: 7, offset: 33964},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1421, col: 5, offset: 34030},
+						pos: position{line: 1422, col: 5, offset: 34053},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1421, col: 5, offset: 34030},
+							pos:   position{line: 1422, col: 5, offset: 34053},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1421, col: 7, offset: 34032},
+								pos:  position{line: 1422, col: 7, offset: 34055},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1422, col: 5, offset: 34121},
+						pos: position{line: 1423, col: 5, offset: 34144},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1422, col: 5, offset: 34121},
+							pos:   position{line: 1423, col: 5, offset: 34144},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1422, col: 7, offset: 34123},
+								pos:  position{line: 1423, col: 7, offset: 34146},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1423, col: 5, offset: 34212},
+						pos: position{line: 1424, col: 5, offset: 34235},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1423, col: 5, offset: 34212},
+							pos:   position{line: 1424, col: 5, offset: 34235},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1423, col: 7, offset: 34214},
+								pos:  position{line: 1424, col: 7, offset: 34237},
 								name: "KSUID",
 							},
 						},
@@ -9677,22 +9677,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1425, col: 1, offset: 34300},
+			pos:  position{line: 1426, col: 1, offset: 34323},
 			expr: &actionExpr{
-				pos: position{line: 1426, col: 5, offset: 34314},
+				pos: position{line: 1427, col: 5, offset: 34337},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1426, col: 5, offset: 34314},
+					pos: position{line: 1427, col: 5, offset: 34337},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1426, col: 6, offset: 34315},
+							pos: position{line: 1427, col: 6, offset: 34338},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1426, col: 6, offset: 34315},
+									pos:  position{line: 1427, col: 6, offset: 34338},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1426, col: 24, offset: 34333},
+									pos:        position{line: 1427, col: 24, offset: 34356},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -9700,16 +9700,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1426, col: 29, offset: 34338},
+							pos: position{line: 1427, col: 29, offset: 34361},
 							expr: &choiceExpr{
-								pos: position{line: 1426, col: 30, offset: 34339},
+								pos: position{line: 1427, col: 30, offset: 34362},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1426, col: 30, offset: 34339},
+										pos:  position{line: 1427, col: 30, offset: 34362},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1426, col: 47, offset: 34356},
+										pos:        position{line: 1427, col: 47, offset: 34379},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -9725,24 +9725,24 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1428, col: 1, offset: 34394},
+			pos:  position{line: 1429, col: 1, offset: 34417},
 			expr: &actionExpr{
-				pos: position{line: 1428, col: 12, offset: 34405},
+				pos: position{line: 1429, col: 12, offset: 34428},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1428, col: 12, offset: 34405},
+					pos: position{line: 1429, col: 12, offset: 34428},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1428, col: 13, offset: 34406},
+							pos: position{line: 1429, col: 13, offset: 34429},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1428, col: 13, offset: 34406},
+									pos:        position{line: 1429, col: 13, offset: 34429},
 									val:        "and",
 									ignoreCase: false,
 									want:       "\"and\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1428, col: 21, offset: 34414},
+									pos:        position{line: 1429, col: 21, offset: 34437},
 									val:        "AND",
 									ignoreCase: false,
 									want:       "\"AND\"",
@@ -9750,9 +9750,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1428, col: 28, offset: 34421},
+							pos: position{line: 1429, col: 28, offset: 34444},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1428, col: 29, offset: 34422},
+								pos:  position{line: 1429, col: 29, offset: 34445},
 								name: "IdentifierRest",
 							},
 						},
@@ -9764,20 +9764,20 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1429, col: 1, offset: 34459},
+			pos:  position{line: 1430, col: 1, offset: 34482},
 			expr: &seqExpr{
-				pos: position{line: 1429, col: 11, offset: 34469},
+				pos: position{line: 1430, col: 11, offset: 34492},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1429, col: 11, offset: 34469},
+						pos:        position{line: 1430, col: 11, offset: 34492},
 						val:        "by",
 						ignoreCase: false,
 						want:       "\"by\"",
 					},
 					&notExpr{
-						pos: position{line: 1429, col: 16, offset: 34474},
+						pos: position{line: 1430, col: 16, offset: 34497},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1429, col: 17, offset: 34475},
+							pos:  position{line: 1430, col: 17, offset: 34498},
 							name: "IdentifierRest",
 						},
 					},
@@ -9788,20 +9788,20 @@ var g = &grammar{
 		},
 		{
 			name: "FalseToken",
-			pos:  position{line: 1430, col: 1, offset: 34490},
+			pos:  position{line: 1431, col: 1, offset: 34513},
 			expr: &seqExpr{
-				pos: position{line: 1430, col: 14, offset: 34503},
+				pos: position{line: 1431, col: 14, offset: 34526},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1430, col: 14, offset: 34503},
+						pos:        position{line: 1431, col: 14, offset: 34526},
 						val:        "false",
 						ignoreCase: false,
 						want:       "\"false\"",
 					},
 					&notExpr{
-						pos: position{line: 1430, col: 22, offset: 34511},
+						pos: position{line: 1431, col: 22, offset: 34534},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1430, col: 23, offset: 34512},
+							pos:  position{line: 1431, col: 23, offset: 34535},
 							name: "IdentifierRest",
 						},
 					},
@@ -9812,20 +9812,20 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1431, col: 1, offset: 34527},
+			pos:  position{line: 1432, col: 1, offset: 34550},
 			expr: &seqExpr{
-				pos: position{line: 1431, col: 11, offset: 34537},
+				pos: position{line: 1432, col: 11, offset: 34560},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1431, col: 11, offset: 34537},
+						pos:        position{line: 1432, col: 11, offset: 34560},
 						val:        "in",
 						ignoreCase: false,
 						want:       "\"in\"",
 					},
 					&notExpr{
-						pos: position{line: 1431, col: 16, offset: 34542},
+						pos: position{line: 1432, col: 16, offset: 34565},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1431, col: 17, offset: 34543},
+							pos:  position{line: 1432, col: 17, offset: 34566},
 							name: "IdentifierRest",
 						},
 					},
@@ -9836,24 +9836,24 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1432, col: 1, offset: 34558},
+			pos:  position{line: 1433, col: 1, offset: 34581},
 			expr: &actionExpr{
-				pos: position{line: 1432, col: 12, offset: 34569},
+				pos: position{line: 1433, col: 12, offset: 34592},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1432, col: 12, offset: 34569},
+					pos: position{line: 1433, col: 12, offset: 34592},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1432, col: 13, offset: 34570},
+							pos: position{line: 1433, col: 13, offset: 34593},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1432, col: 13, offset: 34570},
+									pos:        position{line: 1433, col: 13, offset: 34593},
 									val:        "not",
 									ignoreCase: false,
 									want:       "\"not\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1432, col: 21, offset: 34578},
+									pos:        position{line: 1433, col: 21, offset: 34601},
 									val:        "NOT",
 									ignoreCase: false,
 									want:       "\"NOT\"",
@@ -9861,9 +9861,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1432, col: 28, offset: 34585},
+							pos: position{line: 1433, col: 28, offset: 34608},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1432, col: 29, offset: 34586},
+								pos:  position{line: 1433, col: 29, offset: 34609},
 								name: "IdentifierRest",
 							},
 						},
@@ -9875,20 +9875,20 @@ var g = &grammar{
 		},
 		{
 			name: "NullToken",
-			pos:  position{line: 1433, col: 1, offset: 34623},
+			pos:  position{line: 1434, col: 1, offset: 34646},
 			expr: &seqExpr{
-				pos: position{line: 1433, col: 13, offset: 34635},
+				pos: position{line: 1434, col: 13, offset: 34658},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1433, col: 13, offset: 34635},
+						pos:        position{line: 1434, col: 13, offset: 34658},
 						val:        "null",
 						ignoreCase: false,
 						want:       "\"null\"",
 					},
 					&notExpr{
-						pos: position{line: 1433, col: 20, offset: 34642},
+						pos: position{line: 1434, col: 20, offset: 34665},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1433, col: 21, offset: 34643},
+							pos:  position{line: 1434, col: 21, offset: 34666},
 							name: "IdentifierRest",
 						},
 					},
@@ -9899,24 +9899,24 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1434, col: 1, offset: 34658},
+			pos:  position{line: 1435, col: 1, offset: 34681},
 			expr: &actionExpr{
-				pos: position{line: 1434, col: 11, offset: 34668},
+				pos: position{line: 1435, col: 11, offset: 34691},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1434, col: 11, offset: 34668},
+					pos: position{line: 1435, col: 11, offset: 34691},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1434, col: 12, offset: 34669},
+							pos: position{line: 1435, col: 12, offset: 34692},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1434, col: 12, offset: 34669},
+									pos:        position{line: 1435, col: 12, offset: 34692},
 									val:        "or",
 									ignoreCase: false,
 									want:       "\"or\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1434, col: 19, offset: 34676},
+									pos:        position{line: 1435, col: 19, offset: 34699},
 									val:        "OR",
 									ignoreCase: false,
 									want:       "\"OR\"",
@@ -9924,9 +9924,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1434, col: 25, offset: 34682},
+							pos: position{line: 1435, col: 25, offset: 34705},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1434, col: 26, offset: 34683},
+								pos:  position{line: 1435, col: 26, offset: 34706},
 								name: "IdentifierRest",
 							},
 						},
@@ -9938,20 +9938,20 @@ var g = &grammar{
 		},
 		{
 			name: "TrueToken",
-			pos:  position{line: 1435, col: 1, offset: 34719},
+			pos:  position{line: 1436, col: 1, offset: 34742},
 			expr: &seqExpr{
-				pos: position{line: 1435, col: 13, offset: 34731},
+				pos: position{line: 1436, col: 13, offset: 34754},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1435, col: 13, offset: 34731},
+						pos:        position{line: 1436, col: 13, offset: 34754},
 						val:        "true",
 						ignoreCase: false,
 						want:       "\"true\"",
 					},
 					&notExpr{
-						pos: position{line: 1435, col: 20, offset: 34738},
+						pos: position{line: 1436, col: 20, offset: 34761},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1435, col: 21, offset: 34739},
+							pos:  position{line: 1436, col: 21, offset: 34762},
 							name: "IdentifierRest",
 						},
 					},
@@ -9962,15 +9962,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1437, col: 1, offset: 34755},
+			pos:  position{line: 1438, col: 1, offset: 34778},
 			expr: &actionExpr{
-				pos: position{line: 1438, col: 5, offset: 34770},
+				pos: position{line: 1439, col: 5, offset: 34793},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1438, col: 5, offset: 34770},
+					pos:   position{line: 1439, col: 5, offset: 34793},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1438, col: 8, offset: 34773},
+						pos:  position{line: 1439, col: 8, offset: 34796},
 						name: "IdentifierName",
 					},
 				},
@@ -9980,51 +9980,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1446, col: 1, offset: 34906},
+			pos:  position{line: 1447, col: 1, offset: 34929},
 			expr: &actionExpr{
-				pos: position{line: 1447, col: 5, offset: 34922},
+				pos: position{line: 1448, col: 5, offset: 34945},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1447, col: 5, offset: 34922},
+					pos: position{line: 1448, col: 5, offset: 34945},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1447, col: 5, offset: 34922},
+							pos:   position{line: 1448, col: 5, offset: 34945},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1447, col: 11, offset: 34928},
+								pos:  position{line: 1448, col: 11, offset: 34951},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1447, col: 22, offset: 34939},
+							pos:   position{line: 1448, col: 22, offset: 34962},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1447, col: 27, offset: 34944},
+								pos: position{line: 1448, col: 27, offset: 34967},
 								expr: &actionExpr{
-									pos: position{line: 1447, col: 28, offset: 34945},
+									pos: position{line: 1448, col: 28, offset: 34968},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1447, col: 28, offset: 34945},
+										pos: position{line: 1448, col: 28, offset: 34968},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1447, col: 28, offset: 34945},
+												pos:  position{line: 1448, col: 28, offset: 34968},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1447, col: 31, offset: 34948},
+												pos:        position{line: 1448, col: 31, offset: 34971},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1447, col: 35, offset: 34952},
+												pos:  position{line: 1448, col: 35, offset: 34975},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1447, col: 38, offset: 34955},
+												pos:   position{line: 1448, col: 38, offset: 34978},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1447, col: 43, offset: 34960},
+													pos:  position{line: 1448, col: 43, offset: 34983},
 													name: "Identifier",
 												},
 											},
@@ -10041,29 +10041,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1451, col: 1, offset: 35038},
+			pos:  position{line: 1452, col: 1, offset: 35061},
 			expr: &choiceExpr{
-				pos: position{line: 1452, col: 5, offset: 35057},
+				pos: position{line: 1453, col: 5, offset: 35080},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1452, col: 5, offset: 35057},
+						pos: position{line: 1453, col: 5, offset: 35080},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1452, col: 5, offset: 35057},
+							pos: position{line: 1453, col: 5, offset: 35080},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1452, col: 5, offset: 35057},
+									pos: position{line: 1453, col: 5, offset: 35080},
 									expr: &seqExpr{
-										pos: position{line: 1452, col: 7, offset: 35059},
+										pos: position{line: 1453, col: 7, offset: 35082},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1452, col: 7, offset: 35059},
+												pos:  position{line: 1453, col: 7, offset: 35082},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1452, col: 15, offset: 35067},
+												pos: position{line: 1453, col: 15, offset: 35090},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1452, col: 16, offset: 35068},
+													pos:  position{line: 1453, col: 16, offset: 35091},
 													name: "IdentifierRest",
 												},
 											},
@@ -10071,13 +10071,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1452, col: 32, offset: 35084},
+									pos:  position{line: 1453, col: 32, offset: 35107},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1452, col: 48, offset: 35100},
+									pos: position{line: 1453, col: 48, offset: 35123},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1452, col: 48, offset: 35100},
+										pos:  position{line: 1453, col: 48, offset: 35123},
 										name: "IdentifierRest",
 									},
 								},
@@ -10085,32 +10085,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1453, col: 5, offset: 35151},
+						pos: position{line: 1454, col: 5, offset: 35174},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1453, col: 5, offset: 35151},
+							pos:        position{line: 1454, col: 5, offset: 35174},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1454, col: 5, offset: 35190},
+						pos: position{line: 1455, col: 5, offset: 35213},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1454, col: 5, offset: 35190},
+							pos: position{line: 1455, col: 5, offset: 35213},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1454, col: 5, offset: 35190},
+									pos:        position{line: 1455, col: 5, offset: 35213},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1454, col: 10, offset: 35195},
+									pos:   position{line: 1455, col: 10, offset: 35218},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1454, col: 13, offset: 35198},
+										pos:  position{line: 1455, col: 13, offset: 35221},
 										name: "IDGuard",
 									},
 								},
@@ -10118,10 +10118,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1456, col: 5, offset: 35289},
+						pos: position{line: 1457, col: 5, offset: 35312},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1456, col: 5, offset: 35289},
+							pos:        position{line: 1457, col: 5, offset: 35312},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
@@ -10134,22 +10134,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1458, col: 1, offset: 35328},
+			pos:  position{line: 1459, col: 1, offset: 35351},
 			expr: &choiceExpr{
-				pos: position{line: 1459, col: 5, offset: 35348},
+				pos: position{line: 1460, col: 5, offset: 35371},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1459, col: 5, offset: 35348},
+						pos:  position{line: 1460, col: 5, offset: 35371},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1460, col: 5, offset: 35366},
+						pos:        position{line: 1461, col: 5, offset: 35389},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1461, col: 5, offset: 35374},
+						pos:        position{line: 1462, col: 5, offset: 35397},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10161,24 +10161,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1463, col: 1, offset: 35379},
+			pos:  position{line: 1464, col: 1, offset: 35402},
 			expr: &choiceExpr{
-				pos: position{line: 1464, col: 5, offset: 35398},
+				pos: position{line: 1465, col: 5, offset: 35421},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1464, col: 5, offset: 35398},
+						pos:  position{line: 1465, col: 5, offset: 35421},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1465, col: 5, offset: 35418},
+						pos:  position{line: 1466, col: 5, offset: 35441},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1466, col: 5, offset: 35443},
+						pos:  position{line: 1467, col: 5, offset: 35466},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1467, col: 5, offset: 35460},
+						pos:  position{line: 1468, col: 5, offset: 35483},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10188,24 +10188,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1469, col: 1, offset: 35489},
+			pos:  position{line: 1470, col: 1, offset: 35512},
 			expr: &choiceExpr{
-				pos: position{line: 1470, col: 5, offset: 35501},
+				pos: position{line: 1471, col: 5, offset: 35524},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1470, col: 5, offset: 35501},
+						pos:  position{line: 1471, col: 5, offset: 35524},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1471, col: 5, offset: 35520},
+						pos:  position{line: 1472, col: 5, offset: 35543},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1472, col: 5, offset: 35536},
+						pos:  position{line: 1473, col: 5, offset: 35559},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1473, col: 5, offset: 35544},
+						pos:  position{line: 1474, col: 5, offset: 35567},
 						name: "Infinity",
 					},
 				},
@@ -10215,25 +10215,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1475, col: 1, offset: 35554},
+			pos:  position{line: 1476, col: 1, offset: 35577},
 			expr: &actionExpr{
-				pos: position{line: 1476, col: 5, offset: 35563},
+				pos: position{line: 1477, col: 5, offset: 35586},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1476, col: 5, offset: 35563},
+					pos: position{line: 1477, col: 5, offset: 35586},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1476, col: 5, offset: 35563},
+							pos:  position{line: 1477, col: 5, offset: 35586},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1476, col: 14, offset: 35572},
+							pos:        position{line: 1477, col: 14, offset: 35595},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1476, col: 18, offset: 35576},
+							pos:  position{line: 1477, col: 18, offset: 35599},
 							name: "FullTime",
 						},
 					},
@@ -10244,32 +10244,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1480, col: 1, offset: 35652},
+			pos:  position{line: 1481, col: 1, offset: 35675},
 			expr: &seqExpr{
-				pos: position{line: 1480, col: 12, offset: 35663},
+				pos: position{line: 1481, col: 12, offset: 35686},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1480, col: 12, offset: 35663},
+						pos:  position{line: 1481, col: 12, offset: 35686},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1480, col: 15, offset: 35666},
+						pos:        position{line: 1481, col: 15, offset: 35689},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1480, col: 19, offset: 35670},
+						pos:  position{line: 1481, col: 19, offset: 35693},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1480, col: 22, offset: 35673},
+						pos:        position{line: 1481, col: 22, offset: 35696},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1480, col: 26, offset: 35677},
+						pos:  position{line: 1481, col: 26, offset: 35700},
 						name: "D2",
 					},
 				},
@@ -10279,33 +10279,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1482, col: 1, offset: 35681},
+			pos:  position{line: 1483, col: 1, offset: 35704},
 			expr: &seqExpr{
-				pos: position{line: 1482, col: 6, offset: 35686},
+				pos: position{line: 1483, col: 6, offset: 35709},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1482, col: 6, offset: 35686},
+						pos:        position{line: 1483, col: 6, offset: 35709},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1482, col: 11, offset: 35691},
+						pos:        position{line: 1483, col: 11, offset: 35714},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1482, col: 16, offset: 35696},
+						pos:        position{line: 1483, col: 16, offset: 35719},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1482, col: 21, offset: 35701},
+						pos:        position{line: 1483, col: 21, offset: 35724},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10318,19 +10318,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1483, col: 1, offset: 35707},
+			pos:  position{line: 1484, col: 1, offset: 35730},
 			expr: &seqExpr{
-				pos: position{line: 1483, col: 6, offset: 35712},
+				pos: position{line: 1484, col: 6, offset: 35735},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1483, col: 6, offset: 35712},
+						pos:        position{line: 1484, col: 6, offset: 35735},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1483, col: 11, offset: 35717},
+						pos:        position{line: 1484, col: 11, offset: 35740},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10343,16 +10343,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1485, col: 1, offset: 35724},
+			pos:  position{line: 1486, col: 1, offset: 35747},
 			expr: &seqExpr{
-				pos: position{line: 1485, col: 12, offset: 35735},
+				pos: position{line: 1486, col: 12, offset: 35758},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1485, col: 12, offset: 35735},
+						pos:  position{line: 1486, col: 12, offset: 35758},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1485, col: 24, offset: 35747},
+						pos:  position{line: 1486, col: 24, offset: 35770},
 						name: "TimeOffset",
 					},
 				},
@@ -10362,49 +10362,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1487, col: 1, offset: 35759},
+			pos:  position{line: 1488, col: 1, offset: 35782},
 			expr: &seqExpr{
-				pos: position{line: 1487, col: 15, offset: 35773},
+				pos: position{line: 1488, col: 15, offset: 35796},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1487, col: 15, offset: 35773},
+						pos:  position{line: 1488, col: 15, offset: 35796},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1487, col: 18, offset: 35776},
+						pos:        position{line: 1488, col: 18, offset: 35799},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1487, col: 22, offset: 35780},
+						pos:  position{line: 1488, col: 22, offset: 35803},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1487, col: 25, offset: 35783},
+						pos:        position{line: 1488, col: 25, offset: 35806},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1487, col: 29, offset: 35787},
+						pos:  position{line: 1488, col: 29, offset: 35810},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1487, col: 32, offset: 35790},
+						pos: position{line: 1488, col: 32, offset: 35813},
 						expr: &seqExpr{
-							pos: position{line: 1487, col: 33, offset: 35791},
+							pos: position{line: 1488, col: 33, offset: 35814},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1487, col: 33, offset: 35791},
+									pos:        position{line: 1488, col: 33, offset: 35814},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1487, col: 37, offset: 35795},
+									pos: position{line: 1488, col: 37, offset: 35818},
 									expr: &charClassMatcher{
-										pos:        position{line: 1487, col: 37, offset: 35795},
+										pos:        position{line: 1488, col: 37, offset: 35818},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10421,30 +10421,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1489, col: 1, offset: 35805},
+			pos:  position{line: 1490, col: 1, offset: 35828},
 			expr: &choiceExpr{
-				pos: position{line: 1490, col: 5, offset: 35820},
+				pos: position{line: 1491, col: 5, offset: 35843},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1490, col: 5, offset: 35820},
+						pos:        position{line: 1491, col: 5, offset: 35843},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1491, col: 5, offset: 35828},
+						pos: position{line: 1492, col: 5, offset: 35851},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1491, col: 6, offset: 35829},
+								pos: position{line: 1492, col: 6, offset: 35852},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1491, col: 6, offset: 35829},
+										pos:        position{line: 1492, col: 6, offset: 35852},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1491, col: 12, offset: 35835},
+										pos:        position{line: 1492, col: 12, offset: 35858},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10452,34 +10452,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1491, col: 17, offset: 35840},
+								pos:  position{line: 1492, col: 17, offset: 35863},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1491, col: 20, offset: 35843},
+								pos:        position{line: 1492, col: 20, offset: 35866},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1491, col: 24, offset: 35847},
+								pos:  position{line: 1492, col: 24, offset: 35870},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1491, col: 27, offset: 35850},
+								pos: position{line: 1492, col: 27, offset: 35873},
 								expr: &seqExpr{
-									pos: position{line: 1491, col: 28, offset: 35851},
+									pos: position{line: 1492, col: 28, offset: 35874},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1491, col: 28, offset: 35851},
+											pos:        position{line: 1492, col: 28, offset: 35874},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1491, col: 32, offset: 35855},
+											pos: position{line: 1492, col: 32, offset: 35878},
 											expr: &charClassMatcher{
-												pos:        position{line: 1491, col: 32, offset: 35855},
+												pos:        position{line: 1492, col: 32, offset: 35878},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10498,33 +10498,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1493, col: 1, offset: 35865},
+			pos:  position{line: 1494, col: 1, offset: 35888},
 			expr: &actionExpr{
-				pos: position{line: 1494, col: 5, offset: 35878},
+				pos: position{line: 1495, col: 5, offset: 35901},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1494, col: 5, offset: 35878},
+					pos: position{line: 1495, col: 5, offset: 35901},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1494, col: 5, offset: 35878},
+							pos: position{line: 1495, col: 5, offset: 35901},
 							expr: &litMatcher{
-								pos:        position{line: 1494, col: 5, offset: 35878},
+								pos:        position{line: 1495, col: 5, offset: 35901},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1494, col: 10, offset: 35883},
+							pos: position{line: 1495, col: 10, offset: 35906},
 							expr: &seqExpr{
-								pos: position{line: 1494, col: 11, offset: 35884},
+								pos: position{line: 1495, col: 11, offset: 35907},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1494, col: 11, offset: 35884},
+										pos:  position{line: 1495, col: 11, offset: 35907},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1494, col: 19, offset: 35892},
+										pos:  position{line: 1495, col: 19, offset: 35915},
 										name: "TimeUnit",
 									},
 								},
@@ -10538,27 +10538,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1498, col: 1, offset: 35974},
+			pos:  position{line: 1499, col: 1, offset: 35997},
 			expr: &seqExpr{
-				pos: position{line: 1498, col: 11, offset: 35984},
+				pos: position{line: 1499, col: 11, offset: 36007},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1498, col: 11, offset: 35984},
+						pos:  position{line: 1499, col: 11, offset: 36007},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1498, col: 16, offset: 35989},
+						pos: position{line: 1499, col: 16, offset: 36012},
 						expr: &seqExpr{
-							pos: position{line: 1498, col: 17, offset: 35990},
+							pos: position{line: 1499, col: 17, offset: 36013},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1498, col: 17, offset: 35990},
+									pos:        position{line: 1499, col: 17, offset: 36013},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1498, col: 21, offset: 35994},
+									pos:  position{line: 1499, col: 21, offset: 36017},
 									name: "UInt",
 								},
 							},
@@ -10571,60 +10571,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1500, col: 1, offset: 36002},
+			pos:  position{line: 1501, col: 1, offset: 36025},
 			expr: &choiceExpr{
-				pos: position{line: 1501, col: 5, offset: 36015},
+				pos: position{line: 1502, col: 5, offset: 36038},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1501, col: 5, offset: 36015},
+						pos:        position{line: 1502, col: 5, offset: 36038},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1502, col: 5, offset: 36024},
+						pos:        position{line: 1503, col: 5, offset: 36047},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1503, col: 5, offset: 36033},
+						pos:        position{line: 1504, col: 5, offset: 36056},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1504, col: 5, offset: 36042},
+						pos:        position{line: 1505, col: 5, offset: 36065},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1505, col: 5, offset: 36050},
+						pos:        position{line: 1506, col: 5, offset: 36073},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1506, col: 5, offset: 36058},
+						pos:        position{line: 1507, col: 5, offset: 36081},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1507, col: 5, offset: 36066},
+						pos:        position{line: 1508, col: 5, offset: 36089},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1508, col: 5, offset: 36074},
+						pos:        position{line: 1509, col: 5, offset: 36097},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1509, col: 5, offset: 36082},
+						pos:        position{line: 1510, col: 5, offset: 36105},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10636,45 +10636,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1511, col: 1, offset: 36087},
+			pos:  position{line: 1512, col: 1, offset: 36110},
 			expr: &actionExpr{
-				pos: position{line: 1512, col: 5, offset: 36094},
+				pos: position{line: 1513, col: 5, offset: 36117},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1512, col: 5, offset: 36094},
+					pos: position{line: 1513, col: 5, offset: 36117},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1512, col: 5, offset: 36094},
+							pos:  position{line: 1513, col: 5, offset: 36117},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 10, offset: 36099},
+							pos:        position{line: 1513, col: 10, offset: 36122},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1512, col: 14, offset: 36103},
+							pos:  position{line: 1513, col: 14, offset: 36126},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 19, offset: 36108},
+							pos:        position{line: 1513, col: 19, offset: 36131},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1512, col: 23, offset: 36112},
+							pos:  position{line: 1513, col: 23, offset: 36135},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 28, offset: 36117},
+							pos:        position{line: 1513, col: 28, offset: 36140},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1512, col: 32, offset: 36121},
+							pos:  position{line: 1513, col: 32, offset: 36144},
 							name: "UInt",
 						},
 					},
@@ -10685,43 +10685,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1514, col: 1, offset: 36158},
+			pos:  position{line: 1515, col: 1, offset: 36181},
 			expr: &actionExpr{
-				pos: position{line: 1515, col: 5, offset: 36166},
+				pos: position{line: 1516, col: 5, offset: 36189},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1515, col: 5, offset: 36166},
+					pos: position{line: 1516, col: 5, offset: 36189},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1515, col: 5, offset: 36166},
+							pos: position{line: 1516, col: 5, offset: 36189},
 							expr: &seqExpr{
-								pos: position{line: 1515, col: 7, offset: 36168},
+								pos: position{line: 1516, col: 7, offset: 36191},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1515, col: 7, offset: 36168},
+										pos:  position{line: 1516, col: 7, offset: 36191},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1515, col: 11, offset: 36172},
+										pos:        position{line: 1516, col: 11, offset: 36195},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1515, col: 15, offset: 36176},
+										pos:  position{line: 1516, col: 15, offset: 36199},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1515, col: 19, offset: 36180},
+										pos: position{line: 1516, col: 19, offset: 36203},
 										expr: &choiceExpr{
-											pos: position{line: 1515, col: 21, offset: 36182},
+											pos: position{line: 1516, col: 21, offset: 36205},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1515, col: 21, offset: 36182},
+													pos:  position{line: 1516, col: 21, offset: 36205},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1515, col: 32, offset: 36193},
+													pos:        position{line: 1516, col: 32, offset: 36216},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10733,10 +10733,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1515, col: 38, offset: 36199},
+							pos:   position{line: 1516, col: 38, offset: 36222},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1515, col: 40, offset: 36201},
+								pos:  position{line: 1516, col: 40, offset: 36224},
 								name: "IP6Variations",
 							},
 						},
@@ -10748,32 +10748,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1519, col: 1, offset: 36365},
+			pos:  position{line: 1520, col: 1, offset: 36388},
 			expr: &choiceExpr{
-				pos: position{line: 1520, col: 5, offset: 36383},
+				pos: position{line: 1521, col: 5, offset: 36406},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1520, col: 5, offset: 36383},
+						pos: position{line: 1521, col: 5, offset: 36406},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1520, col: 5, offset: 36383},
+							pos: position{line: 1521, col: 5, offset: 36406},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1520, col: 5, offset: 36383},
+									pos:   position{line: 1521, col: 5, offset: 36406},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1520, col: 7, offset: 36385},
+										pos: position{line: 1521, col: 7, offset: 36408},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1520, col: 7, offset: 36385},
+											pos:  position{line: 1521, col: 7, offset: 36408},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1520, col: 17, offset: 36395},
+									pos:   position{line: 1521, col: 17, offset: 36418},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1520, col: 19, offset: 36397},
+										pos:  position{line: 1521, col: 19, offset: 36420},
 										name: "IP6Tail",
 									},
 								},
@@ -10781,52 +10781,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1523, col: 5, offset: 36461},
+						pos: position{line: 1524, col: 5, offset: 36484},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1523, col: 5, offset: 36461},
+							pos: position{line: 1524, col: 5, offset: 36484},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1523, col: 5, offset: 36461},
+									pos:   position{line: 1524, col: 5, offset: 36484},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1523, col: 7, offset: 36463},
+										pos:  position{line: 1524, col: 7, offset: 36486},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1523, col: 11, offset: 36467},
+									pos:   position{line: 1524, col: 11, offset: 36490},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1523, col: 13, offset: 36469},
+										pos: position{line: 1524, col: 13, offset: 36492},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1523, col: 13, offset: 36469},
+											pos:  position{line: 1524, col: 13, offset: 36492},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1523, col: 23, offset: 36479},
+									pos:        position{line: 1524, col: 23, offset: 36502},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1523, col: 28, offset: 36484},
+									pos:   position{line: 1524, col: 28, offset: 36507},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1523, col: 30, offset: 36486},
+										pos: position{line: 1524, col: 30, offset: 36509},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1523, col: 30, offset: 36486},
+											pos:  position{line: 1524, col: 30, offset: 36509},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1523, col: 40, offset: 36496},
+									pos:   position{line: 1524, col: 40, offset: 36519},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1523, col: 42, offset: 36498},
+										pos:  position{line: 1524, col: 42, offset: 36521},
 										name: "IP6Tail",
 									},
 								},
@@ -10834,33 +10834,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1526, col: 5, offset: 36597},
+						pos: position{line: 1527, col: 5, offset: 36620},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1526, col: 5, offset: 36597},
+							pos: position{line: 1527, col: 5, offset: 36620},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1526, col: 5, offset: 36597},
+									pos:        position{line: 1527, col: 5, offset: 36620},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1526, col: 10, offset: 36602},
+									pos:   position{line: 1527, col: 10, offset: 36625},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1526, col: 12, offset: 36604},
+										pos: position{line: 1527, col: 12, offset: 36627},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1526, col: 12, offset: 36604},
+											pos:  position{line: 1527, col: 12, offset: 36627},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1526, col: 22, offset: 36614},
+									pos:   position{line: 1527, col: 22, offset: 36637},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1526, col: 24, offset: 36616},
+										pos:  position{line: 1527, col: 24, offset: 36639},
 										name: "IP6Tail",
 									},
 								},
@@ -10868,32 +10868,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1529, col: 5, offset: 36687},
+						pos: position{line: 1530, col: 5, offset: 36710},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1529, col: 5, offset: 36687},
+							pos: position{line: 1530, col: 5, offset: 36710},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1529, col: 5, offset: 36687},
+									pos:   position{line: 1530, col: 5, offset: 36710},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1529, col: 7, offset: 36689},
+										pos:  position{line: 1530, col: 7, offset: 36712},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1529, col: 11, offset: 36693},
+									pos:   position{line: 1530, col: 11, offset: 36716},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1529, col: 13, offset: 36695},
+										pos: position{line: 1530, col: 13, offset: 36718},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1529, col: 13, offset: 36695},
+											pos:  position{line: 1530, col: 13, offset: 36718},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1529, col: 23, offset: 36705},
+									pos:        position{line: 1530, col: 23, offset: 36728},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -10902,10 +10902,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1532, col: 5, offset: 36773},
+						pos: position{line: 1533, col: 5, offset: 36796},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1532, col: 5, offset: 36773},
+							pos:        position{line: 1533, col: 5, offset: 36796},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10918,16 +10918,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1536, col: 1, offset: 36810},
+			pos:  position{line: 1537, col: 1, offset: 36833},
 			expr: &choiceExpr{
-				pos: position{line: 1537, col: 5, offset: 36822},
+				pos: position{line: 1538, col: 5, offset: 36845},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1537, col: 5, offset: 36822},
+						pos:  position{line: 1538, col: 5, offset: 36845},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1538, col: 5, offset: 36829},
+						pos:  position{line: 1539, col: 5, offset: 36852},
 						name: "Hex",
 					},
 				},
@@ -10937,24 +10937,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1540, col: 1, offset: 36834},
+			pos:  position{line: 1541, col: 1, offset: 36857},
 			expr: &actionExpr{
-				pos: position{line: 1540, col: 12, offset: 36845},
+				pos: position{line: 1541, col: 12, offset: 36868},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1540, col: 12, offset: 36845},
+					pos: position{line: 1541, col: 12, offset: 36868},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1540, col: 12, offset: 36845},
+							pos:        position{line: 1541, col: 12, offset: 36868},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1540, col: 16, offset: 36849},
+							pos:   position{line: 1541, col: 16, offset: 36872},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1540, col: 18, offset: 36851},
+								pos:  position{line: 1541, col: 18, offset: 36874},
 								name: "Hex",
 							},
 						},
@@ -10966,23 +10966,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1542, col: 1, offset: 36889},
+			pos:  position{line: 1543, col: 1, offset: 36912},
 			expr: &actionExpr{
-				pos: position{line: 1542, col: 12, offset: 36900},
+				pos: position{line: 1543, col: 12, offset: 36923},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1542, col: 12, offset: 36900},
+					pos: position{line: 1543, col: 12, offset: 36923},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1542, col: 12, offset: 36900},
+							pos:   position{line: 1543, col: 12, offset: 36923},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1542, col: 14, offset: 36902},
+								pos:  position{line: 1543, col: 14, offset: 36925},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1542, col: 18, offset: 36906},
+							pos:        position{line: 1543, col: 18, offset: 36929},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10995,32 +10995,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1544, col: 1, offset: 36944},
+			pos:  position{line: 1545, col: 1, offset: 36967},
 			expr: &actionExpr{
-				pos: position{line: 1545, col: 5, offset: 36955},
+				pos: position{line: 1546, col: 5, offset: 36978},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1545, col: 5, offset: 36955},
+					pos: position{line: 1546, col: 5, offset: 36978},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1545, col: 5, offset: 36955},
+							pos:   position{line: 1546, col: 5, offset: 36978},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1545, col: 7, offset: 36957},
+								pos:  position{line: 1546, col: 7, offset: 36980},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 10, offset: 36960},
+							pos:        position{line: 1546, col: 10, offset: 36983},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1545, col: 14, offset: 36964},
+							pos:   position{line: 1546, col: 14, offset: 36987},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1545, col: 16, offset: 36966},
+								pos:  position{line: 1546, col: 16, offset: 36989},
 								name: "UIntString",
 							},
 						},
@@ -11032,32 +11032,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1549, col: 1, offset: 37034},
+			pos:  position{line: 1550, col: 1, offset: 37057},
 			expr: &actionExpr{
-				pos: position{line: 1550, col: 5, offset: 37045},
+				pos: position{line: 1551, col: 5, offset: 37068},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1550, col: 5, offset: 37045},
+					pos: position{line: 1551, col: 5, offset: 37068},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1550, col: 5, offset: 37045},
+							pos:   position{line: 1551, col: 5, offset: 37068},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1550, col: 7, offset: 37047},
+								pos:  position{line: 1551, col: 7, offset: 37070},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1550, col: 11, offset: 37051},
+							pos:        position{line: 1551, col: 11, offset: 37074},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1550, col: 15, offset: 37055},
+							pos:   position{line: 1551, col: 15, offset: 37078},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1550, col: 17, offset: 37057},
+								pos:  position{line: 1551, col: 17, offset: 37080},
 								name: "UIntString",
 							},
 						},
@@ -11069,15 +11069,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1554, col: 1, offset: 37125},
+			pos:  position{line: 1555, col: 1, offset: 37148},
 			expr: &actionExpr{
-				pos: position{line: 1555, col: 4, offset: 37133},
+				pos: position{line: 1556, col: 4, offset: 37156},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1555, col: 4, offset: 37133},
+					pos:   position{line: 1556, col: 4, offset: 37156},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1555, col: 6, offset: 37135},
+						pos:  position{line: 1556, col: 6, offset: 37158},
 						name: "UIntString",
 					},
 				},
@@ -11087,16 +11087,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1557, col: 1, offset: 37175},
+			pos:  position{line: 1558, col: 1, offset: 37198},
 			expr: &choiceExpr{
-				pos: position{line: 1558, col: 5, offset: 37189},
+				pos: position{line: 1559, col: 5, offset: 37212},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1558, col: 5, offset: 37189},
+						pos:  position{line: 1559, col: 5, offset: 37212},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1559, col: 5, offset: 37204},
+						pos:  position{line: 1560, col: 5, offset: 37227},
 						name: "MinusIntString",
 					},
 				},
@@ -11106,14 +11106,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1561, col: 1, offset: 37220},
+			pos:  position{line: 1562, col: 1, offset: 37243},
 			expr: &actionExpr{
-				pos: position{line: 1561, col: 14, offset: 37233},
+				pos: position{line: 1562, col: 14, offset: 37256},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1561, col: 14, offset: 37233},
+					pos: position{line: 1562, col: 14, offset: 37256},
 					expr: &charClassMatcher{
-						pos:        position{line: 1561, col: 14, offset: 37233},
+						pos:        position{line: 1562, col: 14, offset: 37256},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11126,21 +11126,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1563, col: 1, offset: 37272},
+			pos:  position{line: 1564, col: 1, offset: 37295},
 			expr: &actionExpr{
-				pos: position{line: 1564, col: 5, offset: 37291},
+				pos: position{line: 1565, col: 5, offset: 37314},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1564, col: 5, offset: 37291},
+					pos: position{line: 1565, col: 5, offset: 37314},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1564, col: 5, offset: 37291},
+							pos:        position{line: 1565, col: 5, offset: 37314},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1564, col: 9, offset: 37295},
+							pos:  position{line: 1565, col: 9, offset: 37318},
 							name: "UIntString",
 						},
 					},
@@ -11151,29 +11151,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1566, col: 1, offset: 37338},
+			pos:  position{line: 1567, col: 1, offset: 37361},
 			expr: &choiceExpr{
-				pos: position{line: 1567, col: 5, offset: 37354},
+				pos: position{line: 1568, col: 5, offset: 37377},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1567, col: 5, offset: 37354},
+						pos: position{line: 1568, col: 5, offset: 37377},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1567, col: 5, offset: 37354},
+							pos: position{line: 1568, col: 5, offset: 37377},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1567, col: 5, offset: 37354},
+									pos: position{line: 1568, col: 5, offset: 37377},
 									expr: &litMatcher{
-										pos:        position{line: 1567, col: 5, offset: 37354},
+										pos:        position{line: 1568, col: 5, offset: 37377},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1567, col: 10, offset: 37359},
+									pos: position{line: 1568, col: 10, offset: 37382},
 									expr: &charClassMatcher{
-										pos:        position{line: 1567, col: 10, offset: 37359},
+										pos:        position{line: 1568, col: 10, offset: 37382},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11181,15 +11181,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1567, col: 17, offset: 37366},
+									pos:        position{line: 1568, col: 17, offset: 37389},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1567, col: 21, offset: 37370},
+									pos: position{line: 1568, col: 21, offset: 37393},
 									expr: &charClassMatcher{
-										pos:        position{line: 1567, col: 21, offset: 37370},
+										pos:        position{line: 1568, col: 21, offset: 37393},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11197,9 +11197,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1567, col: 28, offset: 37377},
+									pos: position{line: 1568, col: 28, offset: 37400},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1567, col: 28, offset: 37377},
+										pos:  position{line: 1568, col: 28, offset: 37400},
 										name: "ExponentPart",
 									},
 								},
@@ -11207,30 +11207,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1568, col: 5, offset: 37426},
+						pos: position{line: 1569, col: 5, offset: 37449},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1568, col: 5, offset: 37426},
+							pos: position{line: 1569, col: 5, offset: 37449},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1568, col: 5, offset: 37426},
+									pos: position{line: 1569, col: 5, offset: 37449},
 									expr: &litMatcher{
-										pos:        position{line: 1568, col: 5, offset: 37426},
+										pos:        position{line: 1569, col: 5, offset: 37449},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1568, col: 10, offset: 37431},
+									pos:        position{line: 1569, col: 10, offset: 37454},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1568, col: 14, offset: 37435},
+									pos: position{line: 1569, col: 14, offset: 37458},
 									expr: &charClassMatcher{
-										pos:        position{line: 1568, col: 14, offset: 37435},
+										pos:        position{line: 1569, col: 14, offset: 37458},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11238,9 +11238,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1568, col: 21, offset: 37442},
+									pos: position{line: 1569, col: 21, offset: 37465},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1568, col: 21, offset: 37442},
+										pos:  position{line: 1569, col: 21, offset: 37465},
 										name: "ExponentPart",
 									},
 								},
@@ -11248,17 +11248,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1569, col: 5, offset: 37491},
+						pos: position{line: 1570, col: 5, offset: 37514},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1569, col: 6, offset: 37492},
+							pos: position{line: 1570, col: 6, offset: 37515},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1569, col: 6, offset: 37492},
+									pos:  position{line: 1570, col: 6, offset: 37515},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1569, col: 12, offset: 37498},
+									pos:  position{line: 1570, col: 12, offset: 37521},
 									name: "Infinity",
 								},
 							},
@@ -11271,20 +11271,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1572, col: 1, offset: 37541},
+			pos:  position{line: 1573, col: 1, offset: 37564},
 			expr: &seqExpr{
-				pos: position{line: 1572, col: 16, offset: 37556},
+				pos: position{line: 1573, col: 16, offset: 37579},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1572, col: 16, offset: 37556},
+						pos:        position{line: 1573, col: 16, offset: 37579},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1572, col: 21, offset: 37561},
+						pos: position{line: 1573, col: 21, offset: 37584},
 						expr: &charClassMatcher{
-							pos:        position{line: 1572, col: 21, offset: 37561},
+							pos:        position{line: 1573, col: 21, offset: 37584},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11292,7 +11292,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1572, col: 27, offset: 37567},
+						pos:  position{line: 1573, col: 27, offset: 37590},
 						name: "UIntString",
 					},
 				},
@@ -11302,9 +11302,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1574, col: 1, offset: 37579},
+			pos:  position{line: 1575, col: 1, offset: 37602},
 			expr: &litMatcher{
-				pos:        position{line: 1574, col: 7, offset: 37585},
+				pos:        position{line: 1575, col: 7, offset: 37608},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11314,23 +11314,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1576, col: 1, offset: 37592},
+			pos:  position{line: 1577, col: 1, offset: 37615},
 			expr: &seqExpr{
-				pos: position{line: 1576, col: 12, offset: 37603},
+				pos: position{line: 1577, col: 12, offset: 37626},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1576, col: 12, offset: 37603},
+						pos: position{line: 1577, col: 12, offset: 37626},
 						expr: &choiceExpr{
-							pos: position{line: 1576, col: 13, offset: 37604},
+							pos: position{line: 1577, col: 13, offset: 37627},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1576, col: 13, offset: 37604},
+									pos:        position{line: 1577, col: 13, offset: 37627},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1576, col: 19, offset: 37610},
+									pos:        position{line: 1577, col: 19, offset: 37633},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11339,7 +11339,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1576, col: 25, offset: 37616},
+						pos:        position{line: 1577, col: 25, offset: 37639},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11351,14 +11351,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1578, col: 1, offset: 37623},
+			pos:  position{line: 1579, col: 1, offset: 37646},
 			expr: &actionExpr{
-				pos: position{line: 1578, col: 7, offset: 37629},
+				pos: position{line: 1579, col: 7, offset: 37652},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1578, col: 7, offset: 37629},
+					pos: position{line: 1579, col: 7, offset: 37652},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1578, col: 7, offset: 37629},
+						pos:  position{line: 1579, col: 7, offset: 37652},
 						name: "HexDigit",
 					},
 				},
@@ -11368,9 +11368,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1580, col: 1, offset: 37671},
+			pos:  position{line: 1581, col: 1, offset: 37694},
 			expr: &charClassMatcher{
-				pos:        position{line: 1580, col: 12, offset: 37682},
+				pos:        position{line: 1581, col: 12, offset: 37705},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11381,35 +11381,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1582, col: 1, offset: 37695},
+			pos:  position{line: 1583, col: 1, offset: 37718},
 			expr: &choiceExpr{
-				pos: position{line: 1583, col: 5, offset: 37712},
+				pos: position{line: 1584, col: 5, offset: 37735},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1583, col: 5, offset: 37712},
+						pos: position{line: 1584, col: 5, offset: 37735},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1583, col: 5, offset: 37712},
+							pos: position{line: 1584, col: 5, offset: 37735},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1583, col: 5, offset: 37712},
+									pos:        position{line: 1584, col: 5, offset: 37735},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1583, col: 9, offset: 37716},
+									pos:   position{line: 1584, col: 9, offset: 37739},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1583, col: 11, offset: 37718},
+										pos: position{line: 1584, col: 11, offset: 37741},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1583, col: 11, offset: 37718},
+											pos:  position{line: 1584, col: 11, offset: 37741},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1583, col: 29, offset: 37736},
+									pos:        position{line: 1584, col: 29, offset: 37759},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11418,30 +11418,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1584, col: 5, offset: 37773},
+						pos: position{line: 1585, col: 5, offset: 37796},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1584, col: 5, offset: 37773},
+							pos: position{line: 1585, col: 5, offset: 37796},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1584, col: 5, offset: 37773},
+									pos:        position{line: 1585, col: 5, offset: 37796},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1584, col: 9, offset: 37777},
+									pos:   position{line: 1585, col: 9, offset: 37800},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1584, col: 11, offset: 37779},
+										pos: position{line: 1585, col: 11, offset: 37802},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1584, col: 11, offset: 37779},
+											pos:  position{line: 1585, col: 11, offset: 37802},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1584, col: 29, offset: 37797},
+									pos:        position{line: 1585, col: 29, offset: 37820},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11456,57 +11456,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1586, col: 1, offset: 37831},
+			pos:  position{line: 1587, col: 1, offset: 37854},
 			expr: &choiceExpr{
-				pos: position{line: 1587, col: 5, offset: 37852},
+				pos: position{line: 1588, col: 5, offset: 37875},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1587, col: 5, offset: 37852},
+						pos: position{line: 1588, col: 5, offset: 37875},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1587, col: 5, offset: 37852},
+							pos: position{line: 1588, col: 5, offset: 37875},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1587, col: 5, offset: 37852},
+									pos: position{line: 1588, col: 5, offset: 37875},
 									expr: &choiceExpr{
-										pos: position{line: 1587, col: 7, offset: 37854},
+										pos: position{line: 1588, col: 7, offset: 37877},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1587, col: 7, offset: 37854},
+												pos:        position{line: 1588, col: 7, offset: 37877},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1587, col: 13, offset: 37860},
+												pos:  position{line: 1588, col: 13, offset: 37883},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1587, col: 26, offset: 37873,
+									line: 1588, col: 26, offset: 37896,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1588, col: 5, offset: 37910},
+						pos: position{line: 1589, col: 5, offset: 37933},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1588, col: 5, offset: 37910},
+							pos: position{line: 1589, col: 5, offset: 37933},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1588, col: 5, offset: 37910},
+									pos:        position{line: 1589, col: 5, offset: 37933},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1588, col: 10, offset: 37915},
+									pos:   position{line: 1589, col: 10, offset: 37938},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1588, col: 12, offset: 37917},
+										pos:  position{line: 1589, col: 12, offset: 37940},
 										name: "EscapeSequence",
 									},
 								},
@@ -11520,28 +11520,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1590, col: 1, offset: 37951},
+			pos:  position{line: 1591, col: 1, offset: 37974},
 			expr: &actionExpr{
-				pos: position{line: 1591, col: 5, offset: 37963},
+				pos: position{line: 1592, col: 5, offset: 37986},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1591, col: 5, offset: 37963},
+					pos: position{line: 1592, col: 5, offset: 37986},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1591, col: 5, offset: 37963},
+							pos:   position{line: 1592, col: 5, offset: 37986},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1591, col: 10, offset: 37968},
+								pos:  position{line: 1592, col: 10, offset: 37991},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1591, col: 23, offset: 37981},
+							pos:   position{line: 1592, col: 23, offset: 38004},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1591, col: 28, offset: 37986},
+								pos: position{line: 1592, col: 28, offset: 38009},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1591, col: 28, offset: 37986},
+									pos:  position{line: 1592, col: 28, offset: 38009},
 									name: "KeyWordRest",
 								},
 							},
@@ -11554,16 +11554,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1593, col: 1, offset: 38048},
+			pos:  position{line: 1594, col: 1, offset: 38071},
 			expr: &choiceExpr{
-				pos: position{line: 1594, col: 5, offset: 38065},
+				pos: position{line: 1595, col: 5, offset: 38088},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1594, col: 5, offset: 38065},
+						pos:  position{line: 1595, col: 5, offset: 38088},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1595, col: 5, offset: 38082},
+						pos:  position{line: 1596, col: 5, offset: 38105},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11573,16 +11573,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1597, col: 1, offset: 38094},
+			pos:  position{line: 1598, col: 1, offset: 38117},
 			expr: &choiceExpr{
-				pos: position{line: 1598, col: 5, offset: 38110},
+				pos: position{line: 1599, col: 5, offset: 38133},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1598, col: 5, offset: 38110},
+						pos:  position{line: 1599, col: 5, offset: 38133},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 5, offset: 38127},
+						pos:        position{line: 1600, col: 5, offset: 38150},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11595,19 +11595,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1601, col: 1, offset: 38134},
+			pos:  position{line: 1602, col: 1, offset: 38157},
 			expr: &actionExpr{
-				pos: position{line: 1601, col: 16, offset: 38149},
+				pos: position{line: 1602, col: 16, offset: 38172},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1601, col: 17, offset: 38150},
+					pos: position{line: 1602, col: 17, offset: 38173},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1601, col: 17, offset: 38150},
+							pos:  position{line: 1602, col: 17, offset: 38173},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1601, col: 33, offset: 38166},
+							pos:        position{line: 1602, col: 33, offset: 38189},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11621,31 +11621,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1603, col: 1, offset: 38210},
+			pos:  position{line: 1604, col: 1, offset: 38233},
 			expr: &actionExpr{
-				pos: position{line: 1603, col: 14, offset: 38223},
+				pos: position{line: 1604, col: 14, offset: 38246},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1603, col: 14, offset: 38223},
+					pos: position{line: 1604, col: 14, offset: 38246},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1603, col: 14, offset: 38223},
+							pos:        position{line: 1604, col: 14, offset: 38246},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1603, col: 19, offset: 38228},
+							pos:   position{line: 1604, col: 19, offset: 38251},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1603, col: 22, offset: 38231},
+								pos: position{line: 1604, col: 22, offset: 38254},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1603, col: 22, offset: 38231},
+										pos:  position{line: 1604, col: 22, offset: 38254},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1603, col: 38, offset: 38247},
+										pos:  position{line: 1604, col: 38, offset: 38270},
 										name: "EscapeSequence",
 									},
 								},
@@ -11659,42 +11659,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1605, col: 1, offset: 38282},
+			pos:  position{line: 1606, col: 1, offset: 38305},
 			expr: &actionExpr{
-				pos: position{line: 1606, col: 5, offset: 38298},
+				pos: position{line: 1607, col: 5, offset: 38321},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1606, col: 5, offset: 38298},
+					pos: position{line: 1607, col: 5, offset: 38321},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1606, col: 5, offset: 38298},
+							pos: position{line: 1607, col: 5, offset: 38321},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1606, col: 6, offset: 38299},
+								pos:  position{line: 1607, col: 6, offset: 38322},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1606, col: 22, offset: 38315},
+							pos: position{line: 1607, col: 22, offset: 38338},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1606, col: 23, offset: 38316},
+								pos:  position{line: 1607, col: 23, offset: 38339},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1606, col: 35, offset: 38328},
+							pos:   position{line: 1607, col: 35, offset: 38351},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1606, col: 40, offset: 38333},
+								pos:  position{line: 1607, col: 40, offset: 38356},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1606, col: 50, offset: 38343},
+							pos:   position{line: 1607, col: 50, offset: 38366},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1606, col: 55, offset: 38348},
+								pos: position{line: 1607, col: 55, offset: 38371},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1606, col: 55, offset: 38348},
+									pos:  position{line: 1607, col: 55, offset: 38371},
 									name: "GlobRest",
 								},
 							},
@@ -11707,28 +11707,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1610, col: 1, offset: 38417},
+			pos:  position{line: 1611, col: 1, offset: 38440},
 			expr: &choiceExpr{
-				pos: position{line: 1610, col: 19, offset: 38435},
+				pos: position{line: 1611, col: 19, offset: 38458},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1610, col: 19, offset: 38435},
+						pos:  position{line: 1611, col: 19, offset: 38458},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1610, col: 34, offset: 38450},
+						pos: position{line: 1611, col: 34, offset: 38473},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1610, col: 34, offset: 38450},
+								pos: position{line: 1611, col: 34, offset: 38473},
 								expr: &litMatcher{
-									pos:        position{line: 1610, col: 34, offset: 38450},
+									pos:        position{line: 1611, col: 34, offset: 38473},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1610, col: 39, offset: 38455},
+								pos:  position{line: 1611, col: 39, offset: 38478},
 								name: "KeyWordRest",
 							},
 						},
@@ -11740,19 +11740,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1611, col: 1, offset: 38467},
+			pos:  position{line: 1612, col: 1, offset: 38490},
 			expr: &seqExpr{
-				pos: position{line: 1611, col: 15, offset: 38481},
+				pos: position{line: 1612, col: 15, offset: 38504},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1611, col: 15, offset: 38481},
+						pos: position{line: 1612, col: 15, offset: 38504},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1611, col: 15, offset: 38481},
+							pos:  position{line: 1612, col: 15, offset: 38504},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1611, col: 28, offset: 38494},
+						pos:        position{line: 1612, col: 28, offset: 38517},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11764,23 +11764,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1613, col: 1, offset: 38499},
+			pos:  position{line: 1614, col: 1, offset: 38522},
 			expr: &choiceExpr{
-				pos: position{line: 1614, col: 5, offset: 38513},
+				pos: position{line: 1615, col: 5, offset: 38536},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1614, col: 5, offset: 38513},
+						pos:  position{line: 1615, col: 5, offset: 38536},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1615, col: 5, offset: 38530},
+						pos:  position{line: 1616, col: 5, offset: 38553},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1616, col: 5, offset: 38542},
+						pos: position{line: 1617, col: 5, offset: 38565},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1616, col: 5, offset: 38542},
+							pos:        position{line: 1617, col: 5, offset: 38565},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -11793,16 +11793,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1618, col: 1, offset: 38567},
+			pos:  position{line: 1619, col: 1, offset: 38590},
 			expr: &choiceExpr{
-				pos: position{line: 1619, col: 5, offset: 38580},
+				pos: position{line: 1620, col: 5, offset: 38603},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1619, col: 5, offset: 38580},
+						pos:  position{line: 1620, col: 5, offset: 38603},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1620, col: 5, offset: 38594},
+						pos:        position{line: 1621, col: 5, offset: 38617},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11815,31 +11815,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1622, col: 1, offset: 38601},
+			pos:  position{line: 1623, col: 1, offset: 38624},
 			expr: &actionExpr{
-				pos: position{line: 1622, col: 11, offset: 38611},
+				pos: position{line: 1623, col: 11, offset: 38634},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1622, col: 11, offset: 38611},
+					pos: position{line: 1623, col: 11, offset: 38634},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1622, col: 11, offset: 38611},
+							pos:        position{line: 1623, col: 11, offset: 38634},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1622, col: 16, offset: 38616},
+							pos:   position{line: 1623, col: 16, offset: 38639},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1622, col: 19, offset: 38619},
+								pos: position{line: 1623, col: 19, offset: 38642},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1622, col: 19, offset: 38619},
+										pos:  position{line: 1623, col: 19, offset: 38642},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1622, col: 32, offset: 38632},
+										pos:  position{line: 1623, col: 32, offset: 38655},
 										name: "EscapeSequence",
 									},
 								},
@@ -11853,32 +11853,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1624, col: 1, offset: 38667},
+			pos:  position{line: 1625, col: 1, offset: 38690},
 			expr: &choiceExpr{
-				pos: position{line: 1625, col: 5, offset: 38682},
+				pos: position{line: 1626, col: 5, offset: 38705},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1625, col: 5, offset: 38682},
+						pos: position{line: 1626, col: 5, offset: 38705},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1625, col: 5, offset: 38682},
+							pos:        position{line: 1626, col: 5, offset: 38705},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1626, col: 5, offset: 38710},
+						pos: position{line: 1627, col: 5, offset: 38733},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1626, col: 5, offset: 38710},
+							pos:        position{line: 1627, col: 5, offset: 38733},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1627, col: 5, offset: 38740},
+						pos:        position{line: 1628, col: 5, offset: 38763},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11891,57 +11891,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1629, col: 1, offset: 38746},
+			pos:  position{line: 1630, col: 1, offset: 38769},
 			expr: &choiceExpr{
-				pos: position{line: 1630, col: 5, offset: 38767},
+				pos: position{line: 1631, col: 5, offset: 38790},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1630, col: 5, offset: 38767},
+						pos: position{line: 1631, col: 5, offset: 38790},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1630, col: 5, offset: 38767},
+							pos: position{line: 1631, col: 5, offset: 38790},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1630, col: 5, offset: 38767},
+									pos: position{line: 1631, col: 5, offset: 38790},
 									expr: &choiceExpr{
-										pos: position{line: 1630, col: 7, offset: 38769},
+										pos: position{line: 1631, col: 7, offset: 38792},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1630, col: 7, offset: 38769},
+												pos:        position{line: 1631, col: 7, offset: 38792},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1630, col: 13, offset: 38775},
+												pos:  position{line: 1631, col: 13, offset: 38798},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1630, col: 26, offset: 38788,
+									line: 1631, col: 26, offset: 38811,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1631, col: 5, offset: 38825},
+						pos: position{line: 1632, col: 5, offset: 38848},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1631, col: 5, offset: 38825},
+							pos: position{line: 1632, col: 5, offset: 38848},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1631, col: 5, offset: 38825},
+									pos:        position{line: 1632, col: 5, offset: 38848},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1631, col: 10, offset: 38830},
+									pos:   position{line: 1632, col: 10, offset: 38853},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1631, col: 12, offset: 38832},
+										pos:  position{line: 1632, col: 12, offset: 38855},
 										name: "EscapeSequence",
 									},
 								},
@@ -11955,16 +11955,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1633, col: 1, offset: 38866},
+			pos:  position{line: 1634, col: 1, offset: 38889},
 			expr: &choiceExpr{
-				pos: position{line: 1634, col: 5, offset: 38885},
+				pos: position{line: 1635, col: 5, offset: 38908},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1634, col: 5, offset: 38885},
+						pos:  position{line: 1635, col: 5, offset: 38908},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 5, offset: 38906},
+						pos:  position{line: 1636, col: 5, offset: 38929},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11974,87 +11974,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1637, col: 1, offset: 38921},
+			pos:  position{line: 1638, col: 1, offset: 38944},
 			expr: &choiceExpr{
-				pos: position{line: 1638, col: 5, offset: 38942},
+				pos: position{line: 1639, col: 5, offset: 38965},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1638, col: 5, offset: 38942},
+						pos:        position{line: 1639, col: 5, offset: 38965},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1639, col: 5, offset: 38950},
+						pos: position{line: 1640, col: 5, offset: 38973},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1639, col: 5, offset: 38950},
+							pos:        position{line: 1640, col: 5, offset: 38973},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1640, col: 5, offset: 38990},
+						pos:        position{line: 1641, col: 5, offset: 39013},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1641, col: 5, offset: 38999},
+						pos: position{line: 1642, col: 5, offset: 39022},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1641, col: 5, offset: 38999},
+							pos:        position{line: 1642, col: 5, offset: 39022},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1642, col: 5, offset: 39028},
+						pos: position{line: 1643, col: 5, offset: 39051},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1642, col: 5, offset: 39028},
+							pos:        position{line: 1643, col: 5, offset: 39051},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1643, col: 5, offset: 39057},
+						pos: position{line: 1644, col: 5, offset: 39080},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1643, col: 5, offset: 39057},
+							pos:        position{line: 1644, col: 5, offset: 39080},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1644, col: 5, offset: 39086},
+						pos: position{line: 1645, col: 5, offset: 39109},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1644, col: 5, offset: 39086},
+							pos:        position{line: 1645, col: 5, offset: 39109},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1645, col: 5, offset: 39115},
+						pos: position{line: 1646, col: 5, offset: 39138},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1645, col: 5, offset: 39115},
+							pos:        position{line: 1646, col: 5, offset: 39138},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1646, col: 5, offset: 39144},
+						pos: position{line: 1647, col: 5, offset: 39167},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1646, col: 5, offset: 39144},
+							pos:        position{line: 1647, col: 5, offset: 39167},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12067,32 +12067,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1648, col: 1, offset: 39170},
+			pos:  position{line: 1649, col: 1, offset: 39193},
 			expr: &choiceExpr{
-				pos: position{line: 1649, col: 5, offset: 39188},
+				pos: position{line: 1650, col: 5, offset: 39211},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1649, col: 5, offset: 39188},
+						pos: position{line: 1650, col: 5, offset: 39211},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1649, col: 5, offset: 39188},
+							pos:        position{line: 1650, col: 5, offset: 39211},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1650, col: 5, offset: 39216},
+						pos: position{line: 1651, col: 5, offset: 39239},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1650, col: 5, offset: 39216},
+							pos:        position{line: 1651, col: 5, offset: 39239},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1651, col: 5, offset: 39244},
+						pos:        position{line: 1652, col: 5, offset: 39267},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12105,42 +12105,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1653, col: 1, offset: 39250},
+			pos:  position{line: 1654, col: 1, offset: 39273},
 			expr: &choiceExpr{
-				pos: position{line: 1654, col: 5, offset: 39268},
+				pos: position{line: 1655, col: 5, offset: 39291},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1654, col: 5, offset: 39268},
+						pos: position{line: 1655, col: 5, offset: 39291},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1654, col: 5, offset: 39268},
+							pos: position{line: 1655, col: 5, offset: 39291},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1654, col: 5, offset: 39268},
+									pos:        position{line: 1655, col: 5, offset: 39291},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1654, col: 9, offset: 39272},
+									pos:   position{line: 1655, col: 9, offset: 39295},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1654, col: 16, offset: 39279},
+										pos: position{line: 1655, col: 16, offset: 39302},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1654, col: 16, offset: 39279},
+												pos:  position{line: 1655, col: 16, offset: 39302},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1654, col: 25, offset: 39288},
+												pos:  position{line: 1655, col: 25, offset: 39311},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1654, col: 34, offset: 39297},
+												pos:  position{line: 1655, col: 34, offset: 39320},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1654, col: 43, offset: 39306},
+												pos:  position{line: 1655, col: 43, offset: 39329},
 												name: "HexDigit",
 											},
 										},
@@ -12150,65 +12150,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1657, col: 5, offset: 39369},
+						pos: position{line: 1658, col: 5, offset: 39392},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1657, col: 5, offset: 39369},
+							pos: position{line: 1658, col: 5, offset: 39392},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1657, col: 5, offset: 39369},
+									pos:        position{line: 1658, col: 5, offset: 39392},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1657, col: 9, offset: 39373},
+									pos:        position{line: 1658, col: 9, offset: 39396},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1657, col: 13, offset: 39377},
+									pos:   position{line: 1658, col: 13, offset: 39400},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1657, col: 20, offset: 39384},
+										pos: position{line: 1658, col: 20, offset: 39407},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1657, col: 20, offset: 39384},
+												pos:  position{line: 1658, col: 20, offset: 39407},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1657, col: 29, offset: 39393},
+												pos: position{line: 1658, col: 29, offset: 39416},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1657, col: 29, offset: 39393},
+													pos:  position{line: 1658, col: 29, offset: 39416},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1657, col: 39, offset: 39403},
+												pos: position{line: 1658, col: 39, offset: 39426},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1657, col: 39, offset: 39403},
+													pos:  position{line: 1658, col: 39, offset: 39426},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1657, col: 49, offset: 39413},
+												pos: position{line: 1658, col: 49, offset: 39436},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1657, col: 49, offset: 39413},
+													pos:  position{line: 1658, col: 49, offset: 39436},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1657, col: 59, offset: 39423},
+												pos: position{line: 1658, col: 59, offset: 39446},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1657, col: 59, offset: 39423},
+													pos:  position{line: 1658, col: 59, offset: 39446},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1657, col: 69, offset: 39433},
+												pos: position{line: 1658, col: 69, offset: 39456},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1657, col: 69, offset: 39433},
+													pos:  position{line: 1658, col: 69, offset: 39456},
 													name: "HexDigit",
 												},
 											},
@@ -12216,7 +12216,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1657, col: 80, offset: 39444},
+									pos:        position{line: 1658, col: 80, offset: 39467},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12231,37 +12231,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1661, col: 1, offset: 39498},
+			pos:  position{line: 1662, col: 1, offset: 39521},
 			expr: &actionExpr{
-				pos: position{line: 1662, col: 5, offset: 39516},
+				pos: position{line: 1663, col: 5, offset: 39539},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1662, col: 5, offset: 39516},
+					pos: position{line: 1663, col: 5, offset: 39539},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1662, col: 5, offset: 39516},
+							pos:        position{line: 1663, col: 5, offset: 39539},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1662, col: 9, offset: 39520},
+							pos:   position{line: 1663, col: 9, offset: 39543},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1662, col: 14, offset: 39525},
+								pos:  position{line: 1663, col: 14, offset: 39548},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1662, col: 25, offset: 39536},
+							pos:        position{line: 1663, col: 25, offset: 39559},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1662, col: 29, offset: 39540},
+							pos: position{line: 1663, col: 29, offset: 39563},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1662, col: 30, offset: 39541},
+								pos:  position{line: 1663, col: 30, offset: 39564},
 								name: "KeyWordStart",
 							},
 						},
@@ -12273,33 +12273,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1664, col: 1, offset: 39576},
+			pos:  position{line: 1665, col: 1, offset: 39599},
 			expr: &actionExpr{
-				pos: position{line: 1665, col: 5, offset: 39591},
+				pos: position{line: 1666, col: 5, offset: 39614},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1665, col: 5, offset: 39591},
+					pos: position{line: 1666, col: 5, offset: 39614},
 					expr: &choiceExpr{
-						pos: position{line: 1665, col: 6, offset: 39592},
+						pos: position{line: 1666, col: 6, offset: 39615},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1665, col: 6, offset: 39592},
+								pos:        position{line: 1666, col: 6, offset: 39615},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1665, col: 15, offset: 39601},
+								pos: position{line: 1666, col: 15, offset: 39624},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1665, col: 15, offset: 39601},
+										pos:        position{line: 1666, col: 15, offset: 39624},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1665, col: 20, offset: 39606,
+										line: 1666, col: 20, offset: 39629,
 									},
 								},
 							},
@@ -12312,9 +12312,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1667, col: 1, offset: 39642},
+			pos:  position{line: 1668, col: 1, offset: 39665},
 			expr: &charClassMatcher{
-				pos:        position{line: 1668, col: 5, offset: 39658},
+				pos:        position{line: 1669, col: 5, offset: 39681},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12326,11 +12326,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1670, col: 1, offset: 39673},
+			pos:  position{line: 1671, col: 1, offset: 39696},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1670, col: 5, offset: 39677},
+				pos: position{line: 1671, col: 5, offset: 39700},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1670, col: 5, offset: 39677},
+					pos:  position{line: 1671, col: 5, offset: 39700},
 					name: "AnySpace",
 				},
 			},
@@ -12339,11 +12339,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1672, col: 1, offset: 39688},
+			pos:  position{line: 1673, col: 1, offset: 39711},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1672, col: 6, offset: 39693},
+				pos: position{line: 1673, col: 6, offset: 39716},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1672, col: 6, offset: 39693},
+					pos:  position{line: 1673, col: 6, offset: 39716},
 					name: "AnySpace",
 				},
 			},
@@ -12352,20 +12352,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1674, col: 1, offset: 39704},
+			pos:  position{line: 1675, col: 1, offset: 39727},
 			expr: &choiceExpr{
-				pos: position{line: 1675, col: 5, offset: 39717},
+				pos: position{line: 1676, col: 5, offset: 39740},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1675, col: 5, offset: 39717},
+						pos:  position{line: 1676, col: 5, offset: 39740},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1676, col: 5, offset: 39732},
+						pos:  position{line: 1677, col: 5, offset: 39755},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1677, col: 5, offset: 39751},
+						pos:  position{line: 1678, col: 5, offset: 39774},
 						name: "Comment",
 					},
 				},
@@ -12375,32 +12375,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1679, col: 1, offset: 39760},
+			pos:  position{line: 1680, col: 1, offset: 39783},
 			expr: &choiceExpr{
-				pos: position{line: 1680, col: 5, offset: 39778},
+				pos: position{line: 1681, col: 5, offset: 39801},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1680, col: 5, offset: 39778},
+						pos:  position{line: 1681, col: 5, offset: 39801},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1681, col: 5, offset: 39785},
+						pos:  position{line: 1682, col: 5, offset: 39808},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1682, col: 5, offset: 39792},
+						pos:  position{line: 1683, col: 5, offset: 39815},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1683, col: 5, offset: 39799},
+						pos:  position{line: 1684, col: 5, offset: 39822},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1684, col: 5, offset: 39806},
+						pos:  position{line: 1685, col: 5, offset: 39829},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1685, col: 5, offset: 39813},
+						pos:  position{line: 1686, col: 5, offset: 39836},
 						name: "Nl",
 					},
 				},
@@ -12410,16 +12410,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1687, col: 1, offset: 39817},
+			pos:  position{line: 1688, col: 1, offset: 39840},
 			expr: &choiceExpr{
-				pos: position{line: 1688, col: 5, offset: 39842},
+				pos: position{line: 1689, col: 5, offset: 39865},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1688, col: 5, offset: 39842},
+						pos:  position{line: 1689, col: 5, offset: 39865},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1689, col: 5, offset: 39849},
+						pos:  position{line: 1690, col: 5, offset: 39872},
 						name: "Mc",
 					},
 				},
@@ -12429,9 +12429,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1691, col: 1, offset: 39853},
+			pos:  position{line: 1692, col: 1, offset: 39876},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1692, col: 5, offset: 39870},
+				pos:  position{line: 1693, col: 5, offset: 39893},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12439,9 +12439,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1694, col: 1, offset: 39874},
+			pos:  position{line: 1695, col: 1, offset: 39897},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1695, col: 5, offset: 39906},
+				pos:  position{line: 1696, col: 5, offset: 39929},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12449,9 +12449,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1701, col: 1, offset: 40087},
+			pos:  position{line: 1702, col: 1, offset: 40110},
 			expr: &charClassMatcher{
-				pos:        position{line: 1701, col: 6, offset: 40092},
+				pos:        position{line: 1702, col: 6, offset: 40115},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12463,9 +12463,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1704, col: 1, offset: 44244},
+			pos:  position{line: 1705, col: 1, offset: 44267},
 			expr: &charClassMatcher{
-				pos:        position{line: 1704, col: 6, offset: 44249},
+				pos:        position{line: 1705, col: 6, offset: 44272},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12477,9 +12477,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1707, col: 1, offset: 44734},
+			pos:  position{line: 1708, col: 1, offset: 44757},
 			expr: &charClassMatcher{
-				pos:        position{line: 1707, col: 6, offset: 44739},
+				pos:        position{line: 1708, col: 6, offset: 44762},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12491,9 +12491,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1710, col: 1, offset: 48186},
+			pos:  position{line: 1711, col: 1, offset: 48209},
 			expr: &charClassMatcher{
-				pos:        position{line: 1710, col: 6, offset: 48191},
+				pos:        position{line: 1711, col: 6, offset: 48214},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12505,9 +12505,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1713, col: 1, offset: 48297},
+			pos:  position{line: 1714, col: 1, offset: 48320},
 			expr: &charClassMatcher{
-				pos:        position{line: 1713, col: 6, offset: 48302},
+				pos:        position{line: 1714, col: 6, offset: 48325},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12519,9 +12519,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1716, col: 1, offset: 52303},
+			pos:  position{line: 1717, col: 1, offset: 52326},
 			expr: &charClassMatcher{
-				pos:        position{line: 1716, col: 6, offset: 52308},
+				pos:        position{line: 1717, col: 6, offset: 52331},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12533,9 +12533,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1719, col: 1, offset: 53496},
+			pos:  position{line: 1720, col: 1, offset: 53519},
 			expr: &charClassMatcher{
-				pos:        position{line: 1719, col: 6, offset: 53501},
+				pos:        position{line: 1720, col: 6, offset: 53524},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12547,9 +12547,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1722, col: 1, offset: 55681},
+			pos:  position{line: 1723, col: 1, offset: 55704},
 			expr: &charClassMatcher{
-				pos:        position{line: 1722, col: 6, offset: 55686},
+				pos:        position{line: 1723, col: 6, offset: 55709},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12560,9 +12560,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1725, col: 1, offset: 56189},
+			pos:  position{line: 1726, col: 1, offset: 56212},
 			expr: &charClassMatcher{
-				pos:        position{line: 1725, col: 6, offset: 56194},
+				pos:        position{line: 1726, col: 6, offset: 56217},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12574,9 +12574,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1728, col: 1, offset: 56308},
+			pos:  position{line: 1729, col: 1, offset: 56331},
 			expr: &charClassMatcher{
-				pos:        position{line: 1728, col: 6, offset: 56313},
+				pos:        position{line: 1729, col: 6, offset: 56336},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12588,9 +12588,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1731, col: 1, offset: 56394},
+			pos:  position{line: 1732, col: 1, offset: 56417},
 			expr: &charClassMatcher{
-				pos:        position{line: 1731, col: 6, offset: 56399},
+				pos:        position{line: 1732, col: 6, offset: 56422},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12602,9 +12602,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1733, col: 1, offset: 56452},
+			pos:  position{line: 1734, col: 1, offset: 56475},
 			expr: &anyMatcher{
-				line: 1734, col: 5, offset: 56472,
+				line: 1735, col: 5, offset: 56495,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12612,48 +12612,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1736, col: 1, offset: 56475},
+			pos:         position{line: 1737, col: 1, offset: 56498},
 			expr: &choiceExpr{
-				pos: position{line: 1737, col: 5, offset: 56503},
+				pos: position{line: 1738, col: 5, offset: 56526},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1737, col: 5, offset: 56503},
+						pos:        position{line: 1738, col: 5, offset: 56526},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1738, col: 5, offset: 56512},
+						pos:        position{line: 1739, col: 5, offset: 56535},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1739, col: 5, offset: 56521},
+						pos:        position{line: 1740, col: 5, offset: 56544},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1740, col: 5, offset: 56530},
+						pos:        position{line: 1741, col: 5, offset: 56553},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1741, col: 5, offset: 56538},
+						pos:        position{line: 1742, col: 5, offset: 56561},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1742, col: 5, offset: 56551},
+						pos:        position{line: 1743, col: 5, offset: 56574},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1743, col: 5, offset: 56564},
+						pos:  position{line: 1744, col: 5, offset: 56587},
 						name: "Zs",
 					},
 				},
@@ -12663,9 +12663,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1745, col: 1, offset: 56568},
+			pos:  position{line: 1746, col: 1, offset: 56591},
 			expr: &charClassMatcher{
-				pos:        position{line: 1746, col: 5, offset: 56587},
+				pos:        position{line: 1747, col: 5, offset: 56610},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12677,9 +12677,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1752, col: 1, offset: 56917},
+			pos:         position{line: 1753, col: 1, offset: 56940},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1755, col: 5, offset: 56988},
+				pos:  position{line: 1756, col: 5, offset: 57011},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -12687,39 +12687,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1757, col: 1, offset: 57007},
+			pos:  position{line: 1758, col: 1, offset: 57030},
 			expr: &seqExpr{
-				pos: position{line: 1758, col: 5, offset: 57028},
+				pos: position{line: 1759, col: 5, offset: 57051},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1758, col: 5, offset: 57028},
+						pos:        position{line: 1759, col: 5, offset: 57051},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1758, col: 10, offset: 57033},
+						pos: position{line: 1759, col: 10, offset: 57056},
 						expr: &seqExpr{
-							pos: position{line: 1758, col: 11, offset: 57034},
+							pos: position{line: 1759, col: 11, offset: 57057},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1758, col: 11, offset: 57034},
+									pos: position{line: 1759, col: 11, offset: 57057},
 									expr: &litMatcher{
-										pos:        position{line: 1758, col: 12, offset: 57035},
+										pos:        position{line: 1759, col: 12, offset: 57058},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1758, col: 17, offset: 57040},
+									pos:  position{line: 1759, col: 17, offset: 57063},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1758, col: 35, offset: 57058},
+						pos:        position{line: 1759, col: 35, offset: 57081},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12731,30 +12731,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1760, col: 1, offset: 57064},
+			pos:  position{line: 1761, col: 1, offset: 57087},
 			expr: &seqExpr{
-				pos: position{line: 1761, col: 5, offset: 57086},
+				pos: position{line: 1762, col: 5, offset: 57109},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1761, col: 5, offset: 57086},
+						pos:        position{line: 1762, col: 5, offset: 57109},
 						val:        "//",
 						ignoreCase: false,
 						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1761, col: 10, offset: 57091},
+						pos: position{line: 1762, col: 10, offset: 57114},
 						expr: &seqExpr{
-							pos: position{line: 1761, col: 11, offset: 57092},
+							pos: position{line: 1762, col: 11, offset: 57115},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1761, col: 11, offset: 57092},
+									pos: position{line: 1762, col: 11, offset: 57115},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1761, col: 12, offset: 57093},
+										pos:  position{line: 1762, col: 12, offset: 57116},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1761, col: 27, offset: 57108},
+									pos:  position{line: 1762, col: 27, offset: 57131},
 									name: "SourceCharacter",
 								},
 							},
@@ -12767,19 +12767,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1763, col: 1, offset: 57127},
+			pos:  position{line: 1764, col: 1, offset: 57150},
 			expr: &seqExpr{
-				pos: position{line: 1763, col: 7, offset: 57133},
+				pos: position{line: 1764, col: 7, offset: 57156},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1763, col: 7, offset: 57133},
+						pos: position{line: 1764, col: 7, offset: 57156},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1763, col: 7, offset: 57133},
+							pos:  position{line: 1764, col: 7, offset: 57156},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1763, col: 19, offset: 57145},
+						pos:  position{line: 1764, col: 19, offset: 57168},
 						name: "LineTerminator",
 					},
 				},
@@ -12789,16 +12789,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1765, col: 1, offset: 57161},
+			pos:  position{line: 1766, col: 1, offset: 57184},
 			expr: &choiceExpr{
-				pos: position{line: 1765, col: 7, offset: 57167},
+				pos: position{line: 1766, col: 7, offset: 57190},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1765, col: 7, offset: 57167},
+						pos:  position{line: 1766, col: 7, offset: 57190},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1765, col: 11, offset: 57171},
+						pos:  position{line: 1766, col: 11, offset: 57194},
 						name: "EOF",
 					},
 				},
@@ -12808,11 +12808,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1767, col: 1, offset: 57176},
+			pos:  position{line: 1768, col: 1, offset: 57199},
 			expr: &notExpr{
-				pos: position{line: 1767, col: 7, offset: 57182},
+				pos: position{line: 1768, col: 7, offset: 57205},
 				expr: &anyMatcher{
-					line: 1767, col: 8, offset: 57183,
+					line: 1768, col: 8, offset: 57206,
 				},
 			},
 			leader:        false,
@@ -12820,11 +12820,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1769, col: 1, offset: 57186},
+			pos:  position{line: 1770, col: 1, offset: 57209},
 			expr: &notExpr{
-				pos: position{line: 1769, col: 8, offset: 57193},
+				pos: position{line: 1770, col: 8, offset: 57216},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1769, col: 9, offset: 57194},
+					pos:  position{line: 1770, col: 9, offset: 57217},
 					name: "KeyWordChars",
 				},
 			},
@@ -14991,9 +14991,9 @@ func (c *current) onCaseExpr2(cases, else_ any) (any, error) {
 	whens := sliceOf[ast.When](cases)
 	cond := &ast.Conditional{
 		Kind: "Conditional",
-		Loc:  loc(c),
 		Cond: whens[0].Cond,
 		Then: whens[0].Then,
+		Loc:  loc(c),
 	}
 	last := cond
 	for _, when := range whens[1:] {
@@ -15001,7 +15001,7 @@ func (c *current) onCaseExpr2(cases, else_ any) (any, error) {
 			Kind: "Conditional",
 			Cond: when.Cond,
 			Then: when.Then,
-			Loc:  loc(c),
+			Loc:  when.Loc,
 		}
 		last.Else = next
 		last = next
@@ -15044,6 +15044,7 @@ func (c *current) onWhen1(cond, then any) (any, error) {
 		Kind: "When",
 		Cond: cond.(ast.Expr),
 		Then: then.(ast.Expr),
+		Loc:  loc(c),
 	}, nil
 
 }

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -6587,6 +6587,10 @@ var g = &grammar{
 					},
 					&ruleRefExpr{
 						pos:  position{line: 986, col: 5, offset: 23500},
+						name: "CaseExpr",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 987, col: 5, offset: 23513},
 						name: "Primary",
 					},
 				},
@@ -6596,16 +6600,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 988, col: 1, offset: 23509},
+			pos:  position{line: 989, col: 1, offset: 23522},
 			expr: &choiceExpr{
-				pos: position{line: 989, col: 5, offset: 23522},
+				pos: position{line: 990, col: 5, offset: 23535},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 989, col: 5, offset: 23522},
+						pos:  position{line: 990, col: 5, offset: 23535},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 990, col: 5, offset: 23531},
+						pos:  position{line: 991, col: 5, offset: 23544},
 						name: "Function",
 					},
 				},
@@ -6615,20 +6619,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 992, col: 1, offset: 23541},
+			pos:  position{line: 993, col: 1, offset: 23554},
 			expr: &seqExpr{
-				pos: position{line: 992, col: 13, offset: 23553},
+				pos: position{line: 993, col: 13, offset: 23566},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 992, col: 13, offset: 23553},
+						pos:  position{line: 993, col: 13, offset: 23566},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 992, col: 22, offset: 23562},
+						pos:  position{line: 993, col: 22, offset: 23575},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 992, col: 25, offset: 23565},
+						pos:        position{line: 993, col: 25, offset: 23578},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -6640,18 +6644,18 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 994, col: 1, offset: 23570},
+			pos:  position{line: 995, col: 1, offset: 23583},
 			expr: &choiceExpr{
-				pos: position{line: 995, col: 5, offset: 23583},
+				pos: position{line: 996, col: 5, offset: 23596},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 995, col: 5, offset: 23583},
+						pos:        position{line: 996, col: 5, offset: 23596},
 						val:        "not",
 						ignoreCase: false,
 						want:       "\"not\"",
 					},
 					&litMatcher{
-						pos:        position{line: 996, col: 5, offset: 23593},
+						pos:        position{line: 997, col: 5, offset: 23606},
 						val:        "select",
 						ignoreCase: false,
 						want:       "\"select\"",
@@ -6663,58 +6667,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 998, col: 1, offset: 23603},
+			pos:  position{line: 999, col: 1, offset: 23616},
 			expr: &actionExpr{
-				pos: position{line: 999, col: 5, offset: 23612},
+				pos: position{line: 1000, col: 5, offset: 23625},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 999, col: 5, offset: 23612},
+					pos: position{line: 1000, col: 5, offset: 23625},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 999, col: 5, offset: 23612},
+							pos:   position{line: 1000, col: 5, offset: 23625},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 999, col: 9, offset: 23616},
+								pos:  position{line: 1000, col: 9, offset: 23629},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 999, col: 21, offset: 23628},
+							pos:  position{line: 1000, col: 21, offset: 23641},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 999, col: 24, offset: 23631},
+							pos:        position{line: 1000, col: 24, offset: 23644},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 999, col: 28, offset: 23635},
+							pos:  position{line: 1000, col: 28, offset: 23648},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 999, col: 31, offset: 23638},
+							pos:   position{line: 1000, col: 31, offset: 23651},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 999, col: 37, offset: 23644},
+								pos: position{line: 1000, col: 37, offset: 23657},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 999, col: 37, offset: 23644},
+										pos:  position{line: 1000, col: 37, offset: 23657},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 999, col: 48, offset: 23655},
+										pos:  position{line: 1000, col: 48, offset: 23668},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 999, col: 54, offset: 23661},
+							pos:  position{line: 1000, col: 54, offset: 23674},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 999, col: 57, offset: 23664},
+							pos:        position{line: 1000, col: 57, offset: 23677},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -6727,87 +6731,87 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1003, col: 1, offset: 23777},
+			pos:  position{line: 1004, col: 1, offset: 23790},
 			expr: &choiceExpr{
-				pos: position{line: 1004, col: 5, offset: 23790},
+				pos: position{line: 1005, col: 5, offset: 23803},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1004, col: 5, offset: 23790},
+						pos:  position{line: 1005, col: 5, offset: 23803},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1006, col: 5, offset: 23877},
+						pos: position{line: 1007, col: 5, offset: 23890},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1006, col: 5, offset: 23877},
+							pos: position{line: 1007, col: 5, offset: 23890},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1006, col: 5, offset: 23877},
+									pos:        position{line: 1007, col: 5, offset: 23890},
 									val:        "regexp",
 									ignoreCase: false,
 									want:       "\"regexp\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 14, offset: 23886},
+									pos:  position{line: 1007, col: 14, offset: 23899},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1006, col: 17, offset: 23889},
+									pos:        position{line: 1007, col: 17, offset: 23902},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 21, offset: 23893},
+									pos:  position{line: 1007, col: 21, offset: 23906},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1006, col: 24, offset: 23896},
+									pos:   position{line: 1007, col: 24, offset: 23909},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1006, col: 29, offset: 23901},
+										pos:  position{line: 1007, col: 29, offset: 23914},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 45, offset: 23917},
+									pos:  position{line: 1007, col: 45, offset: 23930},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1006, col: 48, offset: 23920},
+									pos:        position{line: 1007, col: 48, offset: 23933},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 52, offset: 23924},
+									pos:  position{line: 1007, col: 52, offset: 23937},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1006, col: 55, offset: 23927},
+									pos:   position{line: 1007, col: 55, offset: 23940},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1006, col: 60, offset: 23932},
+										pos:  position{line: 1007, col: 60, offset: 23945},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 65, offset: 23937},
+									pos:  position{line: 1007, col: 65, offset: 23950},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1006, col: 68, offset: 23940},
+									pos:        position{line: 1007, col: 68, offset: 23953},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1006, col: 72, offset: 23944},
+									pos:   position{line: 1007, col: 72, offset: 23957},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1006, col: 78, offset: 23950},
+										pos: position{line: 1007, col: 78, offset: 23963},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1006, col: 78, offset: 23950},
+											pos:  position{line: 1007, col: 78, offset: 23963},
 											name: "WhereClause",
 										},
 									},
@@ -6816,100 +6820,100 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1010, col: 5, offset: 24129},
+						pos: position{line: 1011, col: 5, offset: 24142},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1010, col: 5, offset: 24129},
+							pos: position{line: 1011, col: 5, offset: 24142},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1010, col: 5, offset: 24129},
+									pos:        position{line: 1011, col: 5, offset: 24142},
 									val:        "regexp_replace",
 									ignoreCase: false,
 									want:       "\"regexp_replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1010, col: 22, offset: 24146},
+									pos:  position{line: 1011, col: 22, offset: 24159},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1010, col: 25, offset: 24149},
+									pos:        position{line: 1011, col: 25, offset: 24162},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1010, col: 29, offset: 24153},
+									pos:  position{line: 1011, col: 29, offset: 24166},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1010, col: 32, offset: 24156},
+									pos:   position{line: 1011, col: 32, offset: 24169},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1010, col: 37, offset: 24161},
+										pos:  position{line: 1011, col: 37, offset: 24174},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1010, col: 42, offset: 24166},
+									pos:  position{line: 1011, col: 42, offset: 24179},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1010, col: 45, offset: 24169},
+									pos:        position{line: 1011, col: 45, offset: 24182},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1010, col: 49, offset: 24173},
+									pos:  position{line: 1011, col: 49, offset: 24186},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1010, col: 52, offset: 24176},
+									pos:   position{line: 1011, col: 52, offset: 24189},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1010, col: 57, offset: 24181},
+										pos:  position{line: 1011, col: 57, offset: 24194},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1010, col: 73, offset: 24197},
+									pos:  position{line: 1011, col: 73, offset: 24210},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1010, col: 76, offset: 24200},
+									pos:        position{line: 1011, col: 76, offset: 24213},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1010, col: 80, offset: 24204},
+									pos:  position{line: 1011, col: 80, offset: 24217},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1010, col: 83, offset: 24207},
+									pos:   position{line: 1011, col: 83, offset: 24220},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1010, col: 88, offset: 24212},
+										pos:  position{line: 1011, col: 88, offset: 24225},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1010, col: 93, offset: 24217},
+									pos:  position{line: 1011, col: 93, offset: 24230},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1010, col: 96, offset: 24220},
+									pos:        position{line: 1011, col: 96, offset: 24233},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1010, col: 100, offset: 24224},
+									pos:   position{line: 1011, col: 100, offset: 24237},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1010, col: 106, offset: 24230},
+										pos: position{line: 1011, col: 106, offset: 24243},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1010, col: 106, offset: 24230},
+											pos:  position{line: 1011, col: 106, offset: 24243},
 											name: "WhereClause",
 										},
 									},
@@ -6918,69 +6922,319 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1014, col: 5, offset: 24424},
+						pos: position{line: 1015, col: 5, offset: 24437},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1014, col: 5, offset: 24424},
+							pos: position{line: 1015, col: 5, offset: 24437},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1014, col: 5, offset: 24424},
+									pos: position{line: 1015, col: 5, offset: 24437},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1014, col: 6, offset: 24425},
+										pos:  position{line: 1015, col: 6, offset: 24438},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1014, col: 16, offset: 24435},
+									pos:   position{line: 1015, col: 16, offset: 24448},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1014, col: 19, offset: 24438},
+										pos:  position{line: 1015, col: 19, offset: 24451},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1014, col: 30, offset: 24449},
+									pos:  position{line: 1015, col: 30, offset: 24462},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1014, col: 33, offset: 24452},
+									pos:        position{line: 1015, col: 33, offset: 24465},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1014, col: 37, offset: 24456},
+									pos:  position{line: 1015, col: 37, offset: 24469},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1014, col: 40, offset: 24459},
+									pos:   position{line: 1015, col: 40, offset: 24472},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1014, col: 45, offset: 24464},
+										pos:  position{line: 1015, col: 45, offset: 24477},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1014, col: 58, offset: 24477},
+									pos:  position{line: 1015, col: 58, offset: 24490},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1014, col: 61, offset: 24480},
+									pos:        position{line: 1015, col: 61, offset: 24493},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1014, col: 65, offset: 24484},
+									pos:   position{line: 1015, col: 65, offset: 24497},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1014, col: 71, offset: 24490},
+										pos: position{line: 1015, col: 71, offset: 24503},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1014, col: 71, offset: 24490},
+											pos:  position{line: 1015, col: 71, offset: 24503},
 											name: "WhereClause",
 										},
 									},
 								},
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "CaseExpr",
+			pos:  position{line: 1019, col: 1, offset: 24571},
+			expr: &choiceExpr{
+				pos: position{line: 1020, col: 5, offset: 24584},
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 1020, col: 5, offset: 24584},
+						run: (*parser).callonCaseExpr2,
+						expr: &seqExpr{
+							pos: position{line: 1020, col: 5, offset: 24584},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 1020, col: 5, offset: 24584},
+									val:        "case",
+									ignoreCase: true,
+									want:       "\"case\"i",
+								},
+								&labeledExpr{
+									pos:   position{line: 1020, col: 13, offset: 24592},
+									label: "cases",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 1020, col: 19, offset: 24598},
+										expr: &ruleRefExpr{
+											pos:  position{line: 1020, col: 19, offset: 24598},
+											name: "When",
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 1020, col: 25, offset: 24604},
+									label: "else_",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 1020, col: 31, offset: 24610},
+										expr: &seqExpr{
+											pos: position{line: 1020, col: 32, offset: 24611},
+											exprs: []any{
+												&ruleRefExpr{
+													pos:  position{line: 1020, col: 32, offset: 24611},
+													name: "_",
+												},
+												&litMatcher{
+													pos:        position{line: 1020, col: 34, offset: 24613},
+													val:        "else",
+													ignoreCase: false,
+													want:       "\"else\"",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 1020, col: 41, offset: 24620},
+													name: "_",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 1020, col: 43, offset: 24622},
+													name: "Expr",
+												},
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 1020, col: 50, offset: 24629},
+									name: "_",
+								},
+								&litMatcher{
+									pos:        position{line: 1020, col: 52, offset: 24631},
+									val:        "end",
+									ignoreCase: true,
+									want:       "\"end\"i",
+								},
+								&zeroOrOneExpr{
+									pos: position{line: 1020, col: 59, offset: 24638},
+									expr: &seqExpr{
+										pos: position{line: 1020, col: 60, offset: 24639},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 1020, col: 60, offset: 24639},
+												name: "_",
+											},
+											&litMatcher{
+												pos:        position{line: 1020, col: 62, offset: 24641},
+												val:        "case",
+												ignoreCase: true,
+												want:       "\"case\"i",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 1044, col: 5, offset: 25291},
+						run: (*parser).callonCaseExpr21,
+						expr: &seqExpr{
+							pos: position{line: 1044, col: 5, offset: 25291},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 1044, col: 5, offset: 25291},
+									val:        "case",
+									ignoreCase: true,
+									want:       "\"case\"i",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 1044, col: 13, offset: 25299},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 1044, col: 15, offset: 25301},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 1044, col: 20, offset: 25306},
+										name: "Expr",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 1044, col: 25, offset: 25311},
+									label: "whens",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 1044, col: 31, offset: 25317},
+										expr: &ruleRefExpr{
+											pos:  position{line: 1044, col: 31, offset: 25317},
+											name: "When",
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 1044, col: 37, offset: 25323},
+									label: "else_",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 1044, col: 43, offset: 25329},
+										expr: &seqExpr{
+											pos: position{line: 1044, col: 44, offset: 25330},
+											exprs: []any{
+												&ruleRefExpr{
+													pos:  position{line: 1044, col: 44, offset: 25330},
+													name: "_",
+												},
+												&litMatcher{
+													pos:        position{line: 1044, col: 46, offset: 25332},
+													val:        "else",
+													ignoreCase: false,
+													want:       "\"else\"",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 1044, col: 53, offset: 25339},
+													name: "_",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 1044, col: 55, offset: 25341},
+													name: "Expr",
+												},
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 1044, col: 62, offset: 25348},
+									name: "_",
+								},
+								&litMatcher{
+									pos:        position{line: 1044, col: 64, offset: 25350},
+									val:        "end",
+									ignoreCase: true,
+									want:       "\"end\"i",
+								},
+								&zeroOrOneExpr{
+									pos: position{line: 1044, col: 71, offset: 25357},
+									expr: &seqExpr{
+										pos: position{line: 1044, col: 72, offset: 25358},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 1044, col: 72, offset: 25358},
+												name: "_",
+											},
+											&litMatcher{
+												pos:        position{line: 1044, col: 74, offset: 25360},
+												val:        "case",
+												ignoreCase: true,
+												want:       "\"case\"i",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "When",
+			pos:  position{line: 1057, col: 1, offset: 25668},
+			expr: &actionExpr{
+				pos: position{line: 1058, col: 5, offset: 25677},
+				run: (*parser).callonWhen1,
+				expr: &seqExpr{
+					pos: position{line: 1058, col: 5, offset: 25677},
+					exprs: []any{
+						&ruleRefExpr{
+							pos:  position{line: 1058, col: 5, offset: 25677},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 1058, col: 7, offset: 25679},
+							val:        "when",
+							ignoreCase: true,
+							want:       "\"when\"i",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 1058, col: 15, offset: 25687},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 1058, col: 18, offset: 25690},
+							label: "cond",
+							expr: &ruleRefExpr{
+								pos:  position{line: 1058, col: 23, offset: 25695},
+								name: "Expr",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 1058, col: 28, offset: 25700},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 1058, col: 30, offset: 25702},
+							val:        "then",
+							ignoreCase: true,
+							want:       "\"then\"i",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 1058, col: 38, offset: 25710},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 1058, col: 40, offset: 25712},
+							label: "then",
+							expr: &ruleRefExpr{
+								pos:  position{line: 1058, col: 45, offset: 25717},
+								name: "Expr",
 							},
 						},
 					},
@@ -6991,15 +7245,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1018, col: 1, offset: 24558},
+			pos:  position{line: 1066, col: 1, offset: 25851},
 			expr: &actionExpr{
-				pos: position{line: 1019, col: 5, offset: 24578},
+				pos: position{line: 1067, col: 5, offset: 25871},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1019, col: 5, offset: 24578},
+					pos:   position{line: 1067, col: 5, offset: 25871},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1019, col: 9, offset: 24582},
+						pos:  position{line: 1067, col: 9, offset: 25875},
 						name: "RegexpPattern",
 					},
 				},
@@ -7009,24 +7263,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1021, col: 1, offset: 24653},
+			pos:  position{line: 1069, col: 1, offset: 25946},
 			expr: &choiceExpr{
-				pos: position{line: 1022, col: 5, offset: 24670},
+				pos: position{line: 1070, col: 5, offset: 25963},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1022, col: 5, offset: 24670},
+						pos: position{line: 1070, col: 5, offset: 25963},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1022, col: 5, offset: 24670},
+							pos:   position{line: 1070, col: 5, offset: 25963},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1022, col: 7, offset: 24672},
+								pos:  position{line: 1070, col: 7, offset: 25965},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1023, col: 5, offset: 24710},
+						pos:  position{line: 1071, col: 5, offset: 26003},
 						name: "OptionalExprs",
 					},
 				},
@@ -7036,98 +7290,98 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1025, col: 1, offset: 24725},
+			pos:  position{line: 1073, col: 1, offset: 26018},
 			expr: &actionExpr{
-				pos: position{line: 1026, col: 5, offset: 24734},
+				pos: position{line: 1074, col: 5, offset: 26027},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1026, col: 5, offset: 24734},
+					pos: position{line: 1074, col: 5, offset: 26027},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1026, col: 5, offset: 24734},
+							pos:        position{line: 1074, col: 5, offset: 26027},
 							val:        "grep",
 							ignoreCase: false,
 							want:       "\"grep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1026, col: 12, offset: 24741},
+							pos:  position{line: 1074, col: 12, offset: 26034},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1026, col: 15, offset: 24744},
+							pos:        position{line: 1074, col: 15, offset: 26037},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1026, col: 19, offset: 24748},
+							pos:  position{line: 1074, col: 19, offset: 26041},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1026, col: 22, offset: 24751},
+							pos:   position{line: 1074, col: 22, offset: 26044},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1026, col: 31, offset: 24760},
+								pos: position{line: 1074, col: 31, offset: 26053},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1026, col: 31, offset: 24760},
+										pos:  position{line: 1074, col: 31, offset: 26053},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1026, col: 40, offset: 24769},
+										pos:  position{line: 1074, col: 40, offset: 26062},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1026, col: 47, offset: 24776},
+										pos:  position{line: 1074, col: 47, offset: 26069},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1026, col: 53, offset: 24782},
+							pos:  position{line: 1074, col: 53, offset: 26075},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1026, col: 56, offset: 24785},
+							pos:   position{line: 1074, col: 56, offset: 26078},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1026, col: 60, offset: 24789},
+								pos: position{line: 1074, col: 60, offset: 26082},
 								expr: &actionExpr{
-									pos: position{line: 1026, col: 61, offset: 24790},
+									pos: position{line: 1074, col: 61, offset: 26083},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1026, col: 61, offset: 24790},
+										pos: position{line: 1074, col: 61, offset: 26083},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1026, col: 61, offset: 24790},
+												pos:        position{line: 1074, col: 61, offset: 26083},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1026, col: 65, offset: 24794},
+												pos:  position{line: 1074, col: 65, offset: 26087},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1026, col: 68, offset: 24797},
+												pos:   position{line: 1074, col: 68, offset: 26090},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1026, col: 71, offset: 24800},
+													pos: position{line: 1074, col: 71, offset: 26093},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1026, col: 71, offset: 24800},
+															pos:  position{line: 1074, col: 71, offset: 26093},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1026, col: 82, offset: 24811},
+															pos:  position{line: 1074, col: 82, offset: 26104},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1026, col: 88, offset: 24817},
+												pos:  position{line: 1074, col: 88, offset: 26110},
 												name: "__",
 											},
 										},
@@ -7136,7 +7390,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1026, col: 111, offset: 24840},
+							pos:        position{line: 1074, col: 111, offset: 26133},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7149,19 +7403,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1038, col: 1, offset: 25053},
+			pos:  position{line: 1086, col: 1, offset: 26346},
 			expr: &choiceExpr{
-				pos: position{line: 1039, col: 5, offset: 25071},
+				pos: position{line: 1087, col: 5, offset: 26364},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1039, col: 5, offset: 25071},
+						pos:  position{line: 1087, col: 5, offset: 26364},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1040, col: 5, offset: 25081},
+						pos: position{line: 1088, col: 5, offset: 26374},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1040, col: 5, offset: 25081},
+							pos:  position{line: 1088, col: 5, offset: 26374},
 							name: "__",
 						},
 					},
@@ -7172,51 +7426,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1042, col: 1, offset: 25109},
+			pos:  position{line: 1090, col: 1, offset: 26402},
 			expr: &actionExpr{
-				pos: position{line: 1043, col: 5, offset: 25119},
+				pos: position{line: 1091, col: 5, offset: 26412},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1043, col: 5, offset: 25119},
+					pos: position{line: 1091, col: 5, offset: 26412},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1043, col: 5, offset: 25119},
+							pos:   position{line: 1091, col: 5, offset: 26412},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1043, col: 11, offset: 25125},
+								pos:  position{line: 1091, col: 11, offset: 26418},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1043, col: 16, offset: 25130},
+							pos:   position{line: 1091, col: 16, offset: 26423},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1043, col: 21, offset: 25135},
+								pos: position{line: 1091, col: 21, offset: 26428},
 								expr: &actionExpr{
-									pos: position{line: 1043, col: 22, offset: 25136},
+									pos: position{line: 1091, col: 22, offset: 26429},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1043, col: 22, offset: 25136},
+										pos: position{line: 1091, col: 22, offset: 26429},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1043, col: 22, offset: 25136},
+												pos:  position{line: 1091, col: 22, offset: 26429},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1043, col: 25, offset: 25139},
+												pos:        position{line: 1091, col: 25, offset: 26432},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1043, col: 29, offset: 25143},
+												pos:  position{line: 1091, col: 29, offset: 26436},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1043, col: 32, offset: 25146},
+												pos:   position{line: 1091, col: 32, offset: 26439},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1043, col: 34, offset: 25148},
+													pos:  position{line: 1091, col: 34, offset: 26441},
 													name: "Expr",
 												},
 											},
@@ -7233,64 +7487,64 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1047, col: 1, offset: 25221},
+			pos:  position{line: 1095, col: 1, offset: 26514},
 			expr: &choiceExpr{
-				pos: position{line: 1048, col: 5, offset: 25233},
+				pos: position{line: 1096, col: 5, offset: 26526},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1048, col: 5, offset: 25233},
+						pos:  position{line: 1096, col: 5, offset: 26526},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1049, col: 5, offset: 25244},
+						pos:  position{line: 1097, col: 5, offset: 26537},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1050, col: 5, offset: 25254},
+						pos:  position{line: 1098, col: 5, offset: 26547},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1051, col: 5, offset: 25262},
+						pos:  position{line: 1099, col: 5, offset: 26555},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1052, col: 5, offset: 25270},
+						pos:  position{line: 1100, col: 5, offset: 26563},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1053, col: 5, offset: 25282},
+						pos:  position{line: 1101, col: 5, offset: 26575},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1054, col: 5, offset: 25297},
+						pos: position{line: 1102, col: 5, offset: 26590},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1054, col: 5, offset: 25297},
+							pos: position{line: 1102, col: 5, offset: 26590},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1054, col: 5, offset: 25297},
+									pos:        position{line: 1102, col: 5, offset: 26590},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1054, col: 9, offset: 25301},
+									pos:  position{line: 1102, col: 9, offset: 26594},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1054, col: 12, offset: 25304},
+									pos:   position{line: 1102, col: 12, offset: 26597},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1054, col: 17, offset: 25309},
+										pos:  position{line: 1102, col: 17, offset: 26602},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1054, col: 26, offset: 25318},
+									pos:  position{line: 1102, col: 26, offset: 26611},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1054, col: 29, offset: 25321},
+									pos:        position{line: 1102, col: 29, offset: 26614},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7299,35 +7553,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1055, col: 5, offset: 25350},
+						pos: position{line: 1103, col: 5, offset: 26643},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1055, col: 5, offset: 25350},
+							pos: position{line: 1103, col: 5, offset: 26643},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1055, col: 5, offset: 25350},
+									pos:        position{line: 1103, col: 5, offset: 26643},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1055, col: 9, offset: 25354},
+									pos:  position{line: 1103, col: 9, offset: 26647},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1055, col: 12, offset: 25357},
+									pos:   position{line: 1103, col: 12, offset: 26650},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1055, col: 17, offset: 25362},
+										pos:  position{line: 1103, col: 17, offset: 26655},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1055, col: 22, offset: 25367},
+									pos:  position{line: 1103, col: 22, offset: 26660},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1055, col: 25, offset: 25370},
+									pos:        position{line: 1103, col: 25, offset: 26663},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7342,61 +7596,61 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1057, col: 1, offset: 25396},
+			pos:  position{line: 1105, col: 1, offset: 26689},
 			expr: &actionExpr{
-				pos: position{line: 1058, col: 5, offset: 25409},
+				pos: position{line: 1106, col: 5, offset: 26702},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1058, col: 5, offset: 25409},
+					pos: position{line: 1106, col: 5, offset: 26702},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1058, col: 5, offset: 25409},
+							pos:        position{line: 1106, col: 5, offset: 26702},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1058, col: 12, offset: 25416},
+							pos:  position{line: 1106, col: 12, offset: 26709},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1058, col: 14, offset: 25418},
+							pos:   position{line: 1106, col: 14, offset: 26711},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1058, col: 20, offset: 25424},
+								pos:  position{line: 1106, col: 20, offset: 26717},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1058, col: 26, offset: 25430},
+							pos:   position{line: 1106, col: 26, offset: 26723},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1058, col: 33, offset: 25437},
+								pos: position{line: 1106, col: 33, offset: 26730},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1058, col: 33, offset: 25437},
+									pos:  position{line: 1106, col: 33, offset: 26730},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1058, col: 41, offset: 25445},
+							pos:  position{line: 1106, col: 41, offset: 26738},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1058, col: 44, offset: 25448},
+							pos:        position{line: 1106, col: 44, offset: 26741},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1058, col: 48, offset: 25452},
+							pos:  position{line: 1106, col: 48, offset: 26745},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1058, col: 51, offset: 25455},
+							pos:   position{line: 1106, col: 51, offset: 26748},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1058, col: 56, offset: 25460},
+								pos:  position{line: 1106, col: 56, offset: 26753},
 								name: "Seq",
 							},
 						},
@@ -7408,37 +7662,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1068, col: 1, offset: 25691},
+			pos:  position{line: 1116, col: 1, offset: 26984},
 			expr: &actionExpr{
-				pos: position{line: 1069, col: 5, offset: 25702},
+				pos: position{line: 1117, col: 5, offset: 26995},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1069, col: 5, offset: 25702},
+					pos: position{line: 1117, col: 5, offset: 26995},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1069, col: 5, offset: 25702},
+							pos:        position{line: 1117, col: 5, offset: 26995},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1069, col: 9, offset: 25706},
+							pos:  position{line: 1117, col: 9, offset: 26999},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1069, col: 12, offset: 25709},
+							pos:   position{line: 1117, col: 12, offset: 27002},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1069, col: 18, offset: 25715},
+								pos:  position{line: 1117, col: 18, offset: 27008},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1069, col: 30, offset: 25727},
+							pos:  position{line: 1117, col: 30, offset: 27020},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1069, col: 33, offset: 25730},
+							pos:        position{line: 1117, col: 33, offset: 27023},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7451,31 +7705,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1077, col: 1, offset: 25888},
+			pos:  position{line: 1125, col: 1, offset: 27181},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 5, offset: 25904},
+				pos: position{line: 1126, col: 5, offset: 27197},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1078, col: 5, offset: 25904},
+						pos: position{line: 1126, col: 5, offset: 27197},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1078, col: 5, offset: 25904},
+							pos: position{line: 1126, col: 5, offset: 27197},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1078, col: 5, offset: 25904},
+									pos:   position{line: 1126, col: 5, offset: 27197},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1078, col: 11, offset: 25910},
+										pos:  position{line: 1126, col: 11, offset: 27203},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 22, offset: 25921},
+									pos:   position{line: 1126, col: 22, offset: 27214},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1078, col: 27, offset: 25926},
+										pos: position{line: 1126, col: 27, offset: 27219},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1078, col: 27, offset: 25926},
+											pos:  position{line: 1126, col: 27, offset: 27219},
 											name: "RecordElemTail",
 										},
 									},
@@ -7484,10 +7738,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1081, col: 5, offset: 25989},
+						pos: position{line: 1129, col: 5, offset: 27282},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1081, col: 5, offset: 25989},
+							pos:  position{line: 1129, col: 5, offset: 27282},
 							name: "__",
 						},
 					},
@@ -7498,32 +7752,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1083, col: 1, offset: 26013},
+			pos:  position{line: 1131, col: 1, offset: 27306},
 			expr: &actionExpr{
-				pos: position{line: 1083, col: 18, offset: 26030},
+				pos: position{line: 1131, col: 18, offset: 27323},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1083, col: 18, offset: 26030},
+					pos: position{line: 1131, col: 18, offset: 27323},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1083, col: 18, offset: 26030},
+							pos:  position{line: 1131, col: 18, offset: 27323},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 21, offset: 26033},
+							pos:        position{line: 1131, col: 21, offset: 27326},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1083, col: 25, offset: 26037},
+							pos:  position{line: 1131, col: 25, offset: 27330},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1083, col: 28, offset: 26040},
+							pos:   position{line: 1131, col: 28, offset: 27333},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1083, col: 33, offset: 26045},
+								pos:  position{line: 1131, col: 33, offset: 27338},
 								name: "RecordElem",
 							},
 						},
@@ -7535,20 +7789,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1085, col: 1, offset: 26078},
+			pos:  position{line: 1133, col: 1, offset: 27371},
 			expr: &choiceExpr{
-				pos: position{line: 1086, col: 5, offset: 26093},
+				pos: position{line: 1134, col: 5, offset: 27386},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1086, col: 5, offset: 26093},
+						pos:  position{line: 1134, col: 5, offset: 27386},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1087, col: 5, offset: 26104},
+						pos:  position{line: 1135, col: 5, offset: 27397},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1088, col: 5, offset: 26118},
+						pos:  position{line: 1136, col: 5, offset: 27411},
 						name: "Identifier",
 					},
 				},
@@ -7558,28 +7812,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1090, col: 1, offset: 26130},
+			pos:  position{line: 1138, col: 1, offset: 27423},
 			expr: &actionExpr{
-				pos: position{line: 1091, col: 5, offset: 26141},
+				pos: position{line: 1139, col: 5, offset: 27434},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1091, col: 5, offset: 26141},
+					pos: position{line: 1139, col: 5, offset: 27434},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1091, col: 5, offset: 26141},
+							pos:        position{line: 1139, col: 5, offset: 27434},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1091, col: 11, offset: 26147},
+							pos:  position{line: 1139, col: 11, offset: 27440},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1091, col: 14, offset: 26150},
+							pos:   position{line: 1139, col: 14, offset: 27443},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1091, col: 19, offset: 26155},
+								pos:  position{line: 1139, col: 19, offset: 27448},
 								name: "Expr",
 							},
 						},
@@ -7591,40 +7845,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1095, col: 1, offset: 26251},
+			pos:  position{line: 1143, col: 1, offset: 27544},
 			expr: &actionExpr{
-				pos: position{line: 1096, col: 5, offset: 26265},
+				pos: position{line: 1144, col: 5, offset: 27558},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1096, col: 5, offset: 26265},
+					pos: position{line: 1144, col: 5, offset: 27558},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1096, col: 5, offset: 26265},
+							pos:   position{line: 1144, col: 5, offset: 27558},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1096, col: 10, offset: 26270},
+								pos:  position{line: 1144, col: 10, offset: 27563},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1096, col: 15, offset: 26275},
+							pos:  position{line: 1144, col: 15, offset: 27568},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1096, col: 18, offset: 26278},
+							pos:        position{line: 1144, col: 18, offset: 27571},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1096, col: 22, offset: 26282},
+							pos:  position{line: 1144, col: 22, offset: 27575},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1096, col: 25, offset: 26285},
+							pos:   position{line: 1144, col: 25, offset: 27578},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1096, col: 31, offset: 26291},
+								pos:  position{line: 1144, col: 31, offset: 27584},
 								name: "Expr",
 							},
 						},
@@ -7636,37 +7890,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1105, col: 1, offset: 26460},
+			pos:  position{line: 1153, col: 1, offset: 27753},
 			expr: &actionExpr{
-				pos: position{line: 1106, col: 5, offset: 26470},
+				pos: position{line: 1154, col: 5, offset: 27763},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1106, col: 5, offset: 26470},
+					pos: position{line: 1154, col: 5, offset: 27763},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1106, col: 5, offset: 26470},
+							pos:        position{line: 1154, col: 5, offset: 27763},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1106, col: 9, offset: 26474},
+							pos:  position{line: 1154, col: 9, offset: 27767},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1106, col: 12, offset: 26477},
+							pos:   position{line: 1154, col: 12, offset: 27770},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1106, col: 18, offset: 26483},
+								pos:  position{line: 1154, col: 18, offset: 27776},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1106, col: 30, offset: 26495},
+							pos:  position{line: 1154, col: 30, offset: 27788},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1106, col: 33, offset: 26498},
+							pos:        position{line: 1154, col: 33, offset: 27791},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -7679,37 +7933,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1114, col: 1, offset: 26654},
+			pos:  position{line: 1162, col: 1, offset: 27947},
 			expr: &actionExpr{
-				pos: position{line: 1115, col: 5, offset: 26662},
+				pos: position{line: 1163, col: 5, offset: 27955},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1115, col: 5, offset: 26662},
+					pos: position{line: 1163, col: 5, offset: 27955},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1115, col: 5, offset: 26662},
+							pos:        position{line: 1163, col: 5, offset: 27955},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1115, col: 10, offset: 26667},
+							pos:  position{line: 1163, col: 10, offset: 27960},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1115, col: 13, offset: 26670},
+							pos:   position{line: 1163, col: 13, offset: 27963},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1115, col: 19, offset: 26676},
+								pos:  position{line: 1163, col: 19, offset: 27969},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1115, col: 31, offset: 26688},
+							pos:  position{line: 1163, col: 31, offset: 27981},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1115, col: 34, offset: 26691},
+							pos:        position{line: 1163, col: 34, offset: 27984},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -7722,54 +7976,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1123, col: 1, offset: 26844},
+			pos:  position{line: 1171, col: 1, offset: 28137},
 			expr: &choiceExpr{
-				pos: position{line: 1124, col: 5, offset: 26860},
+				pos: position{line: 1172, col: 5, offset: 28153},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1124, col: 5, offset: 26860},
+						pos: position{line: 1172, col: 5, offset: 28153},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1124, col: 5, offset: 26860},
+							pos: position{line: 1172, col: 5, offset: 28153},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1124, col: 5, offset: 26860},
+									pos:   position{line: 1172, col: 5, offset: 28153},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1124, col: 11, offset: 26866},
+										pos:  position{line: 1172, col: 11, offset: 28159},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1124, col: 22, offset: 26877},
+									pos:   position{line: 1172, col: 22, offset: 28170},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1124, col: 27, offset: 26882},
+										pos: position{line: 1172, col: 27, offset: 28175},
 										expr: &actionExpr{
-											pos: position{line: 1124, col: 28, offset: 26883},
+											pos: position{line: 1172, col: 28, offset: 28176},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1124, col: 28, offset: 26883},
+												pos: position{line: 1172, col: 28, offset: 28176},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1124, col: 28, offset: 26883},
+														pos:  position{line: 1172, col: 28, offset: 28176},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1124, col: 31, offset: 26886},
+														pos:        position{line: 1172, col: 31, offset: 28179},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1124, col: 35, offset: 26890},
+														pos:  position{line: 1172, col: 35, offset: 28183},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1124, col: 38, offset: 26893},
+														pos:   position{line: 1172, col: 38, offset: 28186},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1124, col: 40, offset: 26895},
+															pos:  position{line: 1172, col: 40, offset: 28188},
 															name: "VectorElem",
 														},
 													},
@@ -7782,10 +8036,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1127, col: 5, offset: 26977},
+						pos: position{line: 1175, col: 5, offset: 28270},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1127, col: 5, offset: 26977},
+							pos:  position{line: 1175, col: 5, offset: 28270},
 							name: "__",
 						},
 					},
@@ -7796,22 +8050,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1129, col: 1, offset: 27001},
+			pos:  position{line: 1177, col: 1, offset: 28294},
 			expr: &choiceExpr{
-				pos: position{line: 1130, col: 5, offset: 27016},
+				pos: position{line: 1178, col: 5, offset: 28309},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1130, col: 5, offset: 27016},
+						pos:  position{line: 1178, col: 5, offset: 28309},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1131, col: 5, offset: 27027},
+						pos: position{line: 1179, col: 5, offset: 28320},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1131, col: 5, offset: 27027},
+							pos:   position{line: 1179, col: 5, offset: 28320},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1131, col: 7, offset: 27029},
+								pos:  position{line: 1179, col: 7, offset: 28322},
 								name: "Expr",
 							},
 						},
@@ -7823,37 +8077,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1133, col: 1, offset: 27120},
+			pos:  position{line: 1181, col: 1, offset: 28413},
 			expr: &actionExpr{
-				pos: position{line: 1134, col: 5, offset: 27128},
+				pos: position{line: 1182, col: 5, offset: 28421},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1134, col: 5, offset: 27128},
+					pos: position{line: 1182, col: 5, offset: 28421},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1134, col: 5, offset: 27128},
+							pos:        position{line: 1182, col: 5, offset: 28421},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1134, col: 10, offset: 27133},
+							pos:  position{line: 1182, col: 10, offset: 28426},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1134, col: 13, offset: 27136},
+							pos:   position{line: 1182, col: 13, offset: 28429},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1134, col: 19, offset: 27142},
+								pos:  position{line: 1182, col: 19, offset: 28435},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1134, col: 27, offset: 27150},
+							pos:  position{line: 1182, col: 27, offset: 28443},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1134, col: 30, offset: 27153},
+							pos:        position{line: 1182, col: 30, offset: 28446},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -7866,31 +8120,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1142, col: 1, offset: 27307},
+			pos:  position{line: 1190, col: 1, offset: 28600},
 			expr: &choiceExpr{
-				pos: position{line: 1143, col: 5, offset: 27319},
+				pos: position{line: 1191, col: 5, offset: 28612},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1143, col: 5, offset: 27319},
+						pos: position{line: 1191, col: 5, offset: 28612},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1143, col: 5, offset: 27319},
+							pos: position{line: 1191, col: 5, offset: 28612},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1143, col: 5, offset: 27319},
+									pos:   position{line: 1191, col: 5, offset: 28612},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1143, col: 11, offset: 27325},
+										pos:  position{line: 1191, col: 11, offset: 28618},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1143, col: 17, offset: 27331},
+									pos:   position{line: 1191, col: 17, offset: 28624},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1143, col: 22, offset: 27336},
+										pos: position{line: 1191, col: 22, offset: 28629},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1143, col: 22, offset: 27336},
+											pos:  position{line: 1191, col: 22, offset: 28629},
 											name: "EntryTail",
 										},
 									},
@@ -7899,10 +8153,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1146, col: 5, offset: 27394},
+						pos: position{line: 1194, col: 5, offset: 28687},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1146, col: 5, offset: 27394},
+							pos:  position{line: 1194, col: 5, offset: 28687},
 							name: "__",
 						},
 					},
@@ -7913,32 +8167,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1149, col: 1, offset: 27419},
+			pos:  position{line: 1197, col: 1, offset: 28712},
 			expr: &actionExpr{
-				pos: position{line: 1149, col: 13, offset: 27431},
+				pos: position{line: 1197, col: 13, offset: 28724},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1149, col: 13, offset: 27431},
+					pos: position{line: 1197, col: 13, offset: 28724},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 13, offset: 27431},
+							pos:  position{line: 1197, col: 13, offset: 28724},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1149, col: 16, offset: 27434},
+							pos:        position{line: 1197, col: 16, offset: 28727},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 20, offset: 27438},
+							pos:  position{line: 1197, col: 20, offset: 28731},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1149, col: 23, offset: 27441},
+							pos:   position{line: 1197, col: 23, offset: 28734},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1149, col: 25, offset: 27443},
+								pos:  position{line: 1197, col: 25, offset: 28736},
 								name: "Entry",
 							},
 						},
@@ -7950,40 +8204,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1151, col: 1, offset: 27468},
+			pos:  position{line: 1199, col: 1, offset: 28761},
 			expr: &actionExpr{
-				pos: position{line: 1152, col: 5, offset: 27478},
+				pos: position{line: 1200, col: 5, offset: 28771},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1152, col: 5, offset: 27478},
+					pos: position{line: 1200, col: 5, offset: 28771},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1152, col: 5, offset: 27478},
+							pos:   position{line: 1200, col: 5, offset: 28771},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1152, col: 9, offset: 27482},
+								pos:  position{line: 1200, col: 9, offset: 28775},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1152, col: 14, offset: 27487},
+							pos:  position{line: 1200, col: 14, offset: 28780},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1152, col: 17, offset: 27490},
+							pos:        position{line: 1200, col: 17, offset: 28783},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1152, col: 21, offset: 27494},
+							pos:  position{line: 1200, col: 21, offset: 28787},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1152, col: 24, offset: 27497},
+							pos:   position{line: 1200, col: 24, offset: 28790},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1152, col: 30, offset: 27503},
+								pos:  position{line: 1200, col: 30, offset: 28796},
 								name: "Expr",
 							},
 						},
@@ -7995,56 +8249,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1158, col: 1, offset: 27628},
+			pos:  position{line: 1206, col: 1, offset: 28921},
 			expr: &choiceExpr{
-				pos: position{line: 1159, col: 5, offset: 27640},
+				pos: position{line: 1207, col: 5, offset: 28933},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1159, col: 5, offset: 27640},
+						pos:  position{line: 1207, col: 5, offset: 28933},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 5, offset: 27656},
+						pos:  position{line: 1208, col: 5, offset: 28949},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1161, col: 5, offset: 27674},
+						pos:  position{line: 1209, col: 5, offset: 28967},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1162, col: 5, offset: 27686},
+						pos:  position{line: 1210, col: 5, offset: 28979},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1163, col: 5, offset: 27704},
+						pos:  position{line: 1211, col: 5, offset: 28997},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 5, offset: 27723},
+						pos:  position{line: 1212, col: 5, offset: 29016},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 5, offset: 27740},
+						pos:  position{line: 1213, col: 5, offset: 29033},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1166, col: 5, offset: 27753},
+						pos:  position{line: 1214, col: 5, offset: 29046},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 5, offset: 27762},
+						pos:  position{line: 1215, col: 5, offset: 29055},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1168, col: 5, offset: 27779},
+						pos:  position{line: 1216, col: 5, offset: 29072},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1169, col: 5, offset: 27798},
+						pos:  position{line: 1217, col: 5, offset: 29091},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1170, col: 5, offset: 27817},
+						pos:  position{line: 1218, col: 5, offset: 29110},
 						name: "NullLiteral",
 					},
 				},
@@ -8054,28 +8308,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1172, col: 1, offset: 27830},
+			pos:  position{line: 1220, col: 1, offset: 29123},
 			expr: &choiceExpr{
-				pos: position{line: 1173, col: 5, offset: 27848},
+				pos: position{line: 1221, col: 5, offset: 29141},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1173, col: 5, offset: 27848},
+						pos: position{line: 1221, col: 5, offset: 29141},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1173, col: 5, offset: 27848},
+							pos: position{line: 1221, col: 5, offset: 29141},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1173, col: 5, offset: 27848},
+									pos:   position{line: 1221, col: 5, offset: 29141},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1173, col: 7, offset: 27850},
+										pos:  position{line: 1221, col: 7, offset: 29143},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1173, col: 14, offset: 27857},
+									pos: position{line: 1221, col: 14, offset: 29150},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1173, col: 15, offset: 27858},
+										pos:  position{line: 1221, col: 15, offset: 29151},
 										name: "IdentifierRest",
 									},
 								},
@@ -8083,13 +8337,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1176, col: 5, offset: 27938},
+						pos: position{line: 1224, col: 5, offset: 29231},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1176, col: 5, offset: 27938},
+							pos:   position{line: 1224, col: 5, offset: 29231},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1176, col: 7, offset: 27940},
+								pos:  position{line: 1224, col: 7, offset: 29233},
 								name: "IP4Net",
 							},
 						},
@@ -8101,28 +8355,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1180, col: 1, offset: 28009},
+			pos:  position{line: 1228, col: 1, offset: 29302},
 			expr: &choiceExpr{
-				pos: position{line: 1181, col: 5, offset: 28028},
+				pos: position{line: 1229, col: 5, offset: 29321},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1181, col: 5, offset: 28028},
+						pos: position{line: 1229, col: 5, offset: 29321},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1181, col: 5, offset: 28028},
+							pos: position{line: 1229, col: 5, offset: 29321},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1181, col: 5, offset: 28028},
+									pos:   position{line: 1229, col: 5, offset: 29321},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1181, col: 7, offset: 28030},
+										pos:  position{line: 1229, col: 7, offset: 29323},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1181, col: 11, offset: 28034},
+									pos: position{line: 1229, col: 11, offset: 29327},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1181, col: 12, offset: 28035},
+										pos:  position{line: 1229, col: 12, offset: 29328},
 										name: "IdentifierRest",
 									},
 								},
@@ -8130,13 +8384,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1184, col: 5, offset: 28114},
+						pos: position{line: 1232, col: 5, offset: 29407},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1184, col: 5, offset: 28114},
+							pos:   position{line: 1232, col: 5, offset: 29407},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1184, col: 7, offset: 28116},
+								pos:  position{line: 1232, col: 7, offset: 29409},
 								name: "IP",
 							},
 						},
@@ -8148,15 +8402,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1188, col: 1, offset: 28180},
+			pos:  position{line: 1236, col: 1, offset: 29473},
 			expr: &actionExpr{
-				pos: position{line: 1189, col: 5, offset: 28197},
+				pos: position{line: 1237, col: 5, offset: 29490},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1189, col: 5, offset: 28197},
+					pos:   position{line: 1237, col: 5, offset: 29490},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1189, col: 7, offset: 28199},
+						pos:  position{line: 1237, col: 7, offset: 29492},
 						name: "FloatString",
 					},
 				},
@@ -8166,15 +8420,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1193, col: 1, offset: 28277},
+			pos:  position{line: 1241, col: 1, offset: 29570},
 			expr: &actionExpr{
-				pos: position{line: 1194, col: 5, offset: 28296},
+				pos: position{line: 1242, col: 5, offset: 29589},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1194, col: 5, offset: 28296},
+					pos:   position{line: 1242, col: 5, offset: 29589},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1194, col: 7, offset: 28298},
+						pos:  position{line: 1242, col: 7, offset: 29591},
 						name: "IntString",
 					},
 				},
@@ -8184,23 +8438,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1198, col: 1, offset: 28372},
+			pos:  position{line: 1246, col: 1, offset: 29665},
 			expr: &choiceExpr{
-				pos: position{line: 1199, col: 5, offset: 28391},
+				pos: position{line: 1247, col: 5, offset: 29684},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1199, col: 5, offset: 28391},
+						pos: position{line: 1247, col: 5, offset: 29684},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1199, col: 5, offset: 28391},
+							pos:  position{line: 1247, col: 5, offset: 29684},
 							name: "TrueToken",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1200, col: 5, offset: 28454},
+						pos: position{line: 1248, col: 5, offset: 29747},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1200, col: 5, offset: 28454},
+							pos:  position{line: 1248, col: 5, offset: 29747},
 							name: "FalseToken",
 						},
 					},
@@ -8211,12 +8465,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1202, col: 1, offset: 28515},
+			pos:  position{line: 1250, col: 1, offset: 29808},
 			expr: &actionExpr{
-				pos: position{line: 1203, col: 5, offset: 28531},
+				pos: position{line: 1251, col: 5, offset: 29824},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1203, col: 5, offset: 28531},
+					pos:  position{line: 1251, col: 5, offset: 29824},
 					name: "NullToken",
 				},
 			},
@@ -8225,23 +8479,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1205, col: 1, offset: 28586},
+			pos:  position{line: 1253, col: 1, offset: 29879},
 			expr: &actionExpr{
-				pos: position{line: 1206, col: 5, offset: 28603},
+				pos: position{line: 1254, col: 5, offset: 29896},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1206, col: 5, offset: 28603},
+					pos: position{line: 1254, col: 5, offset: 29896},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1206, col: 5, offset: 28603},
+							pos:        position{line: 1254, col: 5, offset: 29896},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1206, col: 10, offset: 28608},
+							pos: position{line: 1254, col: 10, offset: 29901},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1206, col: 10, offset: 28608},
+								pos:  position{line: 1254, col: 10, offset: 29901},
 								name: "HexDigit",
 							},
 						},
@@ -8253,29 +8507,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1210, col: 1, offset: 28682},
+			pos:  position{line: 1258, col: 1, offset: 29975},
 			expr: &actionExpr{
-				pos: position{line: 1211, col: 5, offset: 28698},
+				pos: position{line: 1259, col: 5, offset: 29991},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1211, col: 5, offset: 28698},
+					pos: position{line: 1259, col: 5, offset: 29991},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1211, col: 5, offset: 28698},
+							pos:        position{line: 1259, col: 5, offset: 29991},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1211, col: 9, offset: 28702},
+							pos:   position{line: 1259, col: 9, offset: 29995},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1211, col: 13, offset: 28706},
+								pos:  position{line: 1259, col: 13, offset: 29999},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1211, col: 18, offset: 28711},
+							pos:        position{line: 1259, col: 18, offset: 30004},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8288,16 +8542,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1219, col: 1, offset: 28844},
+			pos:  position{line: 1267, col: 1, offset: 30137},
 			expr: &choiceExpr{
-				pos: position{line: 1220, col: 5, offset: 28853},
+				pos: position{line: 1268, col: 5, offset: 30146},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 5, offset: 28853},
+						pos:  position{line: 1268, col: 5, offset: 30146},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1221, col: 5, offset: 28871},
+						pos:  position{line: 1269, col: 5, offset: 30164},
 						name: "ComplexType",
 					},
 				},
@@ -8307,28 +8561,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1223, col: 1, offset: 28884},
+			pos:  position{line: 1271, col: 1, offset: 30177},
 			expr: &choiceExpr{
-				pos: position{line: 1224, col: 5, offset: 28902},
+				pos: position{line: 1272, col: 5, offset: 30195},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1224, col: 5, offset: 28902},
+						pos: position{line: 1272, col: 5, offset: 30195},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1224, col: 5, offset: 28902},
+							pos: position{line: 1272, col: 5, offset: 30195},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1224, col: 5, offset: 28902},
+									pos:   position{line: 1272, col: 5, offset: 30195},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1224, col: 10, offset: 28907},
+										pos:  position{line: 1272, col: 10, offset: 30200},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1224, col: 24, offset: 28921},
+									pos: position{line: 1272, col: 24, offset: 30214},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1224, col: 25, offset: 28922},
+										pos:  position{line: 1272, col: 25, offset: 30215},
 										name: "IdentifierRest",
 									},
 								},
@@ -8336,45 +8590,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1225, col: 5, offset: 28962},
+						pos: position{line: 1273, col: 5, offset: 30255},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1225, col: 5, offset: 28962},
+							pos: position{line: 1273, col: 5, offset: 30255},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1225, col: 5, offset: 28962},
+									pos:        position{line: 1273, col: 5, offset: 30255},
 									val:        "error",
 									ignoreCase: false,
 									want:       "\"error\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1225, col: 13, offset: 28970},
+									pos:  position{line: 1273, col: 13, offset: 30263},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1225, col: 16, offset: 28973},
+									pos:        position{line: 1273, col: 16, offset: 30266},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1225, col: 20, offset: 28977},
+									pos:  position{line: 1273, col: 20, offset: 30270},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1225, col: 23, offset: 28980},
+									pos:   position{line: 1273, col: 23, offset: 30273},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1225, col: 25, offset: 28982},
+										pos:  position{line: 1273, col: 25, offset: 30275},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1225, col: 30, offset: 28987},
+									pos:  position{line: 1273, col: 30, offset: 30280},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1225, col: 33, offset: 28990},
+									pos:        position{line: 1273, col: 33, offset: 30283},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8383,43 +8637,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1232, col: 5, offset: 29130},
+						pos: position{line: 1280, col: 5, offset: 30423},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1232, col: 5, offset: 29130},
+							pos: position{line: 1280, col: 5, offset: 30423},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1232, col: 5, offset: 29130},
+									pos:   position{line: 1280, col: 5, offset: 30423},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1232, col: 10, offset: 29135},
+										pos:  position{line: 1280, col: 10, offset: 30428},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1232, col: 15, offset: 29140},
+									pos:   position{line: 1280, col: 15, offset: 30433},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1232, col: 19, offset: 29144},
+										pos: position{line: 1280, col: 19, offset: 30437},
 										expr: &seqExpr{
-											pos: position{line: 1232, col: 20, offset: 29145},
+											pos: position{line: 1280, col: 20, offset: 30438},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1232, col: 20, offset: 29145},
+													pos:  position{line: 1280, col: 20, offset: 30438},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1232, col: 23, offset: 29148},
+													pos:        position{line: 1280, col: 23, offset: 30441},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1232, col: 27, offset: 29152},
+													pos:  position{line: 1280, col: 27, offset: 30445},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1232, col: 30, offset: 29155},
+													pos:  position{line: 1280, col: 30, offset: 30448},
 													name: "Type",
 												},
 											},
@@ -8430,31 +8684,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1243, col: 5, offset: 29480},
+						pos: position{line: 1291, col: 5, offset: 30773},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1243, col: 5, offset: 29480},
+							pos: position{line: 1291, col: 5, offset: 30773},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1243, col: 5, offset: 29480},
+									pos:        position{line: 1291, col: 5, offset: 30773},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1243, col: 9, offset: 29484},
+									pos:  position{line: 1291, col: 9, offset: 30777},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1243, col: 12, offset: 29487},
+									pos:   position{line: 1291, col: 12, offset: 30780},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1243, col: 18, offset: 29493},
+										pos:  position{line: 1291, col: 18, offset: 30786},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1243, col: 27, offset: 29502},
+									pos:        position{line: 1291, col: 27, offset: 30795},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8469,28 +8723,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1251, col: 1, offset: 29646},
+			pos:  position{line: 1299, col: 1, offset: 30939},
 			expr: &actionExpr{
-				pos: position{line: 1252, col: 5, offset: 29659},
+				pos: position{line: 1300, col: 5, offset: 30952},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1252, col: 5, offset: 29659},
+					pos: position{line: 1300, col: 5, offset: 30952},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1252, col: 5, offset: 29659},
+							pos:   position{line: 1300, col: 5, offset: 30952},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1252, col: 11, offset: 29665},
+								pos:  position{line: 1300, col: 11, offset: 30958},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1252, col: 16, offset: 29670},
+							pos:   position{line: 1300, col: 16, offset: 30963},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1252, col: 21, offset: 29675},
+								pos: position{line: 1300, col: 21, offset: 30968},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1252, col: 21, offset: 29675},
+									pos:  position{line: 1300, col: 21, offset: 30968},
 									name: "TypeListTail",
 								},
 							},
@@ -8503,32 +8757,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1256, col: 1, offset: 29733},
+			pos:  position{line: 1304, col: 1, offset: 31026},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 16, offset: 29748},
+				pos: position{line: 1304, col: 16, offset: 31041},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1256, col: 16, offset: 29748},
+					pos: position{line: 1304, col: 16, offset: 31041},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 16, offset: 29748},
+							pos:  position{line: 1304, col: 16, offset: 31041},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1256, col: 19, offset: 29751},
+							pos:        position{line: 1304, col: 19, offset: 31044},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 23, offset: 29755},
+							pos:  position{line: 1304, col: 23, offset: 31048},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1256, col: 26, offset: 29758},
+							pos:   position{line: 1304, col: 26, offset: 31051},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1256, col: 30, offset: 29762},
+								pos:  position{line: 1304, col: 30, offset: 31055},
 								name: "Type",
 							},
 						},
@@ -8540,40 +8794,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1258, col: 1, offset: 29788},
+			pos:  position{line: 1306, col: 1, offset: 31081},
 			expr: &choiceExpr{
-				pos: position{line: 1259, col: 5, offset: 29804},
+				pos: position{line: 1307, col: 5, offset: 31097},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1259, col: 5, offset: 29804},
+						pos: position{line: 1307, col: 5, offset: 31097},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1259, col: 5, offset: 29804},
+							pos: position{line: 1307, col: 5, offset: 31097},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1259, col: 5, offset: 29804},
+									pos:        position{line: 1307, col: 5, offset: 31097},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1259, col: 9, offset: 29808},
+									pos:  position{line: 1307, col: 9, offset: 31101},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1259, col: 12, offset: 29811},
+									pos:   position{line: 1307, col: 12, offset: 31104},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1259, col: 19, offset: 29818},
+										pos:  position{line: 1307, col: 19, offset: 31111},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1259, col: 33, offset: 29832},
+									pos:  position{line: 1307, col: 33, offset: 31125},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1259, col: 36, offset: 29835},
+									pos:        position{line: 1307, col: 36, offset: 31128},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -8582,35 +8836,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1266, col: 5, offset: 29997},
+						pos: position{line: 1314, col: 5, offset: 31290},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1266, col: 5, offset: 29997},
+							pos: position{line: 1314, col: 5, offset: 31290},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1266, col: 5, offset: 29997},
+									pos:        position{line: 1314, col: 5, offset: 31290},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1266, col: 9, offset: 30001},
+									pos:  position{line: 1314, col: 9, offset: 31294},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1266, col: 12, offset: 30004},
+									pos:   position{line: 1314, col: 12, offset: 31297},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1266, col: 16, offset: 30008},
+										pos:  position{line: 1314, col: 16, offset: 31301},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1266, col: 21, offset: 30013},
+									pos:  position{line: 1314, col: 21, offset: 31306},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1266, col: 24, offset: 30016},
+									pos:        position{line: 1314, col: 24, offset: 31309},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -8619,35 +8873,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1273, col: 5, offset: 30158},
+						pos: position{line: 1321, col: 5, offset: 31451},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1273, col: 5, offset: 30158},
+							pos: position{line: 1321, col: 5, offset: 31451},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1273, col: 5, offset: 30158},
+									pos:        position{line: 1321, col: 5, offset: 31451},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 10, offset: 30163},
+									pos:  position{line: 1321, col: 10, offset: 31456},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1273, col: 13, offset: 30166},
+									pos:   position{line: 1321, col: 13, offset: 31459},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1273, col: 17, offset: 30170},
+										pos:  position{line: 1321, col: 17, offset: 31463},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 22, offset: 30175},
+									pos:  position{line: 1321, col: 22, offset: 31468},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1273, col: 25, offset: 30178},
+									pos:        position{line: 1321, col: 25, offset: 31471},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -8656,57 +8910,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1280, col: 5, offset: 30317},
+						pos: position{line: 1328, col: 5, offset: 31610},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1280, col: 5, offset: 30317},
+							pos: position{line: 1328, col: 5, offset: 31610},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1280, col: 5, offset: 30317},
+									pos:        position{line: 1328, col: 5, offset: 31610},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1280, col: 10, offset: 30322},
+									pos:  position{line: 1328, col: 10, offset: 31615},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1280, col: 13, offset: 30325},
+									pos:   position{line: 1328, col: 13, offset: 31618},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1280, col: 21, offset: 30333},
+										pos:  position{line: 1328, col: 21, offset: 31626},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1280, col: 26, offset: 30338},
+									pos:  position{line: 1328, col: 26, offset: 31631},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1280, col: 29, offset: 30341},
+									pos:        position{line: 1328, col: 29, offset: 31634},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1280, col: 33, offset: 30345},
+									pos:  position{line: 1328, col: 33, offset: 31638},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1280, col: 36, offset: 30348},
+									pos:   position{line: 1328, col: 36, offset: 31641},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1280, col: 44, offset: 30356},
+										pos:  position{line: 1328, col: 44, offset: 31649},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1280, col: 49, offset: 30361},
+									pos:  position{line: 1328, col: 49, offset: 31654},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1280, col: 52, offset: 30364},
+									pos:        position{line: 1328, col: 52, offset: 31657},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -8721,35 +8975,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1289, col: 1, offset: 30538},
+			pos:  position{line: 1337, col: 1, offset: 31831},
 			expr: &choiceExpr{
-				pos: position{line: 1290, col: 5, offset: 30556},
+				pos: position{line: 1338, col: 5, offset: 31849},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 30556},
+						pos: position{line: 1338, col: 5, offset: 31849},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1290, col: 5, offset: 30556},
+							pos: position{line: 1338, col: 5, offset: 31849},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1290, col: 5, offset: 30556},
+									pos:        position{line: 1338, col: 5, offset: 31849},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1290, col: 9, offset: 30560},
+									pos:   position{line: 1338, col: 9, offset: 31853},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1290, col: 11, offset: 30562},
+										pos: position{line: 1338, col: 11, offset: 31855},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1290, col: 11, offset: 30562},
+											pos:  position{line: 1338, col: 11, offset: 31855},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1290, col: 29, offset: 30580},
+									pos:        position{line: 1338, col: 29, offset: 31873},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8758,30 +9012,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1291, col: 5, offset: 30644},
+						pos: position{line: 1339, col: 5, offset: 31937},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1291, col: 5, offset: 30644},
+							pos: position{line: 1339, col: 5, offset: 31937},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1291, col: 5, offset: 30644},
+									pos:        position{line: 1339, col: 5, offset: 31937},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1291, col: 9, offset: 30648},
+									pos:   position{line: 1339, col: 9, offset: 31941},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1291, col: 11, offset: 30650},
+										pos: position{line: 1339, col: 11, offset: 31943},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1291, col: 11, offset: 30650},
+											pos:  position{line: 1339, col: 11, offset: 31943},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1291, col: 29, offset: 30668},
+									pos:        position{line: 1339, col: 29, offset: 31961},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8796,35 +9050,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1293, col: 1, offset: 30729},
+			pos:  position{line: 1341, col: 1, offset: 32022},
 			expr: &choiceExpr{
-				pos: position{line: 1294, col: 5, offset: 30741},
+				pos: position{line: 1342, col: 5, offset: 32034},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1294, col: 5, offset: 30741},
+						pos: position{line: 1342, col: 5, offset: 32034},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1294, col: 5, offset: 30741},
+							pos: position{line: 1342, col: 5, offset: 32034},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1294, col: 5, offset: 30741},
+									pos:        position{line: 1342, col: 5, offset: 32034},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1294, col: 11, offset: 30747},
+									pos:   position{line: 1342, col: 11, offset: 32040},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1294, col: 13, offset: 30749},
+										pos: position{line: 1342, col: 13, offset: 32042},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1294, col: 13, offset: 30749},
+											pos:  position{line: 1342, col: 13, offset: 32042},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1294, col: 38, offset: 30774},
+									pos:        position{line: 1342, col: 38, offset: 32067},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8833,30 +9087,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1301, col: 5, offset: 30920},
+						pos: position{line: 1349, col: 5, offset: 32213},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1301, col: 5, offset: 30920},
+							pos: position{line: 1349, col: 5, offset: 32213},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1301, col: 5, offset: 30920},
+									pos:        position{line: 1349, col: 5, offset: 32213},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1301, col: 10, offset: 30925},
+									pos:   position{line: 1349, col: 10, offset: 32218},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1301, col: 12, offset: 30927},
+										pos: position{line: 1349, col: 12, offset: 32220},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1301, col: 12, offset: 30927},
+											pos:  position{line: 1349, col: 12, offset: 32220},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1301, col: 37, offset: 30952},
+									pos:        position{line: 1349, col: 37, offset: 32245},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8871,24 +9125,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1309, col: 1, offset: 31095},
+			pos:  position{line: 1357, col: 1, offset: 32388},
 			expr: &choiceExpr{
-				pos: position{line: 1310, col: 5, offset: 31123},
+				pos: position{line: 1358, col: 5, offset: 32416},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1310, col: 5, offset: 31123},
+						pos:  position{line: 1358, col: 5, offset: 32416},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1311, col: 5, offset: 31139},
+						pos: position{line: 1359, col: 5, offset: 32432},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1311, col: 5, offset: 31139},
+							pos:   position{line: 1359, col: 5, offset: 32432},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1311, col: 7, offset: 31141},
+								pos: position{line: 1359, col: 7, offset: 32434},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1311, col: 7, offset: 31141},
+									pos:  position{line: 1359, col: 7, offset: 32434},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -8901,27 +9155,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1315, col: 1, offset: 31264},
+			pos:  position{line: 1363, col: 1, offset: 32557},
 			expr: &choiceExpr{
-				pos: position{line: 1316, col: 5, offset: 31292},
+				pos: position{line: 1364, col: 5, offset: 32585},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 31292},
+						pos: position{line: 1364, col: 5, offset: 32585},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 5, offset: 31292},
+							pos: position{line: 1364, col: 5, offset: 32585},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1316, col: 5, offset: 31292},
+									pos:        position{line: 1364, col: 5, offset: 32585},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1316, col: 10, offset: 31297},
+									pos:   position{line: 1364, col: 10, offset: 32590},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1316, col: 12, offset: 31299},
+										pos:        position{line: 1364, col: 12, offset: 32592},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -8931,25 +9185,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 31325},
+						pos: position{line: 1365, col: 5, offset: 32618},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1317, col: 5, offset: 31325},
+							pos: position{line: 1365, col: 5, offset: 32618},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1317, col: 5, offset: 31325},
+									pos: position{line: 1365, col: 5, offset: 32618},
 									expr: &litMatcher{
-										pos:        position{line: 1317, col: 7, offset: 31327},
+										pos:        position{line: 1365, col: 7, offset: 32620},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1317, col: 12, offset: 31332},
+									pos:   position{line: 1365, col: 12, offset: 32625},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1317, col: 14, offset: 31334},
+										pos:  position{line: 1365, col: 14, offset: 32627},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8963,24 +9217,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1319, col: 1, offset: 31370},
+			pos:  position{line: 1367, col: 1, offset: 32663},
 			expr: &choiceExpr{
-				pos: position{line: 1320, col: 5, offset: 31398},
+				pos: position{line: 1368, col: 5, offset: 32691},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 5, offset: 31398},
+						pos:  position{line: 1368, col: 5, offset: 32691},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1321, col: 5, offset: 31414},
+						pos: position{line: 1369, col: 5, offset: 32707},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1321, col: 5, offset: 31414},
+							pos:   position{line: 1369, col: 5, offset: 32707},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1321, col: 7, offset: 31416},
+								pos: position{line: 1369, col: 7, offset: 32709},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1321, col: 7, offset: 31416},
+									pos:  position{line: 1369, col: 7, offset: 32709},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -8993,27 +9247,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1325, col: 1, offset: 31539},
+			pos:  position{line: 1373, col: 1, offset: 32832},
 			expr: &choiceExpr{
-				pos: position{line: 1326, col: 5, offset: 31567},
+				pos: position{line: 1374, col: 5, offset: 32860},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1326, col: 5, offset: 31567},
+						pos: position{line: 1374, col: 5, offset: 32860},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1326, col: 5, offset: 31567},
+							pos: position{line: 1374, col: 5, offset: 32860},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1326, col: 5, offset: 31567},
+									pos:        position{line: 1374, col: 5, offset: 32860},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1326, col: 10, offset: 31572},
+									pos:   position{line: 1374, col: 10, offset: 32865},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1326, col: 12, offset: 31574},
+										pos:        position{line: 1374, col: 12, offset: 32867},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9023,25 +9277,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1327, col: 5, offset: 31600},
+						pos: position{line: 1375, col: 5, offset: 32893},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1327, col: 5, offset: 31600},
+							pos: position{line: 1375, col: 5, offset: 32893},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1327, col: 5, offset: 31600},
+									pos: position{line: 1375, col: 5, offset: 32893},
 									expr: &litMatcher{
-										pos:        position{line: 1327, col: 7, offset: 31602},
+										pos:        position{line: 1375, col: 7, offset: 32895},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1327, col: 12, offset: 31607},
+									pos:   position{line: 1375, col: 12, offset: 32900},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1327, col: 14, offset: 31609},
+										pos:  position{line: 1375, col: 14, offset: 32902},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9055,37 +9309,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1329, col: 1, offset: 31645},
+			pos:  position{line: 1377, col: 1, offset: 32938},
 			expr: &actionExpr{
-				pos: position{line: 1330, col: 5, offset: 31661},
+				pos: position{line: 1378, col: 5, offset: 32954},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1330, col: 5, offset: 31661},
+					pos: position{line: 1378, col: 5, offset: 32954},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1330, col: 5, offset: 31661},
+							pos:        position{line: 1378, col: 5, offset: 32954},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1330, col: 9, offset: 31665},
+							pos:  position{line: 1378, col: 9, offset: 32958},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1330, col: 12, offset: 31668},
+							pos:   position{line: 1378, col: 12, offset: 32961},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1330, col: 14, offset: 31670},
+								pos:  position{line: 1378, col: 14, offset: 32963},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1330, col: 19, offset: 31675},
+							pos:  position{line: 1378, col: 19, offset: 32968},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1330, col: 22, offset: 31678},
+							pos:        position{line: 1378, col: 22, offset: 32971},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9098,129 +9352,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1338, col: 1, offset: 31813},
+			pos:  position{line: 1386, col: 1, offset: 33106},
 			expr: &actionExpr{
-				pos: position{line: 1339, col: 5, offset: 31831},
+				pos: position{line: 1387, col: 5, offset: 33124},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1339, col: 9, offset: 31835},
+					pos: position{line: 1387, col: 9, offset: 33128},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1339, col: 9, offset: 31835},
+							pos:        position{line: 1387, col: 9, offset: 33128},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1339, col: 19, offset: 31845},
+							pos:        position{line: 1387, col: 19, offset: 33138},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1339, col: 30, offset: 31856},
+							pos:        position{line: 1387, col: 30, offset: 33149},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1339, col: 41, offset: 31867},
+							pos:        position{line: 1387, col: 41, offset: 33160},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1340, col: 9, offset: 31884},
+							pos:        position{line: 1388, col: 9, offset: 33177},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1340, col: 18, offset: 31893},
+							pos:        position{line: 1388, col: 18, offset: 33186},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1340, col: 28, offset: 31903},
+							pos:        position{line: 1388, col: 28, offset: 33196},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1340, col: 38, offset: 31913},
+							pos:        position{line: 1388, col: 38, offset: 33206},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1341, col: 9, offset: 31929},
+							pos:        position{line: 1389, col: 9, offset: 33222},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1341, col: 21, offset: 31941},
+							pos:        position{line: 1389, col: 21, offset: 33234},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1341, col: 33, offset: 31953},
+							pos:        position{line: 1389, col: 33, offset: 33246},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1342, col: 9, offset: 31971},
+							pos:        position{line: 1390, col: 9, offset: 33264},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1342, col: 18, offset: 31980},
+							pos:        position{line: 1390, col: 18, offset: 33273},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 9, offset: 31997},
+							pos:        position{line: 1391, col: 9, offset: 33290},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 22, offset: 32010},
+							pos:        position{line: 1391, col: 22, offset: 33303},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 9, offset: 32025},
+							pos:        position{line: 1392, col: 9, offset: 33318},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 9, offset: 32041},
+							pos:        position{line: 1393, col: 9, offset: 33334},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 16, offset: 32048},
+							pos:        position{line: 1393, col: 16, offset: 33341},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 9, offset: 32062},
+							pos:        position{line: 1394, col: 9, offset: 33355},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 18, offset: 32071},
+							pos:        position{line: 1394, col: 18, offset: 33364},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9233,31 +9487,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1354, col: 1, offset: 32256},
+			pos:  position{line: 1402, col: 1, offset: 33549},
 			expr: &choiceExpr{
-				pos: position{line: 1355, col: 5, offset: 32274},
+				pos: position{line: 1403, col: 5, offset: 33567},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1355, col: 5, offset: 32274},
+						pos: position{line: 1403, col: 5, offset: 33567},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1355, col: 5, offset: 32274},
+							pos: position{line: 1403, col: 5, offset: 33567},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1355, col: 5, offset: 32274},
+									pos:   position{line: 1403, col: 5, offset: 33567},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1355, col: 11, offset: 32280},
+										pos:  position{line: 1403, col: 11, offset: 33573},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1355, col: 21, offset: 32290},
+									pos:   position{line: 1403, col: 21, offset: 33583},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1355, col: 26, offset: 32295},
+										pos: position{line: 1403, col: 26, offset: 33588},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1355, col: 26, offset: 32295},
+											pos:  position{line: 1403, col: 26, offset: 33588},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9266,10 +9520,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1358, col: 5, offset: 32361},
+						pos: position{line: 1406, col: 5, offset: 33654},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1358, col: 5, offset: 32361},
+							pos:        position{line: 1406, col: 5, offset: 33654},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9282,32 +9536,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1360, col: 1, offset: 32385},
+			pos:  position{line: 1408, col: 1, offset: 33678},
 			expr: &actionExpr{
-				pos: position{line: 1360, col: 21, offset: 32405},
+				pos: position{line: 1408, col: 21, offset: 33698},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1360, col: 21, offset: 32405},
+					pos: position{line: 1408, col: 21, offset: 33698},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1360, col: 21, offset: 32405},
+							pos:  position{line: 1408, col: 21, offset: 33698},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1360, col: 24, offset: 32408},
+							pos:        position{line: 1408, col: 24, offset: 33701},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1360, col: 28, offset: 32412},
+							pos:  position{line: 1408, col: 28, offset: 33705},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1360, col: 31, offset: 32415},
+							pos:   position{line: 1408, col: 31, offset: 33708},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1360, col: 35, offset: 32419},
+								pos:  position{line: 1408, col: 35, offset: 33712},
 								name: "TypeField",
 							},
 						},
@@ -9319,40 +9573,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1362, col: 1, offset: 32450},
+			pos:  position{line: 1410, col: 1, offset: 33743},
 			expr: &actionExpr{
-				pos: position{line: 1363, col: 5, offset: 32464},
+				pos: position{line: 1411, col: 5, offset: 33757},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1363, col: 5, offset: 32464},
+					pos: position{line: 1411, col: 5, offset: 33757},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1363, col: 5, offset: 32464},
+							pos:   position{line: 1411, col: 5, offset: 33757},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1363, col: 10, offset: 32469},
+								pos:  position{line: 1411, col: 10, offset: 33762},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1363, col: 15, offset: 32474},
+							pos:  position{line: 1411, col: 15, offset: 33767},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1363, col: 18, offset: 32477},
+							pos:        position{line: 1411, col: 18, offset: 33770},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1363, col: 22, offset: 32481},
+							pos:  position{line: 1411, col: 22, offset: 33774},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1363, col: 25, offset: 32484},
+							pos:   position{line: 1411, col: 25, offset: 33777},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1363, col: 29, offset: 32488},
+								pos:  position{line: 1411, col: 29, offset: 33781},
 								name: "Type",
 							},
 						},
@@ -9364,54 +9618,54 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1371, col: 1, offset: 32637},
+			pos:  position{line: 1419, col: 1, offset: 33930},
 			expr: &choiceExpr{
-				pos: position{line: 1372, col: 5, offset: 32646},
+				pos: position{line: 1420, col: 5, offset: 33939},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1372, col: 5, offset: 32646},
+						pos: position{line: 1420, col: 5, offset: 33939},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1372, col: 5, offset: 32646},
+							pos:   position{line: 1420, col: 5, offset: 33939},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1372, col: 7, offset: 32648},
+								pos:  position{line: 1420, col: 7, offset: 33941},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1373, col: 5, offset: 32737},
+						pos: position{line: 1421, col: 5, offset: 34030},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1373, col: 5, offset: 32737},
+							pos:   position{line: 1421, col: 5, offset: 34030},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1373, col: 7, offset: 32739},
+								pos:  position{line: 1421, col: 7, offset: 34032},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1374, col: 5, offset: 32828},
+						pos: position{line: 1422, col: 5, offset: 34121},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1374, col: 5, offset: 32828},
+							pos:   position{line: 1422, col: 5, offset: 34121},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1374, col: 7, offset: 32830},
+								pos:  position{line: 1422, col: 7, offset: 34123},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1375, col: 5, offset: 32919},
+						pos: position{line: 1423, col: 5, offset: 34212},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1375, col: 5, offset: 32919},
+							pos:   position{line: 1423, col: 5, offset: 34212},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1375, col: 7, offset: 32921},
+								pos:  position{line: 1423, col: 7, offset: 34214},
 								name: "KSUID",
 							},
 						},
@@ -9423,22 +9677,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1377, col: 1, offset: 33007},
+			pos:  position{line: 1425, col: 1, offset: 34300},
 			expr: &actionExpr{
-				pos: position{line: 1378, col: 5, offset: 33021},
+				pos: position{line: 1426, col: 5, offset: 34314},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1378, col: 5, offset: 33021},
+					pos: position{line: 1426, col: 5, offset: 34314},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1378, col: 6, offset: 33022},
+							pos: position{line: 1426, col: 6, offset: 34315},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1378, col: 6, offset: 33022},
+									pos:  position{line: 1426, col: 6, offset: 34315},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1378, col: 24, offset: 33040},
+									pos:        position{line: 1426, col: 24, offset: 34333},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -9446,16 +9700,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1378, col: 29, offset: 33045},
+							pos: position{line: 1426, col: 29, offset: 34338},
 							expr: &choiceExpr{
-								pos: position{line: 1378, col: 30, offset: 33046},
+								pos: position{line: 1426, col: 30, offset: 34339},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1378, col: 30, offset: 33046},
+										pos:  position{line: 1426, col: 30, offset: 34339},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1378, col: 47, offset: 33063},
+										pos:        position{line: 1426, col: 47, offset: 34356},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -9471,24 +9725,24 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1380, col: 1, offset: 33101},
+			pos:  position{line: 1428, col: 1, offset: 34394},
 			expr: &actionExpr{
-				pos: position{line: 1380, col: 12, offset: 33112},
+				pos: position{line: 1428, col: 12, offset: 34405},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1380, col: 12, offset: 33112},
+					pos: position{line: 1428, col: 12, offset: 34405},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1380, col: 13, offset: 33113},
+							pos: position{line: 1428, col: 13, offset: 34406},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1380, col: 13, offset: 33113},
+									pos:        position{line: 1428, col: 13, offset: 34406},
 									val:        "and",
 									ignoreCase: false,
 									want:       "\"and\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1380, col: 21, offset: 33121},
+									pos:        position{line: 1428, col: 21, offset: 34414},
 									val:        "AND",
 									ignoreCase: false,
 									want:       "\"AND\"",
@@ -9496,9 +9750,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1380, col: 28, offset: 33128},
+							pos: position{line: 1428, col: 28, offset: 34421},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1380, col: 29, offset: 33129},
+								pos:  position{line: 1428, col: 29, offset: 34422},
 								name: "IdentifierRest",
 							},
 						},
@@ -9510,20 +9764,20 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1381, col: 1, offset: 33166},
+			pos:  position{line: 1429, col: 1, offset: 34459},
 			expr: &seqExpr{
-				pos: position{line: 1381, col: 11, offset: 33176},
+				pos: position{line: 1429, col: 11, offset: 34469},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1381, col: 11, offset: 33176},
+						pos:        position{line: 1429, col: 11, offset: 34469},
 						val:        "by",
 						ignoreCase: false,
 						want:       "\"by\"",
 					},
 					&notExpr{
-						pos: position{line: 1381, col: 16, offset: 33181},
+						pos: position{line: 1429, col: 16, offset: 34474},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1381, col: 17, offset: 33182},
+							pos:  position{line: 1429, col: 17, offset: 34475},
 							name: "IdentifierRest",
 						},
 					},
@@ -9534,20 +9788,20 @@ var g = &grammar{
 		},
 		{
 			name: "FalseToken",
-			pos:  position{line: 1382, col: 1, offset: 33197},
+			pos:  position{line: 1430, col: 1, offset: 34490},
 			expr: &seqExpr{
-				pos: position{line: 1382, col: 14, offset: 33210},
+				pos: position{line: 1430, col: 14, offset: 34503},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1382, col: 14, offset: 33210},
+						pos:        position{line: 1430, col: 14, offset: 34503},
 						val:        "false",
 						ignoreCase: false,
 						want:       "\"false\"",
 					},
 					&notExpr{
-						pos: position{line: 1382, col: 22, offset: 33218},
+						pos: position{line: 1430, col: 22, offset: 34511},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1382, col: 23, offset: 33219},
+							pos:  position{line: 1430, col: 23, offset: 34512},
 							name: "IdentifierRest",
 						},
 					},
@@ -9558,20 +9812,20 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1383, col: 1, offset: 33234},
+			pos:  position{line: 1431, col: 1, offset: 34527},
 			expr: &seqExpr{
-				pos: position{line: 1383, col: 11, offset: 33244},
+				pos: position{line: 1431, col: 11, offset: 34537},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1383, col: 11, offset: 33244},
+						pos:        position{line: 1431, col: 11, offset: 34537},
 						val:        "in",
 						ignoreCase: false,
 						want:       "\"in\"",
 					},
 					&notExpr{
-						pos: position{line: 1383, col: 16, offset: 33249},
+						pos: position{line: 1431, col: 16, offset: 34542},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1383, col: 17, offset: 33250},
+							pos:  position{line: 1431, col: 17, offset: 34543},
 							name: "IdentifierRest",
 						},
 					},
@@ -9582,24 +9836,24 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1384, col: 1, offset: 33265},
+			pos:  position{line: 1432, col: 1, offset: 34558},
 			expr: &actionExpr{
-				pos: position{line: 1384, col: 12, offset: 33276},
+				pos: position{line: 1432, col: 12, offset: 34569},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1384, col: 12, offset: 33276},
+					pos: position{line: 1432, col: 12, offset: 34569},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1384, col: 13, offset: 33277},
+							pos: position{line: 1432, col: 13, offset: 34570},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1384, col: 13, offset: 33277},
+									pos:        position{line: 1432, col: 13, offset: 34570},
 									val:        "not",
 									ignoreCase: false,
 									want:       "\"not\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1384, col: 21, offset: 33285},
+									pos:        position{line: 1432, col: 21, offset: 34578},
 									val:        "NOT",
 									ignoreCase: false,
 									want:       "\"NOT\"",
@@ -9607,9 +9861,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1384, col: 28, offset: 33292},
+							pos: position{line: 1432, col: 28, offset: 34585},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1384, col: 29, offset: 33293},
+								pos:  position{line: 1432, col: 29, offset: 34586},
 								name: "IdentifierRest",
 							},
 						},
@@ -9621,20 +9875,20 @@ var g = &grammar{
 		},
 		{
 			name: "NullToken",
-			pos:  position{line: 1385, col: 1, offset: 33330},
+			pos:  position{line: 1433, col: 1, offset: 34623},
 			expr: &seqExpr{
-				pos: position{line: 1385, col: 13, offset: 33342},
+				pos: position{line: 1433, col: 13, offset: 34635},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1385, col: 13, offset: 33342},
+						pos:        position{line: 1433, col: 13, offset: 34635},
 						val:        "null",
 						ignoreCase: false,
 						want:       "\"null\"",
 					},
 					&notExpr{
-						pos: position{line: 1385, col: 20, offset: 33349},
+						pos: position{line: 1433, col: 20, offset: 34642},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1385, col: 21, offset: 33350},
+							pos:  position{line: 1433, col: 21, offset: 34643},
 							name: "IdentifierRest",
 						},
 					},
@@ -9645,24 +9899,24 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1386, col: 1, offset: 33365},
+			pos:  position{line: 1434, col: 1, offset: 34658},
 			expr: &actionExpr{
-				pos: position{line: 1386, col: 11, offset: 33375},
+				pos: position{line: 1434, col: 11, offset: 34668},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1386, col: 11, offset: 33375},
+					pos: position{line: 1434, col: 11, offset: 34668},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1386, col: 12, offset: 33376},
+							pos: position{line: 1434, col: 12, offset: 34669},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1386, col: 12, offset: 33376},
+									pos:        position{line: 1434, col: 12, offset: 34669},
 									val:        "or",
 									ignoreCase: false,
 									want:       "\"or\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1386, col: 19, offset: 33383},
+									pos:        position{line: 1434, col: 19, offset: 34676},
 									val:        "OR",
 									ignoreCase: false,
 									want:       "\"OR\"",
@@ -9670,9 +9924,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1386, col: 25, offset: 33389},
+							pos: position{line: 1434, col: 25, offset: 34682},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1386, col: 26, offset: 33390},
+								pos:  position{line: 1434, col: 26, offset: 34683},
 								name: "IdentifierRest",
 							},
 						},
@@ -9684,20 +9938,20 @@ var g = &grammar{
 		},
 		{
 			name: "TrueToken",
-			pos:  position{line: 1387, col: 1, offset: 33426},
+			pos:  position{line: 1435, col: 1, offset: 34719},
 			expr: &seqExpr{
-				pos: position{line: 1387, col: 13, offset: 33438},
+				pos: position{line: 1435, col: 13, offset: 34731},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1387, col: 13, offset: 33438},
+						pos:        position{line: 1435, col: 13, offset: 34731},
 						val:        "true",
 						ignoreCase: false,
 						want:       "\"true\"",
 					},
 					&notExpr{
-						pos: position{line: 1387, col: 20, offset: 33445},
+						pos: position{line: 1435, col: 20, offset: 34738},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1387, col: 21, offset: 33446},
+							pos:  position{line: 1435, col: 21, offset: 34739},
 							name: "IdentifierRest",
 						},
 					},
@@ -9708,15 +9962,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1389, col: 1, offset: 33462},
+			pos:  position{line: 1437, col: 1, offset: 34755},
 			expr: &actionExpr{
-				pos: position{line: 1390, col: 5, offset: 33477},
+				pos: position{line: 1438, col: 5, offset: 34770},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1390, col: 5, offset: 33477},
+					pos:   position{line: 1438, col: 5, offset: 34770},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1390, col: 8, offset: 33480},
+						pos:  position{line: 1438, col: 8, offset: 34773},
 						name: "IdentifierName",
 					},
 				},
@@ -9726,51 +9980,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1398, col: 1, offset: 33613},
+			pos:  position{line: 1446, col: 1, offset: 34906},
 			expr: &actionExpr{
-				pos: position{line: 1399, col: 5, offset: 33629},
+				pos: position{line: 1447, col: 5, offset: 34922},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1399, col: 5, offset: 33629},
+					pos: position{line: 1447, col: 5, offset: 34922},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1399, col: 5, offset: 33629},
+							pos:   position{line: 1447, col: 5, offset: 34922},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1399, col: 11, offset: 33635},
+								pos:  position{line: 1447, col: 11, offset: 34928},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1399, col: 22, offset: 33646},
+							pos:   position{line: 1447, col: 22, offset: 34939},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1399, col: 27, offset: 33651},
+								pos: position{line: 1447, col: 27, offset: 34944},
 								expr: &actionExpr{
-									pos: position{line: 1399, col: 28, offset: 33652},
+									pos: position{line: 1447, col: 28, offset: 34945},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1399, col: 28, offset: 33652},
+										pos: position{line: 1447, col: 28, offset: 34945},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1399, col: 28, offset: 33652},
+												pos:  position{line: 1447, col: 28, offset: 34945},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1399, col: 31, offset: 33655},
+												pos:        position{line: 1447, col: 31, offset: 34948},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1399, col: 35, offset: 33659},
+												pos:  position{line: 1447, col: 35, offset: 34952},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1399, col: 38, offset: 33662},
+												pos:   position{line: 1447, col: 38, offset: 34955},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1399, col: 43, offset: 33667},
+													pos:  position{line: 1447, col: 43, offset: 34960},
 													name: "Identifier",
 												},
 											},
@@ -9787,29 +10041,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1403, col: 1, offset: 33745},
+			pos:  position{line: 1451, col: 1, offset: 35038},
 			expr: &choiceExpr{
-				pos: position{line: 1404, col: 5, offset: 33764},
+				pos: position{line: 1452, col: 5, offset: 35057},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1404, col: 5, offset: 33764},
+						pos: position{line: 1452, col: 5, offset: 35057},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1404, col: 5, offset: 33764},
+							pos: position{line: 1452, col: 5, offset: 35057},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1404, col: 5, offset: 33764},
+									pos: position{line: 1452, col: 5, offset: 35057},
 									expr: &seqExpr{
-										pos: position{line: 1404, col: 7, offset: 33766},
+										pos: position{line: 1452, col: 7, offset: 35059},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1404, col: 7, offset: 33766},
+												pos:  position{line: 1452, col: 7, offset: 35059},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1404, col: 15, offset: 33774},
+												pos: position{line: 1452, col: 15, offset: 35067},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1404, col: 16, offset: 33775},
+													pos:  position{line: 1452, col: 16, offset: 35068},
 													name: "IdentifierRest",
 												},
 											},
@@ -9817,13 +10071,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1404, col: 32, offset: 33791},
+									pos:  position{line: 1452, col: 32, offset: 35084},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1404, col: 48, offset: 33807},
+									pos: position{line: 1452, col: 48, offset: 35100},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1404, col: 48, offset: 33807},
+										pos:  position{line: 1452, col: 48, offset: 35100},
 										name: "IdentifierRest",
 									},
 								},
@@ -9831,32 +10085,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1405, col: 5, offset: 33858},
+						pos: position{line: 1453, col: 5, offset: 35151},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1405, col: 5, offset: 33858},
+							pos:        position{line: 1453, col: 5, offset: 35151},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1406, col: 5, offset: 33897},
+						pos: position{line: 1454, col: 5, offset: 35190},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1406, col: 5, offset: 33897},
+							pos: position{line: 1454, col: 5, offset: 35190},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1406, col: 5, offset: 33897},
+									pos:        position{line: 1454, col: 5, offset: 35190},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1406, col: 10, offset: 33902},
+									pos:   position{line: 1454, col: 10, offset: 35195},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1406, col: 13, offset: 33905},
+										pos:  position{line: 1454, col: 13, offset: 35198},
 										name: "IDGuard",
 									},
 								},
@@ -9864,10 +10118,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1408, col: 5, offset: 33996},
+						pos: position{line: 1456, col: 5, offset: 35289},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1408, col: 5, offset: 33996},
+							pos:        position{line: 1456, col: 5, offset: 35289},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
@@ -9880,22 +10134,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1410, col: 1, offset: 34035},
+			pos:  position{line: 1458, col: 1, offset: 35328},
 			expr: &choiceExpr{
-				pos: position{line: 1411, col: 5, offset: 34055},
+				pos: position{line: 1459, col: 5, offset: 35348},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 5, offset: 34055},
+						pos:  position{line: 1459, col: 5, offset: 35348},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1412, col: 5, offset: 34073},
+						pos:        position{line: 1460, col: 5, offset: 35366},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1413, col: 5, offset: 34081},
+						pos:        position{line: 1461, col: 5, offset: 35374},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -9907,24 +10161,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1415, col: 1, offset: 34086},
+			pos:  position{line: 1463, col: 1, offset: 35379},
 			expr: &choiceExpr{
-				pos: position{line: 1416, col: 5, offset: 34105},
+				pos: position{line: 1464, col: 5, offset: 35398},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1416, col: 5, offset: 34105},
+						pos:  position{line: 1464, col: 5, offset: 35398},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1417, col: 5, offset: 34125},
+						pos:  position{line: 1465, col: 5, offset: 35418},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1418, col: 5, offset: 34150},
+						pos:  position{line: 1466, col: 5, offset: 35443},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1419, col: 5, offset: 34167},
+						pos:  position{line: 1467, col: 5, offset: 35460},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -9934,24 +10188,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1421, col: 1, offset: 34196},
+			pos:  position{line: 1469, col: 1, offset: 35489},
 			expr: &choiceExpr{
-				pos: position{line: 1422, col: 5, offset: 34208},
+				pos: position{line: 1470, col: 5, offset: 35501},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1422, col: 5, offset: 34208},
+						pos:  position{line: 1470, col: 5, offset: 35501},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1423, col: 5, offset: 34227},
+						pos:  position{line: 1471, col: 5, offset: 35520},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1424, col: 5, offset: 34243},
+						pos:  position{line: 1472, col: 5, offset: 35536},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1425, col: 5, offset: 34251},
+						pos:  position{line: 1473, col: 5, offset: 35544},
 						name: "Infinity",
 					},
 				},
@@ -9961,25 +10215,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1427, col: 1, offset: 34261},
+			pos:  position{line: 1475, col: 1, offset: 35554},
 			expr: &actionExpr{
-				pos: position{line: 1428, col: 5, offset: 34270},
+				pos: position{line: 1476, col: 5, offset: 35563},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1428, col: 5, offset: 34270},
+					pos: position{line: 1476, col: 5, offset: 35563},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1428, col: 5, offset: 34270},
+							pos:  position{line: 1476, col: 5, offset: 35563},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1428, col: 14, offset: 34279},
+							pos:        position{line: 1476, col: 14, offset: 35572},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1428, col: 18, offset: 34283},
+							pos:  position{line: 1476, col: 18, offset: 35576},
 							name: "FullTime",
 						},
 					},
@@ -9990,32 +10244,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1432, col: 1, offset: 34359},
+			pos:  position{line: 1480, col: 1, offset: 35652},
 			expr: &seqExpr{
-				pos: position{line: 1432, col: 12, offset: 34370},
+				pos: position{line: 1480, col: 12, offset: 35663},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1432, col: 12, offset: 34370},
+						pos:  position{line: 1480, col: 12, offset: 35663},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1432, col: 15, offset: 34373},
+						pos:        position{line: 1480, col: 15, offset: 35666},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1432, col: 19, offset: 34377},
+						pos:  position{line: 1480, col: 19, offset: 35670},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1432, col: 22, offset: 34380},
+						pos:        position{line: 1480, col: 22, offset: 35673},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1432, col: 26, offset: 34384},
+						pos:  position{line: 1480, col: 26, offset: 35677},
 						name: "D2",
 					},
 				},
@@ -10025,33 +10279,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1434, col: 1, offset: 34388},
+			pos:  position{line: 1482, col: 1, offset: 35681},
 			expr: &seqExpr{
-				pos: position{line: 1434, col: 6, offset: 34393},
+				pos: position{line: 1482, col: 6, offset: 35686},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1434, col: 6, offset: 34393},
+						pos:        position{line: 1482, col: 6, offset: 35686},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1434, col: 11, offset: 34398},
+						pos:        position{line: 1482, col: 11, offset: 35691},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1434, col: 16, offset: 34403},
+						pos:        position{line: 1482, col: 16, offset: 35696},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1434, col: 21, offset: 34408},
+						pos:        position{line: 1482, col: 21, offset: 35701},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10064,19 +10318,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1435, col: 1, offset: 34414},
+			pos:  position{line: 1483, col: 1, offset: 35707},
 			expr: &seqExpr{
-				pos: position{line: 1435, col: 6, offset: 34419},
+				pos: position{line: 1483, col: 6, offset: 35712},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1435, col: 6, offset: 34419},
+						pos:        position{line: 1483, col: 6, offset: 35712},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1435, col: 11, offset: 34424},
+						pos:        position{line: 1483, col: 11, offset: 35717},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10089,16 +10343,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1437, col: 1, offset: 34431},
+			pos:  position{line: 1485, col: 1, offset: 35724},
 			expr: &seqExpr{
-				pos: position{line: 1437, col: 12, offset: 34442},
+				pos: position{line: 1485, col: 12, offset: 35735},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1437, col: 12, offset: 34442},
+						pos:  position{line: 1485, col: 12, offset: 35735},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1437, col: 24, offset: 34454},
+						pos:  position{line: 1485, col: 24, offset: 35747},
 						name: "TimeOffset",
 					},
 				},
@@ -10108,49 +10362,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1439, col: 1, offset: 34466},
+			pos:  position{line: 1487, col: 1, offset: 35759},
 			expr: &seqExpr{
-				pos: position{line: 1439, col: 15, offset: 34480},
+				pos: position{line: 1487, col: 15, offset: 35773},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1439, col: 15, offset: 34480},
+						pos:  position{line: 1487, col: 15, offset: 35773},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1439, col: 18, offset: 34483},
+						pos:        position{line: 1487, col: 18, offset: 35776},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1439, col: 22, offset: 34487},
+						pos:  position{line: 1487, col: 22, offset: 35780},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1439, col: 25, offset: 34490},
+						pos:        position{line: 1487, col: 25, offset: 35783},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1439, col: 29, offset: 34494},
+						pos:  position{line: 1487, col: 29, offset: 35787},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1439, col: 32, offset: 34497},
+						pos: position{line: 1487, col: 32, offset: 35790},
 						expr: &seqExpr{
-							pos: position{line: 1439, col: 33, offset: 34498},
+							pos: position{line: 1487, col: 33, offset: 35791},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1439, col: 33, offset: 34498},
+									pos:        position{line: 1487, col: 33, offset: 35791},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1439, col: 37, offset: 34502},
+									pos: position{line: 1487, col: 37, offset: 35795},
 									expr: &charClassMatcher{
-										pos:        position{line: 1439, col: 37, offset: 34502},
+										pos:        position{line: 1487, col: 37, offset: 35795},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10167,30 +10421,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1441, col: 1, offset: 34512},
+			pos:  position{line: 1489, col: 1, offset: 35805},
 			expr: &choiceExpr{
-				pos: position{line: 1442, col: 5, offset: 34527},
+				pos: position{line: 1490, col: 5, offset: 35820},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1442, col: 5, offset: 34527},
+						pos:        position{line: 1490, col: 5, offset: 35820},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1443, col: 5, offset: 34535},
+						pos: position{line: 1491, col: 5, offset: 35828},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1443, col: 6, offset: 34536},
+								pos: position{line: 1491, col: 6, offset: 35829},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1443, col: 6, offset: 34536},
+										pos:        position{line: 1491, col: 6, offset: 35829},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1443, col: 12, offset: 34542},
+										pos:        position{line: 1491, col: 12, offset: 35835},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10198,34 +10452,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1443, col: 17, offset: 34547},
+								pos:  position{line: 1491, col: 17, offset: 35840},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1443, col: 20, offset: 34550},
+								pos:        position{line: 1491, col: 20, offset: 35843},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1443, col: 24, offset: 34554},
+								pos:  position{line: 1491, col: 24, offset: 35847},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1443, col: 27, offset: 34557},
+								pos: position{line: 1491, col: 27, offset: 35850},
 								expr: &seqExpr{
-									pos: position{line: 1443, col: 28, offset: 34558},
+									pos: position{line: 1491, col: 28, offset: 35851},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1443, col: 28, offset: 34558},
+											pos:        position{line: 1491, col: 28, offset: 35851},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1443, col: 32, offset: 34562},
+											pos: position{line: 1491, col: 32, offset: 35855},
 											expr: &charClassMatcher{
-												pos:        position{line: 1443, col: 32, offset: 34562},
+												pos:        position{line: 1491, col: 32, offset: 35855},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10244,33 +10498,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1445, col: 1, offset: 34572},
+			pos:  position{line: 1493, col: 1, offset: 35865},
 			expr: &actionExpr{
-				pos: position{line: 1446, col: 5, offset: 34585},
+				pos: position{line: 1494, col: 5, offset: 35878},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1446, col: 5, offset: 34585},
+					pos: position{line: 1494, col: 5, offset: 35878},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1446, col: 5, offset: 34585},
+							pos: position{line: 1494, col: 5, offset: 35878},
 							expr: &litMatcher{
-								pos:        position{line: 1446, col: 5, offset: 34585},
+								pos:        position{line: 1494, col: 5, offset: 35878},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1446, col: 10, offset: 34590},
+							pos: position{line: 1494, col: 10, offset: 35883},
 							expr: &seqExpr{
-								pos: position{line: 1446, col: 11, offset: 34591},
+								pos: position{line: 1494, col: 11, offset: 35884},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1446, col: 11, offset: 34591},
+										pos:  position{line: 1494, col: 11, offset: 35884},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1446, col: 19, offset: 34599},
+										pos:  position{line: 1494, col: 19, offset: 35892},
 										name: "TimeUnit",
 									},
 								},
@@ -10284,27 +10538,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1450, col: 1, offset: 34681},
+			pos:  position{line: 1498, col: 1, offset: 35974},
 			expr: &seqExpr{
-				pos: position{line: 1450, col: 11, offset: 34691},
+				pos: position{line: 1498, col: 11, offset: 35984},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1450, col: 11, offset: 34691},
+						pos:  position{line: 1498, col: 11, offset: 35984},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1450, col: 16, offset: 34696},
+						pos: position{line: 1498, col: 16, offset: 35989},
 						expr: &seqExpr{
-							pos: position{line: 1450, col: 17, offset: 34697},
+							pos: position{line: 1498, col: 17, offset: 35990},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1450, col: 17, offset: 34697},
+									pos:        position{line: 1498, col: 17, offset: 35990},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1450, col: 21, offset: 34701},
+									pos:  position{line: 1498, col: 21, offset: 35994},
 									name: "UInt",
 								},
 							},
@@ -10317,60 +10571,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1452, col: 1, offset: 34709},
+			pos:  position{line: 1500, col: 1, offset: 36002},
 			expr: &choiceExpr{
-				pos: position{line: 1453, col: 5, offset: 34722},
+				pos: position{line: 1501, col: 5, offset: 36015},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1453, col: 5, offset: 34722},
+						pos:        position{line: 1501, col: 5, offset: 36015},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1454, col: 5, offset: 34731},
+						pos:        position{line: 1502, col: 5, offset: 36024},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1455, col: 5, offset: 34740},
+						pos:        position{line: 1503, col: 5, offset: 36033},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1456, col: 5, offset: 34749},
+						pos:        position{line: 1504, col: 5, offset: 36042},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1457, col: 5, offset: 34757},
+						pos:        position{line: 1505, col: 5, offset: 36050},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1458, col: 5, offset: 34765},
+						pos:        position{line: 1506, col: 5, offset: 36058},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1459, col: 5, offset: 34773},
+						pos:        position{line: 1507, col: 5, offset: 36066},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1460, col: 5, offset: 34781},
+						pos:        position{line: 1508, col: 5, offset: 36074},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1461, col: 5, offset: 34789},
+						pos:        position{line: 1509, col: 5, offset: 36082},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10382,45 +10636,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1463, col: 1, offset: 34794},
+			pos:  position{line: 1511, col: 1, offset: 36087},
 			expr: &actionExpr{
-				pos: position{line: 1464, col: 5, offset: 34801},
+				pos: position{line: 1512, col: 5, offset: 36094},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1464, col: 5, offset: 34801},
+					pos: position{line: 1512, col: 5, offset: 36094},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1464, col: 5, offset: 34801},
+							pos:  position{line: 1512, col: 5, offset: 36094},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1464, col: 10, offset: 34806},
+							pos:        position{line: 1512, col: 10, offset: 36099},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1464, col: 14, offset: 34810},
+							pos:  position{line: 1512, col: 14, offset: 36103},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1464, col: 19, offset: 34815},
+							pos:        position{line: 1512, col: 19, offset: 36108},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1464, col: 23, offset: 34819},
+							pos:  position{line: 1512, col: 23, offset: 36112},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1464, col: 28, offset: 34824},
+							pos:        position{line: 1512, col: 28, offset: 36117},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1464, col: 32, offset: 34828},
+							pos:  position{line: 1512, col: 32, offset: 36121},
 							name: "UInt",
 						},
 					},
@@ -10431,43 +10685,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1466, col: 1, offset: 34865},
+			pos:  position{line: 1514, col: 1, offset: 36158},
 			expr: &actionExpr{
-				pos: position{line: 1467, col: 5, offset: 34873},
+				pos: position{line: 1515, col: 5, offset: 36166},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1467, col: 5, offset: 34873},
+					pos: position{line: 1515, col: 5, offset: 36166},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1467, col: 5, offset: 34873},
+							pos: position{line: 1515, col: 5, offset: 36166},
 							expr: &seqExpr{
-								pos: position{line: 1467, col: 7, offset: 34875},
+								pos: position{line: 1515, col: 7, offset: 36168},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1467, col: 7, offset: 34875},
+										pos:  position{line: 1515, col: 7, offset: 36168},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1467, col: 11, offset: 34879},
+										pos:        position{line: 1515, col: 11, offset: 36172},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1467, col: 15, offset: 34883},
+										pos:  position{line: 1515, col: 15, offset: 36176},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1467, col: 19, offset: 34887},
+										pos: position{line: 1515, col: 19, offset: 36180},
 										expr: &choiceExpr{
-											pos: position{line: 1467, col: 21, offset: 34889},
+											pos: position{line: 1515, col: 21, offset: 36182},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1467, col: 21, offset: 34889},
+													pos:  position{line: 1515, col: 21, offset: 36182},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1467, col: 32, offset: 34900},
+													pos:        position{line: 1515, col: 32, offset: 36193},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10479,10 +10733,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1467, col: 38, offset: 34906},
+							pos:   position{line: 1515, col: 38, offset: 36199},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1467, col: 40, offset: 34908},
+								pos:  position{line: 1515, col: 40, offset: 36201},
 								name: "IP6Variations",
 							},
 						},
@@ -10494,32 +10748,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1471, col: 1, offset: 35072},
+			pos:  position{line: 1519, col: 1, offset: 36365},
 			expr: &choiceExpr{
-				pos: position{line: 1472, col: 5, offset: 35090},
+				pos: position{line: 1520, col: 5, offset: 36383},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1472, col: 5, offset: 35090},
+						pos: position{line: 1520, col: 5, offset: 36383},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1472, col: 5, offset: 35090},
+							pos: position{line: 1520, col: 5, offset: 36383},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1472, col: 5, offset: 35090},
+									pos:   position{line: 1520, col: 5, offset: 36383},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1472, col: 7, offset: 35092},
+										pos: position{line: 1520, col: 7, offset: 36385},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1472, col: 7, offset: 35092},
+											pos:  position{line: 1520, col: 7, offset: 36385},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 17, offset: 35102},
+									pos:   position{line: 1520, col: 17, offset: 36395},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1472, col: 19, offset: 35104},
+										pos:  position{line: 1520, col: 19, offset: 36397},
 										name: "IP6Tail",
 									},
 								},
@@ -10527,52 +10781,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1475, col: 5, offset: 35168},
+						pos: position{line: 1523, col: 5, offset: 36461},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1475, col: 5, offset: 35168},
+							pos: position{line: 1523, col: 5, offset: 36461},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1475, col: 5, offset: 35168},
+									pos:   position{line: 1523, col: 5, offset: 36461},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1475, col: 7, offset: 35170},
+										pos:  position{line: 1523, col: 7, offset: 36463},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1475, col: 11, offset: 35174},
+									pos:   position{line: 1523, col: 11, offset: 36467},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1475, col: 13, offset: 35176},
+										pos: position{line: 1523, col: 13, offset: 36469},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1475, col: 13, offset: 35176},
+											pos:  position{line: 1523, col: 13, offset: 36469},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1475, col: 23, offset: 35186},
+									pos:        position{line: 1523, col: 23, offset: 36479},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1475, col: 28, offset: 35191},
+									pos:   position{line: 1523, col: 28, offset: 36484},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1475, col: 30, offset: 35193},
+										pos: position{line: 1523, col: 30, offset: 36486},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1475, col: 30, offset: 35193},
+											pos:  position{line: 1523, col: 30, offset: 36486},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1475, col: 40, offset: 35203},
+									pos:   position{line: 1523, col: 40, offset: 36496},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1475, col: 42, offset: 35205},
+										pos:  position{line: 1523, col: 42, offset: 36498},
 										name: "IP6Tail",
 									},
 								},
@@ -10580,33 +10834,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1478, col: 5, offset: 35304},
+						pos: position{line: 1526, col: 5, offset: 36597},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1478, col: 5, offset: 35304},
+							pos: position{line: 1526, col: 5, offset: 36597},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1478, col: 5, offset: 35304},
+									pos:        position{line: 1526, col: 5, offset: 36597},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1478, col: 10, offset: 35309},
+									pos:   position{line: 1526, col: 10, offset: 36602},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1478, col: 12, offset: 35311},
+										pos: position{line: 1526, col: 12, offset: 36604},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1478, col: 12, offset: 35311},
+											pos:  position{line: 1526, col: 12, offset: 36604},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1478, col: 22, offset: 35321},
+									pos:   position{line: 1526, col: 22, offset: 36614},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1478, col: 24, offset: 35323},
+										pos:  position{line: 1526, col: 24, offset: 36616},
 										name: "IP6Tail",
 									},
 								},
@@ -10614,32 +10868,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1481, col: 5, offset: 35394},
+						pos: position{line: 1529, col: 5, offset: 36687},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1481, col: 5, offset: 35394},
+							pos: position{line: 1529, col: 5, offset: 36687},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1481, col: 5, offset: 35394},
+									pos:   position{line: 1529, col: 5, offset: 36687},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1481, col: 7, offset: 35396},
+										pos:  position{line: 1529, col: 7, offset: 36689},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1481, col: 11, offset: 35400},
+									pos:   position{line: 1529, col: 11, offset: 36693},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1481, col: 13, offset: 35402},
+										pos: position{line: 1529, col: 13, offset: 36695},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1481, col: 13, offset: 35402},
+											pos:  position{line: 1529, col: 13, offset: 36695},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1481, col: 23, offset: 35412},
+									pos:        position{line: 1529, col: 23, offset: 36705},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -10648,10 +10902,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1484, col: 5, offset: 35480},
+						pos: position{line: 1532, col: 5, offset: 36773},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1484, col: 5, offset: 35480},
+							pos:        position{line: 1532, col: 5, offset: 36773},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10664,16 +10918,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1488, col: 1, offset: 35517},
+			pos:  position{line: 1536, col: 1, offset: 36810},
 			expr: &choiceExpr{
-				pos: position{line: 1489, col: 5, offset: 35529},
+				pos: position{line: 1537, col: 5, offset: 36822},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1489, col: 5, offset: 35529},
+						pos:  position{line: 1537, col: 5, offset: 36822},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1490, col: 5, offset: 35536},
+						pos:  position{line: 1538, col: 5, offset: 36829},
 						name: "Hex",
 					},
 				},
@@ -10683,24 +10937,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1492, col: 1, offset: 35541},
+			pos:  position{line: 1540, col: 1, offset: 36834},
 			expr: &actionExpr{
-				pos: position{line: 1492, col: 12, offset: 35552},
+				pos: position{line: 1540, col: 12, offset: 36845},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1492, col: 12, offset: 35552},
+					pos: position{line: 1540, col: 12, offset: 36845},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1492, col: 12, offset: 35552},
+							pos:        position{line: 1540, col: 12, offset: 36845},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1492, col: 16, offset: 35556},
+							pos:   position{line: 1540, col: 16, offset: 36849},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1492, col: 18, offset: 35558},
+								pos:  position{line: 1540, col: 18, offset: 36851},
 								name: "Hex",
 							},
 						},
@@ -10712,23 +10966,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1494, col: 1, offset: 35596},
+			pos:  position{line: 1542, col: 1, offset: 36889},
 			expr: &actionExpr{
-				pos: position{line: 1494, col: 12, offset: 35607},
+				pos: position{line: 1542, col: 12, offset: 36900},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1494, col: 12, offset: 35607},
+					pos: position{line: 1542, col: 12, offset: 36900},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1494, col: 12, offset: 35607},
+							pos:   position{line: 1542, col: 12, offset: 36900},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1494, col: 14, offset: 35609},
+								pos:  position{line: 1542, col: 14, offset: 36902},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1494, col: 18, offset: 35613},
+							pos:        position{line: 1542, col: 18, offset: 36906},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10741,32 +10995,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1496, col: 1, offset: 35651},
+			pos:  position{line: 1544, col: 1, offset: 36944},
 			expr: &actionExpr{
-				pos: position{line: 1497, col: 5, offset: 35662},
+				pos: position{line: 1545, col: 5, offset: 36955},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1497, col: 5, offset: 35662},
+					pos: position{line: 1545, col: 5, offset: 36955},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1497, col: 5, offset: 35662},
+							pos:   position{line: 1545, col: 5, offset: 36955},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1497, col: 7, offset: 35664},
+								pos:  position{line: 1545, col: 7, offset: 36957},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1497, col: 10, offset: 35667},
+							pos:        position{line: 1545, col: 10, offset: 36960},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1497, col: 14, offset: 35671},
+							pos:   position{line: 1545, col: 14, offset: 36964},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1497, col: 16, offset: 35673},
+								pos:  position{line: 1545, col: 16, offset: 36966},
 								name: "UIntString",
 							},
 						},
@@ -10778,32 +11032,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1501, col: 1, offset: 35741},
+			pos:  position{line: 1549, col: 1, offset: 37034},
 			expr: &actionExpr{
-				pos: position{line: 1502, col: 5, offset: 35752},
+				pos: position{line: 1550, col: 5, offset: 37045},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1502, col: 5, offset: 35752},
+					pos: position{line: 1550, col: 5, offset: 37045},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1502, col: 5, offset: 35752},
+							pos:   position{line: 1550, col: 5, offset: 37045},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1502, col: 7, offset: 35754},
+								pos:  position{line: 1550, col: 7, offset: 37047},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1502, col: 11, offset: 35758},
+							pos:        position{line: 1550, col: 11, offset: 37051},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1502, col: 15, offset: 35762},
+							pos:   position{line: 1550, col: 15, offset: 37055},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1502, col: 17, offset: 35764},
+								pos:  position{line: 1550, col: 17, offset: 37057},
 								name: "UIntString",
 							},
 						},
@@ -10815,15 +11069,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1506, col: 1, offset: 35832},
+			pos:  position{line: 1554, col: 1, offset: 37125},
 			expr: &actionExpr{
-				pos: position{line: 1507, col: 4, offset: 35840},
+				pos: position{line: 1555, col: 4, offset: 37133},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1507, col: 4, offset: 35840},
+					pos:   position{line: 1555, col: 4, offset: 37133},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1507, col: 6, offset: 35842},
+						pos:  position{line: 1555, col: 6, offset: 37135},
 						name: "UIntString",
 					},
 				},
@@ -10833,16 +11087,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1509, col: 1, offset: 35882},
+			pos:  position{line: 1557, col: 1, offset: 37175},
 			expr: &choiceExpr{
-				pos: position{line: 1510, col: 5, offset: 35896},
+				pos: position{line: 1558, col: 5, offset: 37189},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1510, col: 5, offset: 35896},
+						pos:  position{line: 1558, col: 5, offset: 37189},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1511, col: 5, offset: 35911},
+						pos:  position{line: 1559, col: 5, offset: 37204},
 						name: "MinusIntString",
 					},
 				},
@@ -10852,14 +11106,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1513, col: 1, offset: 35927},
+			pos:  position{line: 1561, col: 1, offset: 37220},
 			expr: &actionExpr{
-				pos: position{line: 1513, col: 14, offset: 35940},
+				pos: position{line: 1561, col: 14, offset: 37233},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1513, col: 14, offset: 35940},
+					pos: position{line: 1561, col: 14, offset: 37233},
 					expr: &charClassMatcher{
-						pos:        position{line: 1513, col: 14, offset: 35940},
+						pos:        position{line: 1561, col: 14, offset: 37233},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10872,21 +11126,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1515, col: 1, offset: 35979},
+			pos:  position{line: 1563, col: 1, offset: 37272},
 			expr: &actionExpr{
-				pos: position{line: 1516, col: 5, offset: 35998},
+				pos: position{line: 1564, col: 5, offset: 37291},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1516, col: 5, offset: 35998},
+					pos: position{line: 1564, col: 5, offset: 37291},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1516, col: 5, offset: 35998},
+							pos:        position{line: 1564, col: 5, offset: 37291},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1516, col: 9, offset: 36002},
+							pos:  position{line: 1564, col: 9, offset: 37295},
 							name: "UIntString",
 						},
 					},
@@ -10897,29 +11151,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1518, col: 1, offset: 36045},
+			pos:  position{line: 1566, col: 1, offset: 37338},
 			expr: &choiceExpr{
-				pos: position{line: 1519, col: 5, offset: 36061},
+				pos: position{line: 1567, col: 5, offset: 37354},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1519, col: 5, offset: 36061},
+						pos: position{line: 1567, col: 5, offset: 37354},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1519, col: 5, offset: 36061},
+							pos: position{line: 1567, col: 5, offset: 37354},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1519, col: 5, offset: 36061},
+									pos: position{line: 1567, col: 5, offset: 37354},
 									expr: &litMatcher{
-										pos:        position{line: 1519, col: 5, offset: 36061},
+										pos:        position{line: 1567, col: 5, offset: 37354},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1519, col: 10, offset: 36066},
+									pos: position{line: 1567, col: 10, offset: 37359},
 									expr: &charClassMatcher{
-										pos:        position{line: 1519, col: 10, offset: 36066},
+										pos:        position{line: 1567, col: 10, offset: 37359},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10927,15 +11181,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1519, col: 17, offset: 36073},
+									pos:        position{line: 1567, col: 17, offset: 37366},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1519, col: 21, offset: 36077},
+									pos: position{line: 1567, col: 21, offset: 37370},
 									expr: &charClassMatcher{
-										pos:        position{line: 1519, col: 21, offset: 36077},
+										pos:        position{line: 1567, col: 21, offset: 37370},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10943,9 +11197,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1519, col: 28, offset: 36084},
+									pos: position{line: 1567, col: 28, offset: 37377},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1519, col: 28, offset: 36084},
+										pos:  position{line: 1567, col: 28, offset: 37377},
 										name: "ExponentPart",
 									},
 								},
@@ -10953,30 +11207,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1520, col: 5, offset: 36133},
+						pos: position{line: 1568, col: 5, offset: 37426},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1520, col: 5, offset: 36133},
+							pos: position{line: 1568, col: 5, offset: 37426},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1520, col: 5, offset: 36133},
+									pos: position{line: 1568, col: 5, offset: 37426},
 									expr: &litMatcher{
-										pos:        position{line: 1520, col: 5, offset: 36133},
+										pos:        position{line: 1568, col: 5, offset: 37426},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1520, col: 10, offset: 36138},
+									pos:        position{line: 1568, col: 10, offset: 37431},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1520, col: 14, offset: 36142},
+									pos: position{line: 1568, col: 14, offset: 37435},
 									expr: &charClassMatcher{
-										pos:        position{line: 1520, col: 14, offset: 36142},
+										pos:        position{line: 1568, col: 14, offset: 37435},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10984,9 +11238,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1520, col: 21, offset: 36149},
+									pos: position{line: 1568, col: 21, offset: 37442},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1520, col: 21, offset: 36149},
+										pos:  position{line: 1568, col: 21, offset: 37442},
 										name: "ExponentPart",
 									},
 								},
@@ -10994,17 +11248,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1521, col: 5, offset: 36198},
+						pos: position{line: 1569, col: 5, offset: 37491},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1521, col: 6, offset: 36199},
+							pos: position{line: 1569, col: 6, offset: 37492},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1521, col: 6, offset: 36199},
+									pos:  position{line: 1569, col: 6, offset: 37492},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1521, col: 12, offset: 36205},
+									pos:  position{line: 1569, col: 12, offset: 37498},
 									name: "Infinity",
 								},
 							},
@@ -11017,20 +11271,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1524, col: 1, offset: 36248},
+			pos:  position{line: 1572, col: 1, offset: 37541},
 			expr: &seqExpr{
-				pos: position{line: 1524, col: 16, offset: 36263},
+				pos: position{line: 1572, col: 16, offset: 37556},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1524, col: 16, offset: 36263},
+						pos:        position{line: 1572, col: 16, offset: 37556},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1524, col: 21, offset: 36268},
+						pos: position{line: 1572, col: 21, offset: 37561},
 						expr: &charClassMatcher{
-							pos:        position{line: 1524, col: 21, offset: 36268},
+							pos:        position{line: 1572, col: 21, offset: 37561},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11038,7 +11292,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1524, col: 27, offset: 36274},
+						pos:  position{line: 1572, col: 27, offset: 37567},
 						name: "UIntString",
 					},
 				},
@@ -11048,9 +11302,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1526, col: 1, offset: 36286},
+			pos:  position{line: 1574, col: 1, offset: 37579},
 			expr: &litMatcher{
-				pos:        position{line: 1526, col: 7, offset: 36292},
+				pos:        position{line: 1574, col: 7, offset: 37585},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11060,23 +11314,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1528, col: 1, offset: 36299},
+			pos:  position{line: 1576, col: 1, offset: 37592},
 			expr: &seqExpr{
-				pos: position{line: 1528, col: 12, offset: 36310},
+				pos: position{line: 1576, col: 12, offset: 37603},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1528, col: 12, offset: 36310},
+						pos: position{line: 1576, col: 12, offset: 37603},
 						expr: &choiceExpr{
-							pos: position{line: 1528, col: 13, offset: 36311},
+							pos: position{line: 1576, col: 13, offset: 37604},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1528, col: 13, offset: 36311},
+									pos:        position{line: 1576, col: 13, offset: 37604},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1528, col: 19, offset: 36317},
+									pos:        position{line: 1576, col: 19, offset: 37610},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11085,7 +11339,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1528, col: 25, offset: 36323},
+						pos:        position{line: 1576, col: 25, offset: 37616},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11097,14 +11351,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1530, col: 1, offset: 36330},
+			pos:  position{line: 1578, col: 1, offset: 37623},
 			expr: &actionExpr{
-				pos: position{line: 1530, col: 7, offset: 36336},
+				pos: position{line: 1578, col: 7, offset: 37629},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1530, col: 7, offset: 36336},
+					pos: position{line: 1578, col: 7, offset: 37629},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1530, col: 7, offset: 36336},
+						pos:  position{line: 1578, col: 7, offset: 37629},
 						name: "HexDigit",
 					},
 				},
@@ -11114,9 +11368,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1532, col: 1, offset: 36378},
+			pos:  position{line: 1580, col: 1, offset: 37671},
 			expr: &charClassMatcher{
-				pos:        position{line: 1532, col: 12, offset: 36389},
+				pos:        position{line: 1580, col: 12, offset: 37682},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11127,35 +11381,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1534, col: 1, offset: 36402},
+			pos:  position{line: 1582, col: 1, offset: 37695},
 			expr: &choiceExpr{
-				pos: position{line: 1535, col: 5, offset: 36419},
+				pos: position{line: 1583, col: 5, offset: 37712},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1535, col: 5, offset: 36419},
+						pos: position{line: 1583, col: 5, offset: 37712},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1535, col: 5, offset: 36419},
+							pos: position{line: 1583, col: 5, offset: 37712},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1535, col: 5, offset: 36419},
+									pos:        position{line: 1583, col: 5, offset: 37712},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1535, col: 9, offset: 36423},
+									pos:   position{line: 1583, col: 9, offset: 37716},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1535, col: 11, offset: 36425},
+										pos: position{line: 1583, col: 11, offset: 37718},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1535, col: 11, offset: 36425},
+											pos:  position{line: 1583, col: 11, offset: 37718},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1535, col: 29, offset: 36443},
+									pos:        position{line: 1583, col: 29, offset: 37736},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11164,30 +11418,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1536, col: 5, offset: 36480},
+						pos: position{line: 1584, col: 5, offset: 37773},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1536, col: 5, offset: 36480},
+							pos: position{line: 1584, col: 5, offset: 37773},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1536, col: 5, offset: 36480},
+									pos:        position{line: 1584, col: 5, offset: 37773},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1536, col: 9, offset: 36484},
+									pos:   position{line: 1584, col: 9, offset: 37777},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1536, col: 11, offset: 36486},
+										pos: position{line: 1584, col: 11, offset: 37779},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1536, col: 11, offset: 36486},
+											pos:  position{line: 1584, col: 11, offset: 37779},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1536, col: 29, offset: 36504},
+									pos:        position{line: 1584, col: 29, offset: 37797},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11202,57 +11456,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1538, col: 1, offset: 36538},
+			pos:  position{line: 1586, col: 1, offset: 37831},
 			expr: &choiceExpr{
-				pos: position{line: 1539, col: 5, offset: 36559},
+				pos: position{line: 1587, col: 5, offset: 37852},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1539, col: 5, offset: 36559},
+						pos: position{line: 1587, col: 5, offset: 37852},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1539, col: 5, offset: 36559},
+							pos: position{line: 1587, col: 5, offset: 37852},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1539, col: 5, offset: 36559},
+									pos: position{line: 1587, col: 5, offset: 37852},
 									expr: &choiceExpr{
-										pos: position{line: 1539, col: 7, offset: 36561},
+										pos: position{line: 1587, col: 7, offset: 37854},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1539, col: 7, offset: 36561},
+												pos:        position{line: 1587, col: 7, offset: 37854},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1539, col: 13, offset: 36567},
+												pos:  position{line: 1587, col: 13, offset: 37860},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1539, col: 26, offset: 36580,
+									line: 1587, col: 26, offset: 37873,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1540, col: 5, offset: 36617},
+						pos: position{line: 1588, col: 5, offset: 37910},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1540, col: 5, offset: 36617},
+							pos: position{line: 1588, col: 5, offset: 37910},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1540, col: 5, offset: 36617},
+									pos:        position{line: 1588, col: 5, offset: 37910},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1540, col: 10, offset: 36622},
+									pos:   position{line: 1588, col: 10, offset: 37915},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1540, col: 12, offset: 36624},
+										pos:  position{line: 1588, col: 12, offset: 37917},
 										name: "EscapeSequence",
 									},
 								},
@@ -11266,28 +11520,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1542, col: 1, offset: 36658},
+			pos:  position{line: 1590, col: 1, offset: 37951},
 			expr: &actionExpr{
-				pos: position{line: 1543, col: 5, offset: 36670},
+				pos: position{line: 1591, col: 5, offset: 37963},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1543, col: 5, offset: 36670},
+					pos: position{line: 1591, col: 5, offset: 37963},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1543, col: 5, offset: 36670},
+							pos:   position{line: 1591, col: 5, offset: 37963},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1543, col: 10, offset: 36675},
+								pos:  position{line: 1591, col: 10, offset: 37968},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1543, col: 23, offset: 36688},
+							pos:   position{line: 1591, col: 23, offset: 37981},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1543, col: 28, offset: 36693},
+								pos: position{line: 1591, col: 28, offset: 37986},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1543, col: 28, offset: 36693},
+									pos:  position{line: 1591, col: 28, offset: 37986},
 									name: "KeyWordRest",
 								},
 							},
@@ -11300,16 +11554,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1545, col: 1, offset: 36755},
+			pos:  position{line: 1593, col: 1, offset: 38048},
 			expr: &choiceExpr{
-				pos: position{line: 1546, col: 5, offset: 36772},
+				pos: position{line: 1594, col: 5, offset: 38065},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1546, col: 5, offset: 36772},
+						pos:  position{line: 1594, col: 5, offset: 38065},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1547, col: 5, offset: 36789},
+						pos:  position{line: 1595, col: 5, offset: 38082},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11319,16 +11573,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1549, col: 1, offset: 36801},
+			pos:  position{line: 1597, col: 1, offset: 38094},
 			expr: &choiceExpr{
-				pos: position{line: 1550, col: 5, offset: 36817},
+				pos: position{line: 1598, col: 5, offset: 38110},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1550, col: 5, offset: 36817},
+						pos:  position{line: 1598, col: 5, offset: 38110},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1551, col: 5, offset: 36834},
+						pos:        position{line: 1599, col: 5, offset: 38127},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11341,19 +11595,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1553, col: 1, offset: 36841},
+			pos:  position{line: 1601, col: 1, offset: 38134},
 			expr: &actionExpr{
-				pos: position{line: 1553, col: 16, offset: 36856},
+				pos: position{line: 1601, col: 16, offset: 38149},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1553, col: 17, offset: 36857},
+					pos: position{line: 1601, col: 17, offset: 38150},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1553, col: 17, offset: 36857},
+							pos:  position{line: 1601, col: 17, offset: 38150},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1553, col: 33, offset: 36873},
+							pos:        position{line: 1601, col: 33, offset: 38166},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11367,31 +11621,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1555, col: 1, offset: 36917},
+			pos:  position{line: 1603, col: 1, offset: 38210},
 			expr: &actionExpr{
-				pos: position{line: 1555, col: 14, offset: 36930},
+				pos: position{line: 1603, col: 14, offset: 38223},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1555, col: 14, offset: 36930},
+					pos: position{line: 1603, col: 14, offset: 38223},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1555, col: 14, offset: 36930},
+							pos:        position{line: 1603, col: 14, offset: 38223},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1555, col: 19, offset: 36935},
+							pos:   position{line: 1603, col: 19, offset: 38228},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1555, col: 22, offset: 36938},
+								pos: position{line: 1603, col: 22, offset: 38231},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1555, col: 22, offset: 36938},
+										pos:  position{line: 1603, col: 22, offset: 38231},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1555, col: 38, offset: 36954},
+										pos:  position{line: 1603, col: 38, offset: 38247},
 										name: "EscapeSequence",
 									},
 								},
@@ -11405,42 +11659,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1557, col: 1, offset: 36989},
+			pos:  position{line: 1605, col: 1, offset: 38282},
 			expr: &actionExpr{
-				pos: position{line: 1558, col: 5, offset: 37005},
+				pos: position{line: 1606, col: 5, offset: 38298},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1558, col: 5, offset: 37005},
+					pos: position{line: 1606, col: 5, offset: 38298},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1558, col: 5, offset: 37005},
+							pos: position{line: 1606, col: 5, offset: 38298},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1558, col: 6, offset: 37006},
+								pos:  position{line: 1606, col: 6, offset: 38299},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1558, col: 22, offset: 37022},
+							pos: position{line: 1606, col: 22, offset: 38315},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1558, col: 23, offset: 37023},
+								pos:  position{line: 1606, col: 23, offset: 38316},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1558, col: 35, offset: 37035},
+							pos:   position{line: 1606, col: 35, offset: 38328},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1558, col: 40, offset: 37040},
+								pos:  position{line: 1606, col: 40, offset: 38333},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1558, col: 50, offset: 37050},
+							pos:   position{line: 1606, col: 50, offset: 38343},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1558, col: 55, offset: 37055},
+								pos: position{line: 1606, col: 55, offset: 38348},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1558, col: 55, offset: 37055},
+									pos:  position{line: 1606, col: 55, offset: 38348},
 									name: "GlobRest",
 								},
 							},
@@ -11453,28 +11707,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1562, col: 1, offset: 37124},
+			pos:  position{line: 1610, col: 1, offset: 38417},
 			expr: &choiceExpr{
-				pos: position{line: 1562, col: 19, offset: 37142},
+				pos: position{line: 1610, col: 19, offset: 38435},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1562, col: 19, offset: 37142},
+						pos:  position{line: 1610, col: 19, offset: 38435},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1562, col: 34, offset: 37157},
+						pos: position{line: 1610, col: 34, offset: 38450},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1562, col: 34, offset: 37157},
+								pos: position{line: 1610, col: 34, offset: 38450},
 								expr: &litMatcher{
-									pos:        position{line: 1562, col: 34, offset: 37157},
+									pos:        position{line: 1610, col: 34, offset: 38450},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1562, col: 39, offset: 37162},
+								pos:  position{line: 1610, col: 39, offset: 38455},
 								name: "KeyWordRest",
 							},
 						},
@@ -11486,19 +11740,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1563, col: 1, offset: 37174},
+			pos:  position{line: 1611, col: 1, offset: 38467},
 			expr: &seqExpr{
-				pos: position{line: 1563, col: 15, offset: 37188},
+				pos: position{line: 1611, col: 15, offset: 38481},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1563, col: 15, offset: 37188},
+						pos: position{line: 1611, col: 15, offset: 38481},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1563, col: 15, offset: 37188},
+							pos:  position{line: 1611, col: 15, offset: 38481},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1563, col: 28, offset: 37201},
+						pos:        position{line: 1611, col: 28, offset: 38494},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11510,23 +11764,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1565, col: 1, offset: 37206},
+			pos:  position{line: 1613, col: 1, offset: 38499},
 			expr: &choiceExpr{
-				pos: position{line: 1566, col: 5, offset: 37220},
+				pos: position{line: 1614, col: 5, offset: 38513},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1566, col: 5, offset: 37220},
+						pos:  position{line: 1614, col: 5, offset: 38513},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1567, col: 5, offset: 37237},
+						pos:  position{line: 1615, col: 5, offset: 38530},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1568, col: 5, offset: 37249},
+						pos: position{line: 1616, col: 5, offset: 38542},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1568, col: 5, offset: 37249},
+							pos:        position{line: 1616, col: 5, offset: 38542},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -11539,16 +11793,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1570, col: 1, offset: 37274},
+			pos:  position{line: 1618, col: 1, offset: 38567},
 			expr: &choiceExpr{
-				pos: position{line: 1571, col: 5, offset: 37287},
+				pos: position{line: 1619, col: 5, offset: 38580},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1571, col: 5, offset: 37287},
+						pos:  position{line: 1619, col: 5, offset: 38580},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1572, col: 5, offset: 37301},
+						pos:        position{line: 1620, col: 5, offset: 38594},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11561,31 +11815,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1574, col: 1, offset: 37308},
+			pos:  position{line: 1622, col: 1, offset: 38601},
 			expr: &actionExpr{
-				pos: position{line: 1574, col: 11, offset: 37318},
+				pos: position{line: 1622, col: 11, offset: 38611},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1574, col: 11, offset: 37318},
+					pos: position{line: 1622, col: 11, offset: 38611},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1574, col: 11, offset: 37318},
+							pos:        position{line: 1622, col: 11, offset: 38611},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1574, col: 16, offset: 37323},
+							pos:   position{line: 1622, col: 16, offset: 38616},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1574, col: 19, offset: 37326},
+								pos: position{line: 1622, col: 19, offset: 38619},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1574, col: 19, offset: 37326},
+										pos:  position{line: 1622, col: 19, offset: 38619},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1574, col: 32, offset: 37339},
+										pos:  position{line: 1622, col: 32, offset: 38632},
 										name: "EscapeSequence",
 									},
 								},
@@ -11599,32 +11853,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1576, col: 1, offset: 37374},
+			pos:  position{line: 1624, col: 1, offset: 38667},
 			expr: &choiceExpr{
-				pos: position{line: 1577, col: 5, offset: 37389},
+				pos: position{line: 1625, col: 5, offset: 38682},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1577, col: 5, offset: 37389},
+						pos: position{line: 1625, col: 5, offset: 38682},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1577, col: 5, offset: 37389},
+							pos:        position{line: 1625, col: 5, offset: 38682},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1578, col: 5, offset: 37417},
+						pos: position{line: 1626, col: 5, offset: 38710},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1578, col: 5, offset: 37417},
+							pos:        position{line: 1626, col: 5, offset: 38710},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1579, col: 5, offset: 37447},
+						pos:        position{line: 1627, col: 5, offset: 38740},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11637,57 +11891,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1581, col: 1, offset: 37453},
+			pos:  position{line: 1629, col: 1, offset: 38746},
 			expr: &choiceExpr{
-				pos: position{line: 1582, col: 5, offset: 37474},
+				pos: position{line: 1630, col: 5, offset: 38767},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1582, col: 5, offset: 37474},
+						pos: position{line: 1630, col: 5, offset: 38767},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1582, col: 5, offset: 37474},
+							pos: position{line: 1630, col: 5, offset: 38767},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1582, col: 5, offset: 37474},
+									pos: position{line: 1630, col: 5, offset: 38767},
 									expr: &choiceExpr{
-										pos: position{line: 1582, col: 7, offset: 37476},
+										pos: position{line: 1630, col: 7, offset: 38769},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1582, col: 7, offset: 37476},
+												pos:        position{line: 1630, col: 7, offset: 38769},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1582, col: 13, offset: 37482},
+												pos:  position{line: 1630, col: 13, offset: 38775},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1582, col: 26, offset: 37495,
+									line: 1630, col: 26, offset: 38788,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1583, col: 5, offset: 37532},
+						pos: position{line: 1631, col: 5, offset: 38825},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1583, col: 5, offset: 37532},
+							pos: position{line: 1631, col: 5, offset: 38825},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1583, col: 5, offset: 37532},
+									pos:        position{line: 1631, col: 5, offset: 38825},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1583, col: 10, offset: 37537},
+									pos:   position{line: 1631, col: 10, offset: 38830},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1583, col: 12, offset: 37539},
+										pos:  position{line: 1631, col: 12, offset: 38832},
 										name: "EscapeSequence",
 									},
 								},
@@ -11701,16 +11955,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1585, col: 1, offset: 37573},
+			pos:  position{line: 1633, col: 1, offset: 38866},
 			expr: &choiceExpr{
-				pos: position{line: 1586, col: 5, offset: 37592},
+				pos: position{line: 1634, col: 5, offset: 38885},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1586, col: 5, offset: 37592},
+						pos:  position{line: 1634, col: 5, offset: 38885},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1587, col: 5, offset: 37613},
+						pos:  position{line: 1635, col: 5, offset: 38906},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11720,87 +11974,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1589, col: 1, offset: 37628},
+			pos:  position{line: 1637, col: 1, offset: 38921},
 			expr: &choiceExpr{
-				pos: position{line: 1590, col: 5, offset: 37649},
+				pos: position{line: 1638, col: 5, offset: 38942},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1590, col: 5, offset: 37649},
+						pos:        position{line: 1638, col: 5, offset: 38942},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1591, col: 5, offset: 37657},
+						pos: position{line: 1639, col: 5, offset: 38950},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1591, col: 5, offset: 37657},
+							pos:        position{line: 1639, col: 5, offset: 38950},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1592, col: 5, offset: 37697},
+						pos:        position{line: 1640, col: 5, offset: 38990},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1593, col: 5, offset: 37706},
+						pos: position{line: 1641, col: 5, offset: 38999},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1593, col: 5, offset: 37706},
+							pos:        position{line: 1641, col: 5, offset: 38999},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1594, col: 5, offset: 37735},
+						pos: position{line: 1642, col: 5, offset: 39028},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1594, col: 5, offset: 37735},
+							pos:        position{line: 1642, col: 5, offset: 39028},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1595, col: 5, offset: 37764},
+						pos: position{line: 1643, col: 5, offset: 39057},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1595, col: 5, offset: 37764},
+							pos:        position{line: 1643, col: 5, offset: 39057},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1596, col: 5, offset: 37793},
+						pos: position{line: 1644, col: 5, offset: 39086},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1596, col: 5, offset: 37793},
+							pos:        position{line: 1644, col: 5, offset: 39086},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1597, col: 5, offset: 37822},
+						pos: position{line: 1645, col: 5, offset: 39115},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1597, col: 5, offset: 37822},
+							pos:        position{line: 1645, col: 5, offset: 39115},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1598, col: 5, offset: 37851},
+						pos: position{line: 1646, col: 5, offset: 39144},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1598, col: 5, offset: 37851},
+							pos:        position{line: 1646, col: 5, offset: 39144},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -11813,32 +12067,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1600, col: 1, offset: 37877},
+			pos:  position{line: 1648, col: 1, offset: 39170},
 			expr: &choiceExpr{
-				pos: position{line: 1601, col: 5, offset: 37895},
+				pos: position{line: 1649, col: 5, offset: 39188},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1601, col: 5, offset: 37895},
+						pos: position{line: 1649, col: 5, offset: 39188},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1601, col: 5, offset: 37895},
+							pos:        position{line: 1649, col: 5, offset: 39188},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1602, col: 5, offset: 37923},
+						pos: position{line: 1650, col: 5, offset: 39216},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1602, col: 5, offset: 37923},
+							pos:        position{line: 1650, col: 5, offset: 39216},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1603, col: 5, offset: 37951},
+						pos:        position{line: 1651, col: 5, offset: 39244},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11851,42 +12105,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1605, col: 1, offset: 37957},
+			pos:  position{line: 1653, col: 1, offset: 39250},
 			expr: &choiceExpr{
-				pos: position{line: 1606, col: 5, offset: 37975},
+				pos: position{line: 1654, col: 5, offset: 39268},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1606, col: 5, offset: 37975},
+						pos: position{line: 1654, col: 5, offset: 39268},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1606, col: 5, offset: 37975},
+							pos: position{line: 1654, col: 5, offset: 39268},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1606, col: 5, offset: 37975},
+									pos:        position{line: 1654, col: 5, offset: 39268},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1606, col: 9, offset: 37979},
+									pos:   position{line: 1654, col: 9, offset: 39272},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1606, col: 16, offset: 37986},
+										pos: position{line: 1654, col: 16, offset: 39279},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1606, col: 16, offset: 37986},
+												pos:  position{line: 1654, col: 16, offset: 39279},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1606, col: 25, offset: 37995},
+												pos:  position{line: 1654, col: 25, offset: 39288},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1606, col: 34, offset: 38004},
+												pos:  position{line: 1654, col: 34, offset: 39297},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1606, col: 43, offset: 38013},
+												pos:  position{line: 1654, col: 43, offset: 39306},
 												name: "HexDigit",
 											},
 										},
@@ -11896,65 +12150,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1609, col: 5, offset: 38076},
+						pos: position{line: 1657, col: 5, offset: 39369},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1609, col: 5, offset: 38076},
+							pos: position{line: 1657, col: 5, offset: 39369},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1609, col: 5, offset: 38076},
+									pos:        position{line: 1657, col: 5, offset: 39369},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1609, col: 9, offset: 38080},
+									pos:        position{line: 1657, col: 9, offset: 39373},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1609, col: 13, offset: 38084},
+									pos:   position{line: 1657, col: 13, offset: 39377},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1609, col: 20, offset: 38091},
+										pos: position{line: 1657, col: 20, offset: 39384},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1609, col: 20, offset: 38091},
+												pos:  position{line: 1657, col: 20, offset: 39384},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1609, col: 29, offset: 38100},
+												pos: position{line: 1657, col: 29, offset: 39393},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1609, col: 29, offset: 38100},
+													pos:  position{line: 1657, col: 29, offset: 39393},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1609, col: 39, offset: 38110},
+												pos: position{line: 1657, col: 39, offset: 39403},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1609, col: 39, offset: 38110},
+													pos:  position{line: 1657, col: 39, offset: 39403},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1609, col: 49, offset: 38120},
+												pos: position{line: 1657, col: 49, offset: 39413},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1609, col: 49, offset: 38120},
+													pos:  position{line: 1657, col: 49, offset: 39413},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1609, col: 59, offset: 38130},
+												pos: position{line: 1657, col: 59, offset: 39423},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1609, col: 59, offset: 38130},
+													pos:  position{line: 1657, col: 59, offset: 39423},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1609, col: 69, offset: 38140},
+												pos: position{line: 1657, col: 69, offset: 39433},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1609, col: 69, offset: 38140},
+													pos:  position{line: 1657, col: 69, offset: 39433},
 													name: "HexDigit",
 												},
 											},
@@ -11962,7 +12216,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1609, col: 80, offset: 38151},
+									pos:        position{line: 1657, col: 80, offset: 39444},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -11977,37 +12231,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1613, col: 1, offset: 38205},
+			pos:  position{line: 1661, col: 1, offset: 39498},
 			expr: &actionExpr{
-				pos: position{line: 1614, col: 5, offset: 38223},
+				pos: position{line: 1662, col: 5, offset: 39516},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1614, col: 5, offset: 38223},
+					pos: position{line: 1662, col: 5, offset: 39516},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1614, col: 5, offset: 38223},
+							pos:        position{line: 1662, col: 5, offset: 39516},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1614, col: 9, offset: 38227},
+							pos:   position{line: 1662, col: 9, offset: 39520},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1614, col: 14, offset: 38232},
+								pos:  position{line: 1662, col: 14, offset: 39525},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1614, col: 25, offset: 38243},
+							pos:        position{line: 1662, col: 25, offset: 39536},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1614, col: 29, offset: 38247},
+							pos: position{line: 1662, col: 29, offset: 39540},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1614, col: 30, offset: 38248},
+								pos:  position{line: 1662, col: 30, offset: 39541},
 								name: "KeyWordStart",
 							},
 						},
@@ -12019,33 +12273,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1616, col: 1, offset: 38283},
+			pos:  position{line: 1664, col: 1, offset: 39576},
 			expr: &actionExpr{
-				pos: position{line: 1617, col: 5, offset: 38298},
+				pos: position{line: 1665, col: 5, offset: 39591},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1617, col: 5, offset: 38298},
+					pos: position{line: 1665, col: 5, offset: 39591},
 					expr: &choiceExpr{
-						pos: position{line: 1617, col: 6, offset: 38299},
+						pos: position{line: 1665, col: 6, offset: 39592},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1617, col: 6, offset: 38299},
+								pos:        position{line: 1665, col: 6, offset: 39592},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1617, col: 15, offset: 38308},
+								pos: position{line: 1665, col: 15, offset: 39601},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1617, col: 15, offset: 38308},
+										pos:        position{line: 1665, col: 15, offset: 39601},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1617, col: 20, offset: 38313,
+										line: 1665, col: 20, offset: 39606,
 									},
 								},
 							},
@@ -12058,9 +12312,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1619, col: 1, offset: 38349},
+			pos:  position{line: 1667, col: 1, offset: 39642},
 			expr: &charClassMatcher{
-				pos:        position{line: 1620, col: 5, offset: 38365},
+				pos:        position{line: 1668, col: 5, offset: 39658},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12072,11 +12326,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1622, col: 1, offset: 38380},
+			pos:  position{line: 1670, col: 1, offset: 39673},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1622, col: 5, offset: 38384},
+				pos: position{line: 1670, col: 5, offset: 39677},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1622, col: 5, offset: 38384},
+					pos:  position{line: 1670, col: 5, offset: 39677},
 					name: "AnySpace",
 				},
 			},
@@ -12085,11 +12339,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1624, col: 1, offset: 38395},
+			pos:  position{line: 1672, col: 1, offset: 39688},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1624, col: 6, offset: 38400},
+				pos: position{line: 1672, col: 6, offset: 39693},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1624, col: 6, offset: 38400},
+					pos:  position{line: 1672, col: 6, offset: 39693},
 					name: "AnySpace",
 				},
 			},
@@ -12098,20 +12352,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1626, col: 1, offset: 38411},
+			pos:  position{line: 1674, col: 1, offset: 39704},
 			expr: &choiceExpr{
-				pos: position{line: 1627, col: 5, offset: 38424},
+				pos: position{line: 1675, col: 5, offset: 39717},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1627, col: 5, offset: 38424},
+						pos:  position{line: 1675, col: 5, offset: 39717},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1628, col: 5, offset: 38439},
+						pos:  position{line: 1676, col: 5, offset: 39732},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1629, col: 5, offset: 38458},
+						pos:  position{line: 1677, col: 5, offset: 39751},
 						name: "Comment",
 					},
 				},
@@ -12121,32 +12375,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1631, col: 1, offset: 38467},
+			pos:  position{line: 1679, col: 1, offset: 39760},
 			expr: &choiceExpr{
-				pos: position{line: 1632, col: 5, offset: 38485},
+				pos: position{line: 1680, col: 5, offset: 39778},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1632, col: 5, offset: 38485},
+						pos:  position{line: 1680, col: 5, offset: 39778},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1633, col: 5, offset: 38492},
+						pos:  position{line: 1681, col: 5, offset: 39785},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1634, col: 5, offset: 38499},
+						pos:  position{line: 1682, col: 5, offset: 39792},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 5, offset: 38506},
+						pos:  position{line: 1683, col: 5, offset: 39799},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1636, col: 5, offset: 38513},
+						pos:  position{line: 1684, col: 5, offset: 39806},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1637, col: 5, offset: 38520},
+						pos:  position{line: 1685, col: 5, offset: 39813},
 						name: "Nl",
 					},
 				},
@@ -12156,16 +12410,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1639, col: 1, offset: 38524},
+			pos:  position{line: 1687, col: 1, offset: 39817},
 			expr: &choiceExpr{
-				pos: position{line: 1640, col: 5, offset: 38549},
+				pos: position{line: 1688, col: 5, offset: 39842},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1640, col: 5, offset: 38549},
+						pos:  position{line: 1688, col: 5, offset: 39842},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1641, col: 5, offset: 38556},
+						pos:  position{line: 1689, col: 5, offset: 39849},
 						name: "Mc",
 					},
 				},
@@ -12175,9 +12429,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1643, col: 1, offset: 38560},
+			pos:  position{line: 1691, col: 1, offset: 39853},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1644, col: 5, offset: 38577},
+				pos:  position{line: 1692, col: 5, offset: 39870},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12185,9 +12439,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1646, col: 1, offset: 38581},
+			pos:  position{line: 1694, col: 1, offset: 39874},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1647, col: 5, offset: 38613},
+				pos:  position{line: 1695, col: 5, offset: 39906},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12195,9 +12449,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1653, col: 1, offset: 38794},
+			pos:  position{line: 1701, col: 1, offset: 40087},
 			expr: &charClassMatcher{
-				pos:        position{line: 1653, col: 6, offset: 38799},
+				pos:        position{line: 1701, col: 6, offset: 40092},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12209,9 +12463,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1656, col: 1, offset: 42951},
+			pos:  position{line: 1704, col: 1, offset: 44244},
 			expr: &charClassMatcher{
-				pos:        position{line: 1656, col: 6, offset: 42956},
+				pos:        position{line: 1704, col: 6, offset: 44249},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12223,9 +12477,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1659, col: 1, offset: 43441},
+			pos:  position{line: 1707, col: 1, offset: 44734},
 			expr: &charClassMatcher{
-				pos:        position{line: 1659, col: 6, offset: 43446},
+				pos:        position{line: 1707, col: 6, offset: 44739},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12237,9 +12491,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1662, col: 1, offset: 46893},
+			pos:  position{line: 1710, col: 1, offset: 48186},
 			expr: &charClassMatcher{
-				pos:        position{line: 1662, col: 6, offset: 46898},
+				pos:        position{line: 1710, col: 6, offset: 48191},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12251,9 +12505,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1665, col: 1, offset: 47004},
+			pos:  position{line: 1713, col: 1, offset: 48297},
 			expr: &charClassMatcher{
-				pos:        position{line: 1665, col: 6, offset: 47009},
+				pos:        position{line: 1713, col: 6, offset: 48302},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12265,9 +12519,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1668, col: 1, offset: 51010},
+			pos:  position{line: 1716, col: 1, offset: 52303},
 			expr: &charClassMatcher{
-				pos:        position{line: 1668, col: 6, offset: 51015},
+				pos:        position{line: 1716, col: 6, offset: 52308},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12279,9 +12533,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1671, col: 1, offset: 52203},
+			pos:  position{line: 1719, col: 1, offset: 53496},
 			expr: &charClassMatcher{
-				pos:        position{line: 1671, col: 6, offset: 52208},
+				pos:        position{line: 1719, col: 6, offset: 53501},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12293,9 +12547,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1674, col: 1, offset: 54388},
+			pos:  position{line: 1722, col: 1, offset: 55681},
 			expr: &charClassMatcher{
-				pos:        position{line: 1674, col: 6, offset: 54393},
+				pos:        position{line: 1722, col: 6, offset: 55686},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12306,9 +12560,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1677, col: 1, offset: 54896},
+			pos:  position{line: 1725, col: 1, offset: 56189},
 			expr: &charClassMatcher{
-				pos:        position{line: 1677, col: 6, offset: 54901},
+				pos:        position{line: 1725, col: 6, offset: 56194},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12320,9 +12574,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1680, col: 1, offset: 55015},
+			pos:  position{line: 1728, col: 1, offset: 56308},
 			expr: &charClassMatcher{
-				pos:        position{line: 1680, col: 6, offset: 55020},
+				pos:        position{line: 1728, col: 6, offset: 56313},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12334,9 +12588,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1683, col: 1, offset: 55101},
+			pos:  position{line: 1731, col: 1, offset: 56394},
 			expr: &charClassMatcher{
-				pos:        position{line: 1683, col: 6, offset: 55106},
+				pos:        position{line: 1731, col: 6, offset: 56399},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12348,9 +12602,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1685, col: 1, offset: 55159},
+			pos:  position{line: 1733, col: 1, offset: 56452},
 			expr: &anyMatcher{
-				line: 1686, col: 5, offset: 55179,
+				line: 1734, col: 5, offset: 56472,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12358,48 +12612,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1688, col: 1, offset: 55182},
+			pos:         position{line: 1736, col: 1, offset: 56475},
 			expr: &choiceExpr{
-				pos: position{line: 1689, col: 5, offset: 55210},
+				pos: position{line: 1737, col: 5, offset: 56503},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1689, col: 5, offset: 55210},
+						pos:        position{line: 1737, col: 5, offset: 56503},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1690, col: 5, offset: 55219},
+						pos:        position{line: 1738, col: 5, offset: 56512},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1691, col: 5, offset: 55228},
+						pos:        position{line: 1739, col: 5, offset: 56521},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1692, col: 5, offset: 55237},
+						pos:        position{line: 1740, col: 5, offset: 56530},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1693, col: 5, offset: 55245},
+						pos:        position{line: 1741, col: 5, offset: 56538},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1694, col: 5, offset: 55258},
+						pos:        position{line: 1742, col: 5, offset: 56551},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1695, col: 5, offset: 55271},
+						pos:  position{line: 1743, col: 5, offset: 56564},
 						name: "Zs",
 					},
 				},
@@ -12409,9 +12663,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1697, col: 1, offset: 55275},
+			pos:  position{line: 1745, col: 1, offset: 56568},
 			expr: &charClassMatcher{
-				pos:        position{line: 1698, col: 5, offset: 55294},
+				pos:        position{line: 1746, col: 5, offset: 56587},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12423,9 +12677,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1704, col: 1, offset: 55624},
+			pos:         position{line: 1752, col: 1, offset: 56917},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1707, col: 5, offset: 55695},
+				pos:  position{line: 1755, col: 5, offset: 56988},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -12433,39 +12687,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1709, col: 1, offset: 55714},
+			pos:  position{line: 1757, col: 1, offset: 57007},
 			expr: &seqExpr{
-				pos: position{line: 1710, col: 5, offset: 55735},
+				pos: position{line: 1758, col: 5, offset: 57028},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1710, col: 5, offset: 55735},
+						pos:        position{line: 1758, col: 5, offset: 57028},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1710, col: 10, offset: 55740},
+						pos: position{line: 1758, col: 10, offset: 57033},
 						expr: &seqExpr{
-							pos: position{line: 1710, col: 11, offset: 55741},
+							pos: position{line: 1758, col: 11, offset: 57034},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1710, col: 11, offset: 55741},
+									pos: position{line: 1758, col: 11, offset: 57034},
 									expr: &litMatcher{
-										pos:        position{line: 1710, col: 12, offset: 55742},
+										pos:        position{line: 1758, col: 12, offset: 57035},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1710, col: 17, offset: 55747},
+									pos:  position{line: 1758, col: 17, offset: 57040},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1710, col: 35, offset: 55765},
+						pos:        position{line: 1758, col: 35, offset: 57058},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12477,30 +12731,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1712, col: 1, offset: 55771},
+			pos:  position{line: 1760, col: 1, offset: 57064},
 			expr: &seqExpr{
-				pos: position{line: 1713, col: 5, offset: 55793},
+				pos: position{line: 1761, col: 5, offset: 57086},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1713, col: 5, offset: 55793},
+						pos:        position{line: 1761, col: 5, offset: 57086},
 						val:        "//",
 						ignoreCase: false,
 						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1713, col: 10, offset: 55798},
+						pos: position{line: 1761, col: 10, offset: 57091},
 						expr: &seqExpr{
-							pos: position{line: 1713, col: 11, offset: 55799},
+							pos: position{line: 1761, col: 11, offset: 57092},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1713, col: 11, offset: 55799},
+									pos: position{line: 1761, col: 11, offset: 57092},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1713, col: 12, offset: 55800},
+										pos:  position{line: 1761, col: 12, offset: 57093},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1713, col: 27, offset: 55815},
+									pos:  position{line: 1761, col: 27, offset: 57108},
 									name: "SourceCharacter",
 								},
 							},
@@ -12513,19 +12767,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1715, col: 1, offset: 55834},
+			pos:  position{line: 1763, col: 1, offset: 57127},
 			expr: &seqExpr{
-				pos: position{line: 1715, col: 7, offset: 55840},
+				pos: position{line: 1763, col: 7, offset: 57133},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1715, col: 7, offset: 55840},
+						pos: position{line: 1763, col: 7, offset: 57133},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1715, col: 7, offset: 55840},
+							pos:  position{line: 1763, col: 7, offset: 57133},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1715, col: 19, offset: 55852},
+						pos:  position{line: 1763, col: 19, offset: 57145},
 						name: "LineTerminator",
 					},
 				},
@@ -12535,16 +12789,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1717, col: 1, offset: 55868},
+			pos:  position{line: 1765, col: 1, offset: 57161},
 			expr: &choiceExpr{
-				pos: position{line: 1717, col: 7, offset: 55874},
+				pos: position{line: 1765, col: 7, offset: 57167},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1717, col: 7, offset: 55874},
+						pos:  position{line: 1765, col: 7, offset: 57167},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1717, col: 11, offset: 55878},
+						pos:  position{line: 1765, col: 11, offset: 57171},
 						name: "EOF",
 					},
 				},
@@ -12554,11 +12808,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1719, col: 1, offset: 55883},
+			pos:  position{line: 1767, col: 1, offset: 57176},
 			expr: &notExpr{
-				pos: position{line: 1719, col: 7, offset: 55889},
+				pos: position{line: 1767, col: 7, offset: 57182},
 				expr: &anyMatcher{
-					line: 1719, col: 8, offset: 55890,
+					line: 1767, col: 8, offset: 57183,
 				},
 			},
 			leader:        false,
@@ -12566,11 +12820,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1721, col: 1, offset: 55893},
+			pos:  position{line: 1769, col: 1, offset: 57186},
 			expr: &notExpr{
-				pos: position{line: 1721, col: 8, offset: 55900},
+				pos: position{line: 1769, col: 8, offset: 57193},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1721, col: 9, offset: 55901},
+					pos:  position{line: 1769, col: 9, offset: 57194},
 					name: "KeyWordChars",
 				},
 			},
@@ -14731,6 +14985,73 @@ func (p *parser) callonFunction44() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFunction44(stack["fn"], stack["args"], stack["where"])
+}
+
+func (c *current) onCaseExpr2(cases, else_ any) (any, error) {
+	whens := sliceOf[ast.When](cases)
+	cond := &ast.Conditional{
+		Kind: "Conditional",
+		Loc:  loc(c),
+		Cond: whens[0].Cond,
+		Then: whens[0].Then,
+	}
+	last := cond
+	for _, when := range whens[1:] {
+		next := &ast.Conditional{
+			Kind: "Conditional",
+			Cond: when.Cond,
+			Then: when.Then,
+			Loc:  loc(c),
+		}
+		last.Else = next
+		last = next
+	}
+	if else_ != nil {
+		last.Else = else_.([]any)[3].(ast.Expr)
+	}
+	return cond, nil
+
+}
+
+func (p *parser) callonCaseExpr2() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCaseExpr2(stack["cases"], stack["else_"])
+}
+
+func (c *current) onCaseExpr21(expr, whens, else_ any) (any, error) {
+	cond := &ast.CaseExpr{
+		Kind:  "CaseExpr",
+		Expr:  expr.(ast.Expr),
+		Whens: sliceOf[ast.When](whens),
+		Loc:   loc(c),
+	}
+	if else_ != nil {
+		cond.Else = else_.([]any)[3].(ast.Expr)
+	}
+	return cond, nil
+
+}
+
+func (p *parser) callonCaseExpr21() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCaseExpr21(stack["expr"], stack["whens"], stack["else_"])
+}
+
+func (c *current) onWhen1(cond, then any) (any, error) {
+	return ast.When{
+		Kind: "When",
+		Cond: cond.(ast.Expr),
+		Then: then.(ast.Expr),
+	}, nil
+
+}
+
+func (p *parser) callonWhen1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onWhen1(stack["cond"], stack["then"])
 }
 
 func (c *current) onRegexpPrimitive1(pat any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -1021,9 +1021,9 @@ CaseExpr
         whens := sliceOf[ast.When](cases)
         cond := &ast.Conditional{
             Kind: "Conditional",
-            Loc: loc(c),
             Cond: whens[0].Cond,
             Then: whens[0].Then,
+            Loc: loc(c),
         }
         last := cond
         for _, when := range whens[1:] {
@@ -1031,7 +1031,7 @@ CaseExpr
                Kind: "Conditional",
                Cond: when.Cond,
                Then: when.Then,
-               Loc: loc(c),
+               Loc: when.Loc,
             }
             last.Else = next
             last = next
@@ -1060,6 +1060,7 @@ When
         Kind: "When",
         Cond: cond.(ast.Expr),
         Then: then.(ast.Expr),
+        Loc: loc(c),
       }, nil
     }
 

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -983,6 +983,7 @@ DerefExpr
       }, nil
     }
   / FuncExpr
+  / CaseExpr
   / Primary
 
 FuncExpr
@@ -1013,6 +1014,53 @@ Function
     }
   / !FuncGuard fn:Identifier __ "(" __ args:FunctionArgs __ ")" where:WhereClause? {
       return newCall(c, fn, args, where), nil
+    }
+
+CaseExpr
+  = "case"i cases:When+ else_:(_ "else" _ Expr)? _ "end"i (_ "case"i)? {
+        whens := sliceOf[ast.When](cases)
+        cond := &ast.Conditional{
+            Kind: "Conditional",
+            Loc: loc(c),
+            Cond: whens[0].Cond,
+            Then: whens[0].Then,
+        }
+        last := cond
+        for _, when := range whens[1:] {
+            next := &ast.Conditional{
+               Kind: "Conditional",
+               Cond: when.Cond,
+               Then: when.Then,
+               Loc: loc(c),
+            }
+            last.Else = next
+            last = next
+        }
+        if else_ != nil {
+            last.Else = else_.([]any)[3].(ast.Expr)
+        }
+        return cond, nil
+    }
+  / "case"i _ expr:Expr whens:When+ else_:(_ "else" _ Expr)? _ "end"i (_ "case"i)? {
+        cond := &ast.CaseExpr{
+            Kind: "CaseExpr",
+            Expr: expr.(ast.Expr),
+            Whens: sliceOf[ast.When](whens),
+            Loc: loc(c),
+        }
+        if else_ != nil {
+            cond.Else = else_.([]any)[3].(ast.Expr)
+        }
+        return cond, nil
+    }
+
+When
+  = _ "when"i __ cond:Expr _ "then"i _ then:Expr {
+      return ast.When{
+        Kind: "When",
+        Cond: cond.(ast.Expr),
+        Then: then.(ast.Expr),
+      }, nil
     }
 
 RegexpPrimitive

--- a/compiler/parser/ztests/case-err.yaml
+++ b/compiler/parser/ztests/case-err.yaml
@@ -1,0 +1,8 @@
+zed: 'yield case x when 1 then "foo" when 2 then "bar" else {y:12} end'
+input: |
+  {x:1}
+  {x:2,y:3}
+  {x:3}
+  1
+
+errorRE: 'case matching-style expressions not yet supported'

--- a/compiler/parser/ztests/case.yaml
+++ b/compiler/parser/ztests/case.yaml
@@ -1,0 +1,13 @@
+zed: 'yield case when x==1 then "foo" when x==2 then "bar" else {y:12} end'
+
+input: |
+  {x:1}
+  {x:2,y:3}
+  {x:3}
+  1
+
+output: |
+  "foo"
+  "bar"
+  {y:12}
+  error({message:"?-operator: bool predicate required",on:error("missing")})

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -237,6 +237,9 @@ func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 		}
 	case *ast.FString:
 		return a.semFString(e)
+	case *ast.CaseExpr:
+		a.error(e, errors.New("case matching-style expressions not yet supported"))
+		return badExpr()
 	}
 	panic(errors.New("invalid expression type"))
 }


### PR DESCRIPTION
This commit adds support to the grammar for SQL-style case expressions. The case-when form is mapped to ast.Conditional and the case-expr-when form currently reports that it is unsupported in the semantic pass (we'll need to add runtime support for this other form).

This will be documented when we add docs for SuperSQL.