### PR TITLE
Remove runtime.Compiler.Parse

### DIFF
--- a/compiler/file.go
+++ b/compiler/file.go
@@ -13,7 +13,6 @@ import (
 )
 
 type fsCompiler struct {
-	anyCompiler
 	src *data.Source
 }
 

--- a/compiler/job.go
+++ b/compiler/job.go
@@ -89,13 +89,15 @@ func (j *Job) Parallelize(n int) error {
 	return err
 }
 
+// Parse concatenates the source files in filenames followed by src and parses
+// the resulting program.
 func Parse(src string, filenames ...string) (ast.Seq, *parser.SourceSet, error) {
 	return parser.ParseSuperPipe(filenames, src)
 }
 
 // MustParse is like Parse but panics if an error is encountered.
 func MustParse(query string) ast.Seq {
-	seq, _, err := (*anyCompiler)(nil).Parse(query)
+	seq, _, err := Parse(query)
 	if err != nil {
 		panic(err)
 	}
@@ -135,12 +137,6 @@ func (j *Job) Puller() zbuf.Puller {
 }
 
 type anyCompiler struct{}
-
-// Parse concatenates the source files in filenames followed by src and parses
-// the resulting program.
-func (*anyCompiler) Parse(src string, filenames ...string) (ast.Seq, *parser.SourceSet, error) {
-	return Parse(src, filenames...)
-}
 
 // VectorCompile is used for testing queries over single VNG object scans
 // where the entire query is vectorizable.  It does not call optimize

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -166,7 +166,7 @@ func (l *local) Delete(ctx context.Context, poolID ksuid.KSUID, branchName strin
 }
 
 func (l *local) DeleteWhere(ctx context.Context, poolID ksuid.KSUID, branchName, src string, commit api.CommitMessage) (ksuid.KSUID, error) {
-	op, sset, err := l.compiler.Parse(src)
+	op, sset, err := compiler.Parse(src)
 	if err != nil {
 		return ksuid.Nil, err
 	}

--- a/runtime/compiler.go
+++ b/runtime/compiler.go
@@ -17,7 +17,6 @@ type Compiler interface {
 	NewQuery(*Context, ast.Seq, []zio.Reader) (Query, error)
 	NewLakeQuery(*Context, ast.Seq, int, *lakeparse.Commitish) (Query, error)
 	NewLakeDeleteQuery(*Context, ast.Seq, *lakeparse.Commitish) (DeleteQuery, error)
-	Parse(string, ...string) (ast.Seq, *parser.SourceSet, error)
 }
 
 type Query interface {

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -168,7 +168,7 @@ func handleCompile(c *Core, w *ResponseWriter, r *Request) {
 	if !r.Unmarshal(w, &req) {
 		return
 	}
-	ast, _, err := c.compiler.Parse(req.Query)
+	ast, _, err := compiler.Parse(req.Query)
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return
@@ -577,7 +577,7 @@ func handleDelete(c *Core, w *ResponseWriter, r *Request) {
 			w.Error(srverr.ErrInvalid("either object_ids or where must be set"))
 			return
 		}
-		program, sset, err2 := c.compiler.Parse(payload.Where)
+		program, sset, err2 := compiler.Parse(payload.Where)
 		if err != nil {
 			w.Error(srverr.ErrInvalid(err2))
 			return

--- a/zed_test.go
+++ b/zed_test.go
@@ -139,7 +139,7 @@ func runOneBoomerang(t *testing.T, format, data string) {
 	dataReader := zio.Reader(dataReadCloser)
 	if format == "parquet" {
 		// Fuse for formats that require uniform values.
-		proc, _, err := compiler.NewCompiler().Parse("fuse")
+		proc, _, err := compiler.Parse("fuse")
 		require.NoError(t, err)
 		rctx := runtime.NewContext(context.Background(), zctx)
 		q, err := compiler.NewCompiler().NewQuery(rctx, proc, []zio.Reader{dataReadCloser})


### PR DESCRIPTION
Its implementation just wraps compiler.Parse so use that directly.