### PR TITLE
allow newlines in SQL LIKE expressions

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -410,7 +410,7 @@ func (a *analyzer) semBinary(e *ast.BinaryExpr) dag.Expr {
 		pattern := likeexpr.ToRegexp(s, '\\', false)
 		return &dag.RegexpSearch{
 			Kind:    "RegexpSearch",
-			Pattern: pattern,
+			Pattern: "(?s)" + pattern,
 			Expr:    lhs,
 		}
 	}

--- a/compiler/ztests/sql/like-newline.yaml
+++ b/compiler/ztests/sql/like-newline.yaml
@@ -1,0 +1,14 @@
+script: |
+  super -z -c "select value this from a.json where a like '%bar%'"
+
+inputs:
+  - name: a.json
+    data: |
+      {a:"foo bar"}
+      {a:"foo\nbar"}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:"foo bar"}
+      {a:"foo\nbar"}

--- a/compiler/ztests/sql/precedence.yaml
+++ b/compiler/ztests/sql/precedence.yaml
@@ -25,7 +25,7 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {"!(10>=15 and 10<=(true) ? 20 : error(\"missing\")) and 1+2 in [3,4,5] or \"foo\"+\"bar\" in null":true,"regexp_search(/^f.*?$/, \"foo\") or false":true,"(true) ? \"x\" : error(\"missing\")+\"y\"":"xy"}
+      {"!(10>=15 and 10<=(true) ? 20 : error(\"missing\")) and 1+2 in [3,4,5] or \"foo\"+\"bar\" in null":true,"regexp_search(/(?s)^f.*?$/, \"foo\") or false":true,"(true) ? \"x\" : error(\"missing\")+\"y\"":"xy"}
       ===
       {Country:"France",Language:"French"}
       ===


### PR DESCRIPTION
This commit fixes a problem with the regexp patterns used in SQL "LIKE" clauses.  We added a prefix of (?s) to the regexp so newlines are included in the matching logic for "." thereby preventing strings containing newlines from foiling the regexp logic.