### PR TITLE
Simplify projection pushdown in reader APIs

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/cli/auto"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/zio"
 	"github.com/brimdata/super/zio/anyio"
@@ -65,7 +64,7 @@ func (f *Flags) Open(ctx context.Context, zctx *super.Context, engine storage.En
 		if path == "-" {
 			path = "stdio:stdin"
 		}
-		file, err := anyio.Open(ctx, zctx, engine, path, demand.All(), f.ReaderOpts)
+		file, err := anyio.Open(ctx, zctx, engine, path, f.ReaderOpts)
 		if err != nil {
 			err = fmt.Errorf("%s: %w", path, err)
 			if stopOnErr {

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -12,7 +12,6 @@ import (
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/dag"
 	"github.com/brimdata/super/compiler/optimizer"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/lake"
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/runtime"
@@ -271,15 +270,15 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		return meta.NewLakeMetaScanner(b.rctx.Context, b.zctx(), b.env.Lake(), v.Meta)
 	case *dag.HTTPScan:
 		body := strings.NewReader(v.Body)
-		return b.env.OpenHTTP(b.rctx.Context, b.zctx(), v.URL, v.Format, v.Method, v.Headers, body, demand.All())
+		return b.env.OpenHTTP(b.rctx.Context, b.zctx(), v.URL, v.Format, v.Method, v.Headers, body, nil)
 	case *dag.FileScan:
-		return b.env.Open(b.rctx.Context, b.zctx(), v.Path, v.Format, b.PushdownOf(v.Filter), demand.All())
+		return b.env.Open(b.rctx.Context, b.zctx(), v.Path, v.Format, nil, b.PushdownOf(v.Filter))
 	case *dag.RobotScan:
 		e, err := compileExpr(v.Expr)
 		if err != nil {
 			return nil, err
 		}
-		return robot.New(b.rctx, b.env, parent, e, v.Format, b.PushdownOf(v.Filter), demand.All()), nil
+		return robot.New(b.rctx, b.env, parent, e, v.Format, nil, b.PushdownOf(v.Filter)), nil
 	case *dag.DefaultScan:
 		pushdown := b.PushdownOf(v.Filter)
 		if len(b.readers) == 1 {

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -17,6 +17,7 @@ import (
 	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/compiler/parser"
 	"github.com/brimdata/super/compiler/semantic"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/pkg/nano"
 	"github.com/brimdata/super/pkg/storage/mock"
 	"github.com/brimdata/super/runtime"
@@ -45,10 +46,10 @@ func ReadZNG(bs []byte) ([]super.Value, error) {
 	return a.Values(), nil
 }
 
-func ReadVNG(bs []byte, demandOut demand.Demand) ([]super.Value, error) {
+func ReadVNG(bs []byte, fields []field.Path) ([]super.Value, error) {
 	bytesReader := bytes.NewReader(bs)
 	context := super.NewContext()
-	reader, err := vngio.NewReader(context, bytesReader, demandOut)
+	reader, err := vngio.NewReader(context, bytesReader, fields)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +82,7 @@ func RunQueryZNG(t testing.TB, buf *bytes.Buffer, querySource string) []super.Va
 
 func RunQueryVNG(t testing.TB, buf *bytes.Buffer, querySource string) []super.Value {
 	zctx := super.NewContext()
-	reader, err := vngio.NewReader(zctx, bytes.NewReader(buf.Bytes()), demand.All())
+	reader, err := vngio.NewReader(zctx, bytes.NewReader(buf.Bytes()), nil)
 	require.NoError(t, err)
 	readers := []zio.Reader{reader}
 	defer zio.CloseReaders(readers)

--- a/lake/data/writer_test.go
+++ b/lake/data/writer_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/lake/data"
 	"github.com/brimdata/super/order"
 	"github.com/brimdata/super/pkg/field"
@@ -32,7 +31,7 @@ func TestDataReaderWriterVector(t *testing.T) {
 	// Read back the VNG file and make sure it's the same.
 	get, err := engine.Get(ctx, object.VectorURI(tmp))
 	require.NoError(t, err)
-	reader, err := vngio.NewReader(super.NewContext(), get, demand.All())
+	reader, err := vngio.NewReader(super.NewContext(), get, nil)
 	require.NoError(t, err)
 	v, err := reader.Read()
 	require.NoError(t, err)

--- a/runtime/sam/op/robot/robot.go
+++ b/runtime/sam/op/robot/robot.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/compiler/optimizer/demand"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/runtime"
 	"github.com/brimdata/super/runtime/exec"
@@ -19,22 +19,22 @@ type Op struct {
 	rctx    *runtime.Context
 	env     *exec.Environment
 	expr    expr.Evaluator
+	fields  []field.Path
 	filter  zbuf.Filter
 	format  string
-	demand  demand.Demand
 	batch   zbuf.Batch
 	off     int
 	src     zbuf.Puller
 	targets []super.Value
 }
 
-func New(rctx *runtime.Context, env *exec.Environment, parent zbuf.Puller, e expr.Evaluator, format string, f zbuf.Filter, d demand.Demand) *Op {
+func New(rctx *runtime.Context, env *exec.Environment, parent zbuf.Puller, e expr.Evaluator, format string, fields []field.Path, f zbuf.Filter) *Op {
 	return &Op{
 		parent: parent,
 		rctx:   rctx,
 		env:    env,
 		expr:   e,
-		demand: d,
+		fields: fields,
 		filter: f,
 		format: format,
 	}
@@ -200,5 +200,5 @@ func (o *Op) open(path string) (zbuf.Puller, error) {
 	if o.env.IsLake() {
 		return nil, fmt.Errorf("%s: cannot open in a data lake environment", path)
 	}
-	return o.env.Open(o.rctx.Context, o.rctx.Zctx, path, o.format, o.filter, o.demand)
+	return o.env.Open(o.rctx.Context, o.rctx.Zctx, path, o.format, o.fields, o.filter)
 }

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/brimdata/super/api/queryio"
 	"github.com/brimdata/super/compiler"
 	"github.com/brimdata/super/compiler/describe"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/compiler/parser"
 	"github.com/brimdata/super/lake"
 	lakeapi "github.com/brimdata/super/lake/api"
@@ -459,7 +458,7 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 		ZNG: zngio.ReaderOpts{Validate: true},
 	}
 	zctx := super.NewContext()
-	zrc, err := anyio.NewReaderWithOpts(zctx, reader, demand.All(), opts)
+	zrc, err := anyio.NewReaderWithOpts(zctx, reader, opts)
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return

--- a/service/request.go
+++ b/service/request.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/api"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/compiler/srcfiles"
 	"github.com/brimdata/super/lake"
 	"github.com/brimdata/super/lake/branches"
@@ -174,7 +173,7 @@ func (r *Request) Unmarshal(w *ResponseWriter, body interface{}, templates ...in
 	if !ok {
 		return false
 	}
-	zrc, err := anyio.NewReaderWithOpts(super.NewContext(), r.Body, demand.All(), anyio.ReaderOpts{Format: format})
+	zrc, err := anyio.NewReaderWithOpts(super.NewContext(), r.Body, anyio.ReaderOpts{Format: format})
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return false

--- a/vng/vng_test.go
+++ b/vng/vng_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/fuzz"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +32,7 @@ func FuzzVngRoundtripBytes(f *testing.F) {
 func roundtrip(t *testing.T, valuesIn []super.Value) {
 	var buf bytes.Buffer
 	fuzz.WriteVNG(t, valuesIn, &buf)
-	valuesOut, err := fuzz.ReadVNG(buf.Bytes(), demand.All())
+	valuesOut, err := fuzz.ReadVNG(buf.Bytes(), nil)
 	require.NoError(t, err)
 	fuzz.CompareValues(t, valuesIn, valuesOut)
 }

--- a/zed_test.go
+++ b/zed_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/compiler/parser"
 	"github.com/brimdata/super/runtime"
 	"github.com/brimdata/super/zio"
@@ -99,7 +98,7 @@ func loadZTestInputsAndOutputs(ztestDirs map[string]struct{}) (map[string]string
 // isValid returns true if and only if s can be read fully without error by
 // anyio and contains at least one value.
 func isValid(s string) bool {
-	zrc, err := anyio.NewReader(super.NewContext(), strings.NewReader(s), demand.All())
+	zrc, err := anyio.NewReader(super.NewContext(), strings.NewReader(s))
 	if err != nil {
 		return false
 	}
@@ -133,7 +132,7 @@ func runAllBoomerangs(t *testing.T, format string, data map[string]string) {
 func runOneBoomerang(t *testing.T, format, data string) {
 	// Create an auto-detecting reader for data.
 	zctx := super.NewContext()
-	dataReadCloser, err := anyio.NewReader(zctx, strings.NewReader(data), demand.All())
+	dataReadCloser, err := anyio.NewReader(zctx, strings.NewReader(data))
 	require.NoError(t, err)
 	defer dataReadCloser.Close()
 
@@ -167,7 +166,7 @@ func runOneBoomerang(t *testing.T, format, data string) {
 	}
 
 	// Create a reader for baseline.
-	baselineReader, err := anyio.NewReaderWithOpts(super.NewContext(), bytes.NewReader(baseline.Bytes()), demand.All(), anyio.ReaderOpts{
+	baselineReader, err := anyio.NewReaderWithOpts(super.NewContext(), bytes.NewReader(baseline.Bytes()), anyio.ReaderOpts{
 		Format: format,
 		ZNG: zngio.ReaderOpts{
 			Validate: true,

--- a/zio/anyio/fifo_test.go
+++ b/zio/anyio/fifo_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +22,7 @@ func TestOpenFifoCancelation(t *testing.T) {
 		errCh := make(chan error)
 		ctx, cancel := context.WithCancel(context.Background())
 		go func() {
-			_, err := Open(ctx, super.NewContext(), storage.NewFileSystem(), path, demand.All(), ReaderOpts{})
+			_, err := Open(ctx, super.NewContext(), storage.NewFileSystem(), path, ReaderOpts{})
 			errCh <- err
 		}()
 		time.Sleep(10 * time.Millisecond)

--- a/zio/anyio/file.go
+++ b/zio/anyio/file.go
@@ -5,14 +5,13 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/zbuf"
 )
 
 // Open uses engine to open path for reading.  path is a local file path or a
 // URI whose scheme is understood by engine.
-func Open(ctx context.Context, zctx *super.Context, engine storage.Engine, path string, demandOut demand.Demand, opts ReaderOpts) (*zbuf.File, error) {
+func Open(ctx context.Context, zctx *super.Context, engine storage.Engine, path string, opts ReaderOpts) (*zbuf.File, error) {
 	uri, err := storage.ParseURI(path)
 	if err != nil {
 		return nil, err
@@ -28,7 +27,7 @@ func Open(ctx context.Context, zctx *super.Context, engine storage.Engine, path 
 			return
 		}
 		// NewFile reads from sr, which might block.
-		zf, err = NewFile(zctx, sr, path, demandOut, opts)
+		zf, err = NewFile(zctx, sr, path, opts)
 		if err != nil {
 			sr.Close()
 		}
@@ -41,12 +40,12 @@ func Open(ctx context.Context, zctx *super.Context, engine storage.Engine, path 
 	}
 }
 
-func NewFile(zctx *super.Context, rc io.ReadCloser, path string, demandOut demand.Demand, opts ReaderOpts) (*zbuf.File, error) {
+func NewFile(zctx *super.Context, rc io.ReadCloser, path string, opts ReaderOpts) (*zbuf.File, error) {
 	r, err := GzipReader(rc)
 	if err != nil {
 		return nil, err
 	}
-	zr, err := NewReaderWithOpts(zctx, r, demandOut, opts)
+	zr, err := NewReaderWithOpts(zctx, r, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/zio/anyio/lookup.go
+++ b/zio/anyio/lookup.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/zio"
 	"github.com/brimdata/super/zio/arrowio"
 	"github.com/brimdata/super/zio/csvio"
@@ -19,14 +18,14 @@ import (
 	"github.com/brimdata/super/zio/zsonio"
 )
 
-func lookupReader(zctx *super.Context, r io.Reader, demandOut demand.Demand, opts ReaderOpts) (zio.ReadCloser, error) {
+func lookupReader(zctx *super.Context, r io.Reader, opts ReaderOpts) (zio.ReadCloser, error) {
 	switch opts.Format {
 	case "arrows":
 		return arrowio.NewReader(zctx, r)
 	case "bsup":
 		return zngio.NewReaderWithOpts(zctx, r, opts.ZNG), nil
 	case "csup":
-		zr, err := vngio.NewReader(zctx, r, demandOut)
+		zr, err := vngio.NewReader(zctx, r, opts.Fields)
 		if err != nil {
 			return nil, err
 		}

--- a/zio/anyio/reader.go
+++ b/zio/anyio/reader.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/compiler/optimizer/demand"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/zio"
 	"github.com/brimdata/super/zio/arrowio"
 	"github.com/brimdata/super/zio/csvio"
@@ -23,18 +23,19 @@ import (
 )
 
 type ReaderOpts struct {
+	Fields []field.Path
 	Format string
 	CSV    csvio.ReaderOpts
 	ZNG    zngio.ReaderOpts
 }
 
-func NewReader(zctx *super.Context, r io.Reader, demandOut demand.Demand) (zio.ReadCloser, error) {
-	return NewReaderWithOpts(zctx, r, demandOut, ReaderOpts{})
+func NewReader(zctx *super.Context, r io.Reader) (zio.ReadCloser, error) {
+	return NewReaderWithOpts(zctx, r, ReaderOpts{})
 }
 
-func NewReaderWithOpts(zctx *super.Context, r io.Reader, demandOut demand.Demand, opts ReaderOpts) (zio.ReadCloser, error) {
+func NewReaderWithOpts(zctx *super.Context, r io.Reader, opts ReaderOpts) (zio.ReadCloser, error) {
 	if opts.Format != "" && opts.Format != "auto" {
-		return lookupReader(zctx, r, demandOut, opts)
+		return lookupReader(zctx, r, opts)
 	}
 
 	var parquetErr, vngErr error
@@ -48,7 +49,7 @@ func NewReaderWithOpts(zctx *super.Context, r io.Reader, demandOut demand.Demand
 			if _, err := rs.Seek(n, io.SeekStart); err != nil {
 				return nil, err
 			}
-			zr, vngErr = vngio.NewReader(zctx, rs, demandOut)
+			zr, vngErr = vngio.NewReader(zctx, rs, opts.Fields)
 			if vngErr == nil {
 				return zio.NopReadCloser(zr), nil
 			}

--- a/zio/vngio/reader.go
+++ b/zio/vngio/reader.go
@@ -5,12 +5,12 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/compiler/optimizer/demand"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/vng"
 	"github.com/brimdata/super/zio"
 )
 
-func NewReader(zctx *super.Context, r io.Reader, demandOut demand.Demand) (zio.Reader, error) {
+func NewReader(zctx *super.Context, r io.Reader, fields []field.Path) (zio.Reader, error) {
 	ra, ok := r.(io.ReaderAt)
 	if !ok {
 		return nil, errors.New("Super Columnar requires a seekable input")

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -137,7 +137,6 @@ import (
 	"github.com/brimdata/super/cli/inputflags"
 	"github.com/brimdata/super/cli/outputflags"
 	"github.com/brimdata/super/compiler"
-	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/compiler/parser"
 	"github.com/brimdata/super/runtime"
 	"github.com/brimdata/super/runtime/vcache"
@@ -505,7 +504,7 @@ func runzq(path, zedProgram, input string, outputFlags []string, inputFlags []st
 		return "", err
 	}
 	zctx := super.NewContext()
-	zrc, err := anyio.NewReaderWithOpts(zctx, r, demand.All(), inflags.Options())
+	zrc, err := anyio.NewReaderWithOpts(zctx, r, inflags.Options())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
* Switch from compiler/optimizer/demand.Demand to pkg/field.Path for reader configuration.

* Move reader configuration from standalone function parameters into zio/anyio.ReaderOpts where possible.