### PR TITLE
simplify file not found messages - less is more

### DIFF
--- a/cmd/super/root/command.go
+++ b/cmd/super/root/command.go
@@ -146,7 +146,7 @@ func (c *Command) Run(args []string) error {
 	}
 	paths, ast, null, err := c.queryFlags.ParseSourcesAndInputs(c.query, args)
 	if err != nil {
-		return fmt.Errorf("super: %w", err)
+		return err
 	}
 	zctx := super.NewContext()
 	local := storage.NewLocalEngine()

--- a/cmd/super/ztests/from-file-error.yaml
+++ b/cmd/super/ztests/from-file-error.yaml
@@ -9,4 +9,4 @@ inputs:
 outputs:
   - name: stderr
     regexp: |
-      a.jsup: file:///.*/a.jsup: file does not exist.*
+      a.jsup: file does not exist.*

--- a/cmd/super/ztests/from-pool-error.yaml
+++ b/cmd/super/ztests/from-pool-error.yaml
@@ -4,4 +4,4 @@ script: |
 outputs:
   - name: stderr
     regexp: |
-      a: file:///.*/a: file does not exist
+      a: file does not exist

--- a/cmd/super/ztests/no-files.yaml
+++ b/cmd/super/ztests/no-files.yaml
@@ -1,9 +1,9 @@
 script: |
-  ! super -z -c doesnotexist
+  ! super -z doesnotexist
 
 outputs:
   - name: stdout
     data: ""
   - name: stderr
     data: |
-      super: no data source found
+      doesnotexist: file does not exist

--- a/cmd/super/ztests/single-arg-error.yaml
+++ b/cmd/super/ztests/single-arg-error.yaml
@@ -4,6 +4,6 @@ script: |
 outputs:
   - name: stderr
     data: |
-      super: parse error at line 1, column 26:
+      parse error at line 1, column 26:
       file sample.jsup | count(
                            === ^ ===

--- a/compiler/parser/ztests/syntax-error.yaml
+++ b/compiler/parser/ztests/syntax-error.yaml
@@ -8,6 +8,6 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      super: parse error at line 1, column 12:
+      parse error at line 1, column 12:
       count() by ,x,y
              === ^ ===

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -235,7 +235,7 @@ super -z -c 'Defunct=' *.jsup
 ```
 produces
 ```mdtest-output
-super: parse error at line 1, column 9:
+parse error at line 1, column 9:
 Defunct=
     === ^ ===
 ```

--- a/lake/data/reader.go
+++ b/lake/data/reader.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/brimdata/super/lake/seekindex"
@@ -22,7 +23,7 @@ func (o *Object) NewReader(ctx context.Context, engine storage.Engine, path *sto
 	objectPath := o.SequenceURI(path)
 	reader, err := engine.Get(ctx, objectPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", objectPath, err)
 	}
 	var r io.Reader
 	var readBytes int64

--- a/lake/ztests/vacuum.yaml
+++ b/lake/ztests/vacuum.yaml
@@ -16,5 +16,5 @@ outputs:
       would vacuum 1 object
       vacuumed 1 object
   - name: stderr
-    regexp:
-      file:.*file does not exist
+    regexp: |
+      file:///.*file does not exist

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -27,12 +27,12 @@ func NewS3() *S3Engine {
 
 func (s *S3Engine) Get(ctx context.Context, u *URI) (Reader, error) {
 	r, err := s3io.NewReader(ctx, u.String(), s.client)
-	return r, wrapErr(err)
+	return r, s3Err(err)
 }
 
 func (s *S3Engine) Put(ctx context.Context, u *URI) (io.WriteCloser, error) {
 	w, err := s3io.NewWriter(ctx, u.String(), s.client)
-	return w, wrapErr(err)
+	return w, s3Err(err)
 }
 
 func (s *S3Engine) PutIfNotExists(context.Context, *URI, []byte) error {
@@ -40,21 +40,21 @@ func (s *S3Engine) PutIfNotExists(context.Context, *URI, []byte) error {
 }
 
 func (s *S3Engine) Delete(ctx context.Context, u *URI) error {
-	return wrapErr(s3io.Remove(ctx, u.String(), s.client))
+	return s3Err(s3io.Remove(ctx, u.String(), s.client))
 }
 
 func (s *S3Engine) DeleteByPrefix(ctx context.Context, u *URI) error {
-	return wrapErr(s3io.RemoveAll(ctx, u.String(), s.client))
+	return s3Err(s3io.RemoveAll(ctx, u.String(), s.client))
 }
 
 func (s *S3Engine) Size(ctx context.Context, u *URI) (int64, error) {
 	info, err := s3io.Stat(ctx, u.String(), s.client)
-	return info.Size, wrapErr(err)
+	return info.Size, s3Err(err)
 }
 
 func (s *S3Engine) Exists(ctx context.Context, u *URI) (bool, error) {
 	ok, err := s3io.Exists(ctx, u.String(), s.client)
-	return ok, wrapErr(err)
+	return ok, s3Err(err)
 }
 
 func (s *S3Engine) List(ctx context.Context, uri *URI) ([]Info, error) {
@@ -72,7 +72,7 @@ func (s *S3Engine) List(ctx context.Context, uri *URI) ([]Info, error) {
 	return infos, nil
 }
 
-func wrapErr(err error) error {
+func s3Err(err error) error {
 	var reqerr awserr.RequestFailure
 	if errors.As(err, &reqerr) && reqerr.StatusCode() == http.StatusNotFound {
 		return fs.ErrNotExist


### PR DESCRIPTION
This commit simplifies file-not-found message by dropping the extra output of the file:/// absolute paths.  We also noticed that "super:" was prefixed some of the times to errors and not others, so we took the "super:" prefix out in the one place it was used.

When a data lake object is not found, the full path is printed. This happens on the vaccum test.  This is not the right UX when trying to scanned vaccumed parts of the lake, but it's how it works for now.