### PR TITLE
Add predicate pushdown fields to projection pushdown

### DIFF
--- a/compiler/optimizer/demand.go
+++ b/compiler/optimizer/demand.go
@@ -44,6 +44,9 @@ func inferDemandSeqOutWith(demands map[dag.Op]demand.Demand, demandSeqOut demand
 		// Infer the demand that `op` places on it's input.
 		var demandOpIn demand.Demand
 		switch op := op.(type) {
+		case *dag.FileScan:
+			demandOpIn = demand.Union(demandOpOut, inferDemandExprIn(demand.All(), op.Filter))
+			demands[op] = demandOpIn
 		case *dag.Filter:
 			demandOpIn = demand.Union(
 				// Everything that downstream operations need.
@@ -51,6 +54,9 @@ func inferDemandSeqOutWith(demands map[dag.Op]demand.Demand, demandSeqOut demand
 				// Everything that affects the outcome of this filter.
 				inferDemandExprIn(demand.All(), op.Expr),
 			)
+		case *dag.SeqScan:
+			demandOpIn = demand.Union(demandOpOut, inferDemandExprIn(demand.All(), op.Filter))
+			demands[op] = demandOpIn
 		case *dag.Summarize:
 			demandOpIn = demand.None()
 			// TODO If LHS not in demandOut, we can ignore RHS

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -1,8 +1,10 @@
 script: |
+  super compile -C -O "from file | a==1 or e==2 | yield c, b, d"
+  echo ===
   export SUPER_DB_LAKE=test
   super db init -q
   super db create -q -orderby ts pool-ts
-  super db compile -C -O "from 'pool-ts' |> x=='hello' or x==1.0" | sed -e 's/lister .*/lister/' -e 's/seqscan .*filter/seqscan filter/'
+  super db compile -C -O "from 'pool-ts' |> x=='hello' or x==1.0 |> yield a" | sed -e 's/lister .*/lister/' -e 's/seqscan .*field/seqscan field/'
   echo ===
   super db compile -C -O "from 'pool-ts' |> x > 1 and y <= 1.0" | sed -e 's/lister .*/lister/' -e 's/seqscan .*filter/seqscan filter/'
   echo ===
@@ -17,9 +19,14 @@ script: |
 outputs:
   - name: stdout
     data: |
+      file file fields a,b,c,d,e filter (a==1 or e==2)
+      |> yield c, b, d
+      |> output main
+      ===
       lister
       |> slicer
-      |> seqscan filter (x=="hello" or x==1.)
+      |> seqscan fields a,x filter (x=="hello" or x==1.)
+      |> yield a
       |> output main
       ===
       lister

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -1,8 +1,12 @@
 package zfmt
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/brimdata/super/compiler/ast"
 	"github.com/brimdata/super/compiler/dag"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/zson"
 )
 
@@ -493,6 +497,9 @@ func (c *canonDAG) op(p dag.Op) {
 			c.expr(p.KeyPruner, "")
 			c.write(")")
 		}
+		if len(p.Fields) > 0 {
+			c.fields(p.Fields)
+		}
 		if p.Filter != nil {
 			c.write(" filter (")
 			c.expr(p.Filter, "")
@@ -525,6 +532,9 @@ func (c *canonDAG) op(p dag.Op) {
 		c.write("file %s", p.Path)
 		if p.Format != "" {
 			c.write(" format %s", p.Format)
+		}
+		if len(p.Fields) > 0 {
+			c.fields(p.Fields)
 		}
 		if p.Filter != nil {
 			c.write(" filter (")
@@ -566,6 +576,15 @@ func (c *canonDAG) op(p dag.Op) {
 		c.open("unknown operator: %T", p)
 		c.close()
 	}
+}
+
+func (c *canonDAG) fields(fields []field.Path) {
+	var ss []string
+	for _, f := range fields {
+		ss = append(ss, f.String())
+	}
+	slices.Sort(ss)
+	c.write(" fields %s", strings.Join(ss, ","))
 }
 
 func (c *canonDAG) over(o *dag.Over) {


### PR DESCRIPTION
Projection pushdown does not include fields referenced in any predicate pushdown, causing the predicate to fail for every value unless the fields it requires are included in the projection for some other reason. Fix that.