### PR TITLE
Fix bug affecting vector min(), max(), sum(), and avg() functions

### DIFF
--- a/runtime/vam/expr/agg/mathfunc.go
+++ b/runtime/vam/expr/agg/mathfunc.go
@@ -83,7 +83,7 @@ func sumOf[T numeric, E numeric](state T, vals []E, index []uint32, counts []uin
 		}
 		return state
 	}
-	for v := range vals {
+	for _, v := range vals {
 		state += T(v)
 	}
 	return state
@@ -127,7 +127,7 @@ func minOf[T numeric, E numeric](state T, vals []E, index []uint32) T {
 		}
 		return state
 	}
-	for v := range vals {
+	for _, v := range vals {
 		if v := T(v); v < state {
 			state = v
 		}
@@ -173,7 +173,7 @@ func maxOf[T numeric, E numeric](state T, vals []E, index []uint32) T {
 		}
 		return state
 	}
-	for v := range vals {
+	for _, v := range vals {
 		if v := T(v); v > state {
 			state = v
 		}


### PR DESCRIPTION
They return incorrect results because the minOf, maxOf, and sumOf functions in runtime/vam/expr/agg update their state with vector slot numbers.  Fix them so they use the values in those slots instead.