### PR TITLE
Change []dag.Op to dag.Seq in compiler

### DIFF
--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -221,9 +221,9 @@ func fieldOf(e dag.Expr) field.Path {
 	return nil
 }
 
-func copyOps(ops []dag.Op) []dag.Op {
-	var copies []dag.Op
-	for _, o := range ops {
+func copySeq(seq dag.Seq) dag.Seq {
+	var copies dag.Seq
+	for _, o := range seq {
 		copies = append(copies, copyOp(o))
 	}
 	return copies

--- a/compiler/semantic/analyzer.go
+++ b/compiler/semantic/analyzer.go
@@ -100,8 +100,8 @@ func AddDefaultSource(ctx context.Context, seq *dag.Seq, source *data.Source, he
 			},
 		}},
 	}
-	ops := newAnalyzer(ctx, &srcfiles.List{}, source, head).semFrom(fromHead, nil)
-	seq.Prepend(ops[0])
+	headSeq := newAnalyzer(ctx, &srcfiles.List{}, source, head).semFrom(fromHead, nil)
+	seq.Prepend(headSeq[0])
 	return nil
 }
 

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -895,7 +895,7 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) dag.Seq {
 	case *ast.Load:
 		if !a.source.IsLake() {
 			a.error(o, errors.New("load operator cannot be used without a lake"))
-			return []dag.Op{badOp()}
+			return dag.Seq{badOp()}
 		}
 		poolID, err := lakeparse.ParseID(o.Pool.Text)
 		if err != nil {

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -71,7 +71,7 @@ func (a *analyzer) semSelect(sel *ast.Select, seq dag.Seq) dag.Seq {
 		}
 	}
 	if len(seq) == 0 {
-		seq = []dag.Op{dag.PassOp}
+		seq = dag.Seq{dag.PassOp}
 	}
 	if sel.Distinct {
 		seq = a.semDistinct(seq)


### PR DESCRIPTION
There are still a few places in compiler/optimizer and compiler/semantic that use []dag.Op.  Change them to dag.Seq for consistency with the rest of the code base.