### PR TITLE
rework how command-line file args are wired into DAG

### DIFF
--- a/cli/queryflags/flags.go
+++ b/cli/queryflags/flags.go
@@ -1,18 +1,10 @@
 package queryflags
 
 import (
-	"context"
-	"errors"
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
-	"slices"
 
-	"github.com/brimdata/super/compiler/data"
-	"github.com/brimdata/super/compiler/parser"
-	"github.com/brimdata/super/compiler/semantic"
-	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/zbuf"
 	"github.com/brimdata/super/zson"
 )
@@ -26,44 +18,6 @@ type Flags struct {
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&f.Stats, "s", false, "display search stats on stderr")
 	fs.Var(&f.Includes, "I", "source file containing Zed query text (may be used multiple times)")
-}
-
-func (f *Flags) ParseSourcesAndInputs(src string, paths []string) ([]string, *parser.AST, bool, error) {
-	if len(paths) == 0 && src != "" {
-		// Consider a lone argument to be a query if it compiles
-		// and appears to start with a from or yield operator.
-		// Otherwise, consider it a file.
-		ast, err := parser.ParseQuery(src, f.Includes...)
-		if err != nil {
-			return nil, nil, false, err
-		}
-		s, err := semantic.Analyze(context.Background(), ast, data.NewSource(storage.NewLocalEngine(), nil), nil)
-		if err != nil {
-			return nil, nil, false, err
-		}
-		//XXX we should simplify this logic, e.g., by inserting a null source
-		// if no source is given (this is how sql "select count(*)" works with no from)
-		if semantic.HasSource(s) {
-			return nil, ast, false, nil
-		}
-		if semantic.StartsWithYield(s) {
-			return nil, ast, true, nil
-		}
-		return nil, nil, false, errors.New("no data source found")
-	}
-	ast, err := parser.ParseQuery(src, f.Includes...)
-	if err != nil {
-		return nil, nil, false, err
-	}
-	return paths, ast, false, nil
-}
-
-func isURLWithKnownScheme(path string, schemes ...string) bool {
-	u, err := url.Parse(path)
-	if err != nil {
-		return false
-	}
-	return slices.Contains(schemes, u.Scheme)
 }
 
 func (f *Flags) PrintStats(stats zbuf.Progress) {

--- a/compiler/file.go
+++ b/compiler/file.go
@@ -3,12 +3,14 @@ package compiler
 import (
 	"errors"
 
+	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/data"
 	"github.com/brimdata/super/compiler/parser"
 	"github.com/brimdata/super/lakeparse"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/runtime"
 	"github.com/brimdata/super/runtime/exec"
+	"github.com/brimdata/super/zbuf"
 	"github.com/brimdata/super/zio"
 )
 
@@ -26,10 +28,9 @@ func (f *fsCompiler) NewQuery(rctx *runtime.Context, ast *parser.AST, readers []
 		return nil, err
 	}
 	if len(readers) == 0 {
-		// If there's no reader but the DAG wants an input, then
-		// flag an error.
+		// If there's no reader but the DAG wants an input, then insert a null source.
 		if _, ok := job.DefaultScan(); ok {
-			return nil, errors.New("no input specified: use a command-line file or a Zed source operator")
+			readers = []zio.Reader{zbuf.NewArray([]super.Value{super.Null})}
 		}
 	} else {
 		// If there's a reader but the DAG doesn't want an input,

--- a/compiler/semantic/analyzer.go
+++ b/compiler/semantic/analyzer.go
@@ -105,16 +105,6 @@ func AddDefaultSource(ctx context.Context, seq *dag.Seq, source *data.Source, he
 	return nil
 }
 
-func StartsWithYield(seq dag.Seq) bool {
-	switch op := seq[0].(type) {
-	case *dag.Yield:
-		return true
-	case *dag.Scope:
-		return StartsWithYield(op.Body)
-	}
-	return false
-}
-
 func (a *analyzer) enterScope() {
 	a.scope = NewScope(a.scope)
 }


### PR DESCRIPTION
This commit moves the logic that determines if there should be a null source from queryflags to the compiler.  This decision really belongs in the semantic pass (as opposed to just after it) but that change will wait until we evolve the interface to file storage to handle broader reflection.