### PR TITLE
Remove compiler/optimizer.orderAsDirection

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -347,7 +347,7 @@ func (o *Optimizer) propagateSortKeyOp(op dag.Op, parents []order.SortKeys) ([]o
 				rhsExpr := k.RHS
 				rhs := fieldOf(rhsExpr)
 				if rhs.Equal(sortKey.Key) || orderPreservingCall(rhsExpr, groupByKey) {
-					op.InputSortDir = orderAsDirection(sortKey.Order)
+					op.InputSortDir = int(sortKey.Order.Direction())
 					// Currently, the groupby operator will sort its
 					// output according to the primary key, but we
 					// should relax this and do an analysis here as

--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -8,14 +8,6 @@ import (
 	"github.com/brimdata/super/order"
 )
 
-// XXX Remove this and use native order.Direction in group-by.  See Issue #4505.
-func orderAsDirection(which order.Which) int {
-	if which == order.Asc {
-		return 1
-	}
-	return -1
-}
-
 func (o *Optimizer) parallelizeScan(ops []dag.Op, replicas int) ([]dag.Op, error) {
 	// For now we parallelize only pool scans and no metadata scans.
 	// We can do the latter when we want to scale the performance of metadata.


### PR DESCRIPTION
It duplicates order.Which.Direction.