### PR TITLE
Super-fy the Super Binary format doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,7 +245,7 @@
 * Substantial improvements to the [Zed language](docs/language/README.md)
 * Revamped [`zed` command](docs/commands/zed.md)
 * New Zed lake format (see #3634 for a migration script)
-* New version of the [ZNG format](docs/formats/zng.md) (with read-only support for the previous version)
+* New version of the [ZNG format](docs/formats/bsup.md) (with read-only support for the previous version)
 * New version of the [ZSON format](docs/formats/jsup.md)
 
 ## v0.33.0
@@ -677,7 +677,7 @@ questions.
 * zqd: Add a Python `zqd` API client for use with tools like [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) (#1564)
 
 ## v0.22.0
-* zq: Change the implementation of the `union` type to conform with the [ZNG spec](docs/formats/zng.md#3114-union-typedef) (#1245)
+* zq: Change the implementation of the `union` type to conform with the [ZNG spec](docs/formats/bsup.md#3114-union-typedef) (#1245)
 * zq: Make options/flags and version reporting consistent across CLI tools (#1249, #1254, #1256, #1296, #1323, #1334, #1328)
 * zqd: Fix an issue that was preventing flows in nanosecond pcaps from opening in Brim (#1243, #1241)
 * zq: Fix an issue where the TZNG reader did not recognize a bad record type as a syntax error (#1260)
@@ -716,7 +716,7 @@ questions.
 * zq: Fix an issue where non-adjacent record fields in Zeek TSV logs could not be read (#1225, #1218)
 * zql: Fix an issue where `cut -c` sometimes returned a "bad uvarint" error (#1227)
 * zq: Add support for empty ZNG records and empty NDJSON objects (#1228)
-* zng: Fix the tag value examples in the [ZNG spec](docs/formats/zng.md) (#1230)
+* zng: Fix the tag value examples in the [ZNG spec](docs/formats/bsup.md) (#1230)
 * zq: Update LZ4 dependency to eliminate some memory allocations (#1232)
 * zar: Add a `-sortmem` flag to allow `zar import` to use more memory to improve performance (#1203)
 * zqd: Fix an issue where file paths containing URI escape codes could not be opened in Brim (#1238)
@@ -745,7 +745,7 @@ questions.
 * zqd: Fix an issue with excess characters in Space names after upgrade (#1112)
 
 ## v0.19.0
-* zq: ZNG output is now LZ4-compressed by default (#1050, #1064, #1063, [ZNG spec](docs/formats/zng.md#313-compressed-value-message-block))
+* zq: ZNG output is now LZ4-compressed by default (#1050, #1064, #1063, [ZNG spec](docs/formats/bsup.md#313-compressed-value-message-block))
 * zar: Adjust import size threshold to account for compression (#1082)
 * zqd: Support starting `zqd` with datapath set to an S3 path (#1072)
 * zq: Fix an issue with panics during pcap import (#1090)
@@ -768,14 +768,14 @@ questions.
 * zq: Introduce spill-to-disk groupby for performing very large aggregations (#932, #963)
 * zql: Use syntax `c=count()` instead of `count() as c` for naming the field that holds the value returned by an aggregate function (#950)
 * zql: Fix an issue where attempts to `tail` too much caused a panic (#958)
-* zng: Readability improvements in the [ZNG specification](docs/formats/zng.md) (#935)
+* zng: Readability improvements in the [ZNG specification](docs/formats/bsup.md) (#935)
 * zql: Fix an issue where use of `cut`, `put`, and `cut` in the same pipeline caused a panic (#980)
 * zql: Fix an issue that was preventing the `uniq` operator from  working in the Brim app (#984)
 * zq: Fix an issue where spurious type IDs were being created (#964)
 * zql: Support renaming a field via the `cut` operator (#969)
 
 ## v0.16.0
-* zng: Readability improvements in the [ZNG specification](docs/formats/zng.md) (#897, #910, #917)
+* zng: Readability improvements in the [ZNG specification](docs/formats/bsup.md) (#897, #910, #917)
 * zq: Support directory output to S3 (#898)
 * zql: Group-by no longer emits records in "deterministic but undefined" order (#914)
 * zqd: Revise constraints on Space names (#853, #926, #944, #945)

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ a number of different elements of the system:
 that underlie the super-structured data formats.
 * The [super data formats](formats/README.md) are a family of
 [human-readable (Super JSON, JSUP)](formats/jsup.md),
-[sequential (Super Binary, BSUP)](formats/zng.md), and
+[sequential (Super Binary, BSUP)](formats/bsup.md), and
 [columnar (Super Columnar, CSUP)](formats/vng.md) formats that all adhere to the
 same abstract super data model.
 * The [SuperPipe language](language/README.md) is the system's pipeline language for performing

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -117,7 +117,7 @@ replication easy to support and deploy.
 
 The cloud objects that comprise a lake, e.g., data objects,
 commit history, transaction journals, partial aggregations, etc.,
-are stored as Zed data, i.e., either as [row-based ZNG](../formats/zng.md)
+are stored as Zed data, i.e., either as [row-based Super Binary](../formats/bsup.md)
 or [columnar VNG](../formats/vng.md).
 This makes introspection of the lake structure straightforward as many key
 lake data structures can be queried with metadata queries and presented

--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -9,7 +9,7 @@ description: A command-line tool that uses the Zed Language for pipeline-style s
 > **TL;DR** `zq` is a command-line tool that uses the [Zed language](../language/README.md)
 for pipeline-style search and analytics.  `zq` can query a variety
 of data formats in files, over HTTP, or in [S3](../integrations/amazon-s3.md) storage.
-It is particularly fast when operating on data in the Zed-native [ZNG](../formats/zng.md) format.
+It is particularly fast when operating on data in the [Super Binary](../formats/bsup.md) format.
 >
 > The `zq` design philosophy blends the query/search-tool approach
 of `jq`, `awk`, and `grep` with the command-line, embedded database approach
@@ -34,7 +34,7 @@ an S3 URL, or standard input specified with `-`.
 For built-in command help and a listing of all available options,
 simply run `zq` with no arguments.
 
-`zq` supports a number of [input](#input-formats) and [output](#output-formats) formats, but [ZNG](../formats/zng.md)
+`zq` supports a number of [input](#input-formats) and [output](#output-formats) formats, but [Super Binary](../formats/bsup.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
 [Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
@@ -103,7 +103,7 @@ Note here that the query `1+1` [implies](../language/pipeline-model.md#implied-o
 | `vng`     |  yes | [VNG - Binary Columnar Format](../formats/vng.md) |
 | `zeek`    |  yes | [Zeek Logs](https://docs.zeek.org/en/master/logs/index.html) |
 | `zjson`   |  yes | [ZJSON - Zed over JSON](../formats/zjson.md) |
-| `zng`     |  yes | [ZNG - Binary Row Format](../formats/zng.md) |
+| `bsup`    |  yes | [Super Binary](../formats/bsup.md) |
 | `zson`    |  yes | [ZSON - Human-readable Format](../formats/jsup.md) |
 
 The input format is typically [detected automatically](#auto-detection) and the formats for which
@@ -189,7 +189,7 @@ typically omit quotes around field names.
 | `vng`     | [VNG - Binary Columnar Format](../formats/vng.md) |
 | `zeek`    | [Zeek Logs](https://docs.zeek.org/en/master/logs/index.html) |
 | `zjson`   | [ZJSON - Zed over JSON](../formats/zjson.md) |
-| `zng`     | [ZNG - Binary Row Format](../formats/zng.md) |
+| `bsup`    | [Super Binary](../formats/bsup.md) |
 | `zson`    | [ZSON - Human-readable Format](../formats/jsup.md) |
 
 The output format defaults to either ZSON or ZNG and may be specified

--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -268,7 +268,7 @@ providing a unified approach to row, columnar, and human-readable formats:
 
 * [Super JSON](jsup.md) is a human-readable format for super-structured data.  All JSON
 documents are Super JSON values as the Super JSON format is a strict superset of the JSON syntax.
-* [Super Binary](zng.md) is a row-based, binary representation somewhat like
+* [Super Binary](bsup.md) is a row-based, binary representation somewhat like
 Avro but leveraging the super data model to represent a sequence of arbitrarily-typed
 values.
 * [Super Columnar](vng.md) is columnar like Parquet or ORC but also

--- a/docs/formats/bsup.md
+++ b/docs/formats/bsup.md
@@ -1,16 +1,16 @@
 ---
 sidebar_position: 2
-sidebar_label: ZNG
+sidebar_label: Super Binary
 ---
 
-# ZNG Specification
+# Super Binary Specification
 
 ## 1. Introduction
 
-ZNG (pronounced "zing") is an efficient, sequence-oriented serialization format for any data
+Super Binary is an efficient, sequence-oriented serialization format for any data
 conforming to the [super data model](zed.md).
 
-ZNG is "row oriented" and
+Super Binary is "row oriented" and
 analogous to [Apache Avro](https://avro.apache.org) but does not
 require schema definitions as it instead utilizes the fine-grained type system
 of the super data model.
@@ -19,32 +19,32 @@ encoding methodology inspired by Avro,
 [Parquet](https://en.wikipedia.org/wiki/Apache_Parquet), and
 [Protocol Buffers](https://developers.google.com/protocol-buffers).
 
-To this end, ZNG embeds all type information
+To this end, Super Binary embeds all type information
 in the stream itself while having a binary serialization format that
 allows "lazy parsing" of fields such that
 only the fields of interest in a stream need to be deserialized and interpreted.
-Unlike Avro, ZNG embeds its "schemas" in the data stream as types and thereby admits
+Unlike Avro, Super Binary embeds its "schemas" in the data stream as types and thereby admits
 an efficient multiplexing of heterogeneous data types by prepending to each
 data value a simple integer identifier to reference its type.
 
-Since no external schema definitions exist in ZNG, a "type context" is constructed
-on the fly by composing dynamic type definitions embedded in the ZNG format.
-ZNG can be readily adapted to systems like
+Since no external schema definitions exist in Super Binary, a "type context" is constructed
+on the fly by composing dynamic type definitions embedded in the format.
+Super Binary can be readily adapted to systems like
 [Apache Kafka](https://kafka.apache.org/) which utilize schema registries,
 by having a connector translate the schemas implied in the
-ZNG stream into registered schemas and vice versa.  Better still, Kafka could
-be used natively with ZNG obviating the need for the schema registry.
+Super Binary stream into registered schemas and vice versa.  Better still, Kafka could
+be used natively with Super Binary obviating the need for the schema registry.
 
-Multiple ZNG streams with different type contexts are easily merged because the
+Multiple Super Binary streams with different type contexts are easily merged because the
 serialization of values does not depend on the details of
 the type context.  One or more streams can be merged by simply merging the
 input contexts into an output context and adjusting the type reference of
-each value in the output ZNG sequence.  The values need not be traversed
+each value in the output sequence.  The values need not be traversed
 or otherwise rewritten to be merged in this fashion.
 
-## 2. The ZNG Format
+## 2. The Super Binary Format
 
-A ZNG stream comprises a sequence of frames where
+A Super Binary stream comprises a sequence of frames where
 each frame contains one of three types of data:
 _types_, _values_, or externally-defined _control_.
 
@@ -83,11 +83,11 @@ Each frame begins with a single-byte "frame code":
 ```
 
 Bit 7 of the frame code must be zero as it defines version 0
-of the ZNG stream format.  If a future version of ZNG
-arises, bit 7 of future ZNG frames will be 1.
-ZNG version 0 readers must ignore and skip over such frames using the
+of the Super Binary stream format.  If a future version of Super Binary
+arises, bit 7 of future Super Binary frames will be 1.
+Super Binary version 0 readers must ignore and skip over such frames using the
 `len` field, which must survive future versions.
-Any future versions of ZNG must be able to integrate version 0 frames
+Any future versions of Super Binary must be able to integrate version 0 frames
 for backward compatibility.
 
 Following the frame code is its encoded length followed by a "frame payload"
@@ -129,20 +129,22 @@ but is useful to an implementation to deterministically
 size decompression buffers in advance of decoding.
 
 Values for the `format` byte are defined in the
-[ZNG compression format specification](./compression.md).
+[Super Binary compression format specification](./compression.md).
 
-> This arrangement of frames separating types and values allows
-> for efficient scanning and parallelization.  In general, values depend
-> on type definitions but as long as all of the types are known when
-> values are used, decoding can be done in parallel.  Likewise, since
-> each block is independently compressed, the blocks can be decompressed
-> in parallel.  Moreover, efficient filtering can be carried out over
-> uncompressed data before it is deserialized into native data structures,
-> e.g., allowing entire frames to be discarded based on
-> heuristics, e.g., knowing a filtering predicate can't be true based on a
-> quick scan of the data perhaps using the Boyer-Moore algorithm to determine
-> that a comparison with a string constant would not work for any
-> value in the buffer.
+:::tip note
+This arrangement of frames separating types and values allows
+for efficient scanning and parallelization.  In general, values depend
+on type definitions but as long as all of the types are known when
+values are used, decoding can be done in parallel.  Likewise, since
+each block is independently compressed, the blocks can be decompressed
+in parallel.  Moreover, efficient filtering can be carried out over
+uncompressed data before it is deserialized into native data structures,
+e.g., allowing entire frames to be discarded based on
+heuristics, e.g., knowing a filtering predicate can't be true based on a
+quick scan of the data perhaps using the Boyer-Moore algorithm to determine
+that a comparison with a string constant would not work for any
+value in the buffer.
+:::
 
 Whether the payload was originally uncompressed or was decompressed, it is
 then interpreted according to the `T` bits of the frame code as a
@@ -187,13 +189,13 @@ Any references to a type ID in the body of a typedef are encoded as a `uvarint`,
 A record typedef creates a new type ID equal to the next stream type ID
 with the following structure:
 ```
----------------------------------------------------------
+--------------------------------------------------------
 |0x00|<nfields>|<name1><type-id-1><name2><type-id-2>...|
----------------------------------------------------------
+--------------------------------------------------------
 ```
 Record types consist of an ordered set of fields where each field consists of
 a name and its type.  Unlike JSON, the ordering of the fields is significant
-and must be preserved through any APIs that consume, process, and emit ZNG records.
+and must be preserved through any APIs that consume, process, and emit Super Binary records.
 
 A record type is encoded as a count of fields, i.e., `<nfields>` from above,
 followed by the field definitions,
@@ -204,16 +206,18 @@ The field names in a record must be unique.
 
 The `<nfields>` value is encoded as a `uvarint`.
 
-The field name is encoded as a UTF-8 string defining a "ZNG identifier".
+The field name is encoded as a UTF-8 string defining a "Super Binary identifier".
 The UTF-8 string
 is further encoded as a "counted string", which is the `uvarint` encoding
 of the length of the string followed by that many bytes of UTF-8 encoded
 string data.
 
-N.B.: As defined by [Super JSON](jsup.md), a field name can be any valid UTF-8 string much like JSON
+:::tip note
+As defined by [Super JSON](jsup.md), a field name can be any valid UTF-8 string much like JSON
 objects can be indexed with arbitrary string keys (via index operator)
 even if the field names available to the dot operator are restricted
 by language syntax for identifiers.
+:::
 
 The type ID follows the field name and is encoded as a `uvarint`.
 
@@ -414,23 +418,23 @@ key/value pair).
 A _control frame_ contains an application-defined control message.
 
 Control frames are available to higher-layer protocols and are carried
-in ZNG as a convenient signaling mechanism.  A ZNG implementation
+in Super Binary as a convenient signaling mechanism.  A Super Binary implementation
 may skip over all control frames and is guaranteed by
 this specification to decode all of the data as described herein even if such
-frames provide additional semantics on top of the base ZNG format.
+frames provide additional semantics on top of the base Super Binary format.
 
 The body of a control frame is a control message and may be JSON,
 Super JSON, Super Binary, arbitrary binary, or UTF-8 text.  The serialization of the control
-frame body is independent of the Super JSON stream containing the control
+frame body is independent of the Super Binary stream containing the control
 frame.
 
 Any control message not known by a Super Binary data receiver shall be ignored.
 
 The delivery order of control messages with respect to the delivery
-order of values of the ZNG stream should be preserved by an API implementing
-ZNG serialization and deserialization.
-In this way, system endpoints that communicate using ZNG can embed
-protocol directives directly into the ZNG stream as control payloads
+order of values of the Super Binary stream should be preserved by an API implementing
+Super Binary serialization and deserialization.
+In this way, system endpoints that communicate using Super Binary can embed
+protocol directives directly into the stream as control payloads
 in an order-preserving semantics rather than defining additional
 layers of encapsulation and synchronization between such layers.
 
@@ -442,36 +446,36 @@ A control frame has the following form:
 ```
 where
 * `<encoding>` is a single byte indicating whether the body is encoded
-as ZNG (0), JSON (1), Super JSON (2), an arbitrary UTF-8 string (3), or arbitrary binary data (4),
+as Super Binary (0), JSON (1), Super JSON (2), an arbitrary UTF-8 string (3), or arbitrary binary data (4),
 * `<len>` is a `uvarint` encoding the length in bytes of the body
 (exclusive of the length 1 encoding byte), and
 * `<body>` is a control message whose semantics are outside the scope of
-the base ZNG specification.
+the base Super Binary specification.
 
-If the encoding type is ZNG, the embedded ZNG data
-starts and ends a single ZNG stream independent of the outer ZNG stream.
+If the encoding type is Super Binary, the embedded Super Binary data
+starts and ends a single Super Binary stream independent of the outer Super Binary stream.
 
 ### 2.4 End of Stream
 
-A ZNG stream must be terminated by an end-of-stream marker.
-A new ZNG stream may begin immediately after an end-of-stream marker.
+A Super Binary stream must be terminated by an end-of-stream marker.
+A new Super Binary stream may begin immediately after an end-of-stream marker.
 Each such stream has its own, independent type context.
 
-In this way, the concatenation of ZNG streams (or ZNG files containing
-ZNG streams) results in a valid ZNG data sequence.
+In this way, the concatenation of Super Binary streams (or Super Binary files containing
+Super Binary streams) results in a valid Super Binary data sequence.
 
-For example, a large ZNG file can be arranged into multiple, smaller streams
+For example, a large Super Binary file can be arranged into multiple, smaller streams
 to facilitate random access at stream boundaries.
 This benefit comes at the cost of some additional overhead --
 the space consumed by stream boundary markers and repeated type definitions.
 Choosing an appropriate stream size that balances this overhead with the
 benefit of enabling random access is left up to implementations.
 
-End-of-stream markers are also useful in the context of sending ZNG over Kafka,
+End-of-stream markers are also useful in the context of sending Super Binary over Kafka,
 as a receiver can easily resynchronize with a live Kafka topic by
 discarding incomplete frames until a frame is found that is terminated
 by an end-of-stream marker (presuming the sender implementation aligns
-the ZNG frames on Kafka message boundaries).
+the Super Binary frames on Kafka message boundaries).
 
 A end-of-stream marker is encoded as follows:
 ```
@@ -489,14 +493,14 @@ be re-emitted
 
 ## 3. Primitive Types
 
-For each ZNG primitive type, the following table describes:
+For each Super Binary primitive type, the following table describes:
 * its type ID, and
 * the interpretation of a length `N` [value frame](#22-values-frame).
 
 All fixed-size multi-byte sequences representing machine words
 are serialized in little-endian format.
 
-| Type         | ID |    N     |       ZNG Value Interpretation                 |
+| Type         | ID |    N     |      Super Binary Value Interpretation         |
 |--------------|---:|:--------:|------------------------------------------------|
 | `uint8`      |  0 | variable | unsigned int of length N                       |
 | `uint16`     |  1 | variable | unsigned int of length N                       |
@@ -531,7 +535,7 @@ are serialized in little-endian format.
 
 ## 4. Type Values
 
-As the super data model supports first-class types and because the ZNG design goals
+As the super data model supports first-class types and because the Super Binary design goals
 require that value serializations cannot change across type contexts, type values
 must be encoded in a fashion that is independent of the type context.
 Thus, a serialized type value encodes the entire type in a canonical form
@@ -547,9 +551,9 @@ complex type it represents as described below.
 
 A record type value has the form:
 ```
----------------------------------------------------
+--------------------------------------------------
 |30|<nfields>|<name1><typeval><name2><typeval>...|
----------------------------------------------------
+--------------------------------------------------
 ```
 where `<nfields>` is the number of fields in the record encoded as a `uvarint`,
 `<name1>` etc. are the field names encoded as in the
@@ -629,7 +633,7 @@ A named type definition has the form:
 |37|<name><typeval>|
 --------------------
 ```
-where `<name>` is encoded as in an named type typedef
+where `<name>` is encoded as in a named type typedef
 and `<typeval>` is a recursive encoding of a type value.  This creates
 a binding between the given name and the indicated type value only within the
 scope of the encoded value and does not affect the type context.
@@ -642,5 +646,5 @@ An named type reference has the form:
 |38|<name>|
 -----------
 ```
-It is an error for an named type reference to appear in a type value with a name
+It is an error for a named type reference to appear in a type value with a name
 that has not been previously defined according to the DFS order.

--- a/docs/formats/bsup.md
+++ b/docs/formats/bsup.md
@@ -425,8 +425,7 @@ frames provide additional semantics on top of the base Super Binary format.
 
 The body of a control frame is a control message and may be JSON,
 Super JSON, Super Binary, arbitrary binary, or UTF-8 text.  The serialization of the control
-frame body is independent of the Super Binary stream containing the control
-frame.
+frame body is independent of the stream containing the control frame.
 
 Any control message not known by a Super Binary data receiver shall be ignored.
 

--- a/docs/formats/compression.md
+++ b/docs/formats/compression.md
@@ -6,7 +6,7 @@ sidebar_label: Compression
 # ZNG Compression Types
 
 This document specifies values for the `<format>` byte of a
-[ZNG compressed value message block](zng.md#2-the-zng-format)
+[Super Binary compressed value message block](bsup.md#2-the-super-binary-format)
 and the corresponding algorithms for the `<compressed payload>` byte sequence.
 
 As new compression algorithms are specified, they will be documented

--- a/docs/formats/vng.md
+++ b/docs/formats/vng.md
@@ -10,7 +10,7 @@ VNG, pronounced "ving", is a file format for columnar data based on
 VNG is the "stacked" version of Zed, where the fields from a stream of
 Zed records are stacked into vectors that form columns.
 Its purpose is to provide for efficient analytics and search over
-bounded-length sequences of [ZNG](zng.md) data that is stored in columnar form.
+bounded-length sequences of [Super Binary](bsup.md) data that is stored in columnar form.
 
 Like [Parquet](https://github.com/apache/parquet-format),
 VNG provides an efficient columnar representation for semi-structured data,
@@ -79,7 +79,7 @@ where a segment is a seek offset and byte length relative to the
 data section.  Each segment contains a sequence of
 [primitive-type Zed values](zed.md#1-primitive-types),
 encoded as counted-length byte sequences where the counted-length is
-variable-length encoded as in the [ZNG specification](zng.md).
+variable-length encoded as in the [Super Binary specification](bsup.md).
 Segments may be compressed.
 
 There is no information in the data section for how segments relate

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -9,7 +9,7 @@ sidebar_label: ZJSON
 
 The [super data model](zed.md)
 is based on richly typed records with a deterministic field order,
-as is implemented by the [Super JSON](jsup.md), [Super Binary](zng.md), and [Super Columnar](vng.md) formats.
+as is implemented by the [Super JSON](jsup.md), [Super Binary](bsup.md), and [Super Columnar](vng.md) formats.
 Given the ubiquity of JSON, it is desirable to also be able to serialize
 super data into the JSON format.   However, encoding super data values
 directly as JSON values would not work without loss of information.

--- a/docs/integrations/fluentd.md
+++ b/docs/integrations/fluentd.md
@@ -396,7 +396,7 @@ the size of the commit objects to which they're initially stored.
 used the [Super JSON format](../formats/jsup.md) format for the shaped data output from
 [`zq`](../commands/zq.md). This text format is typically used in contexts
 where human readability is required. Due to its compact nature,
-[ZNG](../formats/zng.md) format would have been preferred, but in our research
+[Super Binary](../formats/bsup.md) format would have been preferred, but in our research
 we found Fluentd consistently steered us toward using only text formats.
 However, someone more proficient with Fluentd may be able to employ ZNG
 instead.

--- a/docs/integrations/zeek/data-type-compatibility.md
+++ b/docs/integrations/zeek/data-type-compatibility.md
@@ -8,7 +8,7 @@ sidebar_label: Zed/Zeek Data Type Compatibility
 As the [super data model](../../formats/zed.md) was in many ways inspired by the
 [Zeek TSV log format](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs),
 SuperDB's rich storage formats ([Super JSON](../../formats/jsup.md),
-[ZNG](../../formats/zng.md), etc.) maintain comprehensive interoperability
+[Super Binary](../../formats/bsup.md), etc.) maintain comprehensive interoperability
 with Zeek. When Zeek is configured to output its logs in
 JSON format, much of the rich type information is lost in translation, but
 this can be restored by following the guidance for [shaping Zeek JSON](shaping-zeek-json.md).

--- a/docs/integrations/zeek/shaping-zeek-json.md
+++ b/docs/integrations/zeek/shaping-zeek-json.md
@@ -319,7 +319,7 @@ produces
 
 If working in a directory containing many JSON logs, the
 reference shaper can be applied to all the records they contain and
-output them all in a single binary [ZNG](../../formats/zng.md) file as
+output them all in a single [Super Binary](../../formats/bsup.md) file as
 follows:
 
 ```

--- a/docs/language/search-expressions.md
+++ b/docs/language/search-expressions.md
@@ -128,7 +128,7 @@ The search patterns described above can be combined with other "search terms"
 using Boolean logic to form search expressions.
 
 :::tip note
-When processing [Super Binary](../formats/zng.md) data, the SuperDB runtime performs a multi-threaded
+When processing [Super Binary](../formats/bsup.md) data, the SuperDB runtime performs a multi-threaded
 Boyer-Moore scan over decompressed data buffers before parsing any data.
 This allows large buffers of data to be efficiently discarded and skipped when
 searching for rarely occurring values.  For a [SuperDB data lake](../lake/format.md),

--- a/docs/libraries/python.md
+++ b/docs/libraries/python.md
@@ -13,7 +13,7 @@ The Python client interacts with the Zed lake via the REST API served by
 [`zed serve`](../commands/zed.md#serve).
 
 This approach works adequately when high data throughput is not required.
-We will soon introduce native [ZNG](../formats/zng.md) support for
+We will soon introduce native [Super Binary](../formats/bsup.md) support for
 Python that should increase performance substantially for more
 data intensive workloads.
 

--- a/docs/libraries/python.md
+++ b/docs/libraries/python.md
@@ -13,7 +13,7 @@ The Python client interacts with the Zed lake via the REST API served by
 [`zed serve`](../commands/zed.md#serve).
 
 This approach works adequately when high data throughput is not required.
-We will soon introduce native [Super Binary](../formats/bsup.md) support for
+We plan to introduce native [Super Binary](../formats/bsup.md) support for
 Python that should increase performance substantially for more
 data intensive workloads.
 

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -162,7 +162,7 @@ The human-readable format of Zed is called [ZSON](../formats/jsup.md)
 (and yes, that's a play on the acronym JSON).
 
 ZSON is nice because it has a comprehensive type system and you can
-go from ZSON to an efficient binary row format ([ZNG](../formats/zng.md))
+go from ZSON to an efficient binary row format ([Super Binary](../formats/bsup.md))
 and columnar ([VNG](../formats/vng.md)) --- and vice versa ---
 with complete fidelity and no loss of information.  In this tour,
 we'll stick to ZSON (though for large data sets,


### PR DESCRIPTION
In the same spirit as #5368.

## Details

As with other recent super-fying docs PRs, I've selectively removed some excess repeats, i.e., since the three-letter "ZNG" was cheap to say, it was sometimes used multiple times in the same sentence and didn't seem to hurt the flow, but turning each of those into "Super Binary" starts to look a little long-winded. That said, since this is a formal spec, I didn't push it _too_ hard because I figured absolute technical correctness wins out over casual readability here. But if anyone spots more repeats in here you think are worth dropping, please point them out!
