### PR TITLE
Adapt perf-compare script for zed#5436 changes

### DIFF
--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -46,7 +46,7 @@ declare -a DESCRIPTIONS=(
 )
 
 declare -a SPQS=(
-    '*'
+    '? *'
     'cut quiet(ts)'
     'count:=count()'
     'count() by quiet(id.orig_h)'

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -46,7 +46,7 @@ declare -a DESCRIPTIONS=(
 )
 
 declare -a SPQS=(
-    '? *'
+    'pass'
     'cut quiet(ts)'
     'count:=count()'
     'count() by quiet(id.orig_h)'


### PR DESCRIPTION
The perf-compare script has always had an explicit `*` query in it so it'll show up in the results table, and that needs to change to `? *` now.
