### PR TITLE
allow from operators to have parents for robot scans

### DIFF
--- a/compiler/dag/op.go
+++ b/compiler/dag/op.go
@@ -226,7 +226,7 @@ type (
 	}
 	RobotScan struct {
 		Kind   string `json:"kind" unpack:""`
-		Expr   Expr   `json:"path"`
+		Expr   Expr   `json:"expr"`
 		Format string `json:"format"`
 		Filter Expr   `json:"filter"`
 	}

--- a/compiler/dag/op.go
+++ b/compiler/dag/op.go
@@ -197,7 +197,7 @@ type (
 		KeyPruner Expr        `json:"key_pruner"`
 	}
 
-	// Leaf sources
+	// Sources
 
 	// DefaultScan scans an input stream provided by the runtime.
 	DefaultScan struct {
@@ -223,6 +223,12 @@ type (
 		Kind   string      `json:"kind" unpack:""`
 		ID     ksuid.KSUID `json:"id"`
 		Commit ksuid.KSUID `json:"commit"`
+	}
+	RobotScan struct {
+		Kind   string `json:"kind" unpack:""`
+		Expr   Expr   `json:"path"`
+		Format string `json:"format"`
+		Filter Expr   `json:"filter"`
 	}
 	DeleteScan struct {
 		Kind   string      `json:"kind" unpack:""`
@@ -272,6 +278,7 @@ func (*DefaultScan) OpNode()    {}
 func (*FileScan) OpNode()       {}
 func (*HTTPScan) OpNode()       {}
 func (*PoolScan) OpNode()       {}
+func (*RobotScan) OpNode()      {}
 func (*DeleteScan) OpNode()     {}
 func (*LakeMetaScan) OpNode()   {}
 func (*PoolMetaScan) OpNode()   {}

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -30,6 +30,7 @@ import (
 	"github.com/brimdata/super/runtime/sam/op/merge"
 	"github.com/brimdata/super/runtime/sam/op/meta"
 	"github.com/brimdata/super/runtime/sam/op/mirror"
+	"github.com/brimdata/super/runtime/sam/op/robot"
 	"github.com/brimdata/super/runtime/sam/op/shape"
 	"github.com/brimdata/super/runtime/sam/op/sort"
 	"github.com/brimdata/super/runtime/sam/op/switcher"
@@ -273,6 +274,12 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		return b.env.OpenHTTP(b.rctx.Context, b.zctx(), v.URL, v.Format, v.Method, v.Headers, body, demand.All())
 	case *dag.FileScan:
 		return b.env.Open(b.rctx.Context, b.zctx(), v.Path, v.Format, b.PushdownOf(v.Filter), demand.All())
+	case *dag.RobotScan:
+		e, err := compileExpr(v.Expr)
+		if err != nil {
+			return nil, err
+		}
+		return robot.New(b.rctx, b.env, parent, e, v.Format, b.PushdownOf(v.Filter), demand.All()), nil
 	case *dag.DefaultScan:
 		pushdown := b.PushdownOf(v.Filter)
 		if len(b.readers) == 1 {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -13434,7 +13434,7 @@ var g = &grammar{
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
@@ -15556,7 +15556,7 @@ var g = &grammar{
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -35,20 +35,16 @@ func (a *analyzer) semSeq(seq ast.Seq) dag.Seq {
 	return converted
 }
 
-func (a *analyzer) semFrom(from *ast.From, out dag.Seq) dag.Seq {
+func (a *analyzer) semFrom(from *ast.From, seq dag.Seq) dag.Seq {
 	if len(from.Elems) > 1 {
 		a.error(from, errors.New("cross join implied by multiple elements in from clause is not yet supported"))
 		return dag.Seq{badOp()}
 	}
-	if len(out) > 0 {
-		a.error(from, errors.New("from operator with parent input is not yet supported"))
-		return dag.Seq{badOp()}
-	}
-	return a.semFromElem(from.Elems[0])
+	return a.semFromElem(from.Elems[0], seq)
 }
 
-func (a *analyzer) semFromElem(elem *ast.FromElem) dag.Seq {
-	seq := a.semFromEntity(elem.Entity, elem.Args)
+func (a *analyzer) semFromElem(elem *ast.FromElem, seq dag.Seq) dag.Seq {
+	seq = a.semFromEntity(elem.Entity, elem.Args, seq)
 	if elem.Ordinality != nil {
 		a.error(elem.Ordinality, errors.New("WITH ORDINALITY clause is not yet supported"))
 		return dag.Seq{badOp()}
@@ -78,42 +74,79 @@ func wrapAlias(alias string, seq dag.Seq) dag.Seq {
 	})
 }
 
-func (a *analyzer) semFromEntity(entity ast.FromEntity, args ast.FromArgs) dag.Seq {
+func (a *analyzer) semFromEntity(entity ast.FromEntity, args ast.FromArgs, seq dag.Seq) dag.Seq {
 	switch entity := entity.(type) {
 	case *ast.Glob:
+		if a.hasFromParent(entity, seq) {
+			return seq
+		}
 		if a.env.IsLake() {
 			return a.semPoolFromRegexp(entity, reglob.Reglob(entity.Pattern), entity.Pattern, "glob", args)
 		}
 		return dag.Seq{a.semFromFileGlob(entity, entity.Pattern, args)}
 	case *ast.Regexp:
+		if a.hasFromParent(entity, seq) {
+			return seq
+		}
 		if !a.env.IsLake() {
 			a.error(entity, errors.New("cannot use regular expression with from operator on local file system"))
 		}
 		return a.semPoolFromRegexp(entity, entity.Pattern, entity.Pattern, "regexp", args)
 	case *ast.Name:
+		if a.hasFromParent(entity, seq) {
+			return seq
+		}
 		return dag.Seq{a.semFromName(entity, entity.Text, args)}
 	case *ast.ExprEntity:
-		return a.semFromExpr(entity, args)
+		return a.semFromExpr(entity, args, seq)
 	case *ast.LakeMeta:
+		if a.hasFromParent(entity, seq) {
+			return seq
+		}
 		return dag.Seq{a.semLakeMeta(entity)}
 	case *ast.SQLPipe:
-		//XXX pass down parents?
-		return a.semOp(entity, nil)
+		return a.semOp(entity, seq)
 	case *ast.SQLJoin:
-		//XXX pass down parents?
-		return a.semSQLJoin(entity, nil)
+		return a.semSQLJoin(entity, seq)
 	default:
 		panic(fmt.Sprintf("semFromEntity: unknown entity type: %T", entity))
 	}
 }
 
-func (a *analyzer) semFromExpr(entity *ast.ExprEntity, args ast.FromArgs) dag.Seq {
+func (a *analyzer) semFromExpr(entity *ast.ExprEntity, args ast.FromArgs, seq dag.Seq) dag.Seq {
 	expr := a.semExpr(entity.Expr)
 	val, err := kernel.EvalAtCompileTime(a.zctx, expr)
-	if err != nil {
-		a.error(entity, err)
-		return dag.Seq{badOp()}
+	if err == nil && !hasError(val) {
+		if a.hasFromParent(entity, seq) {
+			return seq
+		}
+		return a.semFromConstVal(val, entity, args)
 	}
+	// This is an expression so set up a robot scanner that pulls values from
+	// parent to decide what to scan.
+	e := a.semExpr(entity.Expr)
+	return append(seq, &dag.RobotScan{
+		Kind:   "RobotScan",
+		Expr:   e,
+		Format: a.formatArg(args),
+	})
+}
+
+func hasError(val super.Value) bool {
+	has := function.NewHasError()
+	result := has.Call(nil, []super.Value{val})
+	return result.AsBool()
+}
+
+func (a *analyzer) hasFromParent(loc ast.Node, seq dag.Seq) bool {
+	if len(seq) > 0 {
+		a.error(loc, errors.New("from operator cannot have parent unless from argument is an expression"))
+		return true
+	}
+	return false
+}
+
+func (a *analyzer) semFromConstVal(val super.Value, entity *ast.ExprEntity, args ast.FromArgs) dag.Seq {
 	vals, err := val.Elements()
 	if err != nil {
 		a.error(entity.Expr, errors.New("from expression requires a string array"))
@@ -187,20 +220,24 @@ func asFileArgs(args ast.FromArgs) (*ast.FormatArg, error) {
 	}
 }
 
-func (a *analyzer) semFile(name string, args ast.FromArgs) dag.Op {
+func (a *analyzer) formatArg(args ast.FromArgs) string {
 	formatArg, err := asFileArgs(args)
 	if err != nil {
 		a.error(args, err)
-		return badOp()
+		return ""
 	}
 	var format string
 	if formatArg != nil {
 		format = nullableName(formatArg.Format)
 	}
+	return format
+}
+
+func (a *analyzer) semFile(name string, args ast.FromArgs) dag.Op {
 	return &dag.FileScan{
 		Kind:   "FileScan",
 		Path:   name,
-		Format: format,
+		Format: a.formatArg(args),
 	}
 }
 

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -124,10 +124,9 @@ func (a *analyzer) semFromExpr(entity *ast.ExprEntity, args ast.FromArgs, seq da
 	}
 	// This is an expression so set up a robot scanner that pulls values from
 	// parent to decide what to scan.
-	e := a.semExpr(entity.Expr)
 	return append(seq, &dag.RobotScan{
 		Kind:   "RobotScan",
-		Expr:   e,
+		Expr:   expr,
 		Format: a.formatArg(args),
 	})
 }

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -31,7 +31,7 @@ func (a *analyzer) semSelect(sel *ast.Select, seq dag.Seq) dag.Seq {
 		if _, ok := seq[off].(*dag.RobotScan); !ok {
 			if hasParent {
 				a.error(sel, errors.New("SELECT cannot have both an embedded FROM claue and input from parents"))
-				return append(seq, badOp())
+				return dag.Seq{badOp()}
 			}
 		}
 	}

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -31,7 +31,7 @@ func (a *analyzer) semSelect(sel *ast.Select, seq dag.Seq) dag.Seq {
 		if _, ok := seq[off].(*dag.RobotScan); !ok {
 			if hasParent {
 				a.error(sel, errors.New("SELECT cannot have both an embedded FROM claue and input from parents"))
-				return dag.Seq{badOp()}
+				return append(seq, badOp())
 			}
 		}
 	}

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -18,11 +18,20 @@ import (
 // and may or may not have its sources embedded.
 func (a *analyzer) semSelect(sel *ast.Select, seq dag.Seq) dag.Seq {
 	if sel.From != nil {
-		if len(seq) > 0 {
-			a.error(sel, errors.New("SELECT cannot have both an embedded FROM claue and input from parents"))
-			return append(seq, badOp())
+		off := len(seq)
+		hasParent := off > 0
+		seq = a.semFrom(sel.From, seq)
+		// If we have parents with both a from and select, report an error
+		// but only if it's not a RobotScan where the parent needs to feed
+		// the from.
+		if off < len(seq) {
+			if _, ok := seq[off].(*dag.RobotScan); !ok {
+				if hasParent {
+					a.error(sel, errors.New("SELECT cannot have both an embedded FROM claue and input from parents"))
+					return append(seq, badOp())
+				}
+			}
 		}
-		seq = a.semFrom(sel.From, nil)
 	}
 	if sel.Value {
 		return a.semSelectValue(sel, seq)
@@ -172,10 +181,13 @@ func (a *analyzer) semSQLJoin(join *ast.SQLJoin, seq dag.Seq) dag.Seq {
 		a.error(join.Cond, errors.New("SQL joins currently limited to equijoin on fields"))
 		return append(seq, badOp())
 	}
-	//XXX need to pass down parent
-	leftPath := a.semFromElem(join.Left)
-	rightPath := a.semFromElem(join.Right)
-
+	if len(seq) > 0 {
+		// At some point we might want to let parent data flow into a join somehow,
+		// but for now we flag an error.
+		a.error(join, errors.New("SQL join cannot inherit data from pipeline parent"))
+	}
+	leftPath := a.semFromElem(join.Left, nil)
+	rightPath := a.semFromElem(join.Right, nil)
 	alias := join.Right.Alias.Text
 	assignment := dag.Assignment{
 		Kind: "Assignment",

--- a/runtime/sam/op/robot/robot.go
+++ b/runtime/sam/op/robot/robot.go
@@ -1,0 +1,193 @@
+package robot
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/compiler/optimizer/demand"
+	"github.com/brimdata/super/pkg/storage"
+	"github.com/brimdata/super/runtime"
+	"github.com/brimdata/super/runtime/exec"
+	"github.com/brimdata/super/runtime/sam/expr"
+	"github.com/brimdata/super/zbuf"
+)
+
+type Op struct {
+	parent  zbuf.Puller
+	rctx    *runtime.Context
+	env     *exec.Environment
+	expr    expr.Evaluator
+	filter  zbuf.Filter
+	format  string
+	demand  demand.Demand
+	batch   zbuf.Batch
+	off     int
+	src     zbuf.Puller
+	targets []super.Value
+}
+
+func New(rctx *runtime.Context, env *exec.Environment, parent zbuf.Puller, e expr.Evaluator, format string, f zbuf.Filter, d demand.Demand) *Op {
+	return &Op{
+		parent: parent,
+		rctx:   rctx,
+		env:    env,
+		expr:   e,
+		demand: d,
+		filter: f,
+		format: format,
+	}
+}
+
+func (o *Op) Pull(done bool) (zbuf.Batch, error) {
+	if done {
+		if o.batch != nil {
+			o.batch.Unref()
+		}
+		o.batch = nil
+		src := o.src
+		o.src = nil
+		if closer, ok := src.(io.Closer); ok {
+			if err := closer.Close(); err != nil {
+				return nil, err
+			}
+		}
+		b, err := o.parent.Pull(true)
+		if b != nil {
+			b.Unref()
+		}
+		return nil, err
+	}
+	for {
+		puller, err := o.getPuller()
+		if puller == nil || err != nil {
+			o.src = nil
+			return nil, err
+		}
+		b, err := puller.Pull(false)
+		if b != nil || err != nil {
+			return b, err
+		}
+		if b == nil {
+			o.src = nil
+		}
+	}
+}
+
+func (o *Op) getPuller() (zbuf.Puller, error) {
+	puller := o.src
+	if puller != nil {
+		return puller, nil
+	}
+	if len(o.targets) > 0 {
+		src, err := o.openNext()
+		o.src = src
+		return src, err
+	}
+	src, err := o.nextPuller()
+	o.src = src
+	return src, err
+}
+
+func (o *Op) nextPuller() (zbuf.Puller, error) {
+	b := o.batch
+	if b != nil && o.off >= len(b.Values()) {
+		b.Unref()
+		o.off = 0
+		o.batch = nil
+		b = nil
+	}
+	if b == nil {
+		var err error
+		b, err = o.nextBatch()
+		if err != nil {
+			return nil, err
+		}
+		o.batch = b
+		o.off = 0
+		if b == nil {
+			return nil, nil
+		}
+	}
+	val := b.Values()[o.off]
+	o.off++
+	return o.openFromVal(b, val)
+}
+
+func (o *Op) openFromVal(b zbuf.Batch, val super.Value) (zbuf.Puller, error) {
+	target := o.expr.Eval(b, val)
+	typ := super.TypeUnder(target.Type())
+	if typ == super.TypeString {
+		return o.open(target.AsString())
+	}
+	vals, err := target.Elements()
+	if err != nil || len(vals) == 0 {
+		return o.errOnVal(target), nil
+	}
+	typ = super.TypeUnder(vals[0].Type())
+	if typ != super.TypeString {
+		return o.errOnVal(target), nil
+	}
+	o.targets = vals
+	return o.openNext()
+}
+
+func (o *Op) openNext() (zbuf.Puller, error) {
+	if len(o.targets) == 0 {
+		return nil, nil
+	}
+	val := o.targets[0]
+	o.targets = o.targets[1:]
+	return o.open(val.AsString())
+}
+
+func (o *Op) errOnVal(val super.Value) zbuf.Puller {
+	errVal := o.rctx.Zctx.WrapError("from encountered non-string input", val)
+	return zbuf.NewPuller(zbuf.NewArray([]super.Value{errVal}))
+}
+
+func (o *Op) nextBatch() (zbuf.Batch, error) {
+again:
+	b, err := o.parent.Pull(false)
+	if err != nil {
+		return nil, err
+	}
+	if b == nil {
+		o.batch = nil
+		o.off = 0
+		return nil, nil
+	}
+	if len(b.Values()) == 0 {
+		b.Unref()
+		goto again
+	}
+	o.batch = b
+	o.off = 0
+	return b, nil
+}
+
+func (o *Op) open(path string) (zbuf.Puller, error) {
+	u, err := storage.ParseURI(path)
+	if err == nil && false {
+		//XXX get from AST args, or we can also get this stuff from the
+		// robot expr, e.g., allowning the querying to create a record
+		// to hold these args...
+		var method string
+		var body io.Reader
+		var headers http.Header
+		f, err := o.env.OpenHTTP(o.rctx.Context, o.rctx.Zctx, u.String(), o.format, method, headers, body, nil)
+		if err != nil {
+			return nil, err
+		}
+		return f, err
+	}
+	if o.env.IsLake() {
+		return nil, fmt.Errorf("%s: cannot open in a data lake environment", path)
+	}
+	f, err := o.env.Open(o.rctx.Context, o.rctx.Zctx, path, o.format, o.filter, o.demand)
+	if err != nil {
+		return nil, err
+	}
+	return f, err
+}

--- a/runtime/sam/op/robot/ztests/array.yaml
+++ b/runtime/sam/op/robot/ztests/array.yaml
@@ -1,0 +1,25 @@
+script: |
+  super -z -c 'from which.jsup | select value this from ["a"+string(this)+".jsup","a"+string(this+1)+".jsup"]'
+
+inputs:
+  - name: which.jsup
+    data: |
+      1
+      2
+  - name: a1.jsup
+    data: |
+      "hello"
+  - name: a2.jsup
+    data: |
+      "world"
+  - name: a3.jsup
+    data: |
+      "goodbye"
+
+outputs:
+  - name: stdout
+    data: |
+      "hello"
+      "world"
+      "world"
+      "goodbye"

--- a/runtime/sam/op/robot/ztests/basic.yaml
+++ b/runtime/sam/op/robot/ztests/basic.yaml
@@ -1,0 +1,25 @@
+script: |
+  super -z -c 'from files.jsup | from [f]'
+  echo ===
+  super -z -c 'from files.jsup | select value this from [f]'
+
+inputs:
+  - name: files.jsup
+    data: |
+      {f:"a.jsup"}
+      {f:"b.jsup"}
+  - name: a.jsup
+    data: |
+      "hello"
+  - name: b.jsup
+    data: |
+      "world"
+
+outputs:
+  - name: stdout
+    data: |
+      "hello"
+      "world"
+      ===
+      "hello"
+      "world"

--- a/runtime/sam/op/robot/ztests/example.yaml
+++ b/runtime/sam/op/robot/ztests/example.yaml
@@ -1,0 +1,40 @@
+skip: true
+
+script: |
+  super -z -c 'from files.jsup | from [f]'
+  echo ===
+  super -z -c 'from files.jsup | select value this from [f]'
+
+inputs:
+  - name: files.jsup
+    data: |
+      {f:"a.jsup"}
+      {f:"b.jsup"}
+  - name: a.jsup
+    data: |
+      "hello"
+  - name: b.jsup
+    data: |
+      "world"
+  - name: query.spq
+    data: |
+      FROM gharchive.jsup
+      |> SELECT union(repo.name) AS repo, actor.login AS user
+        GROUP BY user
+        ORDER BY len(repo) DESC
+        LIMIT 5
+      |> FORK (
+        => FROM [f'{user}.jsup']
+          |> SELECT VALUE {user:login,created_at:time(created_at)}
+        => PASS
+        )
+      |> JOIN USING (user)
+
+outputs:
+  - name: stdout
+    data: |
+      "hello"
+      "world"
+      ===
+      "hello"
+      "world"


### PR DESCRIPTION
This commit allows from operators to pull data from its parent and for each incoming value compute a target to open and read. This is repeated successively until the parent fails.  When failures occur, structured errors are propgated downstream.

There is a disabled test mimicing the example in the top-level README.  It will be enabled in a subsequent upon adding support for "join using".