### PR TITLE
bring up JOIN USING and make README query work

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -535,8 +535,7 @@ type (
 		Kind       string      `json:"kind" unpack:""`
 		Style      string      `json:"style"`
 		RightInput Seq         `json:"right_input"`
-		LeftKey    Expr        `json:"left_key"`
-		RightKey   Expr        `json:"right_key"`
+		Cond       JoinExpr    `json:"cond"`
 		Args       Assignments `json:"args"`
 		Loc        `json:"loc"`
 	}

--- a/compiler/ast/sql.go
+++ b/compiler/ast/sql.go
@@ -87,24 +87,24 @@ type (
 
 type JoinExpr interface {
 	Node
-	joinOp()
+	joinExpr()
 }
 
-type JoinOn struct {
+type JoinOnExpr struct {
 	Kind string `json:"kind" unpack:""`
 	Expr Expr   `json:"expr"`
 	Loc  `json:"loc"`
 }
 
-func (*JoinOn) joinOp() {}
+func (*JoinOnExpr) joinExpr() {}
 
-type JoinUsing struct {
+type JoinUsingExpr struct {
 	Kind   string `json:"kind" unpack:""`
 	Fields []Expr `json:"fields"`
 	Loc    `json:"loc"`
 }
 
-func (*JoinUsing) joinOp() {}
+func (*JoinUsingExpr) joinExpr() {}
 
 func (*SQLPipe) OpAST()   {}
 func (*Select) OpAST()    {}

--- a/compiler/ast/unpack.go
+++ b/compiler/ast/unpack.go
@@ -109,8 +109,8 @@ var unpacker = unpack.New(
 	OrderBy{},
 	Limit{},
 	With{},
-	JoinOn{},
-	JoinUsing{},
+	JoinOnExpr{},
+	JoinUsingExpr{},
 )
 
 // UnmarshalOp transforms a JSON representation of an operator into an Op.

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -3751,77 +3751,28 @@ var g = &grammar{
 								name: "JoinRightInput",
 							},
 						},
-						&ruleRefExpr{
-							pos:  position{line: 528, col: 52, offset: 12712},
-							name: "ON",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 528, col: 55, offset: 12715},
-							name: "_",
-						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 57, offset: 12717},
-							label: "key",
+							pos:   position{line: 528, col: 52, offset: 12712},
+							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 61, offset: 12721},
-								name: "JoinKey",
+								pos:  position{line: 528, col: 54, offset: 12714},
+								name: "JoinExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 69, offset: 12729},
-							label: "optKey",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 528, col: 76, offset: 12736},
-								expr: &seqExpr{
-									pos: position{line: 528, col: 77, offset: 12737},
-									exprs: []any{
-										&ruleRefExpr{
-											pos:  position{line: 528, col: 77, offset: 12737},
-											name: "__",
-										},
-										&choiceExpr{
-											pos: position{line: 528, col: 81, offset: 12741},
-											alternatives: []any{
-												&litMatcher{
-													pos:        position{line: 528, col: 81, offset: 12741},
-													val:        "==",
-													ignoreCase: false,
-													want:       "\"==\"",
-												},
-												&litMatcher{
-													pos:        position{line: 528, col: 88, offset: 12748},
-													val:        "=",
-													ignoreCase: false,
-													want:       "\"=\"",
-												},
-											},
-										},
-										&ruleRefExpr{
-											pos:  position{line: 528, col: 93, offset: 12753},
-											name: "__",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 528, col: 96, offset: 12756},
-											name: "JoinKey",
-										},
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 528, col: 106, offset: 12766},
+							pos:   position{line: 528, col: 63, offset: 12723},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 528, col: 114, offset: 12774},
+								pos: position{line: 528, col: 71, offset: 12731},
 								expr: &seqExpr{
-									pos: position{line: 528, col: 115, offset: 12775},
+									pos: position{line: 528, col: 72, offset: 12732},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 528, col: 115, offset: 12775},
+											pos:  position{line: 528, col: 72, offset: 12732},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 528, col: 117, offset: 12777},
+											pos:  position{line: 528, col: 74, offset: 12734},
 											name: "FlexAssignments",
 										},
 									},
@@ -3836,83 +3787,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 547, col: 1, offset: 13227},
+			pos:  position{line: 544, col: 1, offset: 13100},
 			expr: &choiceExpr{
-				pos: position{line: 548, col: 5, offset: 13241},
+				pos: position{line: 545, col: 5, offset: 13114},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 13241},
+						pos: position{line: 545, col: 5, offset: 13114},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 548, col: 5, offset: 13241},
+							pos: position{line: 545, col: 5, offset: 13114},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 5, offset: 13241},
+									pos:  position{line: 545, col: 5, offset: 13114},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 10, offset: 13246},
+									pos:  position{line: 545, col: 10, offset: 13119},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 549, col: 5, offset: 13276},
+						pos: position{line: 546, col: 5, offset: 13149},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 549, col: 5, offset: 13276},
+							pos: position{line: 546, col: 5, offset: 13149},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 549, col: 5, offset: 13276},
+									pos:  position{line: 546, col: 5, offset: 13149},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 549, col: 11, offset: 13282},
+									pos:  position{line: 546, col: 11, offset: 13155},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 550, col: 5, offset: 13312},
+						pos: position{line: 547, col: 5, offset: 13185},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 550, col: 5, offset: 13312},
+							pos: position{line: 547, col: 5, offset: 13185},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 5, offset: 13312},
+									pos:  position{line: 547, col: 5, offset: 13185},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 11, offset: 13318},
+									pos:  position{line: 547, col: 11, offset: 13191},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 551, col: 5, offset: 13347},
+						pos: position{line: 548, col: 5, offset: 13220},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 551, col: 5, offset: 13347},
+							pos: position{line: 548, col: 5, offset: 13220},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 551, col: 5, offset: 13347},
+									pos:  position{line: 548, col: 5, offset: 13220},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 551, col: 11, offset: 13353},
+									pos:  position{line: 548, col: 11, offset: 13226},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 552, col: 5, offset: 13383},
+						pos: position{line: 549, col: 5, offset: 13256},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 552, col: 5, offset: 13383},
+							pos:        position{line: 549, col: 5, offset: 13256},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3925,61 +3876,59 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 554, col: 1, offset: 13418},
+			pos:  position{line: 551, col: 1, offset: 13291},
 			expr: &choiceExpr{
-				pos: position{line: 555, col: 5, offset: 13437},
+				pos: position{line: 552, col: 5, offset: 13310},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 555, col: 5, offset: 13437},
+						pos: position{line: 552, col: 5, offset: 13310},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 555, col: 5, offset: 13437},
+							pos: position{line: 552, col: 5, offset: 13310},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 555, col: 5, offset: 13437},
+									pos:  position{line: 552, col: 5, offset: 13310},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 555, col: 8, offset: 13440},
+									pos:        position{line: 552, col: 8, offset: 13313},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 555, col: 12, offset: 13444},
+									pos:  position{line: 552, col: 12, offset: 13317},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 555, col: 15, offset: 13447},
+									pos:   position{line: 552, col: 15, offset: 13320},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 17, offset: 13449},
+										pos:  position{line: 552, col: 17, offset: 13322},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 555, col: 21, offset: 13453},
+									pos:  position{line: 552, col: 21, offset: 13326},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 555, col: 24, offset: 13456},
+									pos:        position{line: 552, col: 24, offset: 13329},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 555, col: 28, offset: 13460},
-									name: "__",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 556, col: 5, offset: 13485},
-						run: (*parser).callonJoinRightInput12,
-						expr: &ruleRefExpr{
-							pos:  position{line: 556, col: 5, offset: 13485},
-							name: "_",
+						pos: position{line: 553, col: 5, offset: 13355},
+						run: (*parser).callonJoinRightInput11,
+						expr: &litMatcher{
+							pos:        position{line: 553, col: 5, offset: 13355},
+							val:        "",
+							ignoreCase: false,
+							want:       "\"\"",
 						},
 					},
 				},
@@ -3989,36 +3938,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 558, col: 1, offset: 13508},
+			pos:  position{line: 555, col: 1, offset: 13379},
 			expr: &choiceExpr{
-				pos: position{line: 559, col: 5, offset: 13520},
+				pos: position{line: 556, col: 5, offset: 13391},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 559, col: 5, offset: 13520},
+						pos:  position{line: 556, col: 5, offset: 13391},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 560, col: 5, offset: 13529},
+						pos: position{line: 557, col: 5, offset: 13400},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 560, col: 5, offset: 13529},
+							pos: position{line: 557, col: 5, offset: 13400},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 560, col: 5, offset: 13529},
+									pos:        position{line: 557, col: 5, offset: 13400},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 560, col: 9, offset: 13533},
+									pos:   position{line: 557, col: 9, offset: 13404},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 560, col: 14, offset: 13538},
+										pos:  position{line: 557, col: 14, offset: 13409},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 560, col: 19, offset: 13543},
+									pos:        position{line: 557, col: 19, offset: 13414},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4033,44 +3982,44 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 562, col: 1, offset: 13569},
+			pos:  position{line: 559, col: 1, offset: 13440},
 			expr: &actionExpr{
-				pos: position{line: 563, col: 5, offset: 13582},
+				pos: position{line: 560, col: 5, offset: 13453},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 563, col: 5, offset: 13582},
+					pos: position{line: 560, col: 5, offset: 13453},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 563, col: 5, offset: 13582},
+							pos:  position{line: 560, col: 5, offset: 13453},
 							name: "SAMPLE",
 						},
 						&andExpr{
-							pos: position{line: 563, col: 12, offset: 13589},
+							pos: position{line: 560, col: 12, offset: 13460},
 							expr: &ruleRefExpr{
-								pos:  position{line: 563, col: 13, offset: 13590},
+								pos:  position{line: 560, col: 13, offset: 13461},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 563, col: 18, offset: 13595},
+							pos:   position{line: 560, col: 18, offset: 13466},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 563, col: 23, offset: 13600},
+								pos: position{line: 560, col: 23, offset: 13471},
 								expr: &actionExpr{
-									pos: position{line: 563, col: 24, offset: 13601},
+									pos: position{line: 560, col: 24, offset: 13472},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 563, col: 24, offset: 13601},
+										pos: position{line: 560, col: 24, offset: 13472},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 563, col: 24, offset: 13601},
+												pos:  position{line: 560, col: 24, offset: 13472},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 563, col: 26, offset: 13603},
+												pos:   position{line: 560, col: 26, offset: 13474},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 563, col: 28, offset: 13605},
+													pos:  position{line: 560, col: 28, offset: 13476},
 													name: "Lval",
 												},
 											},
@@ -4087,15 +4036,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 576, col: 1, offset: 14043},
+			pos:  position{line: 573, col: 1, offset: 13914},
 			expr: &actionExpr{
-				pos: position{line: 577, col: 5, offset: 14060},
+				pos: position{line: 574, col: 5, offset: 13931},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 577, col: 5, offset: 14060},
+					pos:   position{line: 574, col: 5, offset: 13931},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 577, col: 7, offset: 14062},
+						pos:  position{line: 574, col: 7, offset: 13933},
 						name: "Assignments",
 					},
 				},
@@ -4105,69 +4054,69 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 585, col: 1, offset: 14234},
+			pos:  position{line: 582, col: 1, offset: 14105},
 			expr: &actionExpr{
-				pos: position{line: 586, col: 5, offset: 14245},
+				pos: position{line: 583, col: 5, offset: 14116},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 586, col: 5, offset: 14245},
+					pos: position{line: 583, col: 5, offset: 14116},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 5, offset: 14245},
+							pos:  position{line: 583, col: 5, offset: 14116},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 586, col: 10, offset: 14250},
+							pos:  position{line: 583, col: 10, offset: 14121},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 586, col: 12, offset: 14252},
+							pos:   position{line: 583, col: 12, offset: 14123},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 586, col: 17, offset: 14257},
+								pos:  position{line: 583, col: 17, offset: 14128},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 586, col: 22, offset: 14262},
+							pos:   position{line: 583, col: 22, offset: 14133},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 586, col: 29, offset: 14269},
+								pos: position{line: 583, col: 29, offset: 14140},
 								expr: &ruleRefExpr{
-									pos:  position{line: 586, col: 29, offset: 14269},
+									pos:  position{line: 583, col: 29, offset: 14140},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 586, col: 41, offset: 14281},
+							pos:   position{line: 583, col: 41, offset: 14152},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 586, col: 48, offset: 14288},
+								pos: position{line: 583, col: 48, offset: 14159},
 								expr: &ruleRefExpr{
-									pos:  position{line: 586, col: 48, offset: 14288},
+									pos:  position{line: 583, col: 48, offset: 14159},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 586, col: 59, offset: 14299},
+							pos:   position{line: 583, col: 59, offset: 14170},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 586, col: 67, offset: 14307},
+								pos: position{line: 583, col: 67, offset: 14178},
 								expr: &ruleRefExpr{
-									pos:  position{line: 586, col: 67, offset: 14307},
+									pos:  position{line: 583, col: 67, offset: 14178},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 586, col: 79, offset: 14319},
+							pos:   position{line: 583, col: 79, offset: 14190},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 586, col: 84, offset: 14324},
+								pos: position{line: 583, col: 84, offset: 14195},
 								expr: &ruleRefExpr{
-									pos:  position{line: 586, col: 84, offset: 14324},
+									pos:  position{line: 583, col: 84, offset: 14195},
 									name: "MetaArg",
 								},
 							},
@@ -4180,30 +4129,30 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 598, col: 1, offset: 14606},
+			pos:  position{line: 595, col: 1, offset: 14477},
 			expr: &actionExpr{
-				pos: position{line: 599, col: 5, offset: 14620},
+				pos: position{line: 596, col: 5, offset: 14491},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 599, col: 5, offset: 14620},
+					pos: position{line: 596, col: 5, offset: 14491},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 5, offset: 14620},
+							pos:  position{line: 596, col: 5, offset: 14491},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 7, offset: 14622},
+							pos:  position{line: 596, col: 7, offset: 14493},
 							name: "AUTHOR",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 14, offset: 14629},
+							pos:  position{line: 596, col: 14, offset: 14500},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 599, col: 16, offset: 14631},
+							pos:   position{line: 596, col: 16, offset: 14502},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 599, col: 18, offset: 14633},
+								pos:  position{line: 596, col: 18, offset: 14504},
 								name: "Name",
 							},
 						},
@@ -4215,30 +4164,30 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 601, col: 1, offset: 14657},
+			pos:  position{line: 598, col: 1, offset: 14528},
 			expr: &actionExpr{
-				pos: position{line: 602, col: 5, offset: 14672},
+				pos: position{line: 599, col: 5, offset: 14543},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 602, col: 5, offset: 14672},
+					pos: position{line: 599, col: 5, offset: 14543},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 602, col: 5, offset: 14672},
+							pos:  position{line: 599, col: 5, offset: 14543},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 602, col: 7, offset: 14674},
+							pos:  position{line: 599, col: 7, offset: 14545},
 							name: "MESSAGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 602, col: 15, offset: 14682},
+							pos:  position{line: 599, col: 15, offset: 14553},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 602, col: 17, offset: 14684},
+							pos:   position{line: 599, col: 17, offset: 14555},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 602, col: 19, offset: 14686},
+								pos:  position{line: 599, col: 19, offset: 14557},
 								name: "Name",
 							},
 						},
@@ -4250,30 +4199,30 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 604, col: 1, offset: 14710},
+			pos:  position{line: 601, col: 1, offset: 14581},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 5, offset: 14722},
+				pos: position{line: 602, col: 5, offset: 14593},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 5, offset: 14722},
+					pos: position{line: 602, col: 5, offset: 14593},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 5, offset: 14722},
+							pos:  position{line: 602, col: 5, offset: 14593},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 7, offset: 14724},
+							pos:  position{line: 602, col: 7, offset: 14595},
 							name: "META",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 12, offset: 14729},
+							pos:  position{line: 602, col: 12, offset: 14600},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 605, col: 14, offset: 14731},
+							pos:   position{line: 602, col: 14, offset: 14602},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 605, col: 16, offset: 14733},
+								pos:  position{line: 602, col: 16, offset: 14604},
 								name: "Name",
 							},
 						},
@@ -4285,24 +4234,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 607, col: 1, offset: 14757},
+			pos:  position{line: 604, col: 1, offset: 14628},
 			expr: &actionExpr{
-				pos: position{line: 608, col: 5, offset: 14772},
+				pos: position{line: 605, col: 5, offset: 14643},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 608, col: 5, offset: 14772},
+					pos: position{line: 605, col: 5, offset: 14643},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 608, col: 5, offset: 14772},
+							pos:        position{line: 605, col: 5, offset: 14643},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 608, col: 9, offset: 14776},
+							pos:   position{line: 605, col: 9, offset: 14647},
 							label: "branch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 608, col: 16, offset: 14783},
+								pos:  position{line: 605, col: 16, offset: 14654},
 								name: "Name",
 							},
 						},
@@ -4314,26 +4263,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 610, col: 1, offset: 14812},
+			pos:  position{line: 607, col: 1, offset: 14683},
 			expr: &actionExpr{
-				pos: position{line: 611, col: 5, offset: 14825},
+				pos: position{line: 608, col: 5, offset: 14696},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 611, col: 5, offset: 14825},
+					pos: position{line: 608, col: 5, offset: 14696},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 611, col: 5, offset: 14825},
+							pos:  position{line: 608, col: 5, offset: 14696},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 611, col: 12, offset: 14832},
+							pos:  position{line: 608, col: 12, offset: 14703},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 14, offset: 14834},
+							pos:   position{line: 608, col: 14, offset: 14705},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 19, offset: 14839},
+								pos:  position{line: 608, col: 19, offset: 14710},
 								name: "Identifier",
 							},
 						},
@@ -4345,44 +4294,44 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 619, col: 1, offset: 14973},
+			pos:  position{line: 616, col: 1, offset: 14844},
 			expr: &actionExpr{
-				pos: position{line: 620, col: 5, offset: 14985},
+				pos: position{line: 617, col: 5, offset: 14856},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 620, col: 5, offset: 14985},
+					pos: position{line: 617, col: 5, offset: 14856},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 620, col: 5, offset: 14985},
+							pos:  position{line: 617, col: 5, offset: 14856},
 							name: "DEBUG",
 						},
 						&andExpr{
-							pos: position{line: 620, col: 11, offset: 14991},
+							pos: position{line: 617, col: 11, offset: 14862},
 							expr: &ruleRefExpr{
-								pos:  position{line: 620, col: 12, offset: 14992},
+								pos:  position{line: 617, col: 12, offset: 14863},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 620, col: 17, offset: 14997},
+							pos:   position{line: 617, col: 17, offset: 14868},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 620, col: 22, offset: 15002},
+								pos: position{line: 617, col: 22, offset: 14873},
 								expr: &actionExpr{
-									pos: position{line: 620, col: 23, offset: 15003},
+									pos: position{line: 617, col: 23, offset: 14874},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 620, col: 23, offset: 15003},
+										pos: position{line: 617, col: 23, offset: 14874},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 620, col: 23, offset: 15003},
+												pos:  position{line: 617, col: 23, offset: 14874},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 620, col: 25, offset: 15005},
+												pos:   position{line: 617, col: 25, offset: 14876},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 620, col: 27, offset: 15007},
+													pos:  position{line: 617, col: 27, offset: 14878},
 													name: "Expr",
 												},
 											},
@@ -4399,26 +4348,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 631, col: 1, offset: 15200},
+			pos:  position{line: 628, col: 1, offset: 15071},
 			expr: &actionExpr{
-				pos: position{line: 632, col: 5, offset: 15211},
+				pos: position{line: 629, col: 5, offset: 15082},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 632, col: 5, offset: 15211},
+					pos: position{line: 629, col: 5, offset: 15082},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 632, col: 5, offset: 15211},
+							pos:  position{line: 629, col: 5, offset: 15082},
 							name: "FromKeyWord",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 632, col: 17, offset: 15223},
+							pos:  position{line: 629, col: 17, offset: 15094},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 632, col: 19, offset: 15225},
+							pos:   position{line: 629, col: 19, offset: 15096},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 632, col: 25, offset: 15231},
+								pos:  position{line: 629, col: 25, offset: 15102},
 								name: "FromElems",
 							},
 						},
@@ -4430,16 +4379,16 @@ var g = &grammar{
 		},
 		{
 			name: "FromKeyWord",
-			pos:  position{line: 640, col: 1, offset: 15374},
+			pos:  position{line: 637, col: 1, offset: 15245},
 			expr: &choiceExpr{
-				pos: position{line: 641, col: 5, offset: 15390},
+				pos: position{line: 638, col: 5, offset: 15261},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 641, col: 5, offset: 15390},
+						pos:  position{line: 638, col: 5, offset: 15261},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 642, col: 5, offset: 15399},
+						pos:  position{line: 639, col: 5, offset: 15270},
 						name: "DeprecatedFroms",
 					},
 				},
@@ -4449,24 +4398,24 @@ var g = &grammar{
 		},
 		{
 			name: "DeprecatedFroms",
-			pos:  position{line: 644, col: 1, offset: 15416},
+			pos:  position{line: 641, col: 1, offset: 15287},
 			expr: &choiceExpr{
-				pos: position{line: 644, col: 19, offset: 15434},
+				pos: position{line: 641, col: 19, offset: 15305},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 644, col: 19, offset: 15434},
+						pos:        position{line: 641, col: 19, offset: 15305},
 						val:        "get",
 						ignoreCase: false,
 						want:       "\"get\"",
 					},
 					&litMatcher{
-						pos:        position{line: 644, col: 27, offset: 15442},
+						pos:        position{line: 641, col: 27, offset: 15313},
 						val:        "file",
 						ignoreCase: false,
 						want:       "\"file\"",
 					},
 					&litMatcher{
-						pos:        position{line: 644, col: 36, offset: 15451},
+						pos:        position{line: 641, col: 36, offset: 15322},
 						val:        "pool",
 						ignoreCase: false,
 						want:       "\"pool\"",
@@ -4478,51 +4427,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 646, col: 1, offset: 15459},
+			pos:  position{line: 643, col: 1, offset: 15330},
 			expr: &actionExpr{
-				pos: position{line: 647, col: 5, offset: 15473},
+				pos: position{line: 644, col: 5, offset: 15344},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 647, col: 5, offset: 15473},
+					pos: position{line: 644, col: 5, offset: 15344},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 647, col: 5, offset: 15473},
+							pos:   position{line: 644, col: 5, offset: 15344},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 647, col: 11, offset: 15479},
+								pos:  position{line: 644, col: 11, offset: 15350},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 647, col: 20, offset: 15488},
+							pos:   position{line: 644, col: 20, offset: 15359},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 647, col: 25, offset: 15493},
+								pos: position{line: 644, col: 25, offset: 15364},
 								expr: &actionExpr{
-									pos: position{line: 647, col: 27, offset: 15495},
+									pos: position{line: 644, col: 27, offset: 15366},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 647, col: 27, offset: 15495},
+										pos: position{line: 644, col: 27, offset: 15366},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 647, col: 27, offset: 15495},
+												pos:  position{line: 644, col: 27, offset: 15366},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 647, col: 30, offset: 15498},
+												pos:        position{line: 644, col: 30, offset: 15369},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 647, col: 34, offset: 15502},
+												pos:  position{line: 644, col: 34, offset: 15373},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 647, col: 37, offset: 15505},
+												pos:   position{line: 644, col: 37, offset: 15376},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 647, col: 42, offset: 15510},
+													pos:  position{line: 644, col: 42, offset: 15381},
 													name: "FromElem",
 												},
 											},
@@ -4539,42 +4488,42 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 651, col: 1, offset: 15594},
+			pos:  position{line: 648, col: 1, offset: 15465},
 			expr: &actionExpr{
-				pos: position{line: 652, col: 5, offset: 15607},
+				pos: position{line: 649, col: 5, offset: 15478},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 652, col: 5, offset: 15607},
+					pos: position{line: 649, col: 5, offset: 15478},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 652, col: 5, offset: 15607},
+							pos:   position{line: 649, col: 5, offset: 15478},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 12, offset: 15614},
+								pos:  position{line: 649, col: 12, offset: 15485},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 23, offset: 15625},
+							pos:   position{line: 649, col: 23, offset: 15496},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 28, offset: 15630},
+								pos:  position{line: 649, col: 28, offset: 15501},
 								name: "FromArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 37, offset: 15639},
+							pos:   position{line: 649, col: 37, offset: 15510},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 39, offset: 15641},
+								pos:  position{line: 649, col: 39, offset: 15512},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 53, offset: 15655},
+							pos:   position{line: 649, col: 53, offset: 15526},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 59, offset: 15661},
+								pos:  position{line: 649, col: 59, offset: 15532},
 								name: "OptAlias",
 							},
 						},
@@ -4586,46 +4535,46 @@ var g = &grammar{
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 670, col: 1, offset: 16049},
+			pos:  position{line: 667, col: 1, offset: 15920},
 			expr: &choiceExpr{
-				pos: position{line: 671, col: 5, offset: 16064},
+				pos: position{line: 668, col: 5, offset: 15935},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 671, col: 5, offset: 16064},
+						pos: position{line: 668, col: 5, offset: 15935},
 						run: (*parser).callonFromEntity2,
 						expr: &labeledExpr{
-							pos:   position{line: 671, col: 5, offset: 16064},
+							pos:   position{line: 668, col: 5, offset: 15935},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 671, col: 9, offset: 16068},
+								pos:  position{line: 668, col: 9, offset: 15939},
 								name: "UnquotedURL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 678, col: 5, offset: 16200},
+						pos:  position{line: 675, col: 5, offset: 16071},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 679, col: 5, offset: 16211},
+						pos:  position{line: 676, col: 5, offset: 16082},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 680, col: 5, offset: 16220},
+						pos: position{line: 677, col: 5, offset: 16091},
 						run: (*parser).callonFromEntity7,
 						expr: &seqExpr{
-							pos: position{line: 680, col: 5, offset: 16220},
+							pos: position{line: 677, col: 5, offset: 16091},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 680, col: 5, offset: 16220},
+									pos:        position{line: 677, col: 5, offset: 16091},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 680, col: 9, offset: 16224},
+									pos: position{line: 677, col: 9, offset: 16095},
 									expr: &ruleRefExpr{
-										pos:  position{line: 680, col: 10, offset: 16225},
+										pos:  position{line: 677, col: 10, offset: 16096},
 										name: "ExprGuard",
 									},
 								},
@@ -4633,43 +4582,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 16306},
+						pos: position{line: 678, col: 5, offset: 16177},
 						run: (*parser).callonFromEntity12,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 5, offset: 16306},
+							pos: position{line: 678, col: 5, offset: 16177},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 5, offset: 16306},
+									pos:  position{line: 678, col: 5, offset: 16177},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 10, offset: 16311},
+									pos:  position{line: 678, col: 10, offset: 16182},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 681, col: 13, offset: 16314},
+									pos:        position{line: 678, col: 13, offset: 16185},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 17, offset: 16318},
+									pos:  position{line: 678, col: 17, offset: 16189},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 681, col: 20, offset: 16321},
+									pos:   position{line: 678, col: 20, offset: 16192},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 681, col: 22, offset: 16323},
+										pos:  position{line: 678, col: 22, offset: 16194},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 27, offset: 16328},
+									pos:  position{line: 678, col: 27, offset: 16199},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 681, col: 30, offset: 16331},
+									pos:        position{line: 678, col: 30, offset: 16202},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4678,35 +4627,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 16467},
+						pos: position{line: 685, col: 5, offset: 16338},
 						run: (*parser).callonFromEntity22,
 						expr: &labeledExpr{
-							pos:   position{line: 688, col: 5, offset: 16467},
+							pos:   position{line: 685, col: 5, offset: 16338},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 688, col: 10, offset: 16472},
+								pos:  position{line: 685, col: 10, offset: 16343},
 								name: "PoolMeta",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 16615},
+						pos: position{line: 692, col: 5, offset: 16486},
 						run: (*parser).callonFromEntity25,
 						expr: &seqExpr{
-							pos: position{line: 695, col: 5, offset: 16615},
+							pos: position{line: 692, col: 5, offset: 16486},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 695, col: 5, offset: 16615},
+									pos:   position{line: 692, col: 5, offset: 16486},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 695, col: 10, offset: 16620},
+										pos:  position{line: 692, col: 10, offset: 16491},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 695, col: 24, offset: 16634},
+									pos: position{line: 692, col: 24, offset: 16505},
 									expr: &ruleRefExpr{
-										pos:  position{line: 695, col: 25, offset: 16635},
+										pos:  position{line: 692, col: 25, offset: 16506},
 										name: "AliasClause",
 									},
 								},
@@ -4714,35 +4663,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 696, col: 5, offset: 16670},
+						pos: position{line: 693, col: 5, offset: 16541},
 						run: (*parser).callonFromEntity31,
 						expr: &seqExpr{
-							pos: position{line: 696, col: 5, offset: 16670},
+							pos: position{line: 693, col: 5, offset: 16541},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 696, col: 5, offset: 16670},
+									pos:        position{line: 693, col: 5, offset: 16541},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 696, col: 9, offset: 16674},
+									pos:  position{line: 693, col: 9, offset: 16545},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 696, col: 12, offset: 16677},
+									pos:   position{line: 693, col: 12, offset: 16548},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 696, col: 17, offset: 16682},
+										pos:  position{line: 693, col: 17, offset: 16553},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 696, col: 31, offset: 16696},
+									pos:  position{line: 693, col: 31, offset: 16567},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 696, col: 34, offset: 16699},
+									pos:        position{line: 693, col: 34, offset: 16570},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4751,35 +4700,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 697, col: 5, offset: 16728},
+						pos: position{line: 694, col: 5, offset: 16599},
 						run: (*parser).callonFromEntity39,
 						expr: &seqExpr{
-							pos: position{line: 697, col: 5, offset: 16728},
+							pos: position{line: 694, col: 5, offset: 16599},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 697, col: 5, offset: 16728},
+									pos:        position{line: 694, col: 5, offset: 16599},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 697, col: 9, offset: 16732},
+									pos:  position{line: 694, col: 9, offset: 16603},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 697, col: 12, offset: 16735},
+									pos:   position{line: 694, col: 12, offset: 16606},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 697, col: 14, offset: 16737},
+										pos:  position{line: 694, col: 14, offset: 16608},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 697, col: 22, offset: 16745},
+									pos:  position{line: 694, col: 22, offset: 16616},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 697, col: 25, offset: 16748},
+									pos:        position{line: 694, col: 25, offset: 16619},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4788,13 +4737,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 6, offset: 16785},
+						pos: position{line: 697, col: 6, offset: 16656},
 						run: (*parser).callonFromEntity47,
 						expr: &labeledExpr{
-							pos:   position{line: 700, col: 6, offset: 16785},
+							pos:   position{line: 697, col: 6, offset: 16656},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 700, col: 11, offset: 16790},
+								pos:  position{line: 697, col: 11, offset: 16661},
 								name: "Name",
 							},
 						},
@@ -4806,40 +4755,40 @@ var g = &grammar{
 		},
 		{
 			name: "FromArgs",
-			pos:  position{line: 703, col: 1, offset: 16888},
+			pos:  position{line: 700, col: 1, offset: 16759},
 			expr: &choiceExpr{
-				pos: position{line: 704, col: 5, offset: 16901},
+				pos: position{line: 701, col: 5, offset: 16772},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 704, col: 5, offset: 16901},
+						pos: position{line: 701, col: 5, offset: 16772},
 						run: (*parser).callonFromArgs2,
 						expr: &seqExpr{
-							pos: position{line: 704, col: 5, offset: 16901},
+							pos: position{line: 701, col: 5, offset: 16772},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 704, col: 5, offset: 16901},
+									pos:   position{line: 701, col: 5, offset: 16772},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 704, col: 12, offset: 16908},
+										pos:  position{line: 701, col: 12, offset: 16779},
 										name: "PoolCommit",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 704, col: 23, offset: 16919},
+									pos:   position{line: 701, col: 23, offset: 16790},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 704, col: 28, offset: 16924},
+										pos: position{line: 701, col: 28, offset: 16795},
 										expr: &ruleRefExpr{
-											pos:  position{line: 704, col: 28, offset: 16924},
+											pos:  position{line: 701, col: 28, offset: 16795},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 704, col: 38, offset: 16934},
+									pos:   position{line: 701, col: 38, offset: 16805},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 704, col: 42, offset: 16938},
+										pos:  position{line: 701, col: 42, offset: 16809},
 										name: "TapArg",
 									},
 								},
@@ -4847,24 +4796,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 17142},
+						pos: position{line: 710, col: 5, offset: 17013},
 						run: (*parser).callonFromArgs11,
 						expr: &seqExpr{
-							pos: position{line: 713, col: 5, offset: 17142},
+							pos: position{line: 710, col: 5, offset: 17013},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 713, col: 5, offset: 17142},
+									pos:   position{line: 710, col: 5, offset: 17013},
 									label: "meta",
 									expr: &ruleRefExpr{
-										pos:  position{line: 713, col: 10, offset: 17147},
+										pos:  position{line: 710, col: 10, offset: 17018},
 										name: "PoolMeta",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 713, col: 19, offset: 17156},
+									pos:   position{line: 710, col: 19, offset: 17027},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 713, col: 23, offset: 17160},
+										pos:  position{line: 710, col: 23, offset: 17031},
 										name: "TapArg",
 									},
 								},
@@ -4872,41 +4821,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 721, col: 5, offset: 17326},
+						pos: position{line: 718, col: 5, offset: 17197},
 						run: (*parser).callonFromArgs17,
 						expr: &seqExpr{
-							pos: position{line: 721, col: 5, offset: 17326},
+							pos: position{line: 718, col: 5, offset: 17197},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 721, col: 5, offset: 17326},
+									pos:   position{line: 718, col: 5, offset: 17197},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 721, col: 12, offset: 17333},
+										pos:  position{line: 718, col: 12, offset: 17204},
 										name: "FormatArg",
 									},
 								},
 								&notExpr{
-									pos: position{line: 721, col: 22, offset: 17343},
+									pos: position{line: 718, col: 22, offset: 17214},
 									expr: &seqExpr{
-										pos: position{line: 721, col: 24, offset: 17345},
+										pos: position{line: 718, col: 24, offset: 17216},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 721, col: 24, offset: 17345},
+												pos:  position{line: 718, col: 24, offset: 17216},
 												name: "_",
 											},
 											&choiceExpr{
-												pos: position{line: 721, col: 27, offset: 17348},
+												pos: position{line: 718, col: 27, offset: 17219},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 721, col: 27, offset: 17348},
+														pos:  position{line: 718, col: 27, offset: 17219},
 														name: "METHOD",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 721, col: 36, offset: 17357},
+														pos:  position{line: 718, col: 36, offset: 17228},
 														name: "HEADERS",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 721, col: 46, offset: 17367},
+														pos:  position{line: 718, col: 46, offset: 17238},
 														name: "BODY",
 													},
 												},
@@ -4918,51 +4867,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 728, col: 5, offset: 17512},
+						pos: position{line: 725, col: 5, offset: 17383},
 						run: (*parser).callonFromArgs28,
 						expr: &seqExpr{
-							pos: position{line: 728, col: 5, offset: 17512},
+							pos: position{line: 725, col: 5, offset: 17383},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 728, col: 5, offset: 17512},
+									pos:   position{line: 725, col: 5, offset: 17383},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 728, col: 12, offset: 17519},
+										pos: position{line: 725, col: 12, offset: 17390},
 										expr: &ruleRefExpr{
-											pos:  position{line: 728, col: 12, offset: 17519},
+											pos:  position{line: 725, col: 12, offset: 17390},
 											name: "FormatArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 23, offset: 17530},
+									pos:   position{line: 725, col: 23, offset: 17401},
 									label: "method",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 728, col: 30, offset: 17537},
+										pos: position{line: 725, col: 30, offset: 17408},
 										expr: &ruleRefExpr{
-											pos:  position{line: 728, col: 30, offset: 17537},
+											pos:  position{line: 725, col: 30, offset: 17408},
 											name: "MethodArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 41, offset: 17548},
+									pos:   position{line: 725, col: 41, offset: 17419},
 									label: "headers",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 728, col: 49, offset: 17556},
+										pos: position{line: 725, col: 49, offset: 17427},
 										expr: &ruleRefExpr{
-											pos:  position{line: 728, col: 49, offset: 17556},
+											pos:  position{line: 725, col: 49, offset: 17427},
 											name: "HeadersArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 61, offset: 17568},
+									pos:   position{line: 725, col: 61, offset: 17439},
 									label: "body",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 728, col: 66, offset: 17573},
+										pos: position{line: 725, col: 66, offset: 17444},
 										expr: &ruleRefExpr{
-											pos:  position{line: 728, col: 66, offset: 17573},
+											pos:  position{line: 725, col: 66, offset: 17444},
 											name: "BodyArg",
 										},
 									},
@@ -4977,30 +4926,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 745, col: 1, offset: 17989},
+			pos:  position{line: 742, col: 1, offset: 17860},
 			expr: &actionExpr{
-				pos: position{line: 745, col: 13, offset: 18001},
+				pos: position{line: 742, col: 13, offset: 17872},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 745, col: 13, offset: 18001},
+					pos: position{line: 742, col: 13, offset: 17872},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 745, col: 13, offset: 18001},
+							pos:  position{line: 742, col: 13, offset: 17872},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 745, col: 15, offset: 18003},
+							pos:  position{line: 742, col: 15, offset: 17874},
 							name: "FORMAT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 745, col: 22, offset: 18010},
+							pos:  position{line: 742, col: 22, offset: 17881},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 745, col: 24, offset: 18012},
+							pos:   position{line: 742, col: 24, offset: 17883},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 745, col: 26, offset: 18014},
+								pos:  position{line: 742, col: 26, offset: 17885},
 								name: "Name",
 							},
 						},
@@ -5012,30 +4961,30 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 747, col: 1, offset: 18038},
+			pos:  position{line: 744, col: 1, offset: 17909},
 			expr: &actionExpr{
-				pos: position{line: 747, col: 13, offset: 18050},
+				pos: position{line: 744, col: 13, offset: 17921},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 747, col: 13, offset: 18050},
+					pos: position{line: 744, col: 13, offset: 17921},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 747, col: 13, offset: 18050},
+							pos:  position{line: 744, col: 13, offset: 17921},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 747, col: 15, offset: 18052},
+							pos:  position{line: 744, col: 15, offset: 17923},
 							name: "METHOD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 747, col: 22, offset: 18059},
+							pos:  position{line: 744, col: 22, offset: 17930},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 747, col: 24, offset: 18061},
+							pos:   position{line: 744, col: 24, offset: 17932},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 747, col: 26, offset: 18063},
+								pos:  position{line: 744, col: 26, offset: 17934},
 								name: "Name",
 							},
 						},
@@ -5047,30 +4996,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 749, col: 1, offset: 18087},
+			pos:  position{line: 746, col: 1, offset: 17958},
 			expr: &actionExpr{
-				pos: position{line: 749, col: 14, offset: 18100},
+				pos: position{line: 746, col: 14, offset: 17971},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 749, col: 14, offset: 18100},
+					pos: position{line: 746, col: 14, offset: 17971},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 749, col: 14, offset: 18100},
+							pos:  position{line: 746, col: 14, offset: 17971},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 749, col: 16, offset: 18102},
+							pos:  position{line: 746, col: 16, offset: 17973},
 							name: "HEADERS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 749, col: 24, offset: 18110},
+							pos:  position{line: 746, col: 24, offset: 17981},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 749, col: 26, offset: 18112},
+							pos:   position{line: 746, col: 26, offset: 17983},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 749, col: 28, offset: 18114},
+								pos:  position{line: 746, col: 28, offset: 17985},
 								name: "Record",
 							},
 						},
@@ -5082,30 +5031,30 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 751, col: 1, offset: 18140},
+			pos:  position{line: 748, col: 1, offset: 18011},
 			expr: &actionExpr{
-				pos: position{line: 751, col: 11, offset: 18150},
+				pos: position{line: 748, col: 11, offset: 18021},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 751, col: 11, offset: 18150},
+					pos: position{line: 748, col: 11, offset: 18021},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 751, col: 11, offset: 18150},
+							pos:  position{line: 748, col: 11, offset: 18021},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 751, col: 13, offset: 18152},
+							pos:  position{line: 748, col: 13, offset: 18023},
 							name: "BODY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 751, col: 18, offset: 18157},
+							pos:  position{line: 748, col: 18, offset: 18028},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 751, col: 20, offset: 18159},
+							pos:   position{line: 748, col: 20, offset: 18030},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 751, col: 22, offset: 18161},
+								pos:  position{line: 748, col: 22, offset: 18032},
 								name: "Name",
 							},
 						},
@@ -5117,24 +5066,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 753, col: 1, offset: 18185},
+			pos:  position{line: 750, col: 1, offset: 18056},
 			expr: &actionExpr{
-				pos: position{line: 753, col: 15, offset: 18199},
+				pos: position{line: 750, col: 15, offset: 18070},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 753, col: 15, offset: 18199},
+					pos: position{line: 750, col: 15, offset: 18070},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 753, col: 16, offset: 18200},
+							pos: position{line: 750, col: 16, offset: 18071},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 753, col: 16, offset: 18200},
+									pos:        position{line: 750, col: 16, offset: 18071},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 753, col: 28, offset: 18212},
+									pos:        position{line: 750, col: 28, offset: 18083},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
@@ -5142,9 +5091,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 753, col: 40, offset: 18224},
+							pos: position{line: 750, col: 40, offset: 18095},
 							expr: &ruleRefExpr{
-								pos:  position{line: 753, col: 40, offset: 18224},
+								pos:  position{line: 750, col: 40, offset: 18095},
 								name: "URLChar",
 							},
 						},
@@ -5156,9 +5105,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 755, col: 1, offset: 18265},
+			pos:  position{line: 752, col: 1, offset: 18136},
 			expr: &charClassMatcher{
-				pos:        position{line: 755, col: 11, offset: 18275},
+				pos:        position{line: 752, col: 11, offset: 18146},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -5170,30 +5119,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 758, col: 1, offset: 18339},
+			pos:  position{line: 755, col: 1, offset: 18210},
 			expr: &actionExpr{
-				pos: position{line: 759, col: 5, offset: 18350},
+				pos: position{line: 756, col: 5, offset: 18221},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 759, col: 5, offset: 18350},
+					pos: position{line: 756, col: 5, offset: 18221},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 759, col: 5, offset: 18350},
+							pos:  position{line: 756, col: 5, offset: 18221},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 759, col: 7, offset: 18352},
+							pos:  position{line: 756, col: 7, offset: 18223},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 759, col: 10, offset: 18355},
+							pos:  position{line: 756, col: 10, offset: 18226},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 759, col: 12, offset: 18357},
+							pos:   position{line: 756, col: 12, offset: 18228},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 759, col: 15, offset: 18360},
+								pos:  position{line: 756, col: 15, offset: 18231},
 								name: "KSUID",
 							},
 						},
@@ -5205,14 +5154,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 762, col: 1, offset: 18426},
+			pos:  position{line: 759, col: 1, offset: 18297},
 			expr: &actionExpr{
-				pos: position{line: 762, col: 9, offset: 18434},
+				pos: position{line: 759, col: 9, offset: 18305},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 762, col: 9, offset: 18434},
+					pos: position{line: 759, col: 9, offset: 18305},
 					expr: &charClassMatcher{
-						pos:        position{line: 762, col: 10, offset: 18435},
+						pos:        position{line: 759, col: 10, offset: 18306},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -5225,24 +5174,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 764, col: 1, offset: 18481},
+			pos:  position{line: 761, col: 1, offset: 18352},
 			expr: &actionExpr{
-				pos: position{line: 765, col: 5, offset: 18496},
+				pos: position{line: 762, col: 5, offset: 18367},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 765, col: 5, offset: 18496},
+					pos: position{line: 762, col: 5, offset: 18367},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 765, col: 5, offset: 18496},
+							pos:        position{line: 762, col: 5, offset: 18367},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 9, offset: 18500},
+							pos:   position{line: 762, col: 9, offset: 18371},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 765, col: 11, offset: 18502},
+								pos:  position{line: 762, col: 11, offset: 18373},
 								name: "Name",
 							},
 						},
@@ -5254,24 +5203,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 767, col: 1, offset: 18526},
+			pos:  position{line: 764, col: 1, offset: 18397},
 			expr: &actionExpr{
-				pos: position{line: 768, col: 5, offset: 18539},
+				pos: position{line: 765, col: 5, offset: 18410},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 768, col: 5, offset: 18539},
+					pos: position{line: 765, col: 5, offset: 18410},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 768, col: 5, offset: 18539},
+							pos:        position{line: 765, col: 5, offset: 18410},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 9, offset: 18543},
+							pos:   position{line: 765, col: 9, offset: 18414},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 11, offset: 18545},
+								pos:  position{line: 765, col: 11, offset: 18416},
 								name: "Name",
 							},
 						},
@@ -5283,51 +5232,51 @@ var g = &grammar{
 		},
 		{
 			name: "SortExprs",
-			pos:  position{line: 770, col: 1, offset: 18569},
+			pos:  position{line: 767, col: 1, offset: 18440},
 			expr: &actionExpr{
-				pos: position{line: 771, col: 5, offset: 18583},
+				pos: position{line: 768, col: 5, offset: 18454},
 				run: (*parser).callonSortExprs1,
 				expr: &seqExpr{
-					pos: position{line: 771, col: 5, offset: 18583},
+					pos: position{line: 768, col: 5, offset: 18454},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 771, col: 5, offset: 18583},
+							pos:   position{line: 768, col: 5, offset: 18454},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 771, col: 11, offset: 18589},
+								pos:  position{line: 768, col: 11, offset: 18460},
 								name: "SortExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 771, col: 20, offset: 18598},
+							pos:   position{line: 768, col: 20, offset: 18469},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 771, col: 25, offset: 18603},
+								pos: position{line: 768, col: 25, offset: 18474},
 								expr: &actionExpr{
-									pos: position{line: 771, col: 26, offset: 18604},
+									pos: position{line: 768, col: 26, offset: 18475},
 									run: (*parser).callonSortExprs7,
 									expr: &seqExpr{
-										pos: position{line: 771, col: 26, offset: 18604},
+										pos: position{line: 768, col: 26, offset: 18475},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 771, col: 26, offset: 18604},
+												pos:  position{line: 768, col: 26, offset: 18475},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 771, col: 29, offset: 18607},
+												pos:        position{line: 768, col: 29, offset: 18478},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 771, col: 33, offset: 18611},
+												pos:  position{line: 768, col: 33, offset: 18482},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 771, col: 36, offset: 18614},
+												pos:   position{line: 768, col: 36, offset: 18485},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 771, col: 38, offset: 18616},
+													pos:  position{line: 768, col: 38, offset: 18487},
 													name: "SortExpr",
 												},
 											},
@@ -5344,41 +5293,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortExpr",
-			pos:  position{line: 775, col: 1, offset: 18693},
+			pos:  position{line: 772, col: 1, offset: 18564},
 			expr: &actionExpr{
-				pos: position{line: 776, col: 5, offset: 18706},
+				pos: position{line: 773, col: 5, offset: 18577},
 				run: (*parser).callonSortExpr1,
 				expr: &seqExpr{
-					pos: position{line: 776, col: 5, offset: 18706},
+					pos: position{line: 773, col: 5, offset: 18577},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 776, col: 5, offset: 18706},
+							pos:   position{line: 773, col: 5, offset: 18577},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 776, col: 7, offset: 18708},
+								pos:  position{line: 773, col: 7, offset: 18579},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 776, col: 12, offset: 18713},
+							pos:   position{line: 773, col: 12, offset: 18584},
 							label: "order",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 776, col: 18, offset: 18719},
+								pos: position{line: 773, col: 18, offset: 18590},
 								expr: &actionExpr{
-									pos: position{line: 776, col: 19, offset: 18720},
+									pos: position{line: 773, col: 19, offset: 18591},
 									run: (*parser).callonSortExpr7,
 									expr: &seqExpr{
-										pos: position{line: 776, col: 19, offset: 18720},
+										pos: position{line: 773, col: 19, offset: 18591},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 776, col: 19, offset: 18720},
+												pos:  position{line: 773, col: 19, offset: 18591},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 776, col: 21, offset: 18722},
+												pos:   position{line: 773, col: 21, offset: 18593},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 776, col: 23, offset: 18724},
+													pos:  position{line: 773, col: 23, offset: 18595},
 													name: "OrderSpec",
 												},
 											},
@@ -5395,22 +5344,22 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSpec",
-			pos:  position{line: 784, col: 1, offset: 18923},
+			pos:  position{line: 781, col: 1, offset: 18794},
 			expr: &actionExpr{
-				pos: position{line: 785, col: 5, offset: 18937},
+				pos: position{line: 782, col: 5, offset: 18808},
 				run: (*parser).callonOrderSpec1,
 				expr: &labeledExpr{
-					pos:   position{line: 785, col: 5, offset: 18937},
+					pos:   position{line: 782, col: 5, offset: 18808},
 					label: "o",
 					expr: &choiceExpr{
-						pos: position{line: 785, col: 8, offset: 18940},
+						pos: position{line: 782, col: 8, offset: 18811},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 785, col: 8, offset: 18940},
+								pos:  position{line: 782, col: 8, offset: 18811},
 								name: "ASC",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 785, col: 14, offset: 18946},
+								pos:  position{line: 782, col: 14, offset: 18817},
 								name: "DESC",
 							},
 						},
@@ -5422,32 +5371,32 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 789, col: 1, offset: 19030},
+			pos:  position{line: 786, col: 1, offset: 18901},
 			expr: &choiceExpr{
-				pos: position{line: 790, col: 5, offset: 19041},
+				pos: position{line: 787, col: 5, offset: 18912},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 790, col: 5, offset: 19041},
+						pos: position{line: 787, col: 5, offset: 18912},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 790, col: 5, offset: 19041},
+							pos: position{line: 787, col: 5, offset: 18912},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 790, col: 5, offset: 19041},
+									pos:  position{line: 787, col: 5, offset: 18912},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 790, col: 7, offset: 19043},
+									pos:  position{line: 787, col: 7, offset: 18914},
 									name: "TAP",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 791, col: 5, offset: 19072},
+						pos: position{line: 788, col: 5, offset: 18943},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 791, col: 5, offset: 19072},
+							pos:        position{line: 788, col: 5, offset: 18943},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -5460,28 +5409,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 793, col: 1, offset: 19098},
+			pos:  position{line: 790, col: 1, offset: 18969},
 			expr: &actionExpr{
-				pos: position{line: 794, col: 5, offset: 19109},
+				pos: position{line: 791, col: 5, offset: 18980},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 794, col: 5, offset: 19109},
+					pos: position{line: 791, col: 5, offset: 18980},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 794, col: 5, offset: 19109},
+							pos:  position{line: 791, col: 5, offset: 18980},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 794, col: 10, offset: 19114},
+							pos: position{line: 791, col: 10, offset: 18985},
 							expr: &seqExpr{
-								pos: position{line: 794, col: 12, offset: 19116},
+								pos: position{line: 791, col: 12, offset: 18987},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 794, col: 12, offset: 19116},
+										pos:  position{line: 791, col: 12, offset: 18987},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 794, col: 15, offset: 19119},
+										pos:        position{line: 791, col: 15, offset: 18990},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5490,9 +5439,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 794, col: 20, offset: 19124},
+							pos: position{line: 791, col: 20, offset: 18995},
 							expr: &ruleRefExpr{
-								pos:  position{line: 794, col: 21, offset: 19125},
+								pos:  position{line: 791, col: 21, offset: 18996},
 								name: "EOKW",
 							},
 						},
@@ -5504,44 +5453,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 800, col: 1, offset: 19316},
+			pos:  position{line: 797, col: 1, offset: 19187},
 			expr: &actionExpr{
-				pos: position{line: 801, col: 5, offset: 19330},
+				pos: position{line: 798, col: 5, offset: 19201},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 801, col: 5, offset: 19330},
+					pos: position{line: 798, col: 5, offset: 19201},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 5, offset: 19330},
+							pos:  position{line: 798, col: 5, offset: 19201},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 13, offset: 19338},
+							pos:  position{line: 798, col: 13, offset: 19209},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 15, offset: 19340},
+							pos:   position{line: 798, col: 15, offset: 19211},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 801, col: 20, offset: 19345},
+								pos:  position{line: 798, col: 20, offset: 19216},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 26, offset: 19351},
+							pos:   position{line: 798, col: 26, offset: 19222},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 801, col: 30, offset: 19355},
+								pos:  position{line: 798, col: 30, offset: 19226},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 38, offset: 19363},
+							pos:   position{line: 798, col: 38, offset: 19234},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 801, col: 41, offset: 19366},
+								pos: position{line: 798, col: 41, offset: 19237},
 								expr: &ruleRefExpr{
-									pos:  position{line: 801, col: 41, offset: 19366},
+									pos:  position{line: 798, col: 41, offset: 19237},
 									name: "AsArg",
 								},
 							},
@@ -5554,26 +5503,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 814, col: 1, offset: 19608},
+			pos:  position{line: 811, col: 1, offset: 19479},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 19620},
+				pos: position{line: 812, col: 5, offset: 19491},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 19620},
+					pos: position{line: 812, col: 5, offset: 19491},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 5, offset: 19620},
+							pos:  position{line: 812, col: 5, offset: 19491},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 11, offset: 19626},
+							pos:  position{line: 812, col: 11, offset: 19497},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 13, offset: 19628},
+							pos:   position{line: 812, col: 13, offset: 19499},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 18, offset: 19633},
+								pos:  position{line: 812, col: 18, offset: 19504},
 								name: "Expr",
 							},
 						},
@@ -5585,47 +5534,47 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 823, col: 1, offset: 19760},
+			pos:  position{line: 820, col: 1, offset: 19631},
 			expr: &actionExpr{
-				pos: position{line: 824, col: 5, offset: 19771},
+				pos: position{line: 821, col: 5, offset: 19642},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 824, col: 5, offset: 19771},
+					pos: position{line: 821, col: 5, offset: 19642},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 824, col: 5, offset: 19771},
+							pos:  position{line: 821, col: 5, offset: 19642},
 							name: "OVER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 824, col: 10, offset: 19776},
+							pos:  position{line: 821, col: 10, offset: 19647},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 824, col: 12, offset: 19778},
+							pos:   position{line: 821, col: 12, offset: 19649},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 824, col: 18, offset: 19784},
+								pos:  position{line: 821, col: 18, offset: 19655},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 824, col: 24, offset: 19790},
+							pos:   position{line: 821, col: 24, offset: 19661},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 824, col: 31, offset: 19797},
+								pos: position{line: 821, col: 31, offset: 19668},
 								expr: &ruleRefExpr{
-									pos:  position{line: 824, col: 31, offset: 19797},
+									pos:  position{line: 821, col: 31, offset: 19668},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 824, col: 39, offset: 19805},
+							pos:   position{line: 821, col: 39, offset: 19676},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 824, col: 44, offset: 19810},
+								pos: position{line: 821, col: 44, offset: 19681},
 								expr: &ruleRefExpr{
-									pos:  position{line: 824, col: 44, offset: 19810},
+									pos:  position{line: 821, col: 44, offset: 19681},
 									name: "Lateral",
 								},
 							},
@@ -5638,54 +5587,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 839, col: 1, offset: 20135},
+			pos:  position{line: 836, col: 1, offset: 20006},
 			expr: &choiceExpr{
-				pos: position{line: 840, col: 5, offset: 20147},
+				pos: position{line: 837, col: 5, offset: 20018},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 840, col: 5, offset: 20147},
+						pos: position{line: 837, col: 5, offset: 20018},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 840, col: 5, offset: 20147},
+							pos: position{line: 837, col: 5, offset: 20018},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 840, col: 5, offset: 20147},
+									pos:  position{line: 837, col: 5, offset: 20018},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 840, col: 8, offset: 20150},
+									pos:        position{line: 837, col: 8, offset: 20021},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 840, col: 13, offset: 20155},
+									pos:  position{line: 837, col: 13, offset: 20026},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 840, col: 16, offset: 20158},
+									pos:        position{line: 837, col: 16, offset: 20029},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 840, col: 20, offset: 20162},
+									pos:  position{line: 837, col: 20, offset: 20033},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 840, col: 23, offset: 20165},
+									pos:   position{line: 837, col: 23, offset: 20036},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 840, col: 29, offset: 20171},
+										pos:  position{line: 837, col: 29, offset: 20042},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 840, col: 35, offset: 20177},
+									pos:  position{line: 837, col: 35, offset: 20048},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 840, col: 38, offset: 20180},
+									pos:        position{line: 837, col: 38, offset: 20051},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5694,49 +5643,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 843, col: 5, offset: 20261},
+						pos: position{line: 840, col: 5, offset: 20132},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 843, col: 5, offset: 20261},
+							pos: position{line: 840, col: 5, offset: 20132},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 843, col: 5, offset: 20261},
+									pos:  position{line: 840, col: 5, offset: 20132},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 843, col: 8, offset: 20264},
+									pos:        position{line: 840, col: 8, offset: 20135},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 843, col: 13, offset: 20269},
+									pos:  position{line: 840, col: 13, offset: 20140},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 843, col: 16, offset: 20272},
+									pos:        position{line: 840, col: 16, offset: 20143},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 843, col: 20, offset: 20276},
+									pos:  position{line: 840, col: 20, offset: 20147},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 843, col: 23, offset: 20279},
+									pos:   position{line: 840, col: 23, offset: 20150},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 843, col: 27, offset: 20283},
+										pos:  position{line: 840, col: 27, offset: 20154},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 843, col: 31, offset: 20287},
+									pos:  position{line: 840, col: 31, offset: 20158},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 843, col: 34, offset: 20290},
+									pos:        position{line: 840, col: 34, offset: 20161},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5751,63 +5700,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 847, col: 1, offset: 20346},
+			pos:  position{line: 844, col: 1, offset: 20217},
 			expr: &actionExpr{
-				pos: position{line: 848, col: 5, offset: 20357},
+				pos: position{line: 845, col: 5, offset: 20228},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 848, col: 5, offset: 20357},
+					pos: position{line: 845, col: 5, offset: 20228},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 5, offset: 20357},
+							pos:  position{line: 845, col: 5, offset: 20228},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 7, offset: 20359},
+							pos:  position{line: 845, col: 7, offset: 20230},
 							name: "WITH",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 12, offset: 20364},
+							pos:  position{line: 845, col: 12, offset: 20235},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 848, col: 14, offset: 20366},
+							pos:   position{line: 845, col: 14, offset: 20237},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 20, offset: 20372},
+								pos:  position{line: 845, col: 20, offset: 20243},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 848, col: 37, offset: 20389},
+							pos:   position{line: 845, col: 37, offset: 20260},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 848, col: 42, offset: 20394},
+								pos: position{line: 845, col: 42, offset: 20265},
 								expr: &actionExpr{
-									pos: position{line: 848, col: 43, offset: 20395},
+									pos: position{line: 845, col: 43, offset: 20266},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 848, col: 43, offset: 20395},
+										pos: position{line: 845, col: 43, offset: 20266},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 848, col: 43, offset: 20395},
+												pos:  position{line: 845, col: 43, offset: 20266},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 848, col: 46, offset: 20398},
+												pos:        position{line: 845, col: 46, offset: 20269},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 848, col: 50, offset: 20402},
+												pos:  position{line: 845, col: 50, offset: 20273},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 848, col: 53, offset: 20405},
+												pos:   position{line: 845, col: 53, offset: 20276},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 848, col: 55, offset: 20407},
+													pos:  position{line: 845, col: 55, offset: 20278},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5824,45 +5773,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 852, col: 1, offset: 20492},
+			pos:  position{line: 849, col: 1, offset: 20363},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 5, offset: 20513},
+				pos: position{line: 850, col: 5, offset: 20384},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 853, col: 5, offset: 20513},
+					pos: position{line: 850, col: 5, offset: 20384},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 853, col: 5, offset: 20513},
+							pos:   position{line: 850, col: 5, offset: 20384},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 10, offset: 20518},
+								pos:  position{line: 850, col: 10, offset: 20389},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 21, offset: 20529},
+							pos:   position{line: 850, col: 21, offset: 20400},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 853, col: 25, offset: 20533},
+								pos: position{line: 850, col: 25, offset: 20404},
 								expr: &seqExpr{
-									pos: position{line: 853, col: 26, offset: 20534},
+									pos: position{line: 850, col: 26, offset: 20405},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 26, offset: 20534},
+											pos:  position{line: 850, col: 26, offset: 20405},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 853, col: 29, offset: 20537},
+											pos:        position{line: 850, col: 29, offset: 20408},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 33, offset: 20541},
+											pos:  position{line: 850, col: 33, offset: 20412},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 36, offset: 20544},
+											pos:  position{line: 850, col: 36, offset: 20415},
 											name: "Expr",
 										},
 									},
@@ -5877,26 +5826,26 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 865, col: 1, offset: 20768},
+			pos:  position{line: 862, col: 1, offset: 20639},
 			expr: &actionExpr{
-				pos: position{line: 866, col: 5, offset: 20780},
+				pos: position{line: 863, col: 5, offset: 20651},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 866, col: 5, offset: 20780},
+					pos: position{line: 863, col: 5, offset: 20651},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 866, col: 5, offset: 20780},
+							pos:  position{line: 863, col: 5, offset: 20651},
 							name: "YIELD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 866, col: 11, offset: 20786},
+							pos:  position{line: 863, col: 11, offset: 20657},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 866, col: 13, offset: 20788},
+							pos:   position{line: 863, col: 13, offset: 20659},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 866, col: 19, offset: 20794},
+								pos:  position{line: 863, col: 19, offset: 20665},
 								name: "Exprs",
 							},
 						},
@@ -5908,30 +5857,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 874, col: 1, offset: 20938},
+			pos:  position{line: 871, col: 1, offset: 20809},
 			expr: &actionExpr{
-				pos: position{line: 875, col: 5, offset: 20950},
+				pos: position{line: 872, col: 5, offset: 20821},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 875, col: 5, offset: 20950},
+					pos: position{line: 872, col: 5, offset: 20821},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 875, col: 5, offset: 20950},
+							pos:  position{line: 872, col: 5, offset: 20821},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 875, col: 7, offset: 20952},
+							pos:  position{line: 872, col: 7, offset: 20823},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 875, col: 10, offset: 20955},
+							pos:  position{line: 872, col: 10, offset: 20826},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 875, col: 12, offset: 20957},
+							pos:   position{line: 872, col: 12, offset: 20828},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 875, col: 16, offset: 20961},
+								pos:  position{line: 872, col: 16, offset: 20832},
 								name: "Type",
 							},
 						},
@@ -5943,30 +5892,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 877, col: 1, offset: 20987},
+			pos:  position{line: 874, col: 1, offset: 20858},
 			expr: &actionExpr{
-				pos: position{line: 878, col: 5, offset: 20997},
+				pos: position{line: 875, col: 5, offset: 20868},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 878, col: 5, offset: 20997},
+					pos: position{line: 875, col: 5, offset: 20868},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 5, offset: 20997},
+							pos:  position{line: 875, col: 5, offset: 20868},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 7, offset: 20999},
+							pos:  position{line: 875, col: 7, offset: 20870},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 878, col: 10, offset: 21002},
+							pos:  position{line: 875, col: 10, offset: 20873},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 12, offset: 21004},
+							pos:   position{line: 875, col: 12, offset: 20875},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 878, col: 16, offset: 21008},
+								pos:  position{line: 875, col: 16, offset: 20879},
 								name: "Lval",
 							},
 						},
@@ -5978,9 +5927,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 882, col: 1, offset: 21059},
+			pos:  position{line: 879, col: 1, offset: 20930},
 			expr: &ruleRefExpr{
-				pos:  position{line: 882, col: 8, offset: 21066},
+				pos:  position{line: 879, col: 8, offset: 20937},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5988,51 +5937,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 884, col: 1, offset: 21077},
+			pos:  position{line: 881, col: 1, offset: 20948},
 			expr: &actionExpr{
-				pos: position{line: 885, col: 5, offset: 21087},
+				pos: position{line: 882, col: 5, offset: 20958},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 885, col: 5, offset: 21087},
+					pos: position{line: 882, col: 5, offset: 20958},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 885, col: 5, offset: 21087},
+							pos:   position{line: 882, col: 5, offset: 20958},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 885, col: 11, offset: 21093},
+								pos:  position{line: 882, col: 11, offset: 20964},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 885, col: 16, offset: 21098},
+							pos:   position{line: 882, col: 16, offset: 20969},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 885, col: 21, offset: 21103},
+								pos: position{line: 882, col: 21, offset: 20974},
 								expr: &actionExpr{
-									pos: position{line: 885, col: 22, offset: 21104},
+									pos: position{line: 882, col: 22, offset: 20975},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 885, col: 22, offset: 21104},
+										pos: position{line: 882, col: 22, offset: 20975},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 885, col: 22, offset: 21104},
+												pos:  position{line: 882, col: 22, offset: 20975},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 885, col: 25, offset: 21107},
+												pos:        position{line: 882, col: 25, offset: 20978},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 885, col: 29, offset: 21111},
+												pos:  position{line: 882, col: 29, offset: 20982},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 885, col: 32, offset: 21114},
+												pos:   position{line: 882, col: 32, offset: 20985},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 885, col: 37, offset: 21119},
+													pos:  position{line: 882, col: 37, offset: 20990},
 													name: "Lval",
 												},
 											},
@@ -6049,51 +5998,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 889, col: 1, offset: 21195},
+			pos:  position{line: 886, col: 1, offset: 21066},
 			expr: &actionExpr{
-				pos: position{line: 890, col: 5, offset: 21211},
+				pos: position{line: 887, col: 5, offset: 21082},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 890, col: 5, offset: 21211},
+					pos: position{line: 887, col: 5, offset: 21082},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 890, col: 5, offset: 21211},
+							pos:   position{line: 887, col: 5, offset: 21082},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 890, col: 11, offset: 21217},
+								pos:  position{line: 887, col: 11, offset: 21088},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 890, col: 22, offset: 21228},
+							pos:   position{line: 887, col: 22, offset: 21099},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 890, col: 27, offset: 21233},
+								pos: position{line: 887, col: 27, offset: 21104},
 								expr: &actionExpr{
-									pos: position{line: 890, col: 28, offset: 21234},
+									pos: position{line: 887, col: 28, offset: 21105},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 890, col: 28, offset: 21234},
+										pos: position{line: 887, col: 28, offset: 21105},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 890, col: 28, offset: 21234},
+												pos:  position{line: 887, col: 28, offset: 21105},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 890, col: 31, offset: 21237},
+												pos:        position{line: 887, col: 31, offset: 21108},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 890, col: 35, offset: 21241},
+												pos:  position{line: 887, col: 35, offset: 21112},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 890, col: 38, offset: 21244},
+												pos:   position{line: 887, col: 38, offset: 21115},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 890, col: 40, offset: 21246},
+													pos:  position{line: 887, col: 40, offset: 21117},
 													name: "Assignment",
 												},
 											},
@@ -6110,40 +6059,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 894, col: 1, offset: 21321},
+			pos:  position{line: 891, col: 1, offset: 21192},
 			expr: &actionExpr{
-				pos: position{line: 895, col: 5, offset: 21336},
+				pos: position{line: 892, col: 5, offset: 21207},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 895, col: 5, offset: 21336},
+					pos: position{line: 892, col: 5, offset: 21207},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 895, col: 5, offset: 21336},
+							pos:   position{line: 892, col: 5, offset: 21207},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 895, col: 9, offset: 21340},
+								pos:  position{line: 892, col: 9, offset: 21211},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 895, col: 14, offset: 21345},
+							pos:  position{line: 892, col: 14, offset: 21216},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 895, col: 17, offset: 21348},
+							pos:        position{line: 892, col: 17, offset: 21219},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 895, col: 22, offset: 21353},
+							pos:  position{line: 892, col: 22, offset: 21224},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 895, col: 25, offset: 21356},
+							pos:   position{line: 892, col: 25, offset: 21227},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 895, col: 29, offset: 21360},
+								pos:  position{line: 892, col: 29, offset: 21231},
 								name: "Expr",
 							},
 						},
@@ -6155,9 +6104,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 904, col: 1, offset: 21531},
+			pos:  position{line: 901, col: 1, offset: 21402},
 			expr: &ruleRefExpr{
-				pos:  position{line: 904, col: 8, offset: 21538},
+				pos:  position{line: 901, col: 8, offset: 21409},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -6165,63 +6114,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 906, col: 1, offset: 21555},
+			pos:  position{line: 903, col: 1, offset: 21426},
 			expr: &actionExpr{
-				pos: position{line: 907, col: 5, offset: 21575},
+				pos: position{line: 904, col: 5, offset: 21446},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 907, col: 5, offset: 21575},
+					pos: position{line: 904, col: 5, offset: 21446},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 907, col: 5, offset: 21575},
+							pos:   position{line: 904, col: 5, offset: 21446},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 907, col: 10, offset: 21580},
+								pos:  position{line: 904, col: 10, offset: 21451},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 907, col: 24, offset: 21594},
+							pos:   position{line: 904, col: 24, offset: 21465},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 907, col: 28, offset: 21598},
+								pos: position{line: 904, col: 28, offset: 21469},
 								expr: &seqExpr{
-									pos: position{line: 907, col: 29, offset: 21599},
+									pos: position{line: 904, col: 29, offset: 21470},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 907, col: 29, offset: 21599},
+											pos:  position{line: 904, col: 29, offset: 21470},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 907, col: 32, offset: 21602},
+											pos:        position{line: 904, col: 32, offset: 21473},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 907, col: 36, offset: 21606},
+											pos:  position{line: 904, col: 36, offset: 21477},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 907, col: 39, offset: 21609},
+											pos:  position{line: 904, col: 39, offset: 21480},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 907, col: 44, offset: 21614},
+											pos:  position{line: 904, col: 44, offset: 21485},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 907, col: 47, offset: 21617},
+											pos:        position{line: 904, col: 47, offset: 21488},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 907, col: 51, offset: 21621},
+											pos:  position{line: 904, col: 51, offset: 21492},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 907, col: 54, offset: 21624},
+											pos:  position{line: 904, col: 54, offset: 21495},
 											name: "Expr",
 										},
 									},
@@ -6236,53 +6185,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 921, col: 1, offset: 21945},
+			pos:  position{line: 918, col: 1, offset: 21816},
 			expr: &actionExpr{
-				pos: position{line: 922, col: 5, offset: 21963},
+				pos: position{line: 919, col: 5, offset: 21834},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 922, col: 5, offset: 21963},
+					pos: position{line: 919, col: 5, offset: 21834},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 922, col: 5, offset: 21963},
+							pos:   position{line: 919, col: 5, offset: 21834},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 922, col: 11, offset: 21969},
+								pos:  position{line: 919, col: 11, offset: 21840},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 923, col: 5, offset: 21988},
+							pos:   position{line: 920, col: 5, offset: 21859},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 923, col: 10, offset: 21993},
+								pos: position{line: 920, col: 10, offset: 21864},
 								expr: &actionExpr{
-									pos: position{line: 923, col: 11, offset: 21994},
+									pos: position{line: 920, col: 11, offset: 21865},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 923, col: 11, offset: 21994},
+										pos: position{line: 920, col: 11, offset: 21865},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 923, col: 11, offset: 21994},
+												pos:  position{line: 920, col: 11, offset: 21865},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 923, col: 14, offset: 21997},
+												pos:   position{line: 920, col: 14, offset: 21868},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 923, col: 17, offset: 22000},
+													pos:  position{line: 920, col: 17, offset: 21871},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 923, col: 20, offset: 22003},
+												pos:  position{line: 920, col: 20, offset: 21874},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 923, col: 23, offset: 22006},
+												pos:   position{line: 920, col: 23, offset: 21877},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 923, col: 28, offset: 22011},
+													pos:  position{line: 920, col: 28, offset: 21882},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6299,53 +6248,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 927, col: 1, offset: 22125},
+			pos:  position{line: 924, col: 1, offset: 21996},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 5, offset: 22144},
+				pos: position{line: 925, col: 5, offset: 22015},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 928, col: 5, offset: 22144},
+					pos: position{line: 925, col: 5, offset: 22015},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 928, col: 5, offset: 22144},
+							pos:   position{line: 925, col: 5, offset: 22015},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 928, col: 11, offset: 22150},
+								pos:  position{line: 925, col: 11, offset: 22021},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 929, col: 5, offset: 22162},
+							pos:   position{line: 926, col: 5, offset: 22033},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 929, col: 10, offset: 22167},
+								pos: position{line: 926, col: 10, offset: 22038},
 								expr: &actionExpr{
-									pos: position{line: 929, col: 11, offset: 22168},
+									pos: position{line: 926, col: 11, offset: 22039},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 929, col: 11, offset: 22168},
+										pos: position{line: 926, col: 11, offset: 22039},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 929, col: 11, offset: 22168},
+												pos:  position{line: 926, col: 11, offset: 22039},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 929, col: 14, offset: 22171},
+												pos:   position{line: 926, col: 14, offset: 22042},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 929, col: 17, offset: 22174},
+													pos:  position{line: 926, col: 17, offset: 22045},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 929, col: 21, offset: 22178},
+												pos:  position{line: 926, col: 21, offset: 22049},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 929, col: 24, offset: 22181},
+												pos:   position{line: 926, col: 24, offset: 22052},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 929, col: 29, offset: 22186},
+													pos:  position{line: 926, col: 29, offset: 22057},
 													name: "NotExpr",
 												},
 											},
@@ -6362,43 +6311,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 933, col: 1, offset: 22293},
+			pos:  position{line: 930, col: 1, offset: 22164},
 			expr: &choiceExpr{
-				pos: position{line: 934, col: 5, offset: 22305},
+				pos: position{line: 931, col: 5, offset: 22176},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 934, col: 5, offset: 22305},
+						pos: position{line: 931, col: 5, offset: 22176},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 934, col: 5, offset: 22305},
+							pos: position{line: 931, col: 5, offset: 22176},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 934, col: 6, offset: 22306},
+									pos: position{line: 931, col: 6, offset: 22177},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 934, col: 6, offset: 22306},
+											pos: position{line: 931, col: 6, offset: 22177},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 934, col: 6, offset: 22306},
+													pos:  position{line: 931, col: 6, offset: 22177},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 934, col: 10, offset: 22310},
+													pos:  position{line: 931, col: 10, offset: 22181},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 934, col: 14, offset: 22314},
+											pos: position{line: 931, col: 14, offset: 22185},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 934, col: 14, offset: 22314},
+													pos:        position{line: 931, col: 14, offset: 22185},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 934, col: 18, offset: 22318},
+													pos:  position{line: 931, col: 18, offset: 22189},
 													name: "__",
 												},
 											},
@@ -6406,10 +6355,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 934, col: 22, offset: 22322},
+									pos:   position{line: 931, col: 22, offset: 22193},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 934, col: 24, offset: 22324},
+										pos:  position{line: 931, col: 24, offset: 22195},
 										name: "NotExpr",
 									},
 								},
@@ -6417,7 +6366,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 942, col: 5, offset: 22490},
+						pos:  position{line: 939, col: 5, offset: 22361},
 						name: "BetweenExpr",
 					},
 				},
@@ -6427,61 +6376,61 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 944, col: 1, offset: 22505},
+			pos:  position{line: 941, col: 1, offset: 22376},
 			expr: &choiceExpr{
-				pos: position{line: 945, col: 5, offset: 22521},
+				pos: position{line: 942, col: 5, offset: 22392},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 945, col: 5, offset: 22521},
+						pos: position{line: 942, col: 5, offset: 22392},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 945, col: 5, offset: 22521},
+							pos: position{line: 942, col: 5, offset: 22392},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 945, col: 5, offset: 22521},
+									pos:   position{line: 942, col: 5, offset: 22392},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 945, col: 10, offset: 22526},
+										pos:  position{line: 942, col: 10, offset: 22397},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 945, col: 25, offset: 22541},
+									pos:  position{line: 942, col: 25, offset: 22412},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 945, col: 27, offset: 22543},
+									pos:  position{line: 942, col: 27, offset: 22414},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 945, col: 35, offset: 22551},
+									pos:  position{line: 942, col: 35, offset: 22422},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 945, col: 37, offset: 22553},
+									pos:   position{line: 942, col: 37, offset: 22424},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 945, col: 43, offset: 22559},
+										pos:  position{line: 942, col: 43, offset: 22430},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 945, col: 55, offset: 22571},
+									pos:  position{line: 942, col: 55, offset: 22442},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 945, col: 57, offset: 22573},
+									pos:  position{line: 942, col: 57, offset: 22444},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 945, col: 61, offset: 22577},
+									pos:  position{line: 942, col: 61, offset: 22448},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 945, col: 63, offset: 22579},
+									pos:   position{line: 942, col: 63, offset: 22450},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 945, col: 69, offset: 22585},
+										pos:  position{line: 942, col: 69, offset: 22456},
 										name: "BetweenExpr",
 									},
 								},
@@ -6489,7 +6438,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 953, col: 5, offset: 22771},
+						pos:  position{line: 950, col: 5, offset: 22642},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6499,73 +6448,73 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 955, col: 1, offset: 22787},
+			pos:  position{line: 952, col: 1, offset: 22658},
 			expr: &actionExpr{
-				pos: position{line: 956, col: 5, offset: 22806},
+				pos: position{line: 953, col: 5, offset: 22677},
 				run: (*parser).callonComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 956, col: 5, offset: 22806},
+					pos: position{line: 953, col: 5, offset: 22677},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 956, col: 5, offset: 22806},
+							pos:   position{line: 953, col: 5, offset: 22677},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 956, col: 9, offset: 22810},
+								pos:  position{line: 953, col: 9, offset: 22681},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 956, col: 22, offset: 22823},
+							pos:   position{line: 953, col: 22, offset: 22694},
 							label: "opAndRHS",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 956, col: 31, offset: 22832},
+								pos: position{line: 953, col: 31, offset: 22703},
 								expr: &choiceExpr{
-									pos: position{line: 956, col: 32, offset: 22833},
+									pos: position{line: 953, col: 32, offset: 22704},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 956, col: 32, offset: 22833},
+											pos: position{line: 953, col: 32, offset: 22704},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 956, col: 32, offset: 22833},
+													pos:  position{line: 953, col: 32, offset: 22704},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 956, col: 35, offset: 22836},
+													pos:  position{line: 953, col: 35, offset: 22707},
 													name: "Comparator",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 956, col: 46, offset: 22847},
+													pos:  position{line: 953, col: 46, offset: 22718},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 956, col: 49, offset: 22850},
+													pos:  position{line: 953, col: 49, offset: 22721},
 													name: "AdditiveExpr",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 956, col: 64, offset: 22865},
+											pos: position{line: 953, col: 64, offset: 22736},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 956, col: 64, offset: 22865},
+													pos:  position{line: 953, col: 64, offset: 22736},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 956, col: 68, offset: 22869},
+													pos: position{line: 953, col: 68, offset: 22740},
 													run: (*parser).callonComparisonExpr15,
 													expr: &litMatcher{
-														pos:        position{line: 956, col: 68, offset: 22869},
+														pos:        position{line: 953, col: 68, offset: 22740},
 														val:        "~",
 														ignoreCase: false,
 														want:       "\"~\"",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 956, col: 104, offset: 22905},
+													pos:  position{line: 953, col: 104, offset: 22776},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 956, col: 107, offset: 22908},
+													pos:  position{line: 953, col: 107, offset: 22779},
 													name: "Regexp",
 												},
 											},
@@ -6582,53 +6531,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 969, col: 1, offset: 23193},
+			pos:  position{line: 966, col: 1, offset: 23064},
 			expr: &actionExpr{
-				pos: position{line: 970, col: 5, offset: 23210},
+				pos: position{line: 967, col: 5, offset: 23081},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 970, col: 5, offset: 23210},
+					pos: position{line: 967, col: 5, offset: 23081},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 970, col: 5, offset: 23210},
+							pos:   position{line: 967, col: 5, offset: 23081},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 970, col: 11, offset: 23216},
+								pos:  position{line: 967, col: 11, offset: 23087},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 971, col: 5, offset: 23239},
+							pos:   position{line: 968, col: 5, offset: 23110},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 971, col: 10, offset: 23244},
+								pos: position{line: 968, col: 10, offset: 23115},
 								expr: &actionExpr{
-									pos: position{line: 971, col: 11, offset: 23245},
+									pos: position{line: 968, col: 11, offset: 23116},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 971, col: 11, offset: 23245},
+										pos: position{line: 968, col: 11, offset: 23116},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 971, col: 11, offset: 23245},
+												pos:  position{line: 968, col: 11, offset: 23116},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 971, col: 14, offset: 23248},
+												pos:   position{line: 968, col: 14, offset: 23119},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 971, col: 17, offset: 23251},
+													pos:  position{line: 968, col: 17, offset: 23122},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 971, col: 34, offset: 23268},
+												pos:  position{line: 968, col: 34, offset: 23139},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 971, col: 37, offset: 23271},
+												pos:   position{line: 968, col: 37, offset: 23142},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 971, col: 42, offset: 23276},
+													pos:  position{line: 968, col: 42, offset: 23147},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6645,21 +6594,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 975, col: 1, offset: 23394},
+			pos:  position{line: 972, col: 1, offset: 23265},
 			expr: &actionExpr{
-				pos: position{line: 975, col: 20, offset: 23413},
+				pos: position{line: 972, col: 20, offset: 23284},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 975, col: 21, offset: 23414},
+					pos: position{line: 972, col: 21, offset: 23285},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 975, col: 21, offset: 23414},
+							pos:        position{line: 972, col: 21, offset: 23285},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 975, col: 27, offset: 23420},
+							pos:        position{line: 972, col: 27, offset: 23291},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6672,53 +6621,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 977, col: 1, offset: 23457},
+			pos:  position{line: 974, col: 1, offset: 23328},
 			expr: &actionExpr{
-				pos: position{line: 978, col: 5, offset: 23480},
+				pos: position{line: 975, col: 5, offset: 23351},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 978, col: 5, offset: 23480},
+					pos: position{line: 975, col: 5, offset: 23351},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 978, col: 5, offset: 23480},
+							pos:   position{line: 975, col: 5, offset: 23351},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 978, col: 11, offset: 23486},
+								pos:  position{line: 975, col: 11, offset: 23357},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 979, col: 5, offset: 23501},
+							pos:   position{line: 976, col: 5, offset: 23372},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 979, col: 10, offset: 23506},
+								pos: position{line: 976, col: 10, offset: 23377},
 								expr: &actionExpr{
-									pos: position{line: 979, col: 11, offset: 23507},
+									pos: position{line: 976, col: 11, offset: 23378},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 979, col: 11, offset: 23507},
+										pos: position{line: 976, col: 11, offset: 23378},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 979, col: 11, offset: 23507},
+												pos:  position{line: 976, col: 11, offset: 23378},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 979, col: 14, offset: 23510},
+												pos:   position{line: 976, col: 14, offset: 23381},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 979, col: 17, offset: 23513},
+													pos:  position{line: 976, col: 17, offset: 23384},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 979, col: 40, offset: 23536},
+												pos:  position{line: 976, col: 40, offset: 23407},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 979, col: 43, offset: 23539},
+												pos:   position{line: 976, col: 43, offset: 23410},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 979, col: 48, offset: 23544},
+													pos:  position{line: 976, col: 48, offset: 23415},
 													name: "ConcatExpr",
 												},
 											},
@@ -6735,27 +6684,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 983, col: 1, offset: 23654},
+			pos:  position{line: 980, col: 1, offset: 23525},
 			expr: &actionExpr{
-				pos: position{line: 983, col: 26, offset: 23679},
+				pos: position{line: 980, col: 26, offset: 23550},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 983, col: 27, offset: 23680},
+					pos: position{line: 980, col: 27, offset: 23551},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 983, col: 27, offset: 23680},
+							pos:        position{line: 980, col: 27, offset: 23551},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 983, col: 33, offset: 23686},
+							pos:        position{line: 980, col: 33, offset: 23557},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 983, col: 39, offset: 23692},
+							pos:        position{line: 980, col: 39, offset: 23563},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6768,51 +6717,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 985, col: 1, offset: 23729},
+			pos:  position{line: 982, col: 1, offset: 23600},
 			expr: &actionExpr{
-				pos: position{line: 986, col: 5, offset: 23745},
+				pos: position{line: 983, col: 5, offset: 23616},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 986, col: 5, offset: 23745},
+					pos: position{line: 983, col: 5, offset: 23616},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 986, col: 5, offset: 23745},
+							pos:   position{line: 983, col: 5, offset: 23616},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 986, col: 11, offset: 23751},
+								pos:  position{line: 983, col: 11, offset: 23622},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 987, col: 5, offset: 23772},
+							pos:   position{line: 984, col: 5, offset: 23643},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 987, col: 10, offset: 23777},
+								pos: position{line: 984, col: 10, offset: 23648},
 								expr: &actionExpr{
-									pos: position{line: 987, col: 11, offset: 23778},
+									pos: position{line: 984, col: 11, offset: 23649},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 987, col: 11, offset: 23778},
+										pos: position{line: 984, col: 11, offset: 23649},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 987, col: 11, offset: 23778},
+												pos:  position{line: 984, col: 11, offset: 23649},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 987, col: 14, offset: 23781},
+												pos:        position{line: 984, col: 14, offset: 23652},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 987, col: 19, offset: 23786},
+												pos:  position{line: 984, col: 19, offset: 23657},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 987, col: 22, offset: 23789},
+												pos:   position{line: 984, col: 22, offset: 23660},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 987, col: 27, offset: 23794},
+													pos:  position{line: 984, col: 27, offset: 23665},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6829,40 +6778,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 991, col: 1, offset: 23912},
+			pos:  position{line: 988, col: 1, offset: 23783},
 			expr: &choiceExpr{
-				pos: position{line: 992, col: 5, offset: 23933},
+				pos: position{line: 989, col: 5, offset: 23804},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 992, col: 5, offset: 23933},
+						pos: position{line: 989, col: 5, offset: 23804},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 992, col: 5, offset: 23933},
+							pos: position{line: 989, col: 5, offset: 23804},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 992, col: 5, offset: 23933},
+									pos: position{line: 989, col: 5, offset: 23804},
 									expr: &ruleRefExpr{
-										pos:  position{line: 992, col: 6, offset: 23934},
+										pos:  position{line: 989, col: 6, offset: 23805},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 992, col: 14, offset: 23942},
+									pos:   position{line: 989, col: 14, offset: 23813},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 992, col: 17, offset: 23945},
+										pos:  position{line: 989, col: 17, offset: 23816},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 992, col: 31, offset: 23959},
+									pos:  position{line: 989, col: 31, offset: 23830},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 992, col: 34, offset: 23962},
+									pos:   position{line: 989, col: 34, offset: 23833},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 992, col: 36, offset: 23964},
+										pos:  position{line: 989, col: 36, offset: 23835},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6870,7 +6819,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1001, col: 5, offset: 24148},
+						pos:  position{line: 998, col: 5, offset: 24019},
 						name: "DerefExpr",
 					},
 				},
@@ -6880,21 +6829,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 1003, col: 1, offset: 24159},
+			pos:  position{line: 1000, col: 1, offset: 24030},
 			expr: &actionExpr{
-				pos: position{line: 1003, col: 17, offset: 24175},
+				pos: position{line: 1000, col: 17, offset: 24046},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 1003, col: 18, offset: 24176},
+					pos: position{line: 1000, col: 18, offset: 24047},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1003, col: 18, offset: 24176},
+							pos:        position{line: 1000, col: 18, offset: 24047},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1003, col: 24, offset: 24182},
+							pos:        position{line: 1000, col: 24, offset: 24053},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6907,73 +6856,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 1005, col: 1, offset: 24219},
+			pos:  position{line: 1002, col: 1, offset: 24090},
 			expr: &choiceExpr{
-				pos: position{line: 1006, col: 5, offset: 24233},
+				pos: position{line: 1003, col: 5, offset: 24104},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1006, col: 5, offset: 24233},
+						pos: position{line: 1003, col: 5, offset: 24104},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1006, col: 5, offset: 24233},
+							pos: position{line: 1003, col: 5, offset: 24104},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1006, col: 5, offset: 24233},
+									pos:   position{line: 1003, col: 5, offset: 24104},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1006, col: 10, offset: 24238},
+										pos:  position{line: 1003, col: 10, offset: 24109},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1006, col: 20, offset: 24248},
+									pos:        position{line: 1003, col: 20, offset: 24119},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 24, offset: 24252},
+									pos:  position{line: 1003, col: 24, offset: 24123},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1006, col: 27, offset: 24255},
+									pos:   position{line: 1003, col: 27, offset: 24126},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1006, col: 32, offset: 24260},
+										pos:  position{line: 1003, col: 32, offset: 24131},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 45, offset: 24273},
+									pos:  position{line: 1003, col: 45, offset: 24144},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1006, col: 48, offset: 24276},
+									pos:        position{line: 1003, col: 48, offset: 24147},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 52, offset: 24280},
+									pos:  position{line: 1003, col: 52, offset: 24151},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1006, col: 55, offset: 24283},
+									pos:   position{line: 1003, col: 55, offset: 24154},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1006, col: 58, offset: 24286},
+										pos: position{line: 1003, col: 58, offset: 24157},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1006, col: 58, offset: 24286},
+											pos:  position{line: 1003, col: 58, offset: 24157},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 72, offset: 24300},
+									pos:  position{line: 1003, col: 72, offset: 24171},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1006, col: 75, offset: 24303},
+									pos:        position{line: 1003, col: 75, offset: 24174},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6982,49 +6931,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1018, col: 5, offset: 24542},
+						pos: position{line: 1015, col: 5, offset: 24413},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1018, col: 5, offset: 24542},
+							pos: position{line: 1015, col: 5, offset: 24413},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1018, col: 5, offset: 24542},
+									pos:   position{line: 1015, col: 5, offset: 24413},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1018, col: 10, offset: 24547},
+										pos:  position{line: 1015, col: 10, offset: 24418},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1018, col: 20, offset: 24557},
+									pos:        position{line: 1015, col: 20, offset: 24428},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1018, col: 24, offset: 24561},
+									pos:  position{line: 1015, col: 24, offset: 24432},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1018, col: 27, offset: 24564},
+									pos:        position{line: 1015, col: 27, offset: 24435},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1018, col: 31, offset: 24568},
+									pos:  position{line: 1015, col: 31, offset: 24439},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1018, col: 34, offset: 24571},
+									pos:   position{line: 1015, col: 34, offset: 24442},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1018, col: 37, offset: 24574},
+										pos:  position{line: 1015, col: 37, offset: 24445},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1018, col: 50, offset: 24587},
+									pos:        position{line: 1015, col: 50, offset: 24458},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7033,35 +6982,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1026, col: 5, offset: 24751},
+						pos: position{line: 1023, col: 5, offset: 24622},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1026, col: 5, offset: 24751},
+							pos: position{line: 1023, col: 5, offset: 24622},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1026, col: 5, offset: 24751},
+									pos:   position{line: 1023, col: 5, offset: 24622},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1026, col: 10, offset: 24756},
+										pos:  position{line: 1023, col: 10, offset: 24627},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1026, col: 20, offset: 24766},
+									pos:        position{line: 1023, col: 20, offset: 24637},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1026, col: 24, offset: 24770},
+									pos:   position{line: 1023, col: 24, offset: 24641},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1026, col: 30, offset: 24776},
+										pos:  position{line: 1023, col: 30, offset: 24647},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1026, col: 35, offset: 24781},
+									pos:        position{line: 1023, col: 35, offset: 24652},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7070,30 +7019,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1034, col: 5, offset: 24951},
+						pos: position{line: 1031, col: 5, offset: 24822},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1034, col: 5, offset: 24951},
+							pos: position{line: 1031, col: 5, offset: 24822},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1034, col: 5, offset: 24951},
+									pos:   position{line: 1031, col: 5, offset: 24822},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1034, col: 10, offset: 24956},
+										pos:  position{line: 1031, col: 10, offset: 24827},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1034, col: 20, offset: 24966},
+									pos:        position{line: 1031, col: 20, offset: 24837},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1034, col: 24, offset: 24970},
+									pos:   position{line: 1031, col: 24, offset: 24841},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1034, col: 27, offset: 24973},
+										pos:  position{line: 1031, col: 27, offset: 24844},
 										name: "Identifier",
 									},
 								},
@@ -7101,11 +7050,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1043, col: 5, offset: 25163},
+						pos:  position{line: 1040, col: 5, offset: 25034},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 25176},
+						pos:  position{line: 1041, col: 5, offset: 25047},
 						name: "Primary",
 					},
 				},
@@ -7115,16 +7064,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 1046, col: 1, offset: 25185},
+			pos:  position{line: 1043, col: 1, offset: 25056},
 			expr: &choiceExpr{
-				pos: position{line: 1047, col: 5, offset: 25198},
+				pos: position{line: 1044, col: 5, offset: 25069},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 5, offset: 25198},
+						pos:  position{line: 1044, col: 5, offset: 25069},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1048, col: 5, offset: 25207},
+						pos:  position{line: 1045, col: 5, offset: 25078},
 						name: "Function",
 					},
 				},
@@ -7134,20 +7083,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1050, col: 1, offset: 25217},
+			pos:  position{line: 1047, col: 1, offset: 25088},
 			expr: &seqExpr{
-				pos: position{line: 1050, col: 13, offset: 25229},
+				pos: position{line: 1047, col: 13, offset: 25100},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1050, col: 13, offset: 25229},
+						pos:  position{line: 1047, col: 13, offset: 25100},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1050, col: 22, offset: 25238},
+						pos:  position{line: 1047, col: 22, offset: 25109},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1050, col: 25, offset: 25241},
+						pos:        position{line: 1047, col: 25, offset: 25112},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -7159,16 +7108,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1052, col: 1, offset: 25246},
+			pos:  position{line: 1049, col: 1, offset: 25117},
 			expr: &choiceExpr{
-				pos: position{line: 1053, col: 5, offset: 25259},
+				pos: position{line: 1050, col: 5, offset: 25130},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1053, col: 5, offset: 25259},
+						pos:  position{line: 1050, col: 5, offset: 25130},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1054, col: 5, offset: 25267},
+						pos:  position{line: 1051, col: 5, offset: 25138},
 						name: "SELECT",
 					},
 				},
@@ -7178,58 +7127,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1056, col: 1, offset: 25275},
+			pos:  position{line: 1053, col: 1, offset: 25146},
 			expr: &actionExpr{
-				pos: position{line: 1057, col: 5, offset: 25284},
+				pos: position{line: 1054, col: 5, offset: 25155},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1057, col: 5, offset: 25284},
+					pos: position{line: 1054, col: 5, offset: 25155},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1057, col: 5, offset: 25284},
+							pos:   position{line: 1054, col: 5, offset: 25155},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1057, col: 9, offset: 25288},
+								pos:  position{line: 1054, col: 9, offset: 25159},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1057, col: 21, offset: 25300},
+							pos:  position{line: 1054, col: 21, offset: 25171},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1057, col: 24, offset: 25303},
+							pos:        position{line: 1054, col: 24, offset: 25174},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1057, col: 28, offset: 25307},
+							pos:  position{line: 1054, col: 28, offset: 25178},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1057, col: 31, offset: 25310},
+							pos:   position{line: 1054, col: 31, offset: 25181},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1057, col: 37, offset: 25316},
+								pos: position{line: 1054, col: 37, offset: 25187},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1057, col: 37, offset: 25316},
+										pos:  position{line: 1054, col: 37, offset: 25187},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1057, col: 48, offset: 25327},
+										pos:  position{line: 1054, col: 48, offset: 25198},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1057, col: 54, offset: 25333},
+							pos:  position{line: 1054, col: 54, offset: 25204},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1057, col: 57, offset: 25336},
+							pos:        position{line: 1054, col: 57, offset: 25207},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7242,85 +7191,85 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1061, col: 1, offset: 25449},
+			pos:  position{line: 1058, col: 1, offset: 25320},
 			expr: &choiceExpr{
-				pos: position{line: 1062, col: 5, offset: 25462},
+				pos: position{line: 1059, col: 5, offset: 25333},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1062, col: 5, offset: 25462},
+						pos:  position{line: 1059, col: 5, offset: 25333},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1064, col: 5, offset: 25549},
+						pos: position{line: 1061, col: 5, offset: 25420},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1064, col: 5, offset: 25549},
+							pos: position{line: 1061, col: 5, offset: 25420},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 5, offset: 25549},
+									pos:  position{line: 1061, col: 5, offset: 25420},
 									name: "REGEXP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 12, offset: 25556},
+									pos:  position{line: 1061, col: 12, offset: 25427},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1064, col: 15, offset: 25559},
+									pos:        position{line: 1061, col: 15, offset: 25430},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 19, offset: 25563},
+									pos:  position{line: 1061, col: 19, offset: 25434},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1064, col: 22, offset: 25566},
+									pos:   position{line: 1061, col: 22, offset: 25437},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1064, col: 27, offset: 25571},
+										pos:  position{line: 1061, col: 27, offset: 25442},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 43, offset: 25587},
+									pos:  position{line: 1061, col: 43, offset: 25458},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1064, col: 46, offset: 25590},
+									pos:        position{line: 1061, col: 46, offset: 25461},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 50, offset: 25594},
+									pos:  position{line: 1061, col: 50, offset: 25465},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1064, col: 53, offset: 25597},
+									pos:   position{line: 1061, col: 53, offset: 25468},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1064, col: 58, offset: 25602},
+										pos:  position{line: 1061, col: 58, offset: 25473},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 63, offset: 25607},
+									pos:  position{line: 1061, col: 63, offset: 25478},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1064, col: 66, offset: 25610},
+									pos:        position{line: 1061, col: 66, offset: 25481},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1064, col: 70, offset: 25614},
+									pos:   position{line: 1061, col: 70, offset: 25485},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1064, col: 76, offset: 25620},
+										pos: position{line: 1061, col: 76, offset: 25491},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1064, col: 76, offset: 25620},
+											pos:  position{line: 1061, col: 76, offset: 25491},
 											name: "WhereClause",
 										},
 									},
@@ -7329,98 +7278,98 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1068, col: 5, offset: 25799},
+						pos: position{line: 1065, col: 5, offset: 25670},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1068, col: 5, offset: 25799},
+							pos: position{line: 1065, col: 5, offset: 25670},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 5, offset: 25799},
+									pos:  position{line: 1065, col: 5, offset: 25670},
 									name: "REGEXP_REPLACE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 20, offset: 25814},
+									pos:  position{line: 1065, col: 20, offset: 25685},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1068, col: 23, offset: 25817},
+									pos:        position{line: 1065, col: 23, offset: 25688},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 27, offset: 25821},
+									pos:  position{line: 1065, col: 27, offset: 25692},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1068, col: 30, offset: 25824},
+									pos:   position{line: 1065, col: 30, offset: 25695},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1068, col: 35, offset: 25829},
+										pos:  position{line: 1065, col: 35, offset: 25700},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 40, offset: 25834},
+									pos:  position{line: 1065, col: 40, offset: 25705},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1068, col: 43, offset: 25837},
+									pos:        position{line: 1065, col: 43, offset: 25708},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 47, offset: 25841},
+									pos:  position{line: 1065, col: 47, offset: 25712},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1068, col: 50, offset: 25844},
+									pos:   position{line: 1065, col: 50, offset: 25715},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1068, col: 55, offset: 25849},
+										pos:  position{line: 1065, col: 55, offset: 25720},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 71, offset: 25865},
+									pos:  position{line: 1065, col: 71, offset: 25736},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1068, col: 74, offset: 25868},
+									pos:        position{line: 1065, col: 74, offset: 25739},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 78, offset: 25872},
+									pos:  position{line: 1065, col: 78, offset: 25743},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1068, col: 81, offset: 25875},
+									pos:   position{line: 1065, col: 81, offset: 25746},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1068, col: 86, offset: 25880},
+										pos:  position{line: 1065, col: 86, offset: 25751},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 91, offset: 25885},
+									pos:  position{line: 1065, col: 91, offset: 25756},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1068, col: 94, offset: 25888},
+									pos:        position{line: 1065, col: 94, offset: 25759},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1068, col: 98, offset: 25892},
+									pos:   position{line: 1065, col: 98, offset: 25763},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1068, col: 104, offset: 25898},
+										pos: position{line: 1065, col: 104, offset: 25769},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1068, col: 104, offset: 25898},
+											pos:  position{line: 1065, col: 104, offset: 25769},
 											name: "WhereClause",
 										},
 									},
@@ -7429,65 +7378,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1072, col: 5, offset: 26092},
+						pos: position{line: 1069, col: 5, offset: 25963},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1072, col: 5, offset: 26092},
+							pos: position{line: 1069, col: 5, offset: 25963},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1072, col: 5, offset: 26092},
+									pos: position{line: 1069, col: 5, offset: 25963},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 6, offset: 26093},
+										pos:  position{line: 1069, col: 6, offset: 25964},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1072, col: 16, offset: 26103},
+									pos:   position{line: 1069, col: 16, offset: 25974},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 19, offset: 26106},
+										pos:  position{line: 1069, col: 19, offset: 25977},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 30, offset: 26117},
+									pos:  position{line: 1069, col: 30, offset: 25988},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1072, col: 33, offset: 26120},
+									pos:        position{line: 1069, col: 33, offset: 25991},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 37, offset: 26124},
+									pos:  position{line: 1069, col: 37, offset: 25995},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1072, col: 40, offset: 26127},
+									pos:   position{line: 1069, col: 40, offset: 25998},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 45, offset: 26132},
+										pos:  position{line: 1069, col: 45, offset: 26003},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 58, offset: 26145},
+									pos:  position{line: 1069, col: 58, offset: 26016},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1072, col: 61, offset: 26148},
+									pos:        position{line: 1069, col: 61, offset: 26019},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1072, col: 65, offset: 26152},
+									pos:   position{line: 1069, col: 65, offset: 26023},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1072, col: 71, offset: 26158},
+										pos: position{line: 1069, col: 71, offset: 26029},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1072, col: 71, offset: 26158},
+											pos:  position{line: 1069, col: 71, offset: 26029},
 											name: "WhereClause",
 										},
 									},
@@ -7502,15 +7451,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1076, col: 1, offset: 26226},
+			pos:  position{line: 1073, col: 1, offset: 26097},
 			expr: &actionExpr{
-				pos: position{line: 1077, col: 5, offset: 26246},
+				pos: position{line: 1074, col: 5, offset: 26117},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1077, col: 5, offset: 26246},
+					pos:   position{line: 1074, col: 5, offset: 26117},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1077, col: 9, offset: 26250},
+						pos:  position{line: 1074, col: 9, offset: 26121},
 						name: "RegexpPattern",
 					},
 				},
@@ -7520,24 +7469,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1079, col: 1, offset: 26321},
+			pos:  position{line: 1076, col: 1, offset: 26192},
 			expr: &choiceExpr{
-				pos: position{line: 1080, col: 5, offset: 26338},
+				pos: position{line: 1077, col: 5, offset: 26209},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 26338},
+						pos: position{line: 1077, col: 5, offset: 26209},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1080, col: 5, offset: 26338},
+							pos:   position{line: 1077, col: 5, offset: 26209},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1080, col: 7, offset: 26340},
+								pos:  position{line: 1077, col: 7, offset: 26211},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1081, col: 5, offset: 26378},
+						pos:  position{line: 1078, col: 5, offset: 26249},
 						name: "OptionalExprs",
 					},
 				},
@@ -7547,96 +7496,96 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1083, col: 1, offset: 26393},
+			pos:  position{line: 1080, col: 1, offset: 26264},
 			expr: &actionExpr{
-				pos: position{line: 1084, col: 5, offset: 26402},
+				pos: position{line: 1081, col: 5, offset: 26273},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1084, col: 5, offset: 26402},
+					pos: position{line: 1081, col: 5, offset: 26273},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1084, col: 5, offset: 26402},
+							pos:  position{line: 1081, col: 5, offset: 26273},
 							name: "GREP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1084, col: 10, offset: 26407},
+							pos:  position{line: 1081, col: 10, offset: 26278},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 13, offset: 26410},
+							pos:        position{line: 1081, col: 13, offset: 26281},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1084, col: 17, offset: 26414},
+							pos:  position{line: 1081, col: 17, offset: 26285},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1084, col: 20, offset: 26417},
+							pos:   position{line: 1081, col: 20, offset: 26288},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1084, col: 29, offset: 26426},
+								pos: position{line: 1081, col: 29, offset: 26297},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1084, col: 29, offset: 26426},
+										pos:  position{line: 1081, col: 29, offset: 26297},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1084, col: 38, offset: 26435},
+										pos:  position{line: 1081, col: 38, offset: 26306},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1084, col: 45, offset: 26442},
+										pos:  position{line: 1081, col: 45, offset: 26313},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1084, col: 51, offset: 26448},
+							pos:  position{line: 1081, col: 51, offset: 26319},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1084, col: 54, offset: 26451},
+							pos:   position{line: 1081, col: 54, offset: 26322},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1084, col: 58, offset: 26455},
+								pos: position{line: 1081, col: 58, offset: 26326},
 								expr: &actionExpr{
-									pos: position{line: 1084, col: 59, offset: 26456},
+									pos: position{line: 1081, col: 59, offset: 26327},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1084, col: 59, offset: 26456},
+										pos: position{line: 1081, col: 59, offset: 26327},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1084, col: 59, offset: 26456},
+												pos:        position{line: 1081, col: 59, offset: 26327},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1084, col: 63, offset: 26460},
+												pos:  position{line: 1081, col: 63, offset: 26331},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1084, col: 66, offset: 26463},
+												pos:   position{line: 1081, col: 66, offset: 26334},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1084, col: 69, offset: 26466},
+													pos: position{line: 1081, col: 69, offset: 26337},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1084, col: 69, offset: 26466},
+															pos:  position{line: 1081, col: 69, offset: 26337},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1084, col: 80, offset: 26477},
+															pos:  position{line: 1081, col: 80, offset: 26348},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1084, col: 86, offset: 26483},
+												pos:  position{line: 1081, col: 86, offset: 26354},
 												name: "__",
 											},
 										},
@@ -7645,7 +7594,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1084, col: 109, offset: 26506},
+							pos:        position{line: 1081, col: 109, offset: 26377},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7658,19 +7607,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1096, col: 1, offset: 26719},
+			pos:  position{line: 1093, col: 1, offset: 26590},
 			expr: &choiceExpr{
-				pos: position{line: 1097, col: 5, offset: 26737},
+				pos: position{line: 1094, col: 5, offset: 26608},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1097, col: 5, offset: 26737},
+						pos:  position{line: 1094, col: 5, offset: 26608},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1098, col: 5, offset: 26747},
+						pos: position{line: 1095, col: 5, offset: 26618},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1098, col: 5, offset: 26747},
+							pos:  position{line: 1095, col: 5, offset: 26618},
 							name: "__",
 						},
 					},
@@ -7681,51 +7630,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1100, col: 1, offset: 26775},
+			pos:  position{line: 1097, col: 1, offset: 26646},
 			expr: &actionExpr{
-				pos: position{line: 1101, col: 5, offset: 26785},
+				pos: position{line: 1098, col: 5, offset: 26656},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1101, col: 5, offset: 26785},
+					pos: position{line: 1098, col: 5, offset: 26656},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1101, col: 5, offset: 26785},
+							pos:   position{line: 1098, col: 5, offset: 26656},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1101, col: 11, offset: 26791},
+								pos:  position{line: 1098, col: 11, offset: 26662},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1101, col: 16, offset: 26796},
+							pos:   position{line: 1098, col: 16, offset: 26667},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1101, col: 21, offset: 26801},
+								pos: position{line: 1098, col: 21, offset: 26672},
 								expr: &actionExpr{
-									pos: position{line: 1101, col: 22, offset: 26802},
+									pos: position{line: 1098, col: 22, offset: 26673},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1101, col: 22, offset: 26802},
+										pos: position{line: 1098, col: 22, offset: 26673},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1101, col: 22, offset: 26802},
+												pos:  position{line: 1098, col: 22, offset: 26673},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1101, col: 25, offset: 26805},
+												pos:        position{line: 1098, col: 25, offset: 26676},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1101, col: 29, offset: 26809},
+												pos:  position{line: 1098, col: 29, offset: 26680},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1101, col: 32, offset: 26812},
+												pos:   position{line: 1098, col: 32, offset: 26683},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1101, col: 34, offset: 26814},
+													pos:  position{line: 1098, col: 34, offset: 26685},
 													name: "Expr",
 												},
 											},
@@ -7742,52 +7691,52 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1105, col: 1, offset: 26887},
+			pos:  position{line: 1102, col: 1, offset: 26758},
 			expr: &choiceExpr{
-				pos: position{line: 1106, col: 5, offset: 26899},
+				pos: position{line: 1103, col: 5, offset: 26770},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1106, col: 5, offset: 26899},
+						pos:  position{line: 1103, col: 5, offset: 26770},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1107, col: 5, offset: 26912},
+						pos:  position{line: 1104, col: 5, offset: 26783},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1108, col: 5, offset: 26923},
+						pos:  position{line: 1105, col: 5, offset: 26794},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1109, col: 5, offset: 26933},
+						pos:  position{line: 1106, col: 5, offset: 26804},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1110, col: 5, offset: 26941},
+						pos:  position{line: 1107, col: 5, offset: 26812},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1111, col: 5, offset: 26949},
+						pos:  position{line: 1108, col: 5, offset: 26820},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1112, col: 5, offset: 26961},
+						pos: position{line: 1109, col: 5, offset: 26832},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1112, col: 5, offset: 26961},
+							pos: position{line: 1109, col: 5, offset: 26832},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1112, col: 5, offset: 26961},
+									pos: position{line: 1109, col: 5, offset: 26832},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1112, col: 6, offset: 26962},
+										pos:  position{line: 1109, col: 6, offset: 26833},
 										name: "PipeKeyword",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1112, col: 18, offset: 26974},
+									pos:   position{line: 1109, col: 18, offset: 26845},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1112, col: 21, offset: 26977},
+										pos:  position{line: 1109, col: 21, offset: 26848},
 										name: "Identifier",
 									},
 								},
@@ -7795,39 +7744,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1113, col: 5, offset: 27011},
+						pos:  position{line: 1110, col: 5, offset: 26882},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1114, col: 5, offset: 27021},
+						pos: position{line: 1111, col: 5, offset: 26892},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 1114, col: 5, offset: 27021},
+							pos: position{line: 1111, col: 5, offset: 26892},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1114, col: 5, offset: 27021},
+									pos:        position{line: 1111, col: 5, offset: 26892},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 9, offset: 27025},
+									pos:  position{line: 1111, col: 9, offset: 26896},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 12, offset: 27028},
+									pos:   position{line: 1111, col: 12, offset: 26899},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1114, col: 17, offset: 27033},
+										pos:  position{line: 1111, col: 17, offset: 26904},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 26, offset: 27042},
+									pos:  position{line: 1111, col: 26, offset: 26913},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 29, offset: 27045},
+									pos:        position{line: 1111, col: 29, offset: 26916},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7836,35 +7785,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1115, col: 5, offset: 27074},
+						pos: position{line: 1112, col: 5, offset: 26945},
 						run: (*parser).callonPrimary23,
 						expr: &seqExpr{
-							pos: position{line: 1115, col: 5, offset: 27074},
+							pos: position{line: 1112, col: 5, offset: 26945},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1115, col: 5, offset: 27074},
+									pos:        position{line: 1112, col: 5, offset: 26945},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1115, col: 9, offset: 27078},
+									pos:  position{line: 1112, col: 9, offset: 26949},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1115, col: 12, offset: 27081},
+									pos:   position{line: 1112, col: 12, offset: 26952},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1115, col: 17, offset: 27086},
+										pos:  position{line: 1112, col: 17, offset: 26957},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1115, col: 22, offset: 27091},
+									pos:  position{line: 1112, col: 22, offset: 26962},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1115, col: 25, offset: 27094},
+									pos:        position{line: 1112, col: 25, offset: 26965},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7879,55 +7828,55 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1117, col: 1, offset: 27120},
+			pos:  position{line: 1114, col: 1, offset: 26991},
 			expr: &choiceExpr{
-				pos: position{line: 1118, col: 5, offset: 27133},
+				pos: position{line: 1115, col: 5, offset: 27004},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1118, col: 5, offset: 27133},
+						pos: position{line: 1115, col: 5, offset: 27004},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1118, col: 5, offset: 27133},
+							pos: position{line: 1115, col: 5, offset: 27004},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 5, offset: 27133},
+									pos:  position{line: 1115, col: 5, offset: 27004},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 10, offset: 27138},
+									pos:   position{line: 1115, col: 10, offset: 27009},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1118, col: 16, offset: 27144},
+										pos: position{line: 1115, col: 16, offset: 27015},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1118, col: 16, offset: 27144},
+											pos:  position{line: 1115, col: 16, offset: 27015},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 22, offset: 27150},
+									pos:   position{line: 1115, col: 22, offset: 27021},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1118, col: 28, offset: 27156},
+										pos: position{line: 1115, col: 28, offset: 27027},
 										expr: &seqExpr{
-											pos: position{line: 1118, col: 29, offset: 27157},
+											pos: position{line: 1115, col: 29, offset: 27028},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1118, col: 29, offset: 27157},
+													pos:  position{line: 1115, col: 29, offset: 27028},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 1118, col: 31, offset: 27159},
+													pos:        position{line: 1115, col: 31, offset: 27030},
 													val:        "else",
 													ignoreCase: false,
 													want:       "\"else\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1118, col: 38, offset: 27166},
+													pos:  position{line: 1115, col: 38, offset: 27037},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1118, col: 40, offset: 27168},
+													pos:  position{line: 1115, col: 40, offset: 27039},
 													name: "Expr",
 												},
 											},
@@ -7935,24 +7884,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 47, offset: 27175},
+									pos:  position{line: 1115, col: 47, offset: 27046},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 49, offset: 27177},
+									pos:  position{line: 1115, col: 49, offset: 27048},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1118, col: 53, offset: 27181},
+									pos: position{line: 1115, col: 53, offset: 27052},
 									expr: &seqExpr{
-										pos: position{line: 1118, col: 54, offset: 27182},
+										pos: position{line: 1115, col: 54, offset: 27053},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1118, col: 54, offset: 27182},
+												pos:  position{line: 1115, col: 54, offset: 27053},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1118, col: 56, offset: 27184},
+												pos:  position{line: 1115, col: 56, offset: 27055},
 												name: "CASE",
 											},
 										},
@@ -7962,62 +7911,62 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1142, col: 5, offset: 27833},
+						pos: position{line: 1139, col: 5, offset: 27704},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1142, col: 5, offset: 27833},
+							pos: position{line: 1139, col: 5, offset: 27704},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1142, col: 5, offset: 27833},
+									pos:  position{line: 1139, col: 5, offset: 27704},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1142, col: 10, offset: 27838},
+									pos:  position{line: 1139, col: 10, offset: 27709},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1142, col: 12, offset: 27840},
+									pos:   position{line: 1139, col: 12, offset: 27711},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1142, col: 17, offset: 27845},
+										pos:  position{line: 1139, col: 17, offset: 27716},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1142, col: 22, offset: 27850},
+									pos:   position{line: 1139, col: 22, offset: 27721},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1142, col: 28, offset: 27856},
+										pos: position{line: 1139, col: 28, offset: 27727},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1142, col: 28, offset: 27856},
+											pos:  position{line: 1139, col: 28, offset: 27727},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1142, col: 34, offset: 27862},
+									pos:   position{line: 1139, col: 34, offset: 27733},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1142, col: 40, offset: 27868},
+										pos: position{line: 1139, col: 40, offset: 27739},
 										expr: &seqExpr{
-											pos: position{line: 1142, col: 41, offset: 27869},
+											pos: position{line: 1139, col: 41, offset: 27740},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1142, col: 41, offset: 27869},
+													pos:  position{line: 1139, col: 41, offset: 27740},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 1142, col: 43, offset: 27871},
+													pos:        position{line: 1139, col: 43, offset: 27742},
 													val:        "else",
 													ignoreCase: false,
 													want:       "\"else\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1142, col: 50, offset: 27878},
+													pos:  position{line: 1139, col: 50, offset: 27749},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1142, col: 52, offset: 27880},
+													pos:  position{line: 1139, col: 52, offset: 27751},
 													name: "Expr",
 												},
 											},
@@ -8025,24 +7974,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1142, col: 59, offset: 27887},
+									pos:  position{line: 1139, col: 59, offset: 27758},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1142, col: 61, offset: 27889},
+									pos:  position{line: 1139, col: 61, offset: 27760},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1142, col: 65, offset: 27893},
+									pos: position{line: 1139, col: 65, offset: 27764},
 									expr: &seqExpr{
-										pos: position{line: 1142, col: 66, offset: 27894},
+										pos: position{line: 1139, col: 66, offset: 27765},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1142, col: 66, offset: 27894},
+												pos:  position{line: 1139, col: 66, offset: 27765},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1142, col: 68, offset: 27896},
+												pos:  position{line: 1139, col: 68, offset: 27767},
 												name: "CASE",
 											},
 										},
@@ -8058,50 +8007,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1155, col: 1, offset: 28202},
+			pos:  position{line: 1152, col: 1, offset: 28073},
 			expr: &actionExpr{
-				pos: position{line: 1156, col: 5, offset: 28211},
+				pos: position{line: 1153, col: 5, offset: 28082},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1156, col: 5, offset: 28211},
+					pos: position{line: 1153, col: 5, offset: 28082},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 5, offset: 28211},
+							pos:  position{line: 1153, col: 5, offset: 28082},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 7, offset: 28213},
+							pos:  position{line: 1153, col: 7, offset: 28084},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 12, offset: 28218},
+							pos:  position{line: 1153, col: 12, offset: 28089},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1156, col: 14, offset: 28220},
+							pos:   position{line: 1153, col: 14, offset: 28091},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1156, col: 19, offset: 28225},
+								pos:  position{line: 1153, col: 19, offset: 28096},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 24, offset: 28230},
+							pos:  position{line: 1153, col: 24, offset: 28101},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 26, offset: 28232},
+							pos:  position{line: 1153, col: 26, offset: 28103},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1156, col: 31, offset: 28237},
+							pos:  position{line: 1153, col: 31, offset: 28108},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1156, col: 33, offset: 28239},
+							pos:   position{line: 1153, col: 33, offset: 28110},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1156, col: 38, offset: 28244},
+								pos:  position{line: 1153, col: 38, offset: 28115},
 								name: "Expr",
 							},
 						},
@@ -8113,57 +8062,57 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1165, col: 1, offset: 28403},
+			pos:  position{line: 1162, col: 1, offset: 28274},
 			expr: &actionExpr{
-				pos: position{line: 1166, col: 5, offset: 28416},
+				pos: position{line: 1163, col: 5, offset: 28287},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1166, col: 5, offset: 28416},
+					pos: position{line: 1163, col: 5, offset: 28287},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 5, offset: 28416},
+							pos:  position{line: 1163, col: 5, offset: 28287},
 							name: "OVER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 10, offset: 28421},
+							pos:  position{line: 1163, col: 10, offset: 28292},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1166, col: 12, offset: 28423},
+							pos:   position{line: 1163, col: 12, offset: 28294},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1166, col: 18, offset: 28429},
+								pos:  position{line: 1163, col: 18, offset: 28300},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1166, col: 24, offset: 28435},
+							pos:   position{line: 1163, col: 24, offset: 28306},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1166, col: 31, offset: 28442},
+								pos: position{line: 1163, col: 31, offset: 28313},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1166, col: 31, offset: 28442},
+									pos:  position{line: 1163, col: 31, offset: 28313},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 39, offset: 28450},
+							pos:  position{line: 1163, col: 39, offset: 28321},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 42, offset: 28453},
+							pos:  position{line: 1163, col: 42, offset: 28324},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 47, offset: 28458},
+							pos:  position{line: 1163, col: 47, offset: 28329},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1166, col: 50, offset: 28461},
+							pos:   position{line: 1163, col: 50, offset: 28332},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1166, col: 55, offset: 28466},
+								pos:  position{line: 1163, col: 55, offset: 28337},
 								name: "Seq",
 							},
 						},
@@ -8175,37 +8124,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1176, col: 1, offset: 28697},
+			pos:  position{line: 1173, col: 1, offset: 28568},
 			expr: &actionExpr{
-				pos: position{line: 1177, col: 5, offset: 28708},
+				pos: position{line: 1174, col: 5, offset: 28579},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1177, col: 5, offset: 28708},
+					pos: position{line: 1174, col: 5, offset: 28579},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1177, col: 5, offset: 28708},
+							pos:        position{line: 1174, col: 5, offset: 28579},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1177, col: 9, offset: 28712},
+							pos:  position{line: 1174, col: 9, offset: 28583},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1177, col: 12, offset: 28715},
+							pos:   position{line: 1174, col: 12, offset: 28586},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1177, col: 18, offset: 28721},
+								pos:  position{line: 1174, col: 18, offset: 28592},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1177, col: 30, offset: 28733},
+							pos:  position{line: 1174, col: 30, offset: 28604},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1177, col: 33, offset: 28736},
+							pos:        position{line: 1174, col: 33, offset: 28607},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8218,31 +8167,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1185, col: 1, offset: 28894},
+			pos:  position{line: 1182, col: 1, offset: 28765},
 			expr: &choiceExpr{
-				pos: position{line: 1186, col: 5, offset: 28910},
+				pos: position{line: 1183, col: 5, offset: 28781},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1186, col: 5, offset: 28910},
+						pos: position{line: 1183, col: 5, offset: 28781},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1186, col: 5, offset: 28910},
+							pos: position{line: 1183, col: 5, offset: 28781},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1186, col: 5, offset: 28910},
+									pos:   position{line: 1183, col: 5, offset: 28781},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1186, col: 11, offset: 28916},
+										pos:  position{line: 1183, col: 11, offset: 28787},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1186, col: 22, offset: 28927},
+									pos:   position{line: 1183, col: 22, offset: 28798},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1186, col: 27, offset: 28932},
+										pos: position{line: 1183, col: 27, offset: 28803},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1186, col: 27, offset: 28932},
+											pos:  position{line: 1183, col: 27, offset: 28803},
 											name: "RecordElemTail",
 										},
 									},
@@ -8251,10 +8200,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1189, col: 5, offset: 28995},
+						pos: position{line: 1186, col: 5, offset: 28866},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1189, col: 5, offset: 28995},
+							pos:  position{line: 1186, col: 5, offset: 28866},
 							name: "__",
 						},
 					},
@@ -8265,32 +8214,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1191, col: 1, offset: 29019},
+			pos:  position{line: 1188, col: 1, offset: 28890},
 			expr: &actionExpr{
-				pos: position{line: 1191, col: 18, offset: 29036},
+				pos: position{line: 1188, col: 18, offset: 28907},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1191, col: 18, offset: 29036},
+					pos: position{line: 1188, col: 18, offset: 28907},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1191, col: 18, offset: 29036},
+							pos:  position{line: 1188, col: 18, offset: 28907},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1191, col: 21, offset: 29039},
+							pos:        position{line: 1188, col: 21, offset: 28910},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1191, col: 25, offset: 29043},
+							pos:  position{line: 1188, col: 25, offset: 28914},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1191, col: 28, offset: 29046},
+							pos:   position{line: 1188, col: 28, offset: 28917},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1191, col: 33, offset: 29051},
+								pos:  position{line: 1188, col: 33, offset: 28922},
 								name: "RecordElem",
 							},
 						},
@@ -8302,20 +8251,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1193, col: 1, offset: 29084},
+			pos:  position{line: 1190, col: 1, offset: 28955},
 			expr: &choiceExpr{
-				pos: position{line: 1194, col: 5, offset: 29099},
+				pos: position{line: 1191, col: 5, offset: 28970},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1194, col: 5, offset: 29099},
+						pos:  position{line: 1191, col: 5, offset: 28970},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1195, col: 5, offset: 29110},
+						pos:  position{line: 1192, col: 5, offset: 28981},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1196, col: 5, offset: 29124},
+						pos:  position{line: 1193, col: 5, offset: 28995},
 						name: "Identifier",
 					},
 				},
@@ -8325,28 +8274,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1198, col: 1, offset: 29136},
+			pos:  position{line: 1195, col: 1, offset: 29007},
 			expr: &actionExpr{
-				pos: position{line: 1199, col: 5, offset: 29147},
+				pos: position{line: 1196, col: 5, offset: 29018},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1199, col: 5, offset: 29147},
+					pos: position{line: 1196, col: 5, offset: 29018},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1199, col: 5, offset: 29147},
+							pos:        position{line: 1196, col: 5, offset: 29018},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1199, col: 11, offset: 29153},
+							pos:  position{line: 1196, col: 11, offset: 29024},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1199, col: 14, offset: 29156},
+							pos:   position{line: 1196, col: 14, offset: 29027},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1199, col: 19, offset: 29161},
+								pos:  position{line: 1196, col: 19, offset: 29032},
 								name: "Expr",
 							},
 						},
@@ -8358,40 +8307,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1203, col: 1, offset: 29257},
+			pos:  position{line: 1200, col: 1, offset: 29128},
 			expr: &actionExpr{
-				pos: position{line: 1204, col: 5, offset: 29271},
+				pos: position{line: 1201, col: 5, offset: 29142},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1204, col: 5, offset: 29271},
+					pos: position{line: 1201, col: 5, offset: 29142},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1204, col: 5, offset: 29271},
+							pos:   position{line: 1201, col: 5, offset: 29142},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1204, col: 10, offset: 29276},
+								pos:  position{line: 1201, col: 10, offset: 29147},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1204, col: 15, offset: 29281},
+							pos:  position{line: 1201, col: 15, offset: 29152},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1204, col: 18, offset: 29284},
+							pos:        position{line: 1201, col: 18, offset: 29155},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1204, col: 22, offset: 29288},
+							pos:  position{line: 1201, col: 22, offset: 29159},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1204, col: 25, offset: 29291},
+							pos:   position{line: 1201, col: 25, offset: 29162},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1204, col: 31, offset: 29297},
+								pos:  position{line: 1201, col: 31, offset: 29168},
 								name: "Expr",
 							},
 						},
@@ -8403,37 +8352,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1213, col: 1, offset: 29466},
+			pos:  position{line: 1210, col: 1, offset: 29337},
 			expr: &actionExpr{
-				pos: position{line: 1214, col: 5, offset: 29476},
+				pos: position{line: 1211, col: 5, offset: 29347},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1214, col: 5, offset: 29476},
+					pos: position{line: 1211, col: 5, offset: 29347},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1214, col: 5, offset: 29476},
+							pos:        position{line: 1211, col: 5, offset: 29347},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1214, col: 9, offset: 29480},
+							pos:  position{line: 1211, col: 9, offset: 29351},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1214, col: 12, offset: 29483},
+							pos:   position{line: 1211, col: 12, offset: 29354},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1214, col: 18, offset: 29489},
+								pos:  position{line: 1211, col: 18, offset: 29360},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1214, col: 30, offset: 29501},
+							pos:  position{line: 1211, col: 30, offset: 29372},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1214, col: 33, offset: 29504},
+							pos:        position{line: 1211, col: 33, offset: 29375},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8446,37 +8395,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1222, col: 1, offset: 29660},
+			pos:  position{line: 1219, col: 1, offset: 29531},
 			expr: &actionExpr{
-				pos: position{line: 1223, col: 5, offset: 29668},
+				pos: position{line: 1220, col: 5, offset: 29539},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1223, col: 5, offset: 29668},
+					pos: position{line: 1220, col: 5, offset: 29539},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1223, col: 5, offset: 29668},
+							pos:        position{line: 1220, col: 5, offset: 29539},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1223, col: 10, offset: 29673},
+							pos:  position{line: 1220, col: 10, offset: 29544},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1223, col: 13, offset: 29676},
+							pos:   position{line: 1220, col: 13, offset: 29547},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1223, col: 19, offset: 29682},
+								pos:  position{line: 1220, col: 19, offset: 29553},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1223, col: 31, offset: 29694},
+							pos:  position{line: 1220, col: 31, offset: 29565},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1223, col: 34, offset: 29697},
+							pos:        position{line: 1220, col: 34, offset: 29568},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8489,54 +8438,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1231, col: 1, offset: 29850},
+			pos:  position{line: 1228, col: 1, offset: 29721},
 			expr: &choiceExpr{
-				pos: position{line: 1232, col: 5, offset: 29866},
+				pos: position{line: 1229, col: 5, offset: 29737},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1232, col: 5, offset: 29866},
+						pos: position{line: 1229, col: 5, offset: 29737},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1232, col: 5, offset: 29866},
+							pos: position{line: 1229, col: 5, offset: 29737},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1232, col: 5, offset: 29866},
+									pos:   position{line: 1229, col: 5, offset: 29737},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1232, col: 11, offset: 29872},
+										pos:  position{line: 1229, col: 11, offset: 29743},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1232, col: 22, offset: 29883},
+									pos:   position{line: 1229, col: 22, offset: 29754},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1232, col: 27, offset: 29888},
+										pos: position{line: 1229, col: 27, offset: 29759},
 										expr: &actionExpr{
-											pos: position{line: 1232, col: 28, offset: 29889},
+											pos: position{line: 1229, col: 28, offset: 29760},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1232, col: 28, offset: 29889},
+												pos: position{line: 1229, col: 28, offset: 29760},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1232, col: 28, offset: 29889},
+														pos:  position{line: 1229, col: 28, offset: 29760},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1232, col: 31, offset: 29892},
+														pos:        position{line: 1229, col: 31, offset: 29763},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1232, col: 35, offset: 29896},
+														pos:  position{line: 1229, col: 35, offset: 29767},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1232, col: 38, offset: 29899},
+														pos:   position{line: 1229, col: 38, offset: 29770},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1232, col: 40, offset: 29901},
+															pos:  position{line: 1229, col: 40, offset: 29772},
 															name: "VectorElem",
 														},
 													},
@@ -8549,10 +8498,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1235, col: 5, offset: 29983},
+						pos: position{line: 1232, col: 5, offset: 29854},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1235, col: 5, offset: 29983},
+							pos:  position{line: 1232, col: 5, offset: 29854},
 							name: "__",
 						},
 					},
@@ -8563,22 +8512,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1237, col: 1, offset: 30007},
+			pos:  position{line: 1234, col: 1, offset: 29878},
 			expr: &choiceExpr{
-				pos: position{line: 1238, col: 5, offset: 30022},
+				pos: position{line: 1235, col: 5, offset: 29893},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1238, col: 5, offset: 30022},
+						pos:  position{line: 1235, col: 5, offset: 29893},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1239, col: 5, offset: 30033},
+						pos: position{line: 1236, col: 5, offset: 29904},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1239, col: 5, offset: 30033},
+							pos:   position{line: 1236, col: 5, offset: 29904},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1239, col: 7, offset: 30035},
+								pos:  position{line: 1236, col: 7, offset: 29906},
 								name: "Expr",
 							},
 						},
@@ -8590,37 +8539,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1241, col: 1, offset: 30126},
+			pos:  position{line: 1238, col: 1, offset: 29997},
 			expr: &actionExpr{
-				pos: position{line: 1242, col: 5, offset: 30134},
+				pos: position{line: 1239, col: 5, offset: 30005},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1242, col: 5, offset: 30134},
+					pos: position{line: 1239, col: 5, offset: 30005},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1242, col: 5, offset: 30134},
+							pos:        position{line: 1239, col: 5, offset: 30005},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1242, col: 10, offset: 30139},
+							pos:  position{line: 1239, col: 10, offset: 30010},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1242, col: 13, offset: 30142},
+							pos:   position{line: 1239, col: 13, offset: 30013},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1242, col: 19, offset: 30148},
+								pos:  position{line: 1239, col: 19, offset: 30019},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1242, col: 27, offset: 30156},
+							pos:  position{line: 1239, col: 27, offset: 30027},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1242, col: 30, offset: 30159},
+							pos:        position{line: 1239, col: 30, offset: 30030},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8633,31 +8582,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1250, col: 1, offset: 30313},
+			pos:  position{line: 1247, col: 1, offset: 30184},
 			expr: &choiceExpr{
-				pos: position{line: 1251, col: 5, offset: 30325},
+				pos: position{line: 1248, col: 5, offset: 30196},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1251, col: 5, offset: 30325},
+						pos: position{line: 1248, col: 5, offset: 30196},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1251, col: 5, offset: 30325},
+							pos: position{line: 1248, col: 5, offset: 30196},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1251, col: 5, offset: 30325},
+									pos:   position{line: 1248, col: 5, offset: 30196},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1251, col: 11, offset: 30331},
+										pos:  position{line: 1248, col: 11, offset: 30202},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1251, col: 17, offset: 30337},
+									pos:   position{line: 1248, col: 17, offset: 30208},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1251, col: 22, offset: 30342},
+										pos: position{line: 1248, col: 22, offset: 30213},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1251, col: 22, offset: 30342},
+											pos:  position{line: 1248, col: 22, offset: 30213},
 											name: "EntryTail",
 										},
 									},
@@ -8666,10 +8615,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1254, col: 5, offset: 30400},
+						pos: position{line: 1251, col: 5, offset: 30271},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1254, col: 5, offset: 30400},
+							pos:  position{line: 1251, col: 5, offset: 30271},
 							name: "__",
 						},
 					},
@@ -8680,32 +8629,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1257, col: 1, offset: 30425},
+			pos:  position{line: 1254, col: 1, offset: 30296},
 			expr: &actionExpr{
-				pos: position{line: 1257, col: 13, offset: 30437},
+				pos: position{line: 1254, col: 13, offset: 30308},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1257, col: 13, offset: 30437},
+					pos: position{line: 1254, col: 13, offset: 30308},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1257, col: 13, offset: 30437},
+							pos:  position{line: 1254, col: 13, offset: 30308},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1257, col: 16, offset: 30440},
+							pos:        position{line: 1254, col: 16, offset: 30311},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1257, col: 20, offset: 30444},
+							pos:  position{line: 1254, col: 20, offset: 30315},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1257, col: 23, offset: 30447},
+							pos:   position{line: 1254, col: 23, offset: 30318},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1257, col: 25, offset: 30449},
+								pos:  position{line: 1254, col: 25, offset: 30320},
 								name: "Entry",
 							},
 						},
@@ -8717,40 +8666,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1259, col: 1, offset: 30474},
+			pos:  position{line: 1256, col: 1, offset: 30345},
 			expr: &actionExpr{
-				pos: position{line: 1260, col: 5, offset: 30484},
+				pos: position{line: 1257, col: 5, offset: 30355},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1260, col: 5, offset: 30484},
+					pos: position{line: 1257, col: 5, offset: 30355},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1260, col: 5, offset: 30484},
+							pos:   position{line: 1257, col: 5, offset: 30355},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1260, col: 9, offset: 30488},
+								pos:  position{line: 1257, col: 9, offset: 30359},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1260, col: 14, offset: 30493},
+							pos:  position{line: 1257, col: 14, offset: 30364},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1260, col: 17, offset: 30496},
+							pos:        position{line: 1257, col: 17, offset: 30367},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1260, col: 21, offset: 30500},
+							pos:  position{line: 1257, col: 21, offset: 30371},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1260, col: 24, offset: 30503},
+							pos:   position{line: 1257, col: 24, offset: 30374},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1260, col: 30, offset: 30509},
+								pos:  position{line: 1257, col: 30, offset: 30380},
 								name: "Expr",
 							},
 						},
@@ -8762,61 +8711,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1264, col: 1, offset: 30612},
+			pos:  position{line: 1261, col: 1, offset: 30483},
 			expr: &actionExpr{
-				pos: position{line: 1265, col: 5, offset: 30622},
+				pos: position{line: 1262, col: 5, offset: 30493},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1265, col: 5, offset: 30622},
+					pos: position{line: 1262, col: 5, offset: 30493},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1265, col: 5, offset: 30622},
+							pos:        position{line: 1262, col: 5, offset: 30493},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1265, col: 9, offset: 30626},
+							pos:  position{line: 1262, col: 9, offset: 30497},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1265, col: 12, offset: 30629},
+							pos:   position{line: 1262, col: 12, offset: 30500},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1265, col: 18, offset: 30635},
+								pos:  position{line: 1262, col: 18, offset: 30506},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1265, col: 23, offset: 30640},
+							pos:   position{line: 1262, col: 23, offset: 30511},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1265, col: 28, offset: 30645},
+								pos: position{line: 1262, col: 28, offset: 30516},
 								expr: &actionExpr{
-									pos: position{line: 1265, col: 29, offset: 30646},
+									pos: position{line: 1262, col: 29, offset: 30517},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1265, col: 29, offset: 30646},
+										pos: position{line: 1262, col: 29, offset: 30517},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1265, col: 29, offset: 30646},
+												pos:  position{line: 1262, col: 29, offset: 30517},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1265, col: 32, offset: 30649},
+												pos:        position{line: 1262, col: 32, offset: 30520},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1265, col: 36, offset: 30653},
+												pos:  position{line: 1262, col: 36, offset: 30524},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1265, col: 39, offset: 30656},
+												pos:   position{line: 1262, col: 39, offset: 30527},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1265, col: 41, offset: 30658},
+													pos:  position{line: 1262, col: 41, offset: 30529},
 													name: "Expr",
 												},
 											},
@@ -8826,11 +8775,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1265, col: 66, offset: 30683},
+							pos:  position{line: 1262, col: 66, offset: 30554},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1265, col: 69, offset: 30686},
+							pos:        position{line: 1262, col: 69, offset: 30557},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8843,56 +8792,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1275, col: 1, offset: 30867},
+			pos:  position{line: 1272, col: 1, offset: 30738},
 			expr: &choiceExpr{
-				pos: position{line: 1276, col: 5, offset: 30879},
+				pos: position{line: 1273, col: 5, offset: 30750},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1276, col: 5, offset: 30879},
+						pos:  position{line: 1273, col: 5, offset: 30750},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1277, col: 5, offset: 30895},
+						pos:  position{line: 1274, col: 5, offset: 30766},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 30913},
+						pos:  position{line: 1275, col: 5, offset: 30784},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 5, offset: 30925},
+						pos:  position{line: 1276, col: 5, offset: 30796},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1280, col: 5, offset: 30943},
+						pos:  position{line: 1277, col: 5, offset: 30814},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1281, col: 5, offset: 30962},
+						pos:  position{line: 1278, col: 5, offset: 30833},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1282, col: 5, offset: 30979},
+						pos:  position{line: 1279, col: 5, offset: 30850},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1283, col: 5, offset: 30992},
+						pos:  position{line: 1280, col: 5, offset: 30863},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1284, col: 5, offset: 31001},
+						pos:  position{line: 1281, col: 5, offset: 30872},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1285, col: 5, offset: 31018},
+						pos:  position{line: 1282, col: 5, offset: 30889},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1286, col: 5, offset: 31037},
+						pos:  position{line: 1283, col: 5, offset: 30908},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1287, col: 5, offset: 31056},
+						pos:  position{line: 1284, col: 5, offset: 30927},
 						name: "NullLiteral",
 					},
 				},
@@ -8902,28 +8851,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1289, col: 1, offset: 31069},
+			pos:  position{line: 1286, col: 1, offset: 30940},
 			expr: &choiceExpr{
-				pos: position{line: 1290, col: 5, offset: 31087},
+				pos: position{line: 1287, col: 5, offset: 30958},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 31087},
+						pos: position{line: 1287, col: 5, offset: 30958},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1290, col: 5, offset: 31087},
+							pos: position{line: 1287, col: 5, offset: 30958},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1290, col: 5, offset: 31087},
+									pos:   position{line: 1287, col: 5, offset: 30958},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1290, col: 7, offset: 31089},
+										pos:  position{line: 1287, col: 7, offset: 30960},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1290, col: 14, offset: 31096},
+									pos: position{line: 1287, col: 14, offset: 30967},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1290, col: 15, offset: 31097},
+										pos:  position{line: 1287, col: 15, offset: 30968},
 										name: "IdentifierRest",
 									},
 								},
@@ -8931,13 +8880,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1293, col: 5, offset: 31177},
+						pos: position{line: 1290, col: 5, offset: 31048},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1293, col: 5, offset: 31177},
+							pos:   position{line: 1290, col: 5, offset: 31048},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1293, col: 7, offset: 31179},
+								pos:  position{line: 1290, col: 7, offset: 31050},
 								name: "IP4Net",
 							},
 						},
@@ -8949,28 +8898,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1297, col: 1, offset: 31248},
+			pos:  position{line: 1294, col: 1, offset: 31119},
 			expr: &choiceExpr{
-				pos: position{line: 1298, col: 5, offset: 31267},
+				pos: position{line: 1295, col: 5, offset: 31138},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1298, col: 5, offset: 31267},
+						pos: position{line: 1295, col: 5, offset: 31138},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1298, col: 5, offset: 31267},
+							pos: position{line: 1295, col: 5, offset: 31138},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1298, col: 5, offset: 31267},
+									pos:   position{line: 1295, col: 5, offset: 31138},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1298, col: 7, offset: 31269},
+										pos:  position{line: 1295, col: 7, offset: 31140},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1298, col: 11, offset: 31273},
+									pos: position{line: 1295, col: 11, offset: 31144},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1298, col: 12, offset: 31274},
+										pos:  position{line: 1295, col: 12, offset: 31145},
 										name: "IdentifierRest",
 									},
 								},
@@ -8978,13 +8927,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1301, col: 5, offset: 31353},
+						pos: position{line: 1298, col: 5, offset: 31224},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1301, col: 5, offset: 31353},
+							pos:   position{line: 1298, col: 5, offset: 31224},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1301, col: 7, offset: 31355},
+								pos:  position{line: 1298, col: 7, offset: 31226},
 								name: "IP",
 							},
 						},
@@ -8996,15 +8945,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1305, col: 1, offset: 31419},
+			pos:  position{line: 1302, col: 1, offset: 31290},
 			expr: &actionExpr{
-				pos: position{line: 1306, col: 5, offset: 31436},
+				pos: position{line: 1303, col: 5, offset: 31307},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1306, col: 5, offset: 31436},
+					pos:   position{line: 1303, col: 5, offset: 31307},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1306, col: 7, offset: 31438},
+						pos:  position{line: 1303, col: 7, offset: 31309},
 						name: "FloatString",
 					},
 				},
@@ -9014,15 +8963,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1310, col: 1, offset: 31516},
+			pos:  position{line: 1307, col: 1, offset: 31387},
 			expr: &actionExpr{
-				pos: position{line: 1311, col: 5, offset: 31535},
+				pos: position{line: 1308, col: 5, offset: 31406},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1311, col: 5, offset: 31535},
+					pos:   position{line: 1308, col: 5, offset: 31406},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1311, col: 7, offset: 31537},
+						pos:  position{line: 1308, col: 7, offset: 31408},
 						name: "IntString",
 					},
 				},
@@ -9032,23 +8981,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1315, col: 1, offset: 31611},
+			pos:  position{line: 1312, col: 1, offset: 31482},
 			expr: &choiceExpr{
-				pos: position{line: 1316, col: 5, offset: 31630},
+				pos: position{line: 1313, col: 5, offset: 31501},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 31630},
+						pos: position{line: 1313, col: 5, offset: 31501},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1316, col: 5, offset: 31630},
+							pos:  position{line: 1313, col: 5, offset: 31501},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 31688},
+						pos: position{line: 1314, col: 5, offset: 31559},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1317, col: 5, offset: 31688},
+							pos:  position{line: 1314, col: 5, offset: 31559},
 							name: "FALSE",
 						},
 					},
@@ -9059,12 +9008,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1319, col: 1, offset: 31744},
+			pos:  position{line: 1316, col: 1, offset: 31615},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 5, offset: 31760},
+				pos: position{line: 1317, col: 5, offset: 31631},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1320, col: 5, offset: 31760},
+					pos:  position{line: 1317, col: 5, offset: 31631},
 					name: "NULL",
 				},
 			},
@@ -9073,23 +9022,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1322, col: 1, offset: 31810},
+			pos:  position{line: 1319, col: 1, offset: 31681},
 			expr: &actionExpr{
-				pos: position{line: 1323, col: 5, offset: 31827},
+				pos: position{line: 1320, col: 5, offset: 31698},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1323, col: 5, offset: 31827},
+					pos: position{line: 1320, col: 5, offset: 31698},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1323, col: 5, offset: 31827},
+							pos:        position{line: 1320, col: 5, offset: 31698},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1323, col: 10, offset: 31832},
+							pos: position{line: 1320, col: 10, offset: 31703},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1323, col: 10, offset: 31832},
+								pos:  position{line: 1320, col: 10, offset: 31703},
 								name: "HexDigit",
 							},
 						},
@@ -9101,29 +9050,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1327, col: 1, offset: 31906},
+			pos:  position{line: 1324, col: 1, offset: 31777},
 			expr: &actionExpr{
-				pos: position{line: 1328, col: 5, offset: 31922},
+				pos: position{line: 1325, col: 5, offset: 31793},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1328, col: 5, offset: 31922},
+					pos: position{line: 1325, col: 5, offset: 31793},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1328, col: 5, offset: 31922},
+							pos:        position{line: 1325, col: 5, offset: 31793},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1328, col: 9, offset: 31926},
+							pos:   position{line: 1325, col: 9, offset: 31797},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1328, col: 13, offset: 31930},
+								pos:  position{line: 1325, col: 13, offset: 31801},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1328, col: 18, offset: 31935},
+							pos:        position{line: 1325, col: 18, offset: 31806},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -9136,16 +9085,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1336, col: 1, offset: 32068},
+			pos:  position{line: 1333, col: 1, offset: 31939},
 			expr: &choiceExpr{
-				pos: position{line: 1337, col: 5, offset: 32077},
+				pos: position{line: 1334, col: 5, offset: 31948},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1337, col: 5, offset: 32077},
+						pos:  position{line: 1334, col: 5, offset: 31948},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1338, col: 5, offset: 32095},
+						pos:  position{line: 1335, col: 5, offset: 31966},
 						name: "ComplexType",
 					},
 				},
@@ -9155,28 +9104,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1340, col: 1, offset: 32108},
+			pos:  position{line: 1337, col: 1, offset: 31979},
 			expr: &choiceExpr{
-				pos: position{line: 1341, col: 5, offset: 32126},
+				pos: position{line: 1338, col: 5, offset: 31997},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1341, col: 5, offset: 32126},
+						pos: position{line: 1338, col: 5, offset: 31997},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1341, col: 5, offset: 32126},
+							pos: position{line: 1338, col: 5, offset: 31997},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1341, col: 5, offset: 32126},
+									pos:   position{line: 1338, col: 5, offset: 31997},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1341, col: 10, offset: 32131},
+										pos:  position{line: 1338, col: 10, offset: 32002},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1341, col: 24, offset: 32145},
+									pos: position{line: 1338, col: 24, offset: 32016},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1341, col: 25, offset: 32146},
+										pos:  position{line: 1338, col: 25, offset: 32017},
 										name: "IdentifierRest",
 									},
 								},
@@ -9184,43 +9133,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 32186},
+						pos: position{line: 1339, col: 5, offset: 32057},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1342, col: 5, offset: 32186},
+							pos: position{line: 1339, col: 5, offset: 32057},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1342, col: 5, offset: 32186},
+									pos:  position{line: 1339, col: 5, offset: 32057},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1342, col: 11, offset: 32192},
+									pos:  position{line: 1339, col: 11, offset: 32063},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1342, col: 14, offset: 32195},
+									pos:        position{line: 1339, col: 14, offset: 32066},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1342, col: 18, offset: 32199},
+									pos:  position{line: 1339, col: 18, offset: 32070},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1342, col: 21, offset: 32202},
+									pos:   position{line: 1339, col: 21, offset: 32073},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1342, col: 23, offset: 32204},
+										pos:  position{line: 1339, col: 23, offset: 32075},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1342, col: 28, offset: 32209},
+									pos:  position{line: 1339, col: 28, offset: 32080},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1342, col: 31, offset: 32212},
+									pos:        position{line: 1339, col: 31, offset: 32083},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9229,43 +9178,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1349, col: 5, offset: 32352},
+						pos: position{line: 1346, col: 5, offset: 32223},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1349, col: 5, offset: 32352},
+							pos: position{line: 1346, col: 5, offset: 32223},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1349, col: 5, offset: 32352},
+									pos:   position{line: 1346, col: 5, offset: 32223},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1349, col: 10, offset: 32357},
+										pos:  position{line: 1346, col: 10, offset: 32228},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1349, col: 15, offset: 32362},
+									pos:   position{line: 1346, col: 15, offset: 32233},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1349, col: 19, offset: 32366},
+										pos: position{line: 1346, col: 19, offset: 32237},
 										expr: &seqExpr{
-											pos: position{line: 1349, col: 20, offset: 32367},
+											pos: position{line: 1346, col: 20, offset: 32238},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1349, col: 20, offset: 32367},
+													pos:  position{line: 1346, col: 20, offset: 32238},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1349, col: 23, offset: 32370},
+													pos:        position{line: 1346, col: 23, offset: 32241},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1349, col: 27, offset: 32374},
+													pos:  position{line: 1346, col: 27, offset: 32245},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1349, col: 30, offset: 32377},
+													pos:  position{line: 1346, col: 30, offset: 32248},
 													name: "Type",
 												},
 											},
@@ -9276,31 +9225,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1360, col: 5, offset: 32702},
+						pos: position{line: 1357, col: 5, offset: 32573},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1360, col: 5, offset: 32702},
+							pos: position{line: 1357, col: 5, offset: 32573},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1360, col: 5, offset: 32702},
+									pos:        position{line: 1357, col: 5, offset: 32573},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1360, col: 9, offset: 32706},
+									pos:  position{line: 1357, col: 9, offset: 32577},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1360, col: 12, offset: 32709},
+									pos:   position{line: 1357, col: 12, offset: 32580},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1360, col: 18, offset: 32715},
+										pos:  position{line: 1357, col: 18, offset: 32586},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1360, col: 27, offset: 32724},
+									pos:        position{line: 1357, col: 27, offset: 32595},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9315,28 +9264,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1368, col: 1, offset: 32868},
+			pos:  position{line: 1365, col: 1, offset: 32739},
 			expr: &actionExpr{
-				pos: position{line: 1369, col: 5, offset: 32881},
+				pos: position{line: 1366, col: 5, offset: 32752},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1369, col: 5, offset: 32881},
+					pos: position{line: 1366, col: 5, offset: 32752},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1369, col: 5, offset: 32881},
+							pos:   position{line: 1366, col: 5, offset: 32752},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1369, col: 11, offset: 32887},
+								pos:  position{line: 1366, col: 11, offset: 32758},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1369, col: 16, offset: 32892},
+							pos:   position{line: 1366, col: 16, offset: 32763},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1369, col: 21, offset: 32897},
+								pos: position{line: 1366, col: 21, offset: 32768},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1369, col: 21, offset: 32897},
+									pos:  position{line: 1366, col: 21, offset: 32768},
 									name: "TypeListTail",
 								},
 							},
@@ -9349,32 +9298,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1373, col: 1, offset: 32955},
+			pos:  position{line: 1370, col: 1, offset: 32826},
 			expr: &actionExpr{
-				pos: position{line: 1373, col: 16, offset: 32970},
+				pos: position{line: 1370, col: 16, offset: 32841},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1373, col: 16, offset: 32970},
+					pos: position{line: 1370, col: 16, offset: 32841},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1373, col: 16, offset: 32970},
+							pos:  position{line: 1370, col: 16, offset: 32841},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1373, col: 19, offset: 32973},
+							pos:        position{line: 1370, col: 19, offset: 32844},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1373, col: 23, offset: 32977},
+							pos:  position{line: 1370, col: 23, offset: 32848},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1373, col: 26, offset: 32980},
+							pos:   position{line: 1370, col: 26, offset: 32851},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1373, col: 30, offset: 32984},
+								pos:  position{line: 1370, col: 30, offset: 32855},
 								name: "Type",
 							},
 						},
@@ -9386,40 +9335,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1375, col: 1, offset: 33010},
+			pos:  position{line: 1372, col: 1, offset: 32881},
 			expr: &choiceExpr{
-				pos: position{line: 1376, col: 5, offset: 33026},
+				pos: position{line: 1373, col: 5, offset: 32897},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1376, col: 5, offset: 33026},
+						pos: position{line: 1373, col: 5, offset: 32897},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1376, col: 5, offset: 33026},
+							pos: position{line: 1373, col: 5, offset: 32897},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1376, col: 5, offset: 33026},
+									pos:        position{line: 1373, col: 5, offset: 32897},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1376, col: 9, offset: 33030},
+									pos:  position{line: 1373, col: 9, offset: 32901},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1376, col: 12, offset: 33033},
+									pos:   position{line: 1373, col: 12, offset: 32904},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1376, col: 19, offset: 33040},
+										pos:  position{line: 1373, col: 19, offset: 32911},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1376, col: 33, offset: 33054},
+									pos:  position{line: 1373, col: 33, offset: 32925},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1376, col: 36, offset: 33057},
+									pos:        position{line: 1373, col: 36, offset: 32928},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9428,35 +9377,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1383, col: 5, offset: 33219},
+						pos: position{line: 1380, col: 5, offset: 33090},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1383, col: 5, offset: 33219},
+							pos: position{line: 1380, col: 5, offset: 33090},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1383, col: 5, offset: 33219},
+									pos:        position{line: 1380, col: 5, offset: 33090},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1383, col: 9, offset: 33223},
+									pos:  position{line: 1380, col: 9, offset: 33094},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1383, col: 12, offset: 33226},
+									pos:   position{line: 1380, col: 12, offset: 33097},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1383, col: 16, offset: 33230},
+										pos:  position{line: 1380, col: 16, offset: 33101},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1383, col: 21, offset: 33235},
+									pos:  position{line: 1380, col: 21, offset: 33106},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1383, col: 24, offset: 33238},
+									pos:        position{line: 1380, col: 24, offset: 33109},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9465,35 +9414,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1390, col: 5, offset: 33380},
+						pos: position{line: 1387, col: 5, offset: 33251},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1390, col: 5, offset: 33380},
+							pos: position{line: 1387, col: 5, offset: 33251},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1390, col: 5, offset: 33380},
+									pos:        position{line: 1387, col: 5, offset: 33251},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1390, col: 10, offset: 33385},
+									pos:  position{line: 1387, col: 10, offset: 33256},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1390, col: 13, offset: 33388},
+									pos:   position{line: 1387, col: 13, offset: 33259},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1390, col: 17, offset: 33392},
+										pos:  position{line: 1387, col: 17, offset: 33263},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1390, col: 22, offset: 33397},
+									pos:  position{line: 1387, col: 22, offset: 33268},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1390, col: 25, offset: 33400},
+									pos:        position{line: 1387, col: 25, offset: 33271},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9502,57 +9451,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1397, col: 5, offset: 33539},
+						pos: position{line: 1394, col: 5, offset: 33410},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1397, col: 5, offset: 33539},
+							pos: position{line: 1394, col: 5, offset: 33410},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1397, col: 5, offset: 33539},
+									pos:        position{line: 1394, col: 5, offset: 33410},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1397, col: 10, offset: 33544},
+									pos:  position{line: 1394, col: 10, offset: 33415},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1397, col: 13, offset: 33547},
+									pos:   position{line: 1394, col: 13, offset: 33418},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1397, col: 21, offset: 33555},
+										pos:  position{line: 1394, col: 21, offset: 33426},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1397, col: 26, offset: 33560},
+									pos:  position{line: 1394, col: 26, offset: 33431},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1397, col: 29, offset: 33563},
+									pos:        position{line: 1394, col: 29, offset: 33434},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1397, col: 33, offset: 33567},
+									pos:  position{line: 1394, col: 33, offset: 33438},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1397, col: 36, offset: 33570},
+									pos:   position{line: 1394, col: 36, offset: 33441},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1397, col: 44, offset: 33578},
+										pos:  position{line: 1394, col: 44, offset: 33449},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1397, col: 49, offset: 33583},
+									pos:  position{line: 1394, col: 49, offset: 33454},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1397, col: 52, offset: 33586},
+									pos:        position{line: 1394, col: 52, offset: 33457},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9567,35 +9516,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1406, col: 1, offset: 33760},
+			pos:  position{line: 1403, col: 1, offset: 33631},
 			expr: &choiceExpr{
-				pos: position{line: 1407, col: 5, offset: 33778},
+				pos: position{line: 1404, col: 5, offset: 33649},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1407, col: 5, offset: 33778},
+						pos: position{line: 1404, col: 5, offset: 33649},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1407, col: 5, offset: 33778},
+							pos: position{line: 1404, col: 5, offset: 33649},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1407, col: 5, offset: 33778},
+									pos:        position{line: 1404, col: 5, offset: 33649},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1407, col: 9, offset: 33782},
+									pos:   position{line: 1404, col: 9, offset: 33653},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1407, col: 11, offset: 33784},
+										pos: position{line: 1404, col: 11, offset: 33655},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1407, col: 11, offset: 33784},
+											pos:  position{line: 1404, col: 11, offset: 33655},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1407, col: 29, offset: 33802},
+									pos:        position{line: 1404, col: 29, offset: 33673},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9604,30 +9553,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1408, col: 5, offset: 33866},
+						pos: position{line: 1405, col: 5, offset: 33737},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1408, col: 5, offset: 33866},
+							pos: position{line: 1405, col: 5, offset: 33737},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1408, col: 5, offset: 33866},
+									pos:        position{line: 1405, col: 5, offset: 33737},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1408, col: 9, offset: 33870},
+									pos:   position{line: 1405, col: 9, offset: 33741},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1408, col: 11, offset: 33872},
+										pos: position{line: 1405, col: 11, offset: 33743},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1408, col: 11, offset: 33872},
+											pos:  position{line: 1405, col: 11, offset: 33743},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1408, col: 29, offset: 33890},
+									pos:        position{line: 1405, col: 29, offset: 33761},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9642,35 +9591,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1410, col: 1, offset: 33951},
+			pos:  position{line: 1407, col: 1, offset: 33822},
 			expr: &choiceExpr{
-				pos: position{line: 1411, col: 5, offset: 33963},
+				pos: position{line: 1408, col: 5, offset: 33834},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1411, col: 5, offset: 33963},
+						pos: position{line: 1408, col: 5, offset: 33834},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1411, col: 5, offset: 33963},
+							pos: position{line: 1408, col: 5, offset: 33834},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1411, col: 5, offset: 33963},
+									pos:        position{line: 1408, col: 5, offset: 33834},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1411, col: 11, offset: 33969},
+									pos:   position{line: 1408, col: 11, offset: 33840},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1411, col: 13, offset: 33971},
+										pos: position{line: 1408, col: 13, offset: 33842},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1411, col: 13, offset: 33971},
+											pos:  position{line: 1408, col: 13, offset: 33842},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1411, col: 38, offset: 33996},
+									pos:        position{line: 1408, col: 38, offset: 33867},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9679,30 +9628,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1418, col: 5, offset: 34142},
+						pos: position{line: 1415, col: 5, offset: 34013},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1418, col: 5, offset: 34142},
+							pos: position{line: 1415, col: 5, offset: 34013},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1418, col: 5, offset: 34142},
+									pos:        position{line: 1415, col: 5, offset: 34013},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1418, col: 10, offset: 34147},
+									pos:   position{line: 1415, col: 10, offset: 34018},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1418, col: 12, offset: 34149},
+										pos: position{line: 1415, col: 12, offset: 34020},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1418, col: 12, offset: 34149},
+											pos:  position{line: 1415, col: 12, offset: 34020},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1418, col: 37, offset: 34174},
+									pos:        position{line: 1415, col: 37, offset: 34045},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9717,24 +9666,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1426, col: 1, offset: 34317},
+			pos:  position{line: 1423, col: 1, offset: 34188},
 			expr: &choiceExpr{
-				pos: position{line: 1427, col: 5, offset: 34345},
+				pos: position{line: 1424, col: 5, offset: 34216},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1427, col: 5, offset: 34345},
+						pos:  position{line: 1424, col: 5, offset: 34216},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1428, col: 5, offset: 34361},
+						pos: position{line: 1425, col: 5, offset: 34232},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1428, col: 5, offset: 34361},
+							pos:   position{line: 1425, col: 5, offset: 34232},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1428, col: 7, offset: 34363},
+								pos: position{line: 1425, col: 7, offset: 34234},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1428, col: 7, offset: 34363},
+									pos:  position{line: 1425, col: 7, offset: 34234},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9747,27 +9696,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1432, col: 1, offset: 34486},
+			pos:  position{line: 1429, col: 1, offset: 34357},
 			expr: &choiceExpr{
-				pos: position{line: 1433, col: 5, offset: 34514},
+				pos: position{line: 1430, col: 5, offset: 34385},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1433, col: 5, offset: 34514},
+						pos: position{line: 1430, col: 5, offset: 34385},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1433, col: 5, offset: 34514},
+							pos: position{line: 1430, col: 5, offset: 34385},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1433, col: 5, offset: 34514},
+									pos:        position{line: 1430, col: 5, offset: 34385},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1433, col: 10, offset: 34519},
+									pos:   position{line: 1430, col: 10, offset: 34390},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1433, col: 12, offset: 34521},
+										pos:        position{line: 1430, col: 12, offset: 34392},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9777,25 +9726,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1434, col: 5, offset: 34547},
+						pos: position{line: 1431, col: 5, offset: 34418},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1434, col: 5, offset: 34547},
+							pos: position{line: 1431, col: 5, offset: 34418},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1434, col: 5, offset: 34547},
+									pos: position{line: 1431, col: 5, offset: 34418},
 									expr: &litMatcher{
-										pos:        position{line: 1434, col: 7, offset: 34549},
+										pos:        position{line: 1431, col: 7, offset: 34420},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1434, col: 12, offset: 34554},
+									pos:   position{line: 1431, col: 12, offset: 34425},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1434, col: 14, offset: 34556},
+										pos:  position{line: 1431, col: 14, offset: 34427},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9809,24 +9758,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1436, col: 1, offset: 34592},
+			pos:  position{line: 1433, col: 1, offset: 34463},
 			expr: &choiceExpr{
-				pos: position{line: 1437, col: 5, offset: 34620},
+				pos: position{line: 1434, col: 5, offset: 34491},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1437, col: 5, offset: 34620},
+						pos:  position{line: 1434, col: 5, offset: 34491},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1438, col: 5, offset: 34636},
+						pos: position{line: 1435, col: 5, offset: 34507},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1438, col: 5, offset: 34636},
+							pos:   position{line: 1435, col: 5, offset: 34507},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1438, col: 7, offset: 34638},
+								pos: position{line: 1435, col: 7, offset: 34509},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1438, col: 7, offset: 34638},
+									pos:  position{line: 1435, col: 7, offset: 34509},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9839,27 +9788,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1442, col: 1, offset: 34761},
+			pos:  position{line: 1439, col: 1, offset: 34632},
 			expr: &choiceExpr{
-				pos: position{line: 1443, col: 5, offset: 34789},
+				pos: position{line: 1440, col: 5, offset: 34660},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1443, col: 5, offset: 34789},
+						pos: position{line: 1440, col: 5, offset: 34660},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1443, col: 5, offset: 34789},
+							pos: position{line: 1440, col: 5, offset: 34660},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1443, col: 5, offset: 34789},
+									pos:        position{line: 1440, col: 5, offset: 34660},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1443, col: 10, offset: 34794},
+									pos:   position{line: 1440, col: 10, offset: 34665},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1443, col: 12, offset: 34796},
+										pos:        position{line: 1440, col: 12, offset: 34667},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9869,25 +9818,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1444, col: 5, offset: 34822},
+						pos: position{line: 1441, col: 5, offset: 34693},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1444, col: 5, offset: 34822},
+							pos: position{line: 1441, col: 5, offset: 34693},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1444, col: 5, offset: 34822},
+									pos: position{line: 1441, col: 5, offset: 34693},
 									expr: &litMatcher{
-										pos:        position{line: 1444, col: 7, offset: 34824},
+										pos:        position{line: 1441, col: 7, offset: 34695},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1444, col: 12, offset: 34829},
+									pos:   position{line: 1441, col: 12, offset: 34700},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1444, col: 14, offset: 34831},
+										pos:  position{line: 1441, col: 14, offset: 34702},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9901,37 +9850,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1446, col: 1, offset: 34867},
+			pos:  position{line: 1443, col: 1, offset: 34738},
 			expr: &actionExpr{
-				pos: position{line: 1447, col: 5, offset: 34883},
+				pos: position{line: 1444, col: 5, offset: 34754},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1447, col: 5, offset: 34883},
+					pos: position{line: 1444, col: 5, offset: 34754},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1447, col: 5, offset: 34883},
+							pos:        position{line: 1444, col: 5, offset: 34754},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1447, col: 9, offset: 34887},
+							pos:  position{line: 1444, col: 9, offset: 34758},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1447, col: 12, offset: 34890},
+							pos:   position{line: 1444, col: 12, offset: 34761},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1447, col: 14, offset: 34892},
+								pos:  position{line: 1444, col: 14, offset: 34763},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1447, col: 19, offset: 34897},
+							pos:  position{line: 1444, col: 19, offset: 34768},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1447, col: 22, offset: 34900},
+							pos:        position{line: 1444, col: 22, offset: 34771},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9944,129 +9893,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1455, col: 1, offset: 35035},
+			pos:  position{line: 1452, col: 1, offset: 34906},
 			expr: &actionExpr{
-				pos: position{line: 1456, col: 5, offset: 35053},
+				pos: position{line: 1453, col: 5, offset: 34924},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1456, col: 9, offset: 35057},
+					pos: position{line: 1453, col: 9, offset: 34928},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1456, col: 9, offset: 35057},
+							pos:        position{line: 1453, col: 9, offset: 34928},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1456, col: 19, offset: 35067},
+							pos:        position{line: 1453, col: 19, offset: 34938},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1456, col: 30, offset: 35078},
+							pos:        position{line: 1453, col: 30, offset: 34949},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1456, col: 41, offset: 35089},
+							pos:        position{line: 1453, col: 41, offset: 34960},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1457, col: 9, offset: 35106},
+							pos:        position{line: 1454, col: 9, offset: 34977},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1457, col: 18, offset: 35115},
+							pos:        position{line: 1454, col: 18, offset: 34986},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1457, col: 28, offset: 35125},
+							pos:        position{line: 1454, col: 28, offset: 34996},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1457, col: 38, offset: 35135},
+							pos:        position{line: 1454, col: 38, offset: 35006},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1458, col: 9, offset: 35151},
+							pos:        position{line: 1455, col: 9, offset: 35022},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1458, col: 21, offset: 35163},
+							pos:        position{line: 1455, col: 21, offset: 35034},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1458, col: 33, offset: 35175},
+							pos:        position{line: 1455, col: 33, offset: 35046},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1459, col: 9, offset: 35193},
+							pos:        position{line: 1456, col: 9, offset: 35064},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1459, col: 18, offset: 35202},
+							pos:        position{line: 1456, col: 18, offset: 35073},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1460, col: 9, offset: 35219},
+							pos:        position{line: 1457, col: 9, offset: 35090},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1460, col: 22, offset: 35232},
+							pos:        position{line: 1457, col: 22, offset: 35103},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 9, offset: 35247},
+							pos:        position{line: 1458, col: 9, offset: 35118},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1462, col: 9, offset: 35263},
+							pos:        position{line: 1459, col: 9, offset: 35134},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1462, col: 16, offset: 35270},
+							pos:        position{line: 1459, col: 16, offset: 35141},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1463, col: 9, offset: 35284},
+							pos:        position{line: 1460, col: 9, offset: 35155},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1463, col: 18, offset: 35293},
+							pos:        position{line: 1460, col: 18, offset: 35164},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -10079,31 +10028,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1471, col: 1, offset: 35478},
+			pos:  position{line: 1468, col: 1, offset: 35349},
 			expr: &choiceExpr{
-				pos: position{line: 1472, col: 5, offset: 35496},
+				pos: position{line: 1469, col: 5, offset: 35367},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1472, col: 5, offset: 35496},
+						pos: position{line: 1469, col: 5, offset: 35367},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1472, col: 5, offset: 35496},
+							pos: position{line: 1469, col: 5, offset: 35367},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1472, col: 5, offset: 35496},
+									pos:   position{line: 1469, col: 5, offset: 35367},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1472, col: 11, offset: 35502},
+										pos:  position{line: 1469, col: 11, offset: 35373},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 21, offset: 35512},
+									pos:   position{line: 1469, col: 21, offset: 35383},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1472, col: 26, offset: 35517},
+										pos: position{line: 1469, col: 26, offset: 35388},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1472, col: 26, offset: 35517},
+											pos:  position{line: 1469, col: 26, offset: 35388},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10112,10 +10061,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1475, col: 5, offset: 35583},
+						pos: position{line: 1472, col: 5, offset: 35454},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1475, col: 5, offset: 35583},
+							pos:        position{line: 1472, col: 5, offset: 35454},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10128,32 +10077,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1477, col: 1, offset: 35607},
+			pos:  position{line: 1474, col: 1, offset: 35478},
 			expr: &actionExpr{
-				pos: position{line: 1477, col: 21, offset: 35627},
+				pos: position{line: 1474, col: 21, offset: 35498},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1477, col: 21, offset: 35627},
+					pos: position{line: 1474, col: 21, offset: 35498},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1477, col: 21, offset: 35627},
+							pos:  position{line: 1474, col: 21, offset: 35498},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1477, col: 24, offset: 35630},
+							pos:        position{line: 1474, col: 24, offset: 35501},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1477, col: 28, offset: 35634},
+							pos:  position{line: 1474, col: 28, offset: 35505},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1477, col: 31, offset: 35637},
+							pos:   position{line: 1474, col: 31, offset: 35508},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1477, col: 35, offset: 35641},
+								pos:  position{line: 1474, col: 35, offset: 35512},
 								name: "TypeField",
 							},
 						},
@@ -10165,40 +10114,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1479, col: 1, offset: 35672},
+			pos:  position{line: 1476, col: 1, offset: 35543},
 			expr: &actionExpr{
-				pos: position{line: 1480, col: 5, offset: 35686},
+				pos: position{line: 1477, col: 5, offset: 35557},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1480, col: 5, offset: 35686},
+					pos: position{line: 1477, col: 5, offset: 35557},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1480, col: 5, offset: 35686},
+							pos:   position{line: 1477, col: 5, offset: 35557},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1480, col: 10, offset: 35691},
+								pos:  position{line: 1477, col: 10, offset: 35562},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1480, col: 15, offset: 35696},
+							pos:  position{line: 1477, col: 15, offset: 35567},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1480, col: 18, offset: 35699},
+							pos:        position{line: 1477, col: 18, offset: 35570},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1480, col: 22, offset: 35703},
+							pos:  position{line: 1477, col: 22, offset: 35574},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1480, col: 25, offset: 35706},
+							pos:   position{line: 1477, col: 25, offset: 35577},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1480, col: 29, offset: 35710},
+								pos:  position{line: 1477, col: 29, offset: 35581},
 								name: "Type",
 							},
 						},
@@ -10210,54 +10159,54 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1488, col: 1, offset: 35859},
+			pos:  position{line: 1485, col: 1, offset: 35730},
 			expr: &choiceExpr{
-				pos: position{line: 1489, col: 5, offset: 35868},
+				pos: position{line: 1486, col: 5, offset: 35739},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1489, col: 5, offset: 35868},
+						pos: position{line: 1486, col: 5, offset: 35739},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1489, col: 5, offset: 35868},
+							pos:   position{line: 1486, col: 5, offset: 35739},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1489, col: 7, offset: 35870},
+								pos:  position{line: 1486, col: 7, offset: 35741},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1490, col: 5, offset: 35959},
+						pos: position{line: 1487, col: 5, offset: 35830},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1490, col: 5, offset: 35959},
+							pos:   position{line: 1487, col: 5, offset: 35830},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1490, col: 7, offset: 35961},
+								pos:  position{line: 1487, col: 7, offset: 35832},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1491, col: 5, offset: 36050},
+						pos: position{line: 1488, col: 5, offset: 35921},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1491, col: 5, offset: 36050},
+							pos:   position{line: 1488, col: 5, offset: 35921},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1491, col: 7, offset: 36052},
+								pos:  position{line: 1488, col: 7, offset: 35923},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1492, col: 5, offset: 36141},
+						pos: position{line: 1489, col: 5, offset: 36012},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1492, col: 5, offset: 36141},
+							pos:   position{line: 1489, col: 5, offset: 36012},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1492, col: 7, offset: 36143},
+								pos:  position{line: 1489, col: 7, offset: 36014},
 								name: "KSUID",
 							},
 						},
@@ -10269,22 +10218,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1494, col: 1, offset: 36229},
+			pos:  position{line: 1491, col: 1, offset: 36100},
 			expr: &actionExpr{
-				pos: position{line: 1495, col: 5, offset: 36243},
+				pos: position{line: 1492, col: 5, offset: 36114},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1495, col: 5, offset: 36243},
+					pos: position{line: 1492, col: 5, offset: 36114},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1495, col: 6, offset: 36244},
+							pos: position{line: 1492, col: 6, offset: 36115},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1495, col: 6, offset: 36244},
+									pos:  position{line: 1492, col: 6, offset: 36115},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1495, col: 24, offset: 36262},
+									pos:        position{line: 1492, col: 24, offset: 36133},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -10292,16 +10241,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1495, col: 29, offset: 36267},
+							pos: position{line: 1492, col: 29, offset: 36138},
 							expr: &choiceExpr{
-								pos: position{line: 1495, col: 30, offset: 36268},
+								pos: position{line: 1492, col: 30, offset: 36139},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1495, col: 30, offset: 36268},
+										pos:  position{line: 1492, col: 30, offset: 36139},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1495, col: 47, offset: 36285},
+										pos:        position{line: 1492, col: 47, offset: 36156},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -10317,15 +10266,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1497, col: 1, offset: 36323},
+			pos:  position{line: 1494, col: 1, offset: 36194},
 			expr: &actionExpr{
-				pos: position{line: 1498, col: 5, offset: 36338},
+				pos: position{line: 1495, col: 5, offset: 36209},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1498, col: 5, offset: 36338},
+					pos:   position{line: 1495, col: 5, offset: 36209},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1498, col: 8, offset: 36341},
+						pos:  position{line: 1495, col: 8, offset: 36212},
 						name: "IdentifierName",
 					},
 				},
@@ -10335,51 +10284,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1506, col: 1, offset: 36474},
+			pos:  position{line: 1503, col: 1, offset: 36345},
 			expr: &actionExpr{
-				pos: position{line: 1507, col: 5, offset: 36490},
+				pos: position{line: 1504, col: 5, offset: 36361},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1507, col: 5, offset: 36490},
+					pos: position{line: 1504, col: 5, offset: 36361},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1507, col: 5, offset: 36490},
+							pos:   position{line: 1504, col: 5, offset: 36361},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1507, col: 11, offset: 36496},
+								pos:  position{line: 1504, col: 11, offset: 36367},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1507, col: 22, offset: 36507},
+							pos:   position{line: 1504, col: 22, offset: 36378},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1507, col: 27, offset: 36512},
+								pos: position{line: 1504, col: 27, offset: 36383},
 								expr: &actionExpr{
-									pos: position{line: 1507, col: 28, offset: 36513},
+									pos: position{line: 1504, col: 28, offset: 36384},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1507, col: 28, offset: 36513},
+										pos: position{line: 1504, col: 28, offset: 36384},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1507, col: 28, offset: 36513},
+												pos:  position{line: 1504, col: 28, offset: 36384},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1507, col: 31, offset: 36516},
+												pos:        position{line: 1504, col: 31, offset: 36387},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1507, col: 35, offset: 36520},
+												pos:  position{line: 1504, col: 35, offset: 36391},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1507, col: 38, offset: 36523},
+												pos:   position{line: 1504, col: 38, offset: 36394},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1507, col: 43, offset: 36528},
+													pos:  position{line: 1504, col: 43, offset: 36399},
 													name: "Identifier",
 												},
 											},
@@ -10396,29 +10345,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1511, col: 1, offset: 36606},
+			pos:  position{line: 1508, col: 1, offset: 36477},
 			expr: &choiceExpr{
-				pos: position{line: 1512, col: 5, offset: 36625},
+				pos: position{line: 1509, col: 5, offset: 36496},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1512, col: 5, offset: 36625},
+						pos: position{line: 1509, col: 5, offset: 36496},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1512, col: 5, offset: 36625},
+							pos: position{line: 1509, col: 5, offset: 36496},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1512, col: 5, offset: 36625},
+									pos: position{line: 1509, col: 5, offset: 36496},
 									expr: &seqExpr{
-										pos: position{line: 1512, col: 7, offset: 36627},
+										pos: position{line: 1509, col: 7, offset: 36498},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1512, col: 7, offset: 36627},
+												pos:  position{line: 1509, col: 7, offset: 36498},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1512, col: 15, offset: 36635},
+												pos: position{line: 1509, col: 15, offset: 36506},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1512, col: 16, offset: 36636},
+													pos:  position{line: 1509, col: 16, offset: 36507},
 													name: "IdentifierRest",
 												},
 											},
@@ -10426,13 +10375,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1512, col: 32, offset: 36652},
+									pos:  position{line: 1509, col: 32, offset: 36523},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1512, col: 48, offset: 36668},
+									pos: position{line: 1509, col: 48, offset: 36539},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1512, col: 48, offset: 36668},
+										pos:  position{line: 1509, col: 48, offset: 36539},
 										name: "IdentifierRest",
 									},
 								},
@@ -10440,32 +10389,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1513, col: 5, offset: 36719},
+						pos: position{line: 1510, col: 5, offset: 36590},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1513, col: 5, offset: 36719},
+							pos:        position{line: 1510, col: 5, offset: 36590},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1514, col: 5, offset: 36758},
+						pos: position{line: 1511, col: 5, offset: 36629},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1514, col: 5, offset: 36758},
+							pos: position{line: 1511, col: 5, offset: 36629},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1514, col: 5, offset: 36758},
+									pos:        position{line: 1511, col: 5, offset: 36629},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1514, col: 10, offset: 36763},
+									pos:   position{line: 1511, col: 10, offset: 36634},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1514, col: 13, offset: 36766},
+										pos:  position{line: 1511, col: 13, offset: 36637},
 										name: "IDGuard",
 									},
 								},
@@ -10473,17 +10422,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1516, col: 5, offset: 36857},
+						pos: position{line: 1513, col: 5, offset: 36728},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1516, col: 5, offset: 36857},
+							pos:        position{line: 1513, col: 5, offset: 36728},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1517, col: 5, offset: 36899},
+						pos:  position{line: 1514, col: 5, offset: 36770},
 						name: "BacktickString",
 					},
 				},
@@ -10493,22 +10442,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1519, col: 1, offset: 36916},
+			pos:  position{line: 1516, col: 1, offset: 36787},
 			expr: &choiceExpr{
-				pos: position{line: 1520, col: 5, offset: 36936},
+				pos: position{line: 1517, col: 5, offset: 36807},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1520, col: 5, offset: 36936},
+						pos:  position{line: 1517, col: 5, offset: 36807},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1521, col: 5, offset: 36954},
+						pos:        position{line: 1518, col: 5, offset: 36825},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1522, col: 5, offset: 36962},
+						pos:        position{line: 1519, col: 5, offset: 36833},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10520,24 +10469,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1524, col: 1, offset: 36967},
+			pos:  position{line: 1521, col: 1, offset: 36838},
 			expr: &choiceExpr{
-				pos: position{line: 1525, col: 5, offset: 36986},
+				pos: position{line: 1522, col: 5, offset: 36857},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1525, col: 5, offset: 36986},
+						pos:  position{line: 1522, col: 5, offset: 36857},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1526, col: 5, offset: 37006},
+						pos:  position{line: 1523, col: 5, offset: 36877},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1527, col: 5, offset: 37031},
+						pos:  position{line: 1524, col: 5, offset: 36902},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1528, col: 5, offset: 37048},
+						pos:  position{line: 1525, col: 5, offset: 36919},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10547,24 +10496,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1530, col: 1, offset: 37077},
+			pos:  position{line: 1527, col: 1, offset: 36948},
 			expr: &choiceExpr{
-				pos: position{line: 1531, col: 5, offset: 37089},
+				pos: position{line: 1528, col: 5, offset: 36960},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1531, col: 5, offset: 37089},
+						pos:  position{line: 1528, col: 5, offset: 36960},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1532, col: 5, offset: 37108},
+						pos:  position{line: 1529, col: 5, offset: 36979},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1533, col: 5, offset: 37124},
+						pos:  position{line: 1530, col: 5, offset: 36995},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 5, offset: 37132},
+						pos:  position{line: 1531, col: 5, offset: 37003},
 						name: "Infinity",
 					},
 				},
@@ -10574,25 +10523,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1536, col: 1, offset: 37142},
+			pos:  position{line: 1533, col: 1, offset: 37013},
 			expr: &actionExpr{
-				pos: position{line: 1537, col: 5, offset: 37151},
+				pos: position{line: 1534, col: 5, offset: 37022},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1537, col: 5, offset: 37151},
+					pos: position{line: 1534, col: 5, offset: 37022},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1537, col: 5, offset: 37151},
+							pos:  position{line: 1534, col: 5, offset: 37022},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1537, col: 14, offset: 37160},
+							pos:        position{line: 1534, col: 14, offset: 37031},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1537, col: 18, offset: 37164},
+							pos:  position{line: 1534, col: 18, offset: 37035},
 							name: "FullTime",
 						},
 					},
@@ -10603,32 +10552,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1541, col: 1, offset: 37240},
+			pos:  position{line: 1538, col: 1, offset: 37111},
 			expr: &seqExpr{
-				pos: position{line: 1541, col: 12, offset: 37251},
+				pos: position{line: 1538, col: 12, offset: 37122},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 12, offset: 37251},
+						pos:  position{line: 1538, col: 12, offset: 37122},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1541, col: 15, offset: 37254},
+						pos:        position{line: 1538, col: 15, offset: 37125},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 19, offset: 37258},
+						pos:  position{line: 1538, col: 19, offset: 37129},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1541, col: 22, offset: 37261},
+						pos:        position{line: 1538, col: 22, offset: 37132},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 26, offset: 37265},
+						pos:  position{line: 1538, col: 26, offset: 37136},
 						name: "D2",
 					},
 				},
@@ -10638,33 +10587,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1543, col: 1, offset: 37269},
+			pos:  position{line: 1540, col: 1, offset: 37140},
 			expr: &seqExpr{
-				pos: position{line: 1543, col: 6, offset: 37274},
+				pos: position{line: 1540, col: 6, offset: 37145},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1543, col: 6, offset: 37274},
+						pos:        position{line: 1540, col: 6, offset: 37145},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1543, col: 11, offset: 37279},
+						pos:        position{line: 1540, col: 11, offset: 37150},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1543, col: 16, offset: 37284},
+						pos:        position{line: 1540, col: 16, offset: 37155},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1543, col: 21, offset: 37289},
+						pos:        position{line: 1540, col: 21, offset: 37160},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10677,19 +10626,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1544, col: 1, offset: 37295},
+			pos:  position{line: 1541, col: 1, offset: 37166},
 			expr: &seqExpr{
-				pos: position{line: 1544, col: 6, offset: 37300},
+				pos: position{line: 1541, col: 6, offset: 37171},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1544, col: 6, offset: 37300},
+						pos:        position{line: 1541, col: 6, offset: 37171},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1544, col: 11, offset: 37305},
+						pos:        position{line: 1541, col: 11, offset: 37176},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10702,16 +10651,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1546, col: 1, offset: 37312},
+			pos:  position{line: 1543, col: 1, offset: 37183},
 			expr: &seqExpr{
-				pos: position{line: 1546, col: 12, offset: 37323},
+				pos: position{line: 1543, col: 12, offset: 37194},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1546, col: 12, offset: 37323},
+						pos:  position{line: 1543, col: 12, offset: 37194},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1546, col: 24, offset: 37335},
+						pos:  position{line: 1543, col: 24, offset: 37206},
 						name: "TimeOffset",
 					},
 				},
@@ -10721,49 +10670,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1548, col: 1, offset: 37347},
+			pos:  position{line: 1545, col: 1, offset: 37218},
 			expr: &seqExpr{
-				pos: position{line: 1548, col: 15, offset: 37361},
+				pos: position{line: 1545, col: 15, offset: 37232},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1548, col: 15, offset: 37361},
+						pos:  position{line: 1545, col: 15, offset: 37232},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1548, col: 18, offset: 37364},
+						pos:        position{line: 1545, col: 18, offset: 37235},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1548, col: 22, offset: 37368},
+						pos:  position{line: 1545, col: 22, offset: 37239},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1548, col: 25, offset: 37371},
+						pos:        position{line: 1545, col: 25, offset: 37242},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1548, col: 29, offset: 37375},
+						pos:  position{line: 1545, col: 29, offset: 37246},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1548, col: 32, offset: 37378},
+						pos: position{line: 1545, col: 32, offset: 37249},
 						expr: &seqExpr{
-							pos: position{line: 1548, col: 33, offset: 37379},
+							pos: position{line: 1545, col: 33, offset: 37250},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1548, col: 33, offset: 37379},
+									pos:        position{line: 1545, col: 33, offset: 37250},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1548, col: 37, offset: 37383},
+									pos: position{line: 1545, col: 37, offset: 37254},
 									expr: &charClassMatcher{
-										pos:        position{line: 1548, col: 37, offset: 37383},
+										pos:        position{line: 1545, col: 37, offset: 37254},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10780,30 +10729,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1550, col: 1, offset: 37393},
+			pos:  position{line: 1547, col: 1, offset: 37264},
 			expr: &choiceExpr{
-				pos: position{line: 1551, col: 5, offset: 37408},
+				pos: position{line: 1548, col: 5, offset: 37279},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1551, col: 5, offset: 37408},
+						pos:        position{line: 1548, col: 5, offset: 37279},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1552, col: 5, offset: 37416},
+						pos: position{line: 1549, col: 5, offset: 37287},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1552, col: 6, offset: 37417},
+								pos: position{line: 1549, col: 6, offset: 37288},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1552, col: 6, offset: 37417},
+										pos:        position{line: 1549, col: 6, offset: 37288},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1552, col: 12, offset: 37423},
+										pos:        position{line: 1549, col: 12, offset: 37294},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10811,34 +10760,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1552, col: 17, offset: 37428},
+								pos:  position{line: 1549, col: 17, offset: 37299},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1552, col: 20, offset: 37431},
+								pos:        position{line: 1549, col: 20, offset: 37302},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1552, col: 24, offset: 37435},
+								pos:  position{line: 1549, col: 24, offset: 37306},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1552, col: 27, offset: 37438},
+								pos: position{line: 1549, col: 27, offset: 37309},
 								expr: &seqExpr{
-									pos: position{line: 1552, col: 28, offset: 37439},
+									pos: position{line: 1549, col: 28, offset: 37310},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1552, col: 28, offset: 37439},
+											pos:        position{line: 1549, col: 28, offset: 37310},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1552, col: 32, offset: 37443},
+											pos: position{line: 1549, col: 32, offset: 37314},
 											expr: &charClassMatcher{
-												pos:        position{line: 1552, col: 32, offset: 37443},
+												pos:        position{line: 1549, col: 32, offset: 37314},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10857,33 +10806,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1554, col: 1, offset: 37453},
+			pos:  position{line: 1551, col: 1, offset: 37324},
 			expr: &actionExpr{
-				pos: position{line: 1555, col: 5, offset: 37466},
+				pos: position{line: 1552, col: 5, offset: 37337},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1555, col: 5, offset: 37466},
+					pos: position{line: 1552, col: 5, offset: 37337},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1555, col: 5, offset: 37466},
+							pos: position{line: 1552, col: 5, offset: 37337},
 							expr: &litMatcher{
-								pos:        position{line: 1555, col: 5, offset: 37466},
+								pos:        position{line: 1552, col: 5, offset: 37337},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1555, col: 10, offset: 37471},
+							pos: position{line: 1552, col: 10, offset: 37342},
 							expr: &seqExpr{
-								pos: position{line: 1555, col: 11, offset: 37472},
+								pos: position{line: 1552, col: 11, offset: 37343},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1555, col: 11, offset: 37472},
+										pos:  position{line: 1552, col: 11, offset: 37343},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1555, col: 19, offset: 37480},
+										pos:  position{line: 1552, col: 19, offset: 37351},
 										name: "TimeUnit",
 									},
 								},
@@ -10897,27 +10846,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1559, col: 1, offset: 37562},
+			pos:  position{line: 1556, col: 1, offset: 37433},
 			expr: &seqExpr{
-				pos: position{line: 1559, col: 11, offset: 37572},
+				pos: position{line: 1556, col: 11, offset: 37443},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1559, col: 11, offset: 37572},
+						pos:  position{line: 1556, col: 11, offset: 37443},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1559, col: 16, offset: 37577},
+						pos: position{line: 1556, col: 16, offset: 37448},
 						expr: &seqExpr{
-							pos: position{line: 1559, col: 17, offset: 37578},
+							pos: position{line: 1556, col: 17, offset: 37449},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1559, col: 17, offset: 37578},
+									pos:        position{line: 1556, col: 17, offset: 37449},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1559, col: 21, offset: 37582},
+									pos:  position{line: 1556, col: 21, offset: 37453},
 									name: "UInt",
 								},
 							},
@@ -10930,60 +10879,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1561, col: 1, offset: 37590},
+			pos:  position{line: 1558, col: 1, offset: 37461},
 			expr: &choiceExpr{
-				pos: position{line: 1562, col: 5, offset: 37603},
+				pos: position{line: 1559, col: 5, offset: 37474},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1562, col: 5, offset: 37603},
+						pos:        position{line: 1559, col: 5, offset: 37474},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1563, col: 5, offset: 37612},
+						pos:        position{line: 1560, col: 5, offset: 37483},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 5, offset: 37621},
+						pos:        position{line: 1561, col: 5, offset: 37492},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1565, col: 5, offset: 37630},
+						pos:        position{line: 1562, col: 5, offset: 37501},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1566, col: 5, offset: 37638},
+						pos:        position{line: 1563, col: 5, offset: 37509},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1567, col: 5, offset: 37646},
+						pos:        position{line: 1564, col: 5, offset: 37517},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1568, col: 5, offset: 37654},
+						pos:        position{line: 1565, col: 5, offset: 37525},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1569, col: 5, offset: 37662},
+						pos:        position{line: 1566, col: 5, offset: 37533},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1570, col: 5, offset: 37670},
+						pos:        position{line: 1567, col: 5, offset: 37541},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10995,45 +10944,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1572, col: 1, offset: 37675},
+			pos:  position{line: 1569, col: 1, offset: 37546},
 			expr: &actionExpr{
-				pos: position{line: 1573, col: 5, offset: 37682},
+				pos: position{line: 1570, col: 5, offset: 37553},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1573, col: 5, offset: 37682},
+					pos: position{line: 1570, col: 5, offset: 37553},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1573, col: 5, offset: 37682},
+							pos:  position{line: 1570, col: 5, offset: 37553},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1573, col: 10, offset: 37687},
+							pos:        position{line: 1570, col: 10, offset: 37558},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1573, col: 14, offset: 37691},
+							pos:  position{line: 1570, col: 14, offset: 37562},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1573, col: 19, offset: 37696},
+							pos:        position{line: 1570, col: 19, offset: 37567},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1573, col: 23, offset: 37700},
+							pos:  position{line: 1570, col: 23, offset: 37571},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1573, col: 28, offset: 37705},
+							pos:        position{line: 1570, col: 28, offset: 37576},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1573, col: 32, offset: 37709},
+							pos:  position{line: 1570, col: 32, offset: 37580},
 							name: "UInt",
 						},
 					},
@@ -11044,43 +10993,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1575, col: 1, offset: 37746},
+			pos:  position{line: 1572, col: 1, offset: 37617},
 			expr: &actionExpr{
-				pos: position{line: 1576, col: 5, offset: 37754},
+				pos: position{line: 1573, col: 5, offset: 37625},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1576, col: 5, offset: 37754},
+					pos: position{line: 1573, col: 5, offset: 37625},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1576, col: 5, offset: 37754},
+							pos: position{line: 1573, col: 5, offset: 37625},
 							expr: &seqExpr{
-								pos: position{line: 1576, col: 7, offset: 37756},
+								pos: position{line: 1573, col: 7, offset: 37627},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1576, col: 7, offset: 37756},
+										pos:  position{line: 1573, col: 7, offset: 37627},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1576, col: 11, offset: 37760},
+										pos:        position{line: 1573, col: 11, offset: 37631},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1576, col: 15, offset: 37764},
+										pos:  position{line: 1573, col: 15, offset: 37635},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1576, col: 19, offset: 37768},
+										pos: position{line: 1573, col: 19, offset: 37639},
 										expr: &choiceExpr{
-											pos: position{line: 1576, col: 21, offset: 37770},
+											pos: position{line: 1573, col: 21, offset: 37641},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1576, col: 21, offset: 37770},
+													pos:  position{line: 1573, col: 21, offset: 37641},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1576, col: 32, offset: 37781},
+													pos:        position{line: 1573, col: 32, offset: 37652},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11092,10 +11041,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1576, col: 38, offset: 37787},
+							pos:   position{line: 1573, col: 38, offset: 37658},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1576, col: 40, offset: 37789},
+								pos:  position{line: 1573, col: 40, offset: 37660},
 								name: "IP6Variations",
 							},
 						},
@@ -11107,32 +11056,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1580, col: 1, offset: 37953},
+			pos:  position{line: 1577, col: 1, offset: 37824},
 			expr: &choiceExpr{
-				pos: position{line: 1581, col: 5, offset: 37971},
+				pos: position{line: 1578, col: 5, offset: 37842},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1581, col: 5, offset: 37971},
+						pos: position{line: 1578, col: 5, offset: 37842},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1581, col: 5, offset: 37971},
+							pos: position{line: 1578, col: 5, offset: 37842},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1581, col: 5, offset: 37971},
+									pos:   position{line: 1578, col: 5, offset: 37842},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1581, col: 7, offset: 37973},
+										pos: position{line: 1578, col: 7, offset: 37844},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1581, col: 7, offset: 37973},
+											pos:  position{line: 1578, col: 7, offset: 37844},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1581, col: 17, offset: 37983},
+									pos:   position{line: 1578, col: 17, offset: 37854},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1581, col: 19, offset: 37985},
+										pos:  position{line: 1578, col: 19, offset: 37856},
 										name: "IP6Tail",
 									},
 								},
@@ -11140,52 +11089,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1584, col: 5, offset: 38049},
+						pos: position{line: 1581, col: 5, offset: 37920},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1584, col: 5, offset: 38049},
+							pos: position{line: 1581, col: 5, offset: 37920},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1584, col: 5, offset: 38049},
+									pos:   position{line: 1581, col: 5, offset: 37920},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1584, col: 7, offset: 38051},
+										pos:  position{line: 1581, col: 7, offset: 37922},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1584, col: 11, offset: 38055},
+									pos:   position{line: 1581, col: 11, offset: 37926},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1584, col: 13, offset: 38057},
+										pos: position{line: 1581, col: 13, offset: 37928},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1584, col: 13, offset: 38057},
+											pos:  position{line: 1581, col: 13, offset: 37928},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1584, col: 23, offset: 38067},
+									pos:        position{line: 1581, col: 23, offset: 37938},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1584, col: 28, offset: 38072},
+									pos:   position{line: 1581, col: 28, offset: 37943},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1584, col: 30, offset: 38074},
+										pos: position{line: 1581, col: 30, offset: 37945},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1584, col: 30, offset: 38074},
+											pos:  position{line: 1581, col: 30, offset: 37945},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1584, col: 40, offset: 38084},
+									pos:   position{line: 1581, col: 40, offset: 37955},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1584, col: 42, offset: 38086},
+										pos:  position{line: 1581, col: 42, offset: 37957},
 										name: "IP6Tail",
 									},
 								},
@@ -11193,33 +11142,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1587, col: 5, offset: 38185},
+						pos: position{line: 1584, col: 5, offset: 38056},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1587, col: 5, offset: 38185},
+							pos: position{line: 1584, col: 5, offset: 38056},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1587, col: 5, offset: 38185},
+									pos:        position{line: 1584, col: 5, offset: 38056},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1587, col: 10, offset: 38190},
+									pos:   position{line: 1584, col: 10, offset: 38061},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1587, col: 12, offset: 38192},
+										pos: position{line: 1584, col: 12, offset: 38063},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1587, col: 12, offset: 38192},
+											pos:  position{line: 1584, col: 12, offset: 38063},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1587, col: 22, offset: 38202},
+									pos:   position{line: 1584, col: 22, offset: 38073},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1587, col: 24, offset: 38204},
+										pos:  position{line: 1584, col: 24, offset: 38075},
 										name: "IP6Tail",
 									},
 								},
@@ -11227,32 +11176,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1590, col: 5, offset: 38275},
+						pos: position{line: 1587, col: 5, offset: 38146},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1590, col: 5, offset: 38275},
+							pos: position{line: 1587, col: 5, offset: 38146},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1590, col: 5, offset: 38275},
+									pos:   position{line: 1587, col: 5, offset: 38146},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1590, col: 7, offset: 38277},
+										pos:  position{line: 1587, col: 7, offset: 38148},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1590, col: 11, offset: 38281},
+									pos:   position{line: 1587, col: 11, offset: 38152},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1590, col: 13, offset: 38283},
+										pos: position{line: 1587, col: 13, offset: 38154},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1590, col: 13, offset: 38283},
+											pos:  position{line: 1587, col: 13, offset: 38154},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1590, col: 23, offset: 38293},
+									pos:        position{line: 1587, col: 23, offset: 38164},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -11261,10 +11210,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1593, col: 5, offset: 38361},
+						pos: position{line: 1590, col: 5, offset: 38232},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1593, col: 5, offset: 38361},
+							pos:        position{line: 1590, col: 5, offset: 38232},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11277,16 +11226,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1597, col: 1, offset: 38398},
+			pos:  position{line: 1594, col: 1, offset: 38269},
 			expr: &choiceExpr{
-				pos: position{line: 1598, col: 5, offset: 38410},
+				pos: position{line: 1595, col: 5, offset: 38281},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1598, col: 5, offset: 38410},
+						pos:  position{line: 1595, col: 5, offset: 38281},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1599, col: 5, offset: 38417},
+						pos:  position{line: 1596, col: 5, offset: 38288},
 						name: "Hex",
 					},
 				},
@@ -11296,24 +11245,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1601, col: 1, offset: 38422},
+			pos:  position{line: 1598, col: 1, offset: 38293},
 			expr: &actionExpr{
-				pos: position{line: 1601, col: 12, offset: 38433},
+				pos: position{line: 1598, col: 12, offset: 38304},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1601, col: 12, offset: 38433},
+					pos: position{line: 1598, col: 12, offset: 38304},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1601, col: 12, offset: 38433},
+							pos:        position{line: 1598, col: 12, offset: 38304},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1601, col: 16, offset: 38437},
+							pos:   position{line: 1598, col: 16, offset: 38308},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1601, col: 18, offset: 38439},
+								pos:  position{line: 1598, col: 18, offset: 38310},
 								name: "Hex",
 							},
 						},
@@ -11325,23 +11274,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1603, col: 1, offset: 38477},
+			pos:  position{line: 1600, col: 1, offset: 38348},
 			expr: &actionExpr{
-				pos: position{line: 1603, col: 12, offset: 38488},
+				pos: position{line: 1600, col: 12, offset: 38359},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1603, col: 12, offset: 38488},
+					pos: position{line: 1600, col: 12, offset: 38359},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1603, col: 12, offset: 38488},
+							pos:   position{line: 1600, col: 12, offset: 38359},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1603, col: 14, offset: 38490},
+								pos:  position{line: 1600, col: 14, offset: 38361},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1603, col: 18, offset: 38494},
+							pos:        position{line: 1600, col: 18, offset: 38365},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11354,32 +11303,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1605, col: 1, offset: 38532},
+			pos:  position{line: 1602, col: 1, offset: 38403},
 			expr: &actionExpr{
-				pos: position{line: 1606, col: 5, offset: 38543},
+				pos: position{line: 1603, col: 5, offset: 38414},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1606, col: 5, offset: 38543},
+					pos: position{line: 1603, col: 5, offset: 38414},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1606, col: 5, offset: 38543},
+							pos:   position{line: 1603, col: 5, offset: 38414},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1606, col: 7, offset: 38545},
+								pos:  position{line: 1603, col: 7, offset: 38416},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1606, col: 10, offset: 38548},
+							pos:        position{line: 1603, col: 10, offset: 38419},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1606, col: 14, offset: 38552},
+							pos:   position{line: 1603, col: 14, offset: 38423},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1606, col: 16, offset: 38554},
+								pos:  position{line: 1603, col: 16, offset: 38425},
 								name: "UIntString",
 							},
 						},
@@ -11391,32 +11340,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1610, col: 1, offset: 38622},
+			pos:  position{line: 1607, col: 1, offset: 38493},
 			expr: &actionExpr{
-				pos: position{line: 1611, col: 5, offset: 38633},
+				pos: position{line: 1608, col: 5, offset: 38504},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1611, col: 5, offset: 38633},
+					pos: position{line: 1608, col: 5, offset: 38504},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1611, col: 5, offset: 38633},
+							pos:   position{line: 1608, col: 5, offset: 38504},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1611, col: 7, offset: 38635},
+								pos:  position{line: 1608, col: 7, offset: 38506},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1611, col: 11, offset: 38639},
+							pos:        position{line: 1608, col: 11, offset: 38510},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1611, col: 15, offset: 38643},
+							pos:   position{line: 1608, col: 15, offset: 38514},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1611, col: 17, offset: 38645},
+								pos:  position{line: 1608, col: 17, offset: 38516},
 								name: "UIntString",
 							},
 						},
@@ -11428,15 +11377,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1615, col: 1, offset: 38713},
+			pos:  position{line: 1612, col: 1, offset: 38584},
 			expr: &actionExpr{
-				pos: position{line: 1616, col: 4, offset: 38721},
+				pos: position{line: 1613, col: 4, offset: 38592},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1616, col: 4, offset: 38721},
+					pos:   position{line: 1613, col: 4, offset: 38592},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1616, col: 6, offset: 38723},
+						pos:  position{line: 1613, col: 6, offset: 38594},
 						name: "UIntString",
 					},
 				},
@@ -11446,16 +11395,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1618, col: 1, offset: 38763},
+			pos:  position{line: 1615, col: 1, offset: 38634},
 			expr: &choiceExpr{
-				pos: position{line: 1619, col: 5, offset: 38777},
+				pos: position{line: 1616, col: 5, offset: 38648},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1619, col: 5, offset: 38777},
+						pos:  position{line: 1616, col: 5, offset: 38648},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1620, col: 5, offset: 38792},
+						pos:  position{line: 1617, col: 5, offset: 38663},
 						name: "MinusIntString",
 					},
 				},
@@ -11465,14 +11414,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1622, col: 1, offset: 38808},
+			pos:  position{line: 1619, col: 1, offset: 38679},
 			expr: &actionExpr{
-				pos: position{line: 1622, col: 14, offset: 38821},
+				pos: position{line: 1619, col: 14, offset: 38692},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1622, col: 14, offset: 38821},
+					pos: position{line: 1619, col: 14, offset: 38692},
 					expr: &charClassMatcher{
-						pos:        position{line: 1622, col: 14, offset: 38821},
+						pos:        position{line: 1619, col: 14, offset: 38692},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11485,21 +11434,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1624, col: 1, offset: 38860},
+			pos:  position{line: 1621, col: 1, offset: 38731},
 			expr: &actionExpr{
-				pos: position{line: 1625, col: 5, offset: 38879},
+				pos: position{line: 1622, col: 5, offset: 38750},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1625, col: 5, offset: 38879},
+					pos: position{line: 1622, col: 5, offset: 38750},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1625, col: 5, offset: 38879},
+							pos:        position{line: 1622, col: 5, offset: 38750},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1625, col: 9, offset: 38883},
+							pos:  position{line: 1622, col: 9, offset: 38754},
 							name: "UIntString",
 						},
 					},
@@ -11510,29 +11459,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1627, col: 1, offset: 38926},
+			pos:  position{line: 1624, col: 1, offset: 38797},
 			expr: &choiceExpr{
-				pos: position{line: 1628, col: 5, offset: 38942},
+				pos: position{line: 1625, col: 5, offset: 38813},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1628, col: 5, offset: 38942},
+						pos: position{line: 1625, col: 5, offset: 38813},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1628, col: 5, offset: 38942},
+							pos: position{line: 1625, col: 5, offset: 38813},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1628, col: 5, offset: 38942},
+									pos: position{line: 1625, col: 5, offset: 38813},
 									expr: &litMatcher{
-										pos:        position{line: 1628, col: 5, offset: 38942},
+										pos:        position{line: 1625, col: 5, offset: 38813},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1628, col: 10, offset: 38947},
+									pos: position{line: 1625, col: 10, offset: 38818},
 									expr: &charClassMatcher{
-										pos:        position{line: 1628, col: 10, offset: 38947},
+										pos:        position{line: 1625, col: 10, offset: 38818},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11540,15 +11489,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1628, col: 17, offset: 38954},
+									pos:        position{line: 1625, col: 17, offset: 38825},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1628, col: 21, offset: 38958},
+									pos: position{line: 1625, col: 21, offset: 38829},
 									expr: &charClassMatcher{
-										pos:        position{line: 1628, col: 21, offset: 38958},
+										pos:        position{line: 1625, col: 21, offset: 38829},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11556,9 +11505,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1628, col: 28, offset: 38965},
+									pos: position{line: 1625, col: 28, offset: 38836},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1628, col: 28, offset: 38965},
+										pos:  position{line: 1625, col: 28, offset: 38836},
 										name: "ExponentPart",
 									},
 								},
@@ -11566,30 +11515,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1629, col: 5, offset: 39014},
+						pos: position{line: 1626, col: 5, offset: 38885},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1629, col: 5, offset: 39014},
+							pos: position{line: 1626, col: 5, offset: 38885},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1629, col: 5, offset: 39014},
+									pos: position{line: 1626, col: 5, offset: 38885},
 									expr: &litMatcher{
-										pos:        position{line: 1629, col: 5, offset: 39014},
+										pos:        position{line: 1626, col: 5, offset: 38885},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1629, col: 10, offset: 39019},
+									pos:        position{line: 1626, col: 10, offset: 38890},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1629, col: 14, offset: 39023},
+									pos: position{line: 1626, col: 14, offset: 38894},
 									expr: &charClassMatcher{
-										pos:        position{line: 1629, col: 14, offset: 39023},
+										pos:        position{line: 1626, col: 14, offset: 38894},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11597,9 +11546,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1629, col: 21, offset: 39030},
+									pos: position{line: 1626, col: 21, offset: 38901},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1629, col: 21, offset: 39030},
+										pos:  position{line: 1626, col: 21, offset: 38901},
 										name: "ExponentPart",
 									},
 								},
@@ -11607,17 +11556,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1630, col: 5, offset: 39079},
+						pos: position{line: 1627, col: 5, offset: 38950},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1630, col: 6, offset: 39080},
+							pos: position{line: 1627, col: 6, offset: 38951},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 6, offset: 39080},
+									pos:  position{line: 1627, col: 6, offset: 38951},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 12, offset: 39086},
+									pos:  position{line: 1627, col: 12, offset: 38957},
 									name: "Infinity",
 								},
 							},
@@ -11630,20 +11579,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1633, col: 1, offset: 39129},
+			pos:  position{line: 1630, col: 1, offset: 39000},
 			expr: &seqExpr{
-				pos: position{line: 1633, col: 16, offset: 39144},
+				pos: position{line: 1630, col: 16, offset: 39015},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1633, col: 16, offset: 39144},
+						pos:        position{line: 1630, col: 16, offset: 39015},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1633, col: 21, offset: 39149},
+						pos: position{line: 1630, col: 21, offset: 39020},
 						expr: &charClassMatcher{
-							pos:        position{line: 1633, col: 21, offset: 39149},
+							pos:        position{line: 1630, col: 21, offset: 39020},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11651,7 +11600,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1633, col: 27, offset: 39155},
+						pos:  position{line: 1630, col: 27, offset: 39026},
 						name: "UIntString",
 					},
 				},
@@ -11661,9 +11610,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1635, col: 1, offset: 39167},
+			pos:  position{line: 1632, col: 1, offset: 39038},
 			expr: &litMatcher{
-				pos:        position{line: 1635, col: 7, offset: 39173},
+				pos:        position{line: 1632, col: 7, offset: 39044},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11673,23 +11622,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1637, col: 1, offset: 39180},
+			pos:  position{line: 1634, col: 1, offset: 39051},
 			expr: &seqExpr{
-				pos: position{line: 1637, col: 12, offset: 39191},
+				pos: position{line: 1634, col: 12, offset: 39062},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1637, col: 12, offset: 39191},
+						pos: position{line: 1634, col: 12, offset: 39062},
 						expr: &choiceExpr{
-							pos: position{line: 1637, col: 13, offset: 39192},
+							pos: position{line: 1634, col: 13, offset: 39063},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1637, col: 13, offset: 39192},
+									pos:        position{line: 1634, col: 13, offset: 39063},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1637, col: 19, offset: 39198},
+									pos:        position{line: 1634, col: 19, offset: 39069},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11698,7 +11647,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1637, col: 25, offset: 39204},
+						pos:        position{line: 1634, col: 25, offset: 39075},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11710,14 +11659,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1639, col: 1, offset: 39211},
+			pos:  position{line: 1636, col: 1, offset: 39082},
 			expr: &actionExpr{
-				pos: position{line: 1639, col: 7, offset: 39217},
+				pos: position{line: 1636, col: 7, offset: 39088},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1639, col: 7, offset: 39217},
+					pos: position{line: 1636, col: 7, offset: 39088},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1639, col: 7, offset: 39217},
+						pos:  position{line: 1636, col: 7, offset: 39088},
 						name: "HexDigit",
 					},
 				},
@@ -11727,9 +11676,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1641, col: 1, offset: 39259},
+			pos:  position{line: 1638, col: 1, offset: 39130},
 			expr: &charClassMatcher{
-				pos:        position{line: 1641, col: 12, offset: 39270},
+				pos:        position{line: 1638, col: 12, offset: 39141},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11740,35 +11689,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1643, col: 1, offset: 39283},
+			pos:  position{line: 1640, col: 1, offset: 39154},
 			expr: &choiceExpr{
-				pos: position{line: 1644, col: 5, offset: 39300},
+				pos: position{line: 1641, col: 5, offset: 39171},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1644, col: 5, offset: 39300},
+						pos: position{line: 1641, col: 5, offset: 39171},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1644, col: 5, offset: 39300},
+							pos: position{line: 1641, col: 5, offset: 39171},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1644, col: 5, offset: 39300},
+									pos:        position{line: 1641, col: 5, offset: 39171},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1644, col: 9, offset: 39304},
+									pos:   position{line: 1641, col: 9, offset: 39175},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1644, col: 11, offset: 39306},
+										pos: position{line: 1641, col: 11, offset: 39177},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1644, col: 11, offset: 39306},
+											pos:  position{line: 1641, col: 11, offset: 39177},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1644, col: 29, offset: 39324},
+									pos:        position{line: 1641, col: 29, offset: 39195},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11777,30 +11726,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1645, col: 5, offset: 39361},
+						pos: position{line: 1642, col: 5, offset: 39232},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1645, col: 5, offset: 39361},
+							pos: position{line: 1642, col: 5, offset: 39232},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1645, col: 5, offset: 39361},
+									pos:        position{line: 1642, col: 5, offset: 39232},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1645, col: 9, offset: 39365},
+									pos:   position{line: 1642, col: 9, offset: 39236},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1645, col: 11, offset: 39367},
+										pos: position{line: 1642, col: 11, offset: 39238},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1645, col: 11, offset: 39367},
+											pos:  position{line: 1642, col: 11, offset: 39238},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1645, col: 29, offset: 39385},
+									pos:        position{line: 1642, col: 29, offset: 39256},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11815,57 +11764,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1647, col: 1, offset: 39419},
+			pos:  position{line: 1644, col: 1, offset: 39290},
 			expr: &choiceExpr{
-				pos: position{line: 1648, col: 5, offset: 39440},
+				pos: position{line: 1645, col: 5, offset: 39311},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1648, col: 5, offset: 39440},
+						pos: position{line: 1645, col: 5, offset: 39311},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1648, col: 5, offset: 39440},
+							pos: position{line: 1645, col: 5, offset: 39311},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1648, col: 5, offset: 39440},
+									pos: position{line: 1645, col: 5, offset: 39311},
 									expr: &choiceExpr{
-										pos: position{line: 1648, col: 7, offset: 39442},
+										pos: position{line: 1645, col: 7, offset: 39313},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1648, col: 7, offset: 39442},
+												pos:        position{line: 1645, col: 7, offset: 39313},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1648, col: 13, offset: 39448},
+												pos:  position{line: 1645, col: 13, offset: 39319},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1648, col: 26, offset: 39461,
+									line: 1645, col: 26, offset: 39332,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1649, col: 5, offset: 39498},
+						pos: position{line: 1646, col: 5, offset: 39369},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1649, col: 5, offset: 39498},
+							pos: position{line: 1646, col: 5, offset: 39369},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1649, col: 5, offset: 39498},
+									pos:        position{line: 1646, col: 5, offset: 39369},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1649, col: 10, offset: 39503},
+									pos:   position{line: 1646, col: 10, offset: 39374},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1649, col: 12, offset: 39505},
+										pos:  position{line: 1646, col: 12, offset: 39376},
 										name: "EscapeSequence",
 									},
 								},
@@ -11879,32 +11828,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1651, col: 1, offset: 39539},
+			pos:  position{line: 1648, col: 1, offset: 39410},
 			expr: &actionExpr{
-				pos: position{line: 1652, col: 5, offset: 39558},
+				pos: position{line: 1649, col: 5, offset: 39429},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1652, col: 5, offset: 39558},
+					pos: position{line: 1649, col: 5, offset: 39429},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1652, col: 5, offset: 39558},
+							pos:        position{line: 1649, col: 5, offset: 39429},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1652, col: 9, offset: 39562},
+							pos:   position{line: 1649, col: 9, offset: 39433},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1652, col: 11, offset: 39564},
+								pos: position{line: 1649, col: 11, offset: 39435},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1652, col: 11, offset: 39564},
+									pos:  position{line: 1649, col: 11, offset: 39435},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1652, col: 25, offset: 39578},
+							pos:        position{line: 1649, col: 25, offset: 39449},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11917,57 +11866,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1654, col: 1, offset: 39612},
+			pos:  position{line: 1651, col: 1, offset: 39483},
 			expr: &choiceExpr{
-				pos: position{line: 1655, col: 5, offset: 39629},
+				pos: position{line: 1652, col: 5, offset: 39500},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1655, col: 5, offset: 39629},
+						pos: position{line: 1652, col: 5, offset: 39500},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1655, col: 5, offset: 39629},
+							pos: position{line: 1652, col: 5, offset: 39500},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1655, col: 5, offset: 39629},
+									pos: position{line: 1652, col: 5, offset: 39500},
 									expr: &choiceExpr{
-										pos: position{line: 1655, col: 7, offset: 39631},
+										pos: position{line: 1652, col: 7, offset: 39502},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1655, col: 7, offset: 39631},
+												pos:        position{line: 1652, col: 7, offset: 39502},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1655, col: 13, offset: 39637},
+												pos:  position{line: 1652, col: 13, offset: 39508},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1655, col: 26, offset: 39650,
+									line: 1652, col: 26, offset: 39521,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1656, col: 5, offset: 39687},
+						pos: position{line: 1653, col: 5, offset: 39558},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1656, col: 5, offset: 39687},
+							pos: position{line: 1653, col: 5, offset: 39558},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1656, col: 5, offset: 39687},
+									pos:        position{line: 1653, col: 5, offset: 39558},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1656, col: 10, offset: 39692},
+									pos:   position{line: 1653, col: 10, offset: 39563},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1656, col: 12, offset: 39694},
+										pos:  position{line: 1653, col: 12, offset: 39565},
 										name: "EscapeSequence",
 									},
 								},
@@ -11981,28 +11930,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1658, col: 1, offset: 39728},
+			pos:  position{line: 1655, col: 1, offset: 39599},
 			expr: &actionExpr{
-				pos: position{line: 1659, col: 5, offset: 39740},
+				pos: position{line: 1656, col: 5, offset: 39611},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1659, col: 5, offset: 39740},
+					pos: position{line: 1656, col: 5, offset: 39611},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1659, col: 5, offset: 39740},
+							pos:   position{line: 1656, col: 5, offset: 39611},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1659, col: 10, offset: 39745},
+								pos:  position{line: 1656, col: 10, offset: 39616},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1659, col: 23, offset: 39758},
+							pos:   position{line: 1656, col: 23, offset: 39629},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1659, col: 28, offset: 39763},
+								pos: position{line: 1656, col: 28, offset: 39634},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1659, col: 28, offset: 39763},
+									pos:  position{line: 1656, col: 28, offset: 39634},
 									name: "KeyWordRest",
 								},
 							},
@@ -12015,16 +11964,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1661, col: 1, offset: 39825},
+			pos:  position{line: 1658, col: 1, offset: 39696},
 			expr: &choiceExpr{
-				pos: position{line: 1662, col: 5, offset: 39842},
+				pos: position{line: 1659, col: 5, offset: 39713},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1662, col: 5, offset: 39842},
+						pos:  position{line: 1659, col: 5, offset: 39713},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1663, col: 5, offset: 39859},
+						pos:  position{line: 1660, col: 5, offset: 39730},
 						name: "KeyWordEsc",
 					},
 				},
@@ -12034,16 +11983,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1665, col: 1, offset: 39871},
+			pos:  position{line: 1662, col: 1, offset: 39742},
 			expr: &choiceExpr{
-				pos: position{line: 1666, col: 5, offset: 39887},
+				pos: position{line: 1663, col: 5, offset: 39758},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1666, col: 5, offset: 39887},
+						pos:  position{line: 1663, col: 5, offset: 39758},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1667, col: 5, offset: 39904},
+						pos:        position{line: 1664, col: 5, offset: 39775},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12056,19 +12005,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1669, col: 1, offset: 39911},
+			pos:  position{line: 1666, col: 1, offset: 39782},
 			expr: &actionExpr{
-				pos: position{line: 1669, col: 16, offset: 39926},
+				pos: position{line: 1666, col: 16, offset: 39797},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1669, col: 17, offset: 39927},
+					pos: position{line: 1666, col: 17, offset: 39798},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1669, col: 17, offset: 39927},
+							pos:  position{line: 1666, col: 17, offset: 39798},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1669, col: 33, offset: 39943},
+							pos:        position{line: 1666, col: 33, offset: 39814},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12082,31 +12031,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1671, col: 1, offset: 39987},
+			pos:  position{line: 1668, col: 1, offset: 39858},
 			expr: &actionExpr{
-				pos: position{line: 1671, col: 14, offset: 40000},
+				pos: position{line: 1668, col: 14, offset: 39871},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1671, col: 14, offset: 40000},
+					pos: position{line: 1668, col: 14, offset: 39871},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1671, col: 14, offset: 40000},
+							pos:        position{line: 1668, col: 14, offset: 39871},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1671, col: 19, offset: 40005},
+							pos:   position{line: 1668, col: 19, offset: 39876},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1671, col: 22, offset: 40008},
+								pos: position{line: 1668, col: 22, offset: 39879},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1671, col: 22, offset: 40008},
+										pos:  position{line: 1668, col: 22, offset: 39879},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1671, col: 38, offset: 40024},
+										pos:  position{line: 1668, col: 38, offset: 39895},
 										name: "EscapeSequence",
 									},
 								},
@@ -12120,42 +12069,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1673, col: 1, offset: 40059},
+			pos:  position{line: 1670, col: 1, offset: 39930},
 			expr: &actionExpr{
-				pos: position{line: 1674, col: 5, offset: 40075},
+				pos: position{line: 1671, col: 5, offset: 39946},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1674, col: 5, offset: 40075},
+					pos: position{line: 1671, col: 5, offset: 39946},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1674, col: 5, offset: 40075},
+							pos: position{line: 1671, col: 5, offset: 39946},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1674, col: 6, offset: 40076},
+								pos:  position{line: 1671, col: 6, offset: 39947},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1674, col: 22, offset: 40092},
+							pos: position{line: 1671, col: 22, offset: 39963},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1674, col: 23, offset: 40093},
+								pos:  position{line: 1671, col: 23, offset: 39964},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1674, col: 35, offset: 40105},
+							pos:   position{line: 1671, col: 35, offset: 39976},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1674, col: 40, offset: 40110},
+								pos:  position{line: 1671, col: 40, offset: 39981},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1674, col: 50, offset: 40120},
+							pos:   position{line: 1671, col: 50, offset: 39991},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1674, col: 55, offset: 40125},
+								pos: position{line: 1671, col: 55, offset: 39996},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1674, col: 55, offset: 40125},
+									pos:  position{line: 1671, col: 55, offset: 39996},
 									name: "GlobRest",
 								},
 							},
@@ -12168,28 +12117,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1678, col: 1, offset: 40194},
+			pos:  position{line: 1675, col: 1, offset: 40065},
 			expr: &choiceExpr{
-				pos: position{line: 1678, col: 19, offset: 40212},
+				pos: position{line: 1675, col: 19, offset: 40083},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1678, col: 19, offset: 40212},
+						pos:  position{line: 1675, col: 19, offset: 40083},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1678, col: 34, offset: 40227},
+						pos: position{line: 1675, col: 34, offset: 40098},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1678, col: 34, offset: 40227},
+								pos: position{line: 1675, col: 34, offset: 40098},
 								expr: &litMatcher{
-									pos:        position{line: 1678, col: 34, offset: 40227},
+									pos:        position{line: 1675, col: 34, offset: 40098},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1678, col: 39, offset: 40232},
+								pos:  position{line: 1675, col: 39, offset: 40103},
 								name: "KeyWordRest",
 							},
 						},
@@ -12201,19 +12150,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1679, col: 1, offset: 40244},
+			pos:  position{line: 1676, col: 1, offset: 40115},
 			expr: &seqExpr{
-				pos: position{line: 1679, col: 15, offset: 40258},
+				pos: position{line: 1676, col: 15, offset: 40129},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1679, col: 15, offset: 40258},
+						pos: position{line: 1676, col: 15, offset: 40129},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1679, col: 15, offset: 40258},
+							pos:  position{line: 1676, col: 15, offset: 40129},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1679, col: 28, offset: 40271},
+						pos:        position{line: 1676, col: 28, offset: 40142},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12225,23 +12174,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1681, col: 1, offset: 40276},
+			pos:  position{line: 1678, col: 1, offset: 40147},
 			expr: &choiceExpr{
-				pos: position{line: 1682, col: 5, offset: 40290},
+				pos: position{line: 1679, col: 5, offset: 40161},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1682, col: 5, offset: 40290},
+						pos:  position{line: 1679, col: 5, offset: 40161},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1683, col: 5, offset: 40307},
+						pos:  position{line: 1680, col: 5, offset: 40178},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1684, col: 5, offset: 40319},
+						pos: position{line: 1681, col: 5, offset: 40190},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1684, col: 5, offset: 40319},
+							pos:        position{line: 1681, col: 5, offset: 40190},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12254,16 +12203,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1686, col: 1, offset: 40344},
+			pos:  position{line: 1683, col: 1, offset: 40215},
 			expr: &choiceExpr{
-				pos: position{line: 1687, col: 5, offset: 40357},
+				pos: position{line: 1684, col: 5, offset: 40228},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1687, col: 5, offset: 40357},
+						pos:  position{line: 1684, col: 5, offset: 40228},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1688, col: 5, offset: 40371},
+						pos:        position{line: 1685, col: 5, offset: 40242},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12276,31 +12225,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1690, col: 1, offset: 40378},
+			pos:  position{line: 1687, col: 1, offset: 40249},
 			expr: &actionExpr{
-				pos: position{line: 1690, col: 11, offset: 40388},
+				pos: position{line: 1687, col: 11, offset: 40259},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1690, col: 11, offset: 40388},
+					pos: position{line: 1687, col: 11, offset: 40259},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1690, col: 11, offset: 40388},
+							pos:        position{line: 1687, col: 11, offset: 40259},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1690, col: 16, offset: 40393},
+							pos:   position{line: 1687, col: 16, offset: 40264},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1690, col: 19, offset: 40396},
+								pos: position{line: 1687, col: 19, offset: 40267},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1690, col: 19, offset: 40396},
+										pos:  position{line: 1687, col: 19, offset: 40267},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1690, col: 32, offset: 40409},
+										pos:  position{line: 1687, col: 32, offset: 40280},
 										name: "EscapeSequence",
 									},
 								},
@@ -12314,32 +12263,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1692, col: 1, offset: 40444},
+			pos:  position{line: 1689, col: 1, offset: 40315},
 			expr: &choiceExpr{
-				pos: position{line: 1693, col: 5, offset: 40459},
+				pos: position{line: 1690, col: 5, offset: 40330},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1693, col: 5, offset: 40459},
+						pos: position{line: 1690, col: 5, offset: 40330},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1693, col: 5, offset: 40459},
+							pos:        position{line: 1690, col: 5, offset: 40330},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1694, col: 5, offset: 40487},
+						pos: position{line: 1691, col: 5, offset: 40358},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1694, col: 5, offset: 40487},
+							pos:        position{line: 1691, col: 5, offset: 40358},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1695, col: 5, offset: 40517},
+						pos:        position{line: 1692, col: 5, offset: 40388},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12352,57 +12301,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1697, col: 1, offset: 40523},
+			pos:  position{line: 1694, col: 1, offset: 40394},
 			expr: &choiceExpr{
-				pos: position{line: 1698, col: 5, offset: 40544},
+				pos: position{line: 1695, col: 5, offset: 40415},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1698, col: 5, offset: 40544},
+						pos: position{line: 1695, col: 5, offset: 40415},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1698, col: 5, offset: 40544},
+							pos: position{line: 1695, col: 5, offset: 40415},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1698, col: 5, offset: 40544},
+									pos: position{line: 1695, col: 5, offset: 40415},
 									expr: &choiceExpr{
-										pos: position{line: 1698, col: 7, offset: 40546},
+										pos: position{line: 1695, col: 7, offset: 40417},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1698, col: 7, offset: 40546},
+												pos:        position{line: 1695, col: 7, offset: 40417},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1698, col: 13, offset: 40552},
+												pos:  position{line: 1695, col: 13, offset: 40423},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1698, col: 26, offset: 40565,
+									line: 1695, col: 26, offset: 40436,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1699, col: 5, offset: 40602},
+						pos: position{line: 1696, col: 5, offset: 40473},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1699, col: 5, offset: 40602},
+							pos: position{line: 1696, col: 5, offset: 40473},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1699, col: 5, offset: 40602},
+									pos:        position{line: 1696, col: 5, offset: 40473},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1699, col: 10, offset: 40607},
+									pos:   position{line: 1696, col: 10, offset: 40478},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1699, col: 12, offset: 40609},
+										pos:  position{line: 1696, col: 12, offset: 40480},
 										name: "EscapeSequence",
 									},
 								},
@@ -12416,16 +12365,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1701, col: 1, offset: 40643},
+			pos:  position{line: 1698, col: 1, offset: 40514},
 			expr: &choiceExpr{
-				pos: position{line: 1702, col: 5, offset: 40662},
+				pos: position{line: 1699, col: 5, offset: 40533},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1702, col: 5, offset: 40662},
+						pos:  position{line: 1699, col: 5, offset: 40533},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1703, col: 5, offset: 40683},
+						pos:  position{line: 1700, col: 5, offset: 40554},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12435,87 +12384,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1705, col: 1, offset: 40698},
+			pos:  position{line: 1702, col: 1, offset: 40569},
 			expr: &choiceExpr{
-				pos: position{line: 1706, col: 5, offset: 40719},
+				pos: position{line: 1703, col: 5, offset: 40590},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1706, col: 5, offset: 40719},
+						pos:        position{line: 1703, col: 5, offset: 40590},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1707, col: 5, offset: 40727},
+						pos: position{line: 1704, col: 5, offset: 40598},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1707, col: 5, offset: 40727},
+							pos:        position{line: 1704, col: 5, offset: 40598},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1708, col: 5, offset: 40767},
+						pos:        position{line: 1705, col: 5, offset: 40638},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1709, col: 5, offset: 40776},
+						pos: position{line: 1706, col: 5, offset: 40647},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1709, col: 5, offset: 40776},
+							pos:        position{line: 1706, col: 5, offset: 40647},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1710, col: 5, offset: 40805},
+						pos: position{line: 1707, col: 5, offset: 40676},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1710, col: 5, offset: 40805},
+							pos:        position{line: 1707, col: 5, offset: 40676},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1711, col: 5, offset: 40834},
+						pos: position{line: 1708, col: 5, offset: 40705},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1711, col: 5, offset: 40834},
+							pos:        position{line: 1708, col: 5, offset: 40705},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1712, col: 5, offset: 40863},
+						pos: position{line: 1709, col: 5, offset: 40734},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1712, col: 5, offset: 40863},
+							pos:        position{line: 1709, col: 5, offset: 40734},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1713, col: 5, offset: 40892},
+						pos: position{line: 1710, col: 5, offset: 40763},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1713, col: 5, offset: 40892},
+							pos:        position{line: 1710, col: 5, offset: 40763},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1714, col: 5, offset: 40921},
+						pos: position{line: 1711, col: 5, offset: 40792},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1714, col: 5, offset: 40921},
+							pos:        position{line: 1711, col: 5, offset: 40792},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12528,32 +12477,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1716, col: 1, offset: 40947},
+			pos:  position{line: 1713, col: 1, offset: 40818},
 			expr: &choiceExpr{
-				pos: position{line: 1717, col: 5, offset: 40965},
+				pos: position{line: 1714, col: 5, offset: 40836},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1717, col: 5, offset: 40965},
+						pos: position{line: 1714, col: 5, offset: 40836},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1717, col: 5, offset: 40965},
+							pos:        position{line: 1714, col: 5, offset: 40836},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1718, col: 5, offset: 40993},
+						pos: position{line: 1715, col: 5, offset: 40864},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1718, col: 5, offset: 40993},
+							pos:        position{line: 1715, col: 5, offset: 40864},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1719, col: 5, offset: 41021},
+						pos:        position{line: 1716, col: 5, offset: 40892},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12566,42 +12515,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1721, col: 1, offset: 41027},
+			pos:  position{line: 1718, col: 1, offset: 40898},
 			expr: &choiceExpr{
-				pos: position{line: 1722, col: 5, offset: 41045},
+				pos: position{line: 1719, col: 5, offset: 40916},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1722, col: 5, offset: 41045},
+						pos: position{line: 1719, col: 5, offset: 40916},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1722, col: 5, offset: 41045},
+							pos: position{line: 1719, col: 5, offset: 40916},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1722, col: 5, offset: 41045},
+									pos:        position{line: 1719, col: 5, offset: 40916},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1722, col: 9, offset: 41049},
+									pos:   position{line: 1719, col: 9, offset: 40920},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1722, col: 16, offset: 41056},
+										pos: position{line: 1719, col: 16, offset: 40927},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1722, col: 16, offset: 41056},
+												pos:  position{line: 1719, col: 16, offset: 40927},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1722, col: 25, offset: 41065},
+												pos:  position{line: 1719, col: 25, offset: 40936},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1722, col: 34, offset: 41074},
+												pos:  position{line: 1719, col: 34, offset: 40945},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1722, col: 43, offset: 41083},
+												pos:  position{line: 1719, col: 43, offset: 40954},
 												name: "HexDigit",
 											},
 										},
@@ -12611,65 +12560,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1725, col: 5, offset: 41146},
+						pos: position{line: 1722, col: 5, offset: 41017},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1725, col: 5, offset: 41146},
+							pos: position{line: 1722, col: 5, offset: 41017},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1725, col: 5, offset: 41146},
+									pos:        position{line: 1722, col: 5, offset: 41017},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1725, col: 9, offset: 41150},
+									pos:        position{line: 1722, col: 9, offset: 41021},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1725, col: 13, offset: 41154},
+									pos:   position{line: 1722, col: 13, offset: 41025},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1725, col: 20, offset: 41161},
+										pos: position{line: 1722, col: 20, offset: 41032},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1725, col: 20, offset: 41161},
+												pos:  position{line: 1722, col: 20, offset: 41032},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1725, col: 29, offset: 41170},
+												pos: position{line: 1722, col: 29, offset: 41041},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1725, col: 29, offset: 41170},
+													pos:  position{line: 1722, col: 29, offset: 41041},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1725, col: 39, offset: 41180},
+												pos: position{line: 1722, col: 39, offset: 41051},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1725, col: 39, offset: 41180},
+													pos:  position{line: 1722, col: 39, offset: 41051},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1725, col: 49, offset: 41190},
+												pos: position{line: 1722, col: 49, offset: 41061},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1725, col: 49, offset: 41190},
+													pos:  position{line: 1722, col: 49, offset: 41061},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1725, col: 59, offset: 41200},
+												pos: position{line: 1722, col: 59, offset: 41071},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1725, col: 59, offset: 41200},
+													pos:  position{line: 1722, col: 59, offset: 41071},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1725, col: 69, offset: 41210},
+												pos: position{line: 1722, col: 69, offset: 41081},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1725, col: 69, offset: 41210},
+													pos:  position{line: 1722, col: 69, offset: 41081},
 													name: "HexDigit",
 												},
 											},
@@ -12677,7 +12626,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1725, col: 80, offset: 41221},
+									pos:        position{line: 1722, col: 80, offset: 41092},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12692,37 +12641,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1729, col: 1, offset: 41275},
+			pos:  position{line: 1726, col: 1, offset: 41146},
 			expr: &actionExpr{
-				pos: position{line: 1730, col: 5, offset: 41293},
+				pos: position{line: 1727, col: 5, offset: 41164},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1730, col: 5, offset: 41293},
+					pos: position{line: 1727, col: 5, offset: 41164},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1730, col: 5, offset: 41293},
+							pos:        position{line: 1727, col: 5, offset: 41164},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1730, col: 9, offset: 41297},
+							pos:   position{line: 1727, col: 9, offset: 41168},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1730, col: 14, offset: 41302},
+								pos:  position{line: 1727, col: 14, offset: 41173},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1730, col: 25, offset: 41313},
+							pos:        position{line: 1727, col: 25, offset: 41184},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1730, col: 29, offset: 41317},
+							pos: position{line: 1727, col: 29, offset: 41188},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1730, col: 30, offset: 41318},
+								pos:  position{line: 1727, col: 30, offset: 41189},
 								name: "KeyWordStart",
 							},
 						},
@@ -12734,33 +12683,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1732, col: 1, offset: 41353},
+			pos:  position{line: 1729, col: 1, offset: 41224},
 			expr: &actionExpr{
-				pos: position{line: 1733, col: 5, offset: 41368},
+				pos: position{line: 1730, col: 5, offset: 41239},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1733, col: 5, offset: 41368},
+					pos: position{line: 1730, col: 5, offset: 41239},
 					expr: &choiceExpr{
-						pos: position{line: 1733, col: 6, offset: 41369},
+						pos: position{line: 1730, col: 6, offset: 41240},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1733, col: 6, offset: 41369},
+								pos:        position{line: 1730, col: 6, offset: 41240},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1733, col: 15, offset: 41378},
+								pos: position{line: 1730, col: 15, offset: 41249},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1733, col: 15, offset: 41378},
+										pos:        position{line: 1730, col: 15, offset: 41249},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1733, col: 20, offset: 41383,
+										line: 1730, col: 20, offset: 41254,
 									},
 								},
 							},
@@ -12773,9 +12722,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1735, col: 1, offset: 41419},
+			pos:  position{line: 1732, col: 1, offset: 41290},
 			expr: &charClassMatcher{
-				pos:        position{line: 1736, col: 5, offset: 41435},
+				pos:        position{line: 1733, col: 5, offset: 41306},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12787,11 +12736,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1738, col: 1, offset: 41450},
+			pos:  position{line: 1735, col: 1, offset: 41321},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1738, col: 5, offset: 41454},
+				pos: position{line: 1735, col: 5, offset: 41325},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1738, col: 5, offset: 41454},
+					pos:  position{line: 1735, col: 5, offset: 41325},
 					name: "AnySpace",
 				},
 			},
@@ -12800,11 +12749,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1740, col: 1, offset: 41465},
+			pos:  position{line: 1737, col: 1, offset: 41336},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1740, col: 6, offset: 41470},
+				pos: position{line: 1737, col: 6, offset: 41341},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1740, col: 6, offset: 41470},
+					pos:  position{line: 1737, col: 6, offset: 41341},
 					name: "AnySpace",
 				},
 			},
@@ -12813,20 +12762,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1742, col: 1, offset: 41481},
+			pos:  position{line: 1739, col: 1, offset: 41352},
 			expr: &choiceExpr{
-				pos: position{line: 1743, col: 5, offset: 41494},
+				pos: position{line: 1740, col: 5, offset: 41365},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1743, col: 5, offset: 41494},
+						pos:  position{line: 1740, col: 5, offset: 41365},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 5, offset: 41509},
+						pos:  position{line: 1741, col: 5, offset: 41380},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1745, col: 5, offset: 41528},
+						pos:  position{line: 1742, col: 5, offset: 41399},
 						name: "Comment",
 					},
 				},
@@ -12836,32 +12785,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1747, col: 1, offset: 41537},
+			pos:  position{line: 1744, col: 1, offset: 41408},
 			expr: &choiceExpr{
-				pos: position{line: 1748, col: 5, offset: 41555},
+				pos: position{line: 1745, col: 5, offset: 41426},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1748, col: 5, offset: 41555},
+						pos:  position{line: 1745, col: 5, offset: 41426},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1749, col: 5, offset: 41562},
+						pos:  position{line: 1746, col: 5, offset: 41433},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1750, col: 5, offset: 41569},
+						pos:  position{line: 1747, col: 5, offset: 41440},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1751, col: 5, offset: 41576},
+						pos:  position{line: 1748, col: 5, offset: 41447},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1752, col: 5, offset: 41583},
+						pos:  position{line: 1749, col: 5, offset: 41454},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1753, col: 5, offset: 41590},
+						pos:  position{line: 1750, col: 5, offset: 41461},
 						name: "Nl",
 					},
 				},
@@ -12871,16 +12820,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1755, col: 1, offset: 41594},
+			pos:  position{line: 1752, col: 1, offset: 41465},
 			expr: &choiceExpr{
-				pos: position{line: 1756, col: 5, offset: 41619},
+				pos: position{line: 1753, col: 5, offset: 41490},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1756, col: 5, offset: 41619},
+						pos:  position{line: 1753, col: 5, offset: 41490},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1757, col: 5, offset: 41626},
+						pos:  position{line: 1754, col: 5, offset: 41497},
 						name: "Mc",
 					},
 				},
@@ -12890,9 +12839,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1759, col: 1, offset: 41630},
+			pos:  position{line: 1756, col: 1, offset: 41501},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1760, col: 5, offset: 41647},
+				pos:  position{line: 1757, col: 5, offset: 41518},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12900,9 +12849,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1762, col: 1, offset: 41651},
+			pos:  position{line: 1759, col: 1, offset: 41522},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1763, col: 5, offset: 41683},
+				pos:  position{line: 1760, col: 5, offset: 41554},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12910,9 +12859,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1769, col: 1, offset: 41864},
+			pos:  position{line: 1766, col: 1, offset: 41735},
 			expr: &charClassMatcher{
-				pos:        position{line: 1769, col: 6, offset: 41869},
+				pos:        position{line: 1766, col: 6, offset: 41740},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12924,9 +12873,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1772, col: 1, offset: 46021},
+			pos:  position{line: 1769, col: 1, offset: 45892},
 			expr: &charClassMatcher{
-				pos:        position{line: 1772, col: 6, offset: 46026},
+				pos:        position{line: 1769, col: 6, offset: 45897},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12938,9 +12887,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1775, col: 1, offset: 46511},
+			pos:  position{line: 1772, col: 1, offset: 46382},
 			expr: &charClassMatcher{
-				pos:        position{line: 1775, col: 6, offset: 46516},
+				pos:        position{line: 1772, col: 6, offset: 46387},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12952,9 +12901,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1778, col: 1, offset: 49963},
+			pos:  position{line: 1775, col: 1, offset: 49834},
 			expr: &charClassMatcher{
-				pos:        position{line: 1778, col: 6, offset: 49968},
+				pos:        position{line: 1775, col: 6, offset: 49839},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12966,9 +12915,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1781, col: 1, offset: 50074},
+			pos:  position{line: 1778, col: 1, offset: 49945},
 			expr: &charClassMatcher{
-				pos:        position{line: 1781, col: 6, offset: 50079},
+				pos:        position{line: 1778, col: 6, offset: 49950},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12980,9 +12929,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1784, col: 1, offset: 54080},
+			pos:  position{line: 1781, col: 1, offset: 53951},
 			expr: &charClassMatcher{
-				pos:        position{line: 1784, col: 6, offset: 54085},
+				pos:        position{line: 1781, col: 6, offset: 53956},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12994,9 +12943,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1787, col: 1, offset: 55273},
+			pos:  position{line: 1784, col: 1, offset: 55144},
 			expr: &charClassMatcher{
-				pos:        position{line: 1787, col: 6, offset: 55278},
+				pos:        position{line: 1784, col: 6, offset: 55149},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -13008,9 +12957,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1790, col: 1, offset: 57458},
+			pos:  position{line: 1787, col: 1, offset: 57329},
 			expr: &charClassMatcher{
-				pos:        position{line: 1790, col: 6, offset: 57463},
+				pos:        position{line: 1787, col: 6, offset: 57334},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -13021,9 +12970,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1793, col: 1, offset: 57966},
+			pos:  position{line: 1790, col: 1, offset: 57837},
 			expr: &charClassMatcher{
-				pos:        position{line: 1793, col: 6, offset: 57971},
+				pos:        position{line: 1790, col: 6, offset: 57842},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -13035,9 +12984,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1796, col: 1, offset: 58085},
+			pos:  position{line: 1793, col: 1, offset: 57956},
 			expr: &charClassMatcher{
-				pos:        position{line: 1796, col: 6, offset: 58090},
+				pos:        position{line: 1793, col: 6, offset: 57961},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -13049,9 +12998,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1799, col: 1, offset: 58171},
+			pos:  position{line: 1796, col: 1, offset: 58042},
 			expr: &charClassMatcher{
-				pos:        position{line: 1799, col: 6, offset: 58176},
+				pos:        position{line: 1796, col: 6, offset: 58047},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13063,9 +13012,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1801, col: 1, offset: 58229},
+			pos:  position{line: 1798, col: 1, offset: 58100},
 			expr: &anyMatcher{
-				line: 1802, col: 5, offset: 58249,
+				line: 1799, col: 5, offset: 58120,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13073,48 +13022,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1804, col: 1, offset: 58252},
+			pos:         position{line: 1801, col: 1, offset: 58123},
 			expr: &choiceExpr{
-				pos: position{line: 1805, col: 5, offset: 58280},
+				pos: position{line: 1802, col: 5, offset: 58151},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1805, col: 5, offset: 58280},
+						pos:        position{line: 1802, col: 5, offset: 58151},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1806, col: 5, offset: 58289},
+						pos:        position{line: 1803, col: 5, offset: 58160},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1807, col: 5, offset: 58298},
+						pos:        position{line: 1804, col: 5, offset: 58169},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1808, col: 5, offset: 58307},
+						pos:        position{line: 1805, col: 5, offset: 58178},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1809, col: 5, offset: 58315},
+						pos:        position{line: 1806, col: 5, offset: 58186},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1810, col: 5, offset: 58328},
+						pos:        position{line: 1807, col: 5, offset: 58199},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1811, col: 5, offset: 58341},
+						pos:  position{line: 1808, col: 5, offset: 58212},
 						name: "Zs",
 					},
 				},
@@ -13124,9 +13073,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1813, col: 1, offset: 58345},
+			pos:  position{line: 1810, col: 1, offset: 58216},
 			expr: &charClassMatcher{
-				pos:        position{line: 1814, col: 5, offset: 58364},
+				pos:        position{line: 1811, col: 5, offset: 58235},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13138,9 +13087,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1820, col: 1, offset: 58694},
+			pos:         position{line: 1817, col: 1, offset: 58565},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1823, col: 5, offset: 58765},
+				pos:  position{line: 1820, col: 5, offset: 58636},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -13148,39 +13097,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1825, col: 1, offset: 58784},
+			pos:  position{line: 1822, col: 1, offset: 58655},
 			expr: &seqExpr{
-				pos: position{line: 1826, col: 5, offset: 58805},
+				pos: position{line: 1823, col: 5, offset: 58676},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1826, col: 5, offset: 58805},
+						pos:        position{line: 1823, col: 5, offset: 58676},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1826, col: 10, offset: 58810},
+						pos: position{line: 1823, col: 10, offset: 58681},
 						expr: &seqExpr{
-							pos: position{line: 1826, col: 11, offset: 58811},
+							pos: position{line: 1823, col: 11, offset: 58682},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1826, col: 11, offset: 58811},
+									pos: position{line: 1823, col: 11, offset: 58682},
 									expr: &litMatcher{
-										pos:        position{line: 1826, col: 12, offset: 58812},
+										pos:        position{line: 1823, col: 12, offset: 58683},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1826, col: 17, offset: 58817},
+									pos:  position{line: 1823, col: 17, offset: 58688},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1826, col: 35, offset: 58835},
+						pos:        position{line: 1823, col: 35, offset: 58706},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13192,33 +13141,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1828, col: 1, offset: 58841},
+			pos:  position{line: 1825, col: 1, offset: 58712},
 			expr: &choiceExpr{
-				pos: position{line: 1829, col: 5, offset: 58863},
+				pos: position{line: 1826, col: 5, offset: 58734},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1829, col: 5, offset: 58863},
+						pos: position{line: 1826, col: 5, offset: 58734},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1829, col: 5, offset: 58863},
+								pos:        position{line: 1826, col: 5, offset: 58734},
 								val:        "//",
 								ignoreCase: false,
 								want:       "\"//\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1829, col: 10, offset: 58868},
+								pos: position{line: 1826, col: 10, offset: 58739},
 								expr: &seqExpr{
-									pos: position{line: 1829, col: 11, offset: 58869},
+									pos: position{line: 1826, col: 11, offset: 58740},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1829, col: 11, offset: 58869},
+											pos: position{line: 1826, col: 11, offset: 58740},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1829, col: 12, offset: 58870},
+												pos:  position{line: 1826, col: 12, offset: 58741},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1829, col: 27, offset: 58885},
+											pos:  position{line: 1826, col: 27, offset: 58756},
 											name: "SourceCharacter",
 										},
 									},
@@ -13227,28 +13176,28 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1830, col: 5, offset: 58907},
+						pos: position{line: 1827, col: 5, offset: 58778},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1830, col: 5, offset: 58907},
+								pos:        position{line: 1827, col: 5, offset: 58778},
 								val:        "--",
 								ignoreCase: false,
 								want:       "\"--\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1830, col: 10, offset: 58912},
+								pos: position{line: 1827, col: 10, offset: 58783},
 								expr: &seqExpr{
-									pos: position{line: 1830, col: 11, offset: 58913},
+									pos: position{line: 1827, col: 11, offset: 58784},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1830, col: 11, offset: 58913},
+											pos: position{line: 1827, col: 11, offset: 58784},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1830, col: 12, offset: 58914},
+												pos:  position{line: 1827, col: 12, offset: 58785},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1830, col: 27, offset: 58929},
+											pos:  position{line: 1827, col: 27, offset: 58800},
 											name: "SourceCharacter",
 										},
 									},
@@ -13263,19 +13212,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1832, col: 1, offset: 58948},
+			pos:  position{line: 1829, col: 1, offset: 58819},
 			expr: &seqExpr{
-				pos: position{line: 1832, col: 7, offset: 58954},
+				pos: position{line: 1829, col: 7, offset: 58825},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1832, col: 7, offset: 58954},
+						pos: position{line: 1829, col: 7, offset: 58825},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1832, col: 7, offset: 58954},
+							pos:  position{line: 1829, col: 7, offset: 58825},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1832, col: 19, offset: 58966},
+						pos:  position{line: 1829, col: 19, offset: 58837},
 						name: "LineTerminator",
 					},
 				},
@@ -13285,16 +13234,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1834, col: 1, offset: 58982},
+			pos:  position{line: 1831, col: 1, offset: 58853},
 			expr: &choiceExpr{
-				pos: position{line: 1834, col: 7, offset: 58988},
+				pos: position{line: 1831, col: 7, offset: 58859},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1834, col: 7, offset: 58988},
+						pos:  position{line: 1831, col: 7, offset: 58859},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1834, col: 11, offset: 58992},
+						pos:  position{line: 1831, col: 11, offset: 58863},
 						name: "EOF",
 					},
 				},
@@ -13304,11 +13253,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1836, col: 1, offset: 58997},
+			pos:  position{line: 1833, col: 1, offset: 58868},
 			expr: &notExpr{
-				pos: position{line: 1836, col: 7, offset: 59003},
+				pos: position{line: 1833, col: 7, offset: 58874},
 				expr: &anyMatcher{
-					line: 1836, col: 8, offset: 59004,
+					line: 1833, col: 8, offset: 58875,
 				},
 			},
 			leader:        false,
@@ -13316,11 +13265,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1838, col: 1, offset: 59007},
+			pos:  position{line: 1835, col: 1, offset: 58878},
 			expr: &notExpr{
-				pos: position{line: 1838, col: 8, offset: 59014},
+				pos: position{line: 1835, col: 8, offset: 58885},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1838, col: 9, offset: 59015},
+					pos:  position{line: 1835, col: 9, offset: 58886},
 					name: "KeyWordChars",
 				},
 			},
@@ -13329,15 +13278,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1842, col: 1, offset: 59051},
+			pos:  position{line: 1839, col: 1, offset: 58922},
 			expr: &actionExpr{
-				pos: position{line: 1843, col: 5, offset: 59064},
+				pos: position{line: 1840, col: 5, offset: 58935},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1843, col: 5, offset: 59064},
+					pos:   position{line: 1840, col: 5, offset: 58935},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1843, col: 7, offset: 59066},
+						pos:  position{line: 1840, col: 7, offset: 58937},
 						name: "Seq",
 					},
 				},
@@ -13347,27 +13296,27 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1851, col: 1, offset: 59212},
+			pos:  position{line: 1848, col: 1, offset: 59083},
 			expr: &actionExpr{
-				pos: position{line: 1851, col: 12, offset: 59223},
+				pos: position{line: 1848, col: 12, offset: 59094},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1851, col: 12, offset: 59223},
+					pos: position{line: 1848, col: 12, offset: 59094},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1851, col: 12, offset: 59223},
+							pos: position{line: 1848, col: 12, offset: 59094},
 							expr: &litMatcher{
-								pos:        position{line: 1851, col: 13, offset: 59224},
+								pos:        position{line: 1848, col: 13, offset: 59095},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1851, col: 17, offset: 59228},
+							pos:   position{line: 1848, col: 17, offset: 59099},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1851, col: 20, offset: 59231},
+								pos:  position{line: 1848, col: 20, offset: 59102},
 								name: "SelectExpr",
 							},
 						},
@@ -13379,65 +13328,65 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1853, col: 1, offset: 59261},
+			pos:  position{line: 1850, col: 1, offset: 59132},
 			expr: &actionExpr{
-				pos: position{line: 1854, col: 5, offset: 59277},
+				pos: position{line: 1851, col: 5, offset: 59148},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1854, col: 5, offset: 59277},
+					pos: position{line: 1851, col: 5, offset: 59148},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1854, col: 5, offset: 59277},
+							pos:   position{line: 1851, col: 5, offset: 59148},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1854, col: 10, offset: 59282},
+								pos:  position{line: 1851, col: 10, offset: 59153},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1855, col: 5, offset: 59300},
+							pos:   position{line: 1852, col: 5, offset: 59171},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1856, col: 9, offset: 59315},
+								pos: position{line: 1853, col: 9, offset: 59186},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1856, col: 9, offset: 59315},
+										pos:  position{line: 1853, col: 9, offset: 59186},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1857, col: 9, offset: 59336},
+										pos:  position{line: 1854, col: 9, offset: 59207},
 										name: "Select",
 									},
 									&actionExpr{
-										pos: position{line: 1858, col: 9, offset: 59351},
+										pos: position{line: 1855, col: 9, offset: 59222},
 										run: (*parser).callonSelectExpr9,
 										expr: &seqExpr{
-											pos: position{line: 1858, col: 9, offset: 59351},
+											pos: position{line: 1855, col: 9, offset: 59222},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1858, col: 9, offset: 59351},
+													pos:        position{line: 1855, col: 9, offset: 59222},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1858, col: 13, offset: 59355},
+													pos:  position{line: 1855, col: 13, offset: 59226},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1858, col: 16, offset: 59358},
+													pos:   position{line: 1855, col: 16, offset: 59229},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1858, col: 18, offset: 59360},
+														pos:  position{line: 1855, col: 18, offset: 59231},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1858, col: 26, offset: 59368},
+													pos:  position{line: 1855, col: 26, offset: 59239},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1858, col: 28, offset: 59370},
+													pos:        position{line: 1855, col: 28, offset: 59241},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13449,97 +13398,97 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1860, col: 5, offset: 59407},
+							pos:   position{line: 1857, col: 5, offset: 59278},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1860, col: 13, offset: 59415},
+								pos:  position{line: 1857, col: 13, offset: 59286},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1861, col: 5, offset: 59436},
+							pos:   position{line: 1858, col: 5, offset: 59307},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1861, col: 11, offset: 59442},
+								pos:  position{line: 1858, col: 11, offset: 59313},
 								name: "OptLimitClause",
 							},
 						},
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1881, col: 1, offset: 59828},
+			pos:  position{line: 1878, col: 1, offset: 59699},
 			expr: &actionExpr{
-				pos: position{line: 1882, col: 5, offset: 59840},
+				pos: position{line: 1879, col: 5, offset: 59711},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1882, col: 5, offset: 59840},
+					pos: position{line: 1879, col: 5, offset: 59711},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1882, col: 5, offset: 59840},
+							pos:  position{line: 1879, col: 5, offset: 59711},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1883, col: 5, offset: 59852},
+							pos:   position{line: 1880, col: 5, offset: 59723},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1883, col: 14, offset: 59861},
+								pos:  position{line: 1880, col: 14, offset: 59732},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1884, col: 5, offset: 59877},
+							pos:   position{line: 1881, col: 5, offset: 59748},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1884, col: 11, offset: 59883},
+								pos:  position{line: 1881, col: 11, offset: 59754},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1887, col: 5, offset: 60023},
+							pos:  position{line: 1884, col: 5, offset: 59894},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 7, offset: 60025},
+							pos:   position{line: 1884, col: 7, offset: 59896},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1887, col: 17, offset: 60035},
+								pos:  position{line: 1884, col: 17, offset: 59906},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1888, col: 5, offset: 60049},
+							pos:   position{line: 1885, col: 5, offset: 59920},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1888, col: 10, offset: 60054},
+								pos:  position{line: 1885, col: 10, offset: 59925},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1889, col: 5, offset: 60072},
+							pos:   position{line: 1886, col: 5, offset: 59943},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1889, col: 11, offset: 60078},
+								pos:  position{line: 1886, col: 11, offset: 59949},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1890, col: 5, offset: 60097},
+							pos:   position{line: 1887, col: 5, offset: 59968},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1890, col: 11, offset: 60103},
+								pos:  position{line: 1887, col: 11, offset: 59974},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1891, col: 5, offset: 60122},
+							pos:   position{line: 1888, col: 5, offset: 59993},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1891, col: 12, offset: 60129},
+								pos:  position{line: 1888, col: 12, offset: 60000},
 								name: "OptHavingClause",
 							},
 						},
@@ -13551,49 +13500,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 1917, col: 1, offset: 60735},
+			pos:  position{line: 1914, col: 1, offset: 60606},
 			expr: &choiceExpr{
-				pos: position{line: 1918, col: 5, offset: 60751},
+				pos: position{line: 1915, col: 5, offset: 60622},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1918, col: 5, offset: 60751},
+						pos: position{line: 1915, col: 5, offset: 60622},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 1918, col: 5, offset: 60751},
+							pos: position{line: 1915, col: 5, offset: 60622},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1918, col: 5, offset: 60751},
+									pos:  position{line: 1915, col: 5, offset: 60622},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1918, col: 7, offset: 60753},
+									pos:  position{line: 1915, col: 7, offset: 60624},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1919, col: 5, offset: 60790},
+						pos: position{line: 1916, col: 5, offset: 60661},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 1919, col: 5, offset: 60790},
+							pos: position{line: 1916, col: 5, offset: 60661},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1919, col: 5, offset: 60790},
+									pos:  position{line: 1916, col: 5, offset: 60661},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1919, col: 7, offset: 60792},
+									pos:  position{line: 1916, col: 7, offset: 60663},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1920, col: 5, offset: 60828},
+						pos: position{line: 1917, col: 5, offset: 60699},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 1920, col: 5, offset: 60828},
+							pos:        position{line: 1917, col: 5, offset: 60699},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13606,57 +13555,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 1922, col: 1, offset: 60867},
+			pos:  position{line: 1919, col: 1, offset: 60738},
 			expr: &choiceExpr{
-				pos: position{line: 1923, col: 5, offset: 60886},
+				pos: position{line: 1920, col: 5, offset: 60757},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1923, col: 5, offset: 60886},
+						pos: position{line: 1920, col: 5, offset: 60757},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 1923, col: 5, offset: 60886},
+							pos: position{line: 1920, col: 5, offset: 60757},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1923, col: 5, offset: 60886},
+									pos:  position{line: 1920, col: 5, offset: 60757},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1923, col: 7, offset: 60888},
+									pos:  position{line: 1920, col: 7, offset: 60759},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1923, col: 10, offset: 60891},
+									pos:  position{line: 1920, col: 10, offset: 60762},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1923, col: 12, offset: 60893},
+									pos:  position{line: 1920, col: 12, offset: 60764},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1924, col: 5, offset: 60925},
+						pos: position{line: 1921, col: 5, offset: 60796},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 1924, col: 5, offset: 60925},
+							pos: position{line: 1921, col: 5, offset: 60796},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1924, col: 5, offset: 60925},
+									pos:  position{line: 1921, col: 5, offset: 60796},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1924, col: 7, offset: 60927},
+									pos:  position{line: 1921, col: 7, offset: 60798},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1925, col: 5, offset: 60998},
+						pos: position{line: 1922, col: 5, offset: 60869},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 1925, col: 5, offset: 60998},
+							pos:        position{line: 1922, col: 5, offset: 60869},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13669,19 +13618,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 1927, col: 1, offset: 61041},
+			pos:  position{line: 1924, col: 1, offset: 60912},
 			expr: &choiceExpr{
-				pos: position{line: 1928, col: 5, offset: 61060},
+				pos: position{line: 1925, col: 5, offset: 60931},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1928, col: 5, offset: 61060},
+						pos:  position{line: 1925, col: 5, offset: 60931},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 1929, col: 5, offset: 61076},
+						pos: position{line: 1926, col: 5, offset: 60947},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 1929, col: 5, offset: 61076},
+							pos:        position{line: 1926, col: 5, offset: 60947},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13694,38 +13643,38 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 1931, col: 1, offset: 61109},
+			pos:  position{line: 1928, col: 1, offset: 60980},
 			expr: &actionExpr{
-				pos: position{line: 1932, col: 5, offset: 61125},
+				pos: position{line: 1929, col: 5, offset: 60996},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 1932, col: 5, offset: 61125},
+					pos: position{line: 1929, col: 5, offset: 60996},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1932, col: 5, offset: 61125},
+							pos:  position{line: 1929, col: 5, offset: 60996},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1932, col: 7, offset: 61127},
+							pos:  position{line: 1929, col: 7, offset: 60998},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 1932, col: 12, offset: 61132},
+							pos:   position{line: 1929, col: 12, offset: 61003},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1932, col: 14, offset: 61134},
+								pos:  position{line: 1929, col: 14, offset: 61005},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1932, col: 27, offset: 61147},
+							pos:  position{line: 1929, col: 27, offset: 61018},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1932, col: 29, offset: 61149},
+							pos:   position{line: 1929, col: 29, offset: 61020},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1932, col: 34, offset: 61154},
+								pos:  position{line: 1929, col: 34, offset: 61025},
 								name: "CteList",
 							},
 						},
@@ -13737,32 +13686,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 1941, col: 1, offset: 61339},
+			pos:  position{line: 1938, col: 1, offset: 61210},
 			expr: &choiceExpr{
-				pos: position{line: 1942, col: 5, offset: 61357},
+				pos: position{line: 1939, col: 5, offset: 61228},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1942, col: 5, offset: 61357},
+						pos: position{line: 1939, col: 5, offset: 61228},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 1942, col: 5, offset: 61357},
+							pos: position{line: 1939, col: 5, offset: 61228},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1942, col: 5, offset: 61357},
+									pos:  position{line: 1939, col: 5, offset: 61228},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1942, col: 7, offset: 61359},
+									pos:  position{line: 1939, col: 7, offset: 61230},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1943, col: 5, offset: 61395},
+						pos: position{line: 1940, col: 5, offset: 61266},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 1943, col: 5, offset: 61395},
+							pos:        position{line: 1940, col: 5, offset: 61266},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13775,51 +13724,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 1945, col: 1, offset: 61434},
+			pos:  position{line: 1942, col: 1, offset: 61305},
 			expr: &actionExpr{
-				pos: position{line: 1945, col: 11, offset: 61444},
+				pos: position{line: 1942, col: 11, offset: 61315},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 1945, col: 11, offset: 61444},
+					pos: position{line: 1942, col: 11, offset: 61315},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1945, col: 11, offset: 61444},
+							pos:   position{line: 1942, col: 11, offset: 61315},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1945, col: 17, offset: 61450},
+								pos:  position{line: 1942, col: 17, offset: 61321},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1945, col: 21, offset: 61454},
+							pos:   position{line: 1942, col: 21, offset: 61325},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1945, col: 26, offset: 61459},
+								pos: position{line: 1942, col: 26, offset: 61330},
 								expr: &actionExpr{
-									pos: position{line: 1945, col: 28, offset: 61461},
+									pos: position{line: 1942, col: 28, offset: 61332},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 1945, col: 28, offset: 61461},
+										pos: position{line: 1942, col: 28, offset: 61332},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1945, col: 28, offset: 61461},
+												pos:  position{line: 1942, col: 28, offset: 61332},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1945, col: 31, offset: 61464},
+												pos:        position{line: 1942, col: 31, offset: 61335},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1945, col: 35, offset: 61468},
+												pos:  position{line: 1942, col: 35, offset: 61339},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1945, col: 38, offset: 61471},
+												pos:   position{line: 1942, col: 38, offset: 61342},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1945, col: 42, offset: 61475},
+													pos:  position{line: 1942, col: 42, offset: 61346},
 													name: "Cte",
 												},
 											},
@@ -13836,65 +13785,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 1949, col: 1, offset: 61544},
+			pos:  position{line: 1946, col: 1, offset: 61415},
 			expr: &actionExpr{
-				pos: position{line: 1950, col: 5, offset: 61552},
+				pos: position{line: 1947, col: 5, offset: 61423},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 1950, col: 5, offset: 61552},
+					pos: position{line: 1947, col: 5, offset: 61423},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1950, col: 5, offset: 61552},
+							pos:   position{line: 1947, col: 5, offset: 61423},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1950, col: 10, offset: 61557},
+								pos:  position{line: 1947, col: 10, offset: 61428},
 								name: "AliasName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1950, col: 20, offset: 61567},
+							pos:  position{line: 1947, col: 20, offset: 61438},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1950, col: 22, offset: 61569},
+							pos:  position{line: 1947, col: 22, offset: 61440},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 1950, col: 25, offset: 61572},
+							pos:   position{line: 1947, col: 25, offset: 61443},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1950, col: 27, offset: 61574},
+								pos:  position{line: 1947, col: 27, offset: 61445},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1950, col: 43, offset: 61590},
+							pos:  position{line: 1947, col: 43, offset: 61461},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1950, col: 46, offset: 61593},
+							pos:        position{line: 1947, col: 46, offset: 61464},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1950, col: 50, offset: 61597},
+							pos:  position{line: 1947, col: 50, offset: 61468},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1950, col: 53, offset: 61600},
+							pos:   position{line: 1947, col: 53, offset: 61471},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1950, col: 55, offset: 61602},
+								pos:  position{line: 1947, col: 55, offset: 61473},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1950, col: 63, offset: 61610},
+							pos:  position{line: 1947, col: 63, offset: 61481},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1950, col: 66, offset: 61613},
+							pos:        position{line: 1947, col: 66, offset: 61484},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13907,9 +13856,9 @@ var g = &grammar{
 		},
 		{
 			name: "AliasName",
-			pos:  position{line: 1959, col: 1, offset: 61788},
+			pos:  position{line: 1956, col: 1, offset: 61659},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1959, col: 13, offset: 61800},
+				pos:  position{line: 1956, col: 13, offset: 61671},
 				name: "Identifier",
 			},
 			leader:        false,
@@ -13917,65 +13866,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 1961, col: 1, offset: 61812},
+			pos:  position{line: 1958, col: 1, offset: 61683},
 			expr: &choiceExpr{
-				pos: position{line: 1962, col: 5, offset: 61833},
+				pos: position{line: 1959, col: 5, offset: 61704},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1962, col: 5, offset: 61833},
+						pos: position{line: 1959, col: 5, offset: 61704},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 1962, col: 5, offset: 61833},
+							pos: position{line: 1959, col: 5, offset: 61704},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1962, col: 5, offset: 61833},
+									pos:  position{line: 1959, col: 5, offset: 61704},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1962, col: 7, offset: 61835},
+									pos:  position{line: 1959, col: 7, offset: 61706},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1962, col: 20, offset: 61848},
+									pos:  position{line: 1959, col: 20, offset: 61719},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1963, col: 5, offset: 61887},
+						pos: position{line: 1960, col: 5, offset: 61758},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 1963, col: 5, offset: 61887},
+							pos: position{line: 1960, col: 5, offset: 61758},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1963, col: 5, offset: 61887},
+									pos:  position{line: 1960, col: 5, offset: 61758},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1963, col: 7, offset: 61889},
+									pos:  position{line: 1960, col: 7, offset: 61760},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1963, col: 11, offset: 61893},
+									pos:  position{line: 1960, col: 11, offset: 61764},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1963, col: 13, offset: 61895},
+									pos:  position{line: 1960, col: 13, offset: 61766},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1963, col: 26, offset: 61908},
+									pos:  position{line: 1960, col: 26, offset: 61779},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1964, col: 5, offset: 61939},
+						pos: position{line: 1961, col: 5, offset: 61810},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 1964, col: 5, offset: 61939},
+							pos:        position{line: 1961, col: 5, offset: 61810},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13988,25 +13937,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 1966, col: 1, offset: 61994},
+			pos:  position{line: 1963, col: 1, offset: 61865},
 			expr: &choiceExpr{
-				pos: position{line: 1967, col: 5, offset: 62011},
+				pos: position{line: 1964, col: 5, offset: 61882},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1967, col: 5, offset: 62011},
+						pos: position{line: 1964, col: 5, offset: 61882},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1967, col: 5, offset: 62011},
+								pos:  position{line: 1964, col: 5, offset: 61882},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1967, col: 7, offset: 62013},
+								pos:  position{line: 1964, col: 7, offset: 61884},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1968, col: 5, offset: 62022},
+						pos:        position{line: 1965, col: 5, offset: 61893},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14018,25 +13967,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 1970, col: 1, offset: 62026},
+			pos:  position{line: 1967, col: 1, offset: 61897},
 			expr: &choiceExpr{
-				pos: position{line: 1971, col: 5, offset: 62044},
+				pos: position{line: 1968, col: 5, offset: 61915},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1971, col: 5, offset: 62044},
+						pos: position{line: 1968, col: 5, offset: 61915},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 1971, col: 5, offset: 62044},
+							pos: position{line: 1968, col: 5, offset: 61915},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1971, col: 5, offset: 62044},
+									pos:  position{line: 1968, col: 5, offset: 61915},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1971, col: 7, offset: 62046},
+									pos:   position{line: 1968, col: 7, offset: 61917},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1971, col: 12, offset: 62051},
+										pos:  position{line: 1968, col: 12, offset: 61922},
 										name: "FromOp",
 									},
 								},
@@ -14044,10 +13993,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1974, col: 5, offset: 62093},
+						pos: position{line: 1971, col: 5, offset: 61964},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1974, col: 5, offset: 62093},
+							pos:        position{line: 1971, col: 5, offset: 61964},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14060,27 +14009,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 1976, col: 1, offset: 62134},
+			pos:  position{line: 1973, col: 1, offset: 62005},
 			expr: &choiceExpr{
-				pos: position{line: 1977, col: 5, offset: 62153},
+				pos: position{line: 1974, col: 5, offset: 62024},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1977, col: 5, offset: 62153},
+						pos: position{line: 1974, col: 5, offset: 62024},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 1977, col: 5, offset: 62153},
+							pos:   position{line: 1974, col: 5, offset: 62024},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1977, col: 11, offset: 62159},
+								pos:  position{line: 1974, col: 11, offset: 62030},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1978, col: 5, offset: 62201},
+						pos: position{line: 1975, col: 5, offset: 62072},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 1978, col: 5, offset: 62201},
+							pos:        position{line: 1975, col: 5, offset: 62072},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14093,25 +14042,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 1980, col: 1, offset: 62246},
+			pos:  position{line: 1977, col: 1, offset: 62117},
 			expr: &choiceExpr{
-				pos: position{line: 1981, col: 5, offset: 62265},
+				pos: position{line: 1978, col: 5, offset: 62136},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1981, col: 5, offset: 62265},
+						pos: position{line: 1978, col: 5, offset: 62136},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 1981, col: 5, offset: 62265},
+							pos: position{line: 1978, col: 5, offset: 62136},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1981, col: 5, offset: 62265},
+									pos:  position{line: 1978, col: 5, offset: 62136},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1981, col: 7, offset: 62267},
+									pos:   position{line: 1978, col: 7, offset: 62138},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1981, col: 13, offset: 62273},
+										pos:  position{line: 1978, col: 13, offset: 62144},
 										name: "GroupClause",
 									},
 								},
@@ -14119,10 +14068,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1982, col: 5, offset: 62311},
+						pos: position{line: 1979, col: 5, offset: 62182},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1982, col: 5, offset: 62311},
+							pos:        position{line: 1979, col: 5, offset: 62182},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14135,34 +14084,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 1984, col: 1, offset: 62352},
+			pos:  position{line: 1981, col: 1, offset: 62223},
 			expr: &actionExpr{
-				pos: position{line: 1985, col: 5, offset: 62368},
+				pos: position{line: 1982, col: 5, offset: 62239},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 1985, col: 5, offset: 62368},
+					pos: position{line: 1982, col: 5, offset: 62239},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1985, col: 5, offset: 62368},
+							pos:  position{line: 1982, col: 5, offset: 62239},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1985, col: 11, offset: 62374},
+							pos:  position{line: 1982, col: 11, offset: 62245},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1985, col: 13, offset: 62376},
+							pos:  position{line: 1982, col: 13, offset: 62247},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1985, col: 16, offset: 62379},
+							pos:  position{line: 1982, col: 16, offset: 62250},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1985, col: 18, offset: 62381},
+							pos:   position{line: 1982, col: 18, offset: 62252},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1985, col: 23, offset: 62386},
+								pos:  position{line: 1982, col: 23, offset: 62257},
 								name: "GroupByList",
 							},
 						},
@@ -14174,51 +14123,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 1987, col: 1, offset: 62420},
+			pos:  position{line: 1984, col: 1, offset: 62291},
 			expr: &actionExpr{
-				pos: position{line: 1988, col: 5, offset: 62437},
+				pos: position{line: 1985, col: 5, offset: 62308},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 1988, col: 5, offset: 62437},
+					pos: position{line: 1985, col: 5, offset: 62308},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1988, col: 5, offset: 62437},
+							pos:   position{line: 1985, col: 5, offset: 62308},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1988, col: 11, offset: 62443},
+								pos:  position{line: 1985, col: 11, offset: 62314},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1988, col: 23, offset: 62455},
+							pos:   position{line: 1985, col: 23, offset: 62326},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1988, col: 28, offset: 62460},
+								pos: position{line: 1985, col: 28, offset: 62331},
 								expr: &actionExpr{
-									pos: position{line: 1988, col: 30, offset: 62462},
+									pos: position{line: 1985, col: 30, offset: 62333},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 1988, col: 30, offset: 62462},
+										pos: position{line: 1985, col: 30, offset: 62333},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1988, col: 30, offset: 62462},
+												pos:  position{line: 1985, col: 30, offset: 62333},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1988, col: 33, offset: 62465},
+												pos:        position{line: 1985, col: 33, offset: 62336},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1988, col: 37, offset: 62469},
+												pos:  position{line: 1985, col: 37, offset: 62340},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1988, col: 40, offset: 62472},
+												pos:   position{line: 1985, col: 40, offset: 62343},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1988, col: 42, offset: 62474},
+													pos:  position{line: 1985, col: 42, offset: 62345},
 													name: "GroupByItem",
 												},
 											},
@@ -14235,9 +14184,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 1992, col: 1, offset: 62555},
+			pos:  position{line: 1989, col: 1, offset: 62426},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1992, col: 15, offset: 62569},
+				pos:  position{line: 1989, col: 15, offset: 62440},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14245,25 +14194,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 1994, col: 1, offset: 62575},
+			pos:  position{line: 1991, col: 1, offset: 62446},
 			expr: &choiceExpr{
-				pos: position{line: 1995, col: 5, offset: 62595},
+				pos: position{line: 1992, col: 5, offset: 62466},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1995, col: 5, offset: 62595},
+						pos: position{line: 1992, col: 5, offset: 62466},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 1995, col: 5, offset: 62595},
+							pos: position{line: 1992, col: 5, offset: 62466},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1995, col: 5, offset: 62595},
+									pos:  position{line: 1992, col: 5, offset: 62466},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1995, col: 7, offset: 62597},
+									pos:   position{line: 1992, col: 7, offset: 62468},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1995, col: 9, offset: 62599},
+										pos:  position{line: 1992, col: 9, offset: 62470},
 										name: "HavingClause",
 									},
 								},
@@ -14271,10 +14220,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1996, col: 5, offset: 62634},
+						pos: position{line: 1993, col: 5, offset: 62505},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1996, col: 5, offset: 62634},
+							pos:        position{line: 1993, col: 5, offset: 62505},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14287,26 +14236,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 1998, col: 1, offset: 62658},
+			pos:  position{line: 1995, col: 1, offset: 62529},
 			expr: &actionExpr{
-				pos: position{line: 1999, col: 5, offset: 62675},
+				pos: position{line: 1996, col: 5, offset: 62546},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 1999, col: 5, offset: 62675},
+					pos: position{line: 1996, col: 5, offset: 62546},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1999, col: 5, offset: 62675},
+							pos:  position{line: 1996, col: 5, offset: 62546},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1999, col: 12, offset: 62682},
+							pos:  position{line: 1996, col: 12, offset: 62553},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1999, col: 14, offset: 62684},
+							pos:   position{line: 1996, col: 14, offset: 62555},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1999, col: 16, offset: 62686},
+								pos:  position{line: 1996, col: 16, offset: 62557},
 								name: "Expr",
 							},
 						},
@@ -14318,16 +14267,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2001, col: 1, offset: 62710},
+			pos:  position{line: 1998, col: 1, offset: 62581},
 			expr: &choiceExpr{
-				pos: position{line: 2002, col: 5, offset: 62728},
+				pos: position{line: 1999, col: 5, offset: 62599},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2002, col: 5, offset: 62728},
+						pos:  position{line: 1999, col: 5, offset: 62599},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2003, col: 5, offset: 62742},
+						pos:  position{line: 2000, col: 5, offset: 62613},
 						name: "ConditionJoin",
 					},
 				},
@@ -14337,30 +14286,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2005, col: 1, offset: 62757},
+			pos:  position{line: 2002, col: 1, offset: 62628},
 			expr: &actionExpr{
-				pos: position{line: 2006, col: 5, offset: 62771},
+				pos: position{line: 2003, col: 5, offset: 62642},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2006, col: 5, offset: 62771},
+					pos: position{line: 2003, col: 5, offset: 62642},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2006, col: 5, offset: 62771},
+							pos:   position{line: 2003, col: 5, offset: 62642},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2006, col: 10, offset: 62776},
+								pos:  position{line: 2003, col: 10, offset: 62647},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2006, col: 19, offset: 62785},
+							pos:  position{line: 2003, col: 19, offset: 62656},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2006, col: 31, offset: 62797},
+							pos:   position{line: 2003, col: 31, offset: 62668},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2006, col: 37, offset: 62803},
+								pos:  position{line: 2003, col: 37, offset: 62674},
 								name: "FromElem",
 							},
 						},
@@ -14372,50 +14321,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2015, col: 1, offset: 63005},
+			pos:  position{line: 2012, col: 1, offset: 62876},
 			expr: &choiceExpr{
-				pos: position{line: 2016, col: 5, offset: 63022},
+				pos: position{line: 2013, col: 5, offset: 62893},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2016, col: 5, offset: 63022},
+						pos: position{line: 2013, col: 5, offset: 62893},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2016, col: 5, offset: 63022},
+								pos:  position{line: 2013, col: 5, offset: 62893},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2016, col: 8, offset: 63025},
+								pos:        position{line: 2013, col: 8, offset: 62896},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2016, col: 12, offset: 63029},
+								pos:  position{line: 2013, col: 12, offset: 62900},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2017, col: 5, offset: 63037},
+						pos: position{line: 2014, col: 5, offset: 62908},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2017, col: 5, offset: 63037},
+								pos:  position{line: 2014, col: 5, offset: 62908},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2017, col: 7, offset: 63039},
+								pos:  position{line: 2014, col: 7, offset: 62910},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2017, col: 13, offset: 63045},
+								pos:  position{line: 2014, col: 13, offset: 62916},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2017, col: 15, offset: 63047},
+								pos:  position{line: 2014, col: 15, offset: 62918},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2017, col: 20, offset: 63052},
+								pos:  position{line: 2014, col: 20, offset: 62923},
 								name: "_",
 							},
 						},
@@ -14427,46 +14376,46 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2019, col: 1, offset: 63056},
+			pos:  position{line: 2016, col: 1, offset: 62927},
 			expr: &actionExpr{
-				pos: position{line: 2020, col: 5, offset: 63074},
+				pos: position{line: 2017, col: 5, offset: 62945},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2020, col: 5, offset: 63074},
+					pos: position{line: 2017, col: 5, offset: 62945},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2020, col: 5, offset: 63074},
+							pos:   position{line: 2017, col: 5, offset: 62945},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2020, col: 10, offset: 63079},
+								pos:  position{line: 2017, col: 10, offset: 62950},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2020, col: 19, offset: 63088},
+							pos:   position{line: 2017, col: 19, offset: 62959},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2020, col: 25, offset: 63094},
+								pos:  position{line: 2017, col: 25, offset: 62965},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2020, col: 38, offset: 63107},
+							pos:  position{line: 2017, col: 38, offset: 62978},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2020, col: 40, offset: 63109},
+							pos:   position{line: 2017, col: 40, offset: 62980},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2020, col: 46, offset: 63115},
+								pos:  position{line: 2017, col: 46, offset: 62986},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2020, col: 55, offset: 63124},
+							pos:   position{line: 2017, col: 55, offset: 62995},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2020, col: 57, offset: 63126},
+								pos:  position{line: 2017, col: 57, offset: 62997},
 								name: "JoinExpr",
 							},
 						},
@@ -14478,161 +14427,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2031, col: 1, offset: 63395},
+			pos:  position{line: 2028, col: 1, offset: 63266},
 			expr: &choiceExpr{
-				pos: position{line: 2032, col: 5, offset: 63413},
+				pos: position{line: 2029, col: 5, offset: 63284},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2032, col: 5, offset: 63413},
+						pos: position{line: 2029, col: 5, offset: 63284},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2032, col: 5, offset: 63413},
+							pos: position{line: 2029, col: 5, offset: 63284},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2032, col: 5, offset: 63413},
+									pos: position{line: 2029, col: 5, offset: 63284},
 									expr: &seqExpr{
-										pos: position{line: 2032, col: 6, offset: 63414},
+										pos: position{line: 2029, col: 6, offset: 63285},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2032, col: 6, offset: 63414},
+												pos:  position{line: 2029, col: 6, offset: 63285},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2032, col: 8, offset: 63416},
+												pos:  position{line: 2029, col: 8, offset: 63287},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2032, col: 16, offset: 63424},
+									pos:  position{line: 2029, col: 16, offset: 63295},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2032, col: 18, offset: 63426},
+									pos:  position{line: 2029, col: 18, offset: 63297},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2033, col: 5, offset: 63471},
+						pos: position{line: 2030, col: 5, offset: 63342},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2033, col: 5, offset: 63471},
+							pos: position{line: 2030, col: 5, offset: 63342},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2033, col: 5, offset: 63471},
+									pos:  position{line: 2030, col: 5, offset: 63342},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2033, col: 7, offset: 63473},
+									pos:  position{line: 2030, col: 7, offset: 63344},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2033, col: 12, offset: 63478},
+									pos: position{line: 2030, col: 12, offset: 63349},
 									expr: &seqExpr{
-										pos: position{line: 2033, col: 13, offset: 63479},
+										pos: position{line: 2030, col: 13, offset: 63350},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2033, col: 13, offset: 63479},
+												pos:  position{line: 2030, col: 13, offset: 63350},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2033, col: 15, offset: 63481},
+												pos:  position{line: 2030, col: 15, offset: 63352},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2033, col: 23, offset: 63489},
+									pos:  position{line: 2030, col: 23, offset: 63360},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2033, col: 25, offset: 63491},
+									pos:  position{line: 2030, col: 25, offset: 63362},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2034, col: 5, offset: 63525},
+						pos: position{line: 2031, col: 5, offset: 63396},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2034, col: 5, offset: 63525},
+							pos: position{line: 2031, col: 5, offset: 63396},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2034, col: 5, offset: 63525},
+									pos:  position{line: 2031, col: 5, offset: 63396},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2034, col: 7, offset: 63527},
+									pos:  position{line: 2031, col: 7, offset: 63398},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2034, col: 12, offset: 63532},
+									pos: position{line: 2031, col: 12, offset: 63403},
 									expr: &seqExpr{
-										pos: position{line: 2034, col: 13, offset: 63533},
+										pos: position{line: 2031, col: 13, offset: 63404},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2034, col: 13, offset: 63533},
+												pos:  position{line: 2031, col: 13, offset: 63404},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2034, col: 15, offset: 63535},
+												pos:  position{line: 2031, col: 15, offset: 63406},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2034, col: 23, offset: 63543},
+									pos:  position{line: 2031, col: 23, offset: 63414},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2034, col: 25, offset: 63545},
+									pos:  position{line: 2031, col: 25, offset: 63416},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2035, col: 5, offset: 63579},
+						pos: position{line: 2032, col: 5, offset: 63450},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2035, col: 5, offset: 63579},
+							pos: position{line: 2032, col: 5, offset: 63450},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 5, offset: 63579},
+									pos:  position{line: 2032, col: 5, offset: 63450},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 7, offset: 63581},
+									pos:  position{line: 2032, col: 7, offset: 63452},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2035, col: 13, offset: 63587},
+									pos: position{line: 2032, col: 13, offset: 63458},
 									expr: &seqExpr{
-										pos: position{line: 2035, col: 14, offset: 63588},
+										pos: position{line: 2032, col: 14, offset: 63459},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2035, col: 14, offset: 63588},
+												pos:  position{line: 2032, col: 14, offset: 63459},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2035, col: 16, offset: 63590},
+												pos:  position{line: 2032, col: 16, offset: 63461},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 24, offset: 63598},
+									pos:  position{line: 2032, col: 24, offset: 63469},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 26, offset: 63600},
+									pos:  position{line: 2032, col: 26, offset: 63471},
 									name: "JOIN",
 								},
 							},
@@ -14645,33 +14594,33 @@ var g = &grammar{
 		},
 		{
 			name: "JoinExpr",
-			pos:  position{line: 2037, col: 1, offset: 63632},
+			pos:  position{line: 2034, col: 1, offset: 63503},
 			expr: &choiceExpr{
-				pos: position{line: 2038, col: 5, offset: 63646},
+				pos: position{line: 2035, col: 5, offset: 63517},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2038, col: 5, offset: 63646},
+						pos: position{line: 2035, col: 5, offset: 63517},
 						run: (*parser).callonJoinExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2038, col: 5, offset: 63646},
+							pos: position{line: 2035, col: 5, offset: 63517},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2038, col: 5, offset: 63646},
+									pos:  position{line: 2035, col: 5, offset: 63517},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2038, col: 7, offset: 63648},
+									pos:  position{line: 2035, col: 7, offset: 63519},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2038, col: 10, offset: 63651},
+									pos:  position{line: 2035, col: 10, offset: 63522},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2038, col: 12, offset: 63653},
+									pos:   position{line: 2035, col: 12, offset: 63524},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2038, col: 14, offset: 63655},
+										pos:  position{line: 2035, col: 14, offset: 63526},
 										name: "Expr",
 									},
 								},
@@ -14679,47 +14628,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2044, col: 5, offset: 63777},
+						pos: position{line: 2041, col: 5, offset: 63656},
 						run: (*parser).callonJoinExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2044, col: 5, offset: 63777},
+							pos: position{line: 2041, col: 5, offset: 63656},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2044, col: 5, offset: 63777},
+									pos:  position{line: 2041, col: 5, offset: 63656},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2044, col: 7, offset: 63779},
+									pos:  position{line: 2041, col: 7, offset: 63658},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2044, col: 13, offset: 63785},
+									pos:  position{line: 2041, col: 13, offset: 63664},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2044, col: 16, offset: 63788},
+									pos:        position{line: 2041, col: 16, offset: 63667},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2044, col: 20, offset: 63792},
+									pos:  position{line: 2041, col: 20, offset: 63671},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2044, col: 23, offset: 63795},
+									pos:   position{line: 2041, col: 23, offset: 63674},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2044, col: 30, offset: 63802},
-										name: "FieldExprs",
+										pos:  position{line: 2041, col: 30, offset: 63681},
+										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2044, col: 41, offset: 63813},
+									pos:  position{line: 2041, col: 36, offset: 63687},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2044, col: 44, offset: 63816},
+									pos:        position{line: 2041, col: 39, offset: 63690},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14734,40 +14683,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2051, col: 1, offset: 63953},
+			pos:  position{line: 2048, col: 1, offset: 63835},
 			expr: &choiceExpr{
-				pos: position{line: 2052, col: 5, offset: 63972},
+				pos: position{line: 2049, col: 5, offset: 63854},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2052, col: 5, offset: 63972},
+						pos: position{line: 2049, col: 5, offset: 63854},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2052, col: 5, offset: 63972},
+							pos: position{line: 2049, col: 5, offset: 63854},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2052, col: 5, offset: 63972},
+									pos:  position{line: 2049, col: 5, offset: 63854},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2052, col: 7, offset: 63974},
+									pos:  position{line: 2049, col: 7, offset: 63856},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2052, col: 12, offset: 63979},
+									pos:  position{line: 2049, col: 12, offset: 63861},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2052, col: 14, offset: 63981},
+									pos:  position{line: 2049, col: 14, offset: 63863},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2058, col: 5, offset: 64110},
+						pos: position{line: 2055, col: 5, offset: 63992},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2058, col: 5, offset: 64110},
+							pos:        position{line: 2055, col: 5, offset: 63992},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14780,25 +14729,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2060, col: 1, offset: 64159},
+			pos:  position{line: 2057, col: 1, offset: 64041},
 			expr: &choiceExpr{
-				pos: position{line: 2061, col: 5, offset: 64172},
+				pos: position{line: 2058, col: 5, offset: 64054},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2061, col: 5, offset: 64172},
+						pos: position{line: 2058, col: 5, offset: 64054},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2061, col: 5, offset: 64172},
+							pos: position{line: 2058, col: 5, offset: 64054},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2061, col: 5, offset: 64172},
+									pos:  position{line: 2058, col: 5, offset: 64054},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2061, col: 7, offset: 64174},
+									pos:   position{line: 2058, col: 7, offset: 64056},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2061, col: 9, offset: 64176},
+										pos:  position{line: 2058, col: 9, offset: 64058},
 										name: "AliasClause",
 									},
 								},
@@ -14806,10 +14755,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2062, col: 5, offset: 64210},
+						pos: position{line: 2059, col: 5, offset: 64092},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2062, col: 5, offset: 64210},
+							pos:        position{line: 2059, col: 5, offset: 64092},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14822,50 +14771,50 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2064, col: 1, offset: 64247},
+			pos:  position{line: 2061, col: 1, offset: 64129},
 			expr: &actionExpr{
-				pos: position{line: 2065, col: 5, offset: 64264},
+				pos: position{line: 2062, col: 5, offset: 64146},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2065, col: 5, offset: 64264},
+					pos: position{line: 2062, col: 5, offset: 64146},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2065, col: 5, offset: 64264},
+							pos: position{line: 2062, col: 5, offset: 64146},
 							expr: &seqExpr{
-								pos: position{line: 2065, col: 6, offset: 64265},
+								pos: position{line: 2062, col: 6, offset: 64147},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2065, col: 6, offset: 64265},
+										pos:  position{line: 2062, col: 6, offset: 64147},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2065, col: 9, offset: 64268},
+										pos:  position{line: 2062, col: 9, offset: 64150},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2065, col: 13, offset: 64272},
+							pos: position{line: 2062, col: 13, offset: 64154},
 							expr: &choiceExpr{
-								pos: position{line: 2065, col: 15, offset: 64274},
+								pos: position{line: 2062, col: 15, offset: 64156},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2065, col: 15, offset: 64274},
+										pos:  position{line: 2062, col: 15, offset: 64156},
 										name: "SQLGuard",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2065, col: 26, offset: 64285},
+										pos:  position{line: 2062, col: 26, offset: 64167},
 										name: "DeprecatedFroms",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2065, col: 43, offset: 64302},
+							pos:   position{line: 2062, col: 43, offset: 64184},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2065, col: 48, offset: 64307},
+								pos:  position{line: 2062, col: 48, offset: 64189},
 								name: "IdentifierName",
 							},
 						},
@@ -14877,51 +14826,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2069, col: 1, offset: 64440},
+			pos:  position{line: 2066, col: 1, offset: 64322},
 			expr: &actionExpr{
-				pos: position{line: 2070, col: 5, offset: 64454},
+				pos: position{line: 2067, col: 5, offset: 64336},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2070, col: 5, offset: 64454},
+					pos: position{line: 2067, col: 5, offset: 64336},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2070, col: 5, offset: 64454},
+							pos:   position{line: 2067, col: 5, offset: 64336},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2070, col: 11, offset: 64460},
+								pos:  position{line: 2067, col: 11, offset: 64342},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2070, col: 22, offset: 64471},
+							pos:   position{line: 2067, col: 22, offset: 64353},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2070, col: 27, offset: 64476},
+								pos: position{line: 2067, col: 27, offset: 64358},
 								expr: &actionExpr{
-									pos: position{line: 2070, col: 29, offset: 64478},
+									pos: position{line: 2067, col: 29, offset: 64360},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2070, col: 29, offset: 64478},
+										pos: position{line: 2067, col: 29, offset: 64360},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2070, col: 29, offset: 64478},
+												pos:  position{line: 2067, col: 29, offset: 64360},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2070, col: 32, offset: 64481},
+												pos:        position{line: 2067, col: 32, offset: 64363},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2070, col: 36, offset: 64485},
+												pos:  position{line: 2067, col: 36, offset: 64367},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2070, col: 39, offset: 64488},
+												pos:   position{line: 2067, col: 39, offset: 64370},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2070, col: 41, offset: 64490},
+													pos:  position{line: 2067, col: 41, offset: 64372},
 													name: "SelectElem",
 												},
 											},
@@ -14938,29 +14887,29 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2079, col: 1, offset: 64716},
+			pos:  position{line: 2076, col: 1, offset: 64598},
 			expr: &choiceExpr{
-				pos: position{line: 2080, col: 5, offset: 64732},
+				pos: position{line: 2077, col: 5, offset: 64614},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2080, col: 5, offset: 64732},
+						pos: position{line: 2077, col: 5, offset: 64614},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2080, col: 5, offset: 64732},
+							pos: position{line: 2077, col: 5, offset: 64614},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2080, col: 5, offset: 64732},
+									pos:   position{line: 2077, col: 5, offset: 64614},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2080, col: 7, offset: 64734},
+										pos:  position{line: 2077, col: 7, offset: 64616},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2080, col: 12, offset: 64739},
+									pos:   position{line: 2077, col: 12, offset: 64621},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2080, col: 15, offset: 64742},
+										pos:  position{line: 2077, col: 15, offset: 64624},
 										name: "OptAsClause",
 									},
 								},
@@ -14968,10 +14917,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2091, col: 5, offset: 64958},
+						pos: position{line: 2088, col: 5, offset: 64840},
 						run: (*parser).callonSelectElem8,
 						expr: &litMatcher{
-							pos:        position{line: 2091, col: 5, offset: 64958},
+							pos:        position{line: 2088, col: 5, offset: 64840},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -14984,33 +14933,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2096, col: 1, offset: 65060},
+			pos:  position{line: 2093, col: 1, offset: 64942},
 			expr: &choiceExpr{
-				pos: position{line: 2097, col: 5, offset: 65077},
+				pos: position{line: 2094, col: 5, offset: 64959},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2097, col: 5, offset: 65077},
+						pos: position{line: 2094, col: 5, offset: 64959},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2097, col: 5, offset: 65077},
+							pos: position{line: 2094, col: 5, offset: 64959},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2097, col: 5, offset: 65077},
+									pos:  position{line: 2094, col: 5, offset: 64959},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2097, col: 7, offset: 65079},
+									pos:  position{line: 2094, col: 7, offset: 64961},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2097, col: 10, offset: 65082},
+									pos:  position{line: 2094, col: 10, offset: 64964},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2097, col: 12, offset: 65084},
+									pos:   position{line: 2094, col: 12, offset: 64966},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2097, col: 15, offset: 65087},
+										pos:  position{line: 2094, col: 15, offset: 64969},
 										name: "Identifier",
 									},
 								},
@@ -15018,10 +14967,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2098, col: 5, offset: 65121},
+						pos: position{line: 2095, col: 5, offset: 65003},
 						run: (*parser).callonOptAsClause9,
 						expr: &litMatcher{
-							pos:        position{line: 2098, col: 5, offset: 65121},
+							pos:        position{line: 2095, col: 5, offset: 65003},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15034,41 +14983,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2100, col: 1, offset: 65146},
+			pos:  position{line: 2097, col: 1, offset: 65028},
 			expr: &choiceExpr{
-				pos: position{line: 2101, col: 5, offset: 65168},
+				pos: position{line: 2098, col: 5, offset: 65050},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2101, col: 5, offset: 65168},
+						pos: position{line: 2098, col: 5, offset: 65050},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2101, col: 5, offset: 65168},
+							pos: position{line: 2098, col: 5, offset: 65050},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 5, offset: 65168},
+									pos:  position{line: 2098, col: 5, offset: 65050},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 7, offset: 65170},
+									pos:  position{line: 2098, col: 7, offset: 65052},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 13, offset: 65176},
+									pos:  position{line: 2098, col: 13, offset: 65058},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 15, offset: 65178},
+									pos:  position{line: 2098, col: 15, offset: 65060},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 18, offset: 65181},
+									pos:  position{line: 2098, col: 18, offset: 65063},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2101, col: 20, offset: 65183},
+									pos:   position{line: 2098, col: 20, offset: 65065},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2101, col: 25, offset: 65188},
+										pos:  position{line: 2098, col: 25, offset: 65070},
 										name: "OrderByList",
 									},
 								},
@@ -15076,10 +15025,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2108, col: 5, offset: 65347},
+						pos: position{line: 2105, col: 5, offset: 65229},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2108, col: 5, offset: 65347},
+							pos:        position{line: 2105, col: 5, offset: 65229},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15092,51 +15041,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2110, col: 1, offset: 65380},
+			pos:  position{line: 2107, col: 1, offset: 65262},
 			expr: &actionExpr{
-				pos: position{line: 2111, col: 5, offset: 65397},
+				pos: position{line: 2108, col: 5, offset: 65279},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2111, col: 5, offset: 65397},
+					pos: position{line: 2108, col: 5, offset: 65279},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2111, col: 5, offset: 65397},
+							pos:   position{line: 2108, col: 5, offset: 65279},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2111, col: 11, offset: 65403},
+								pos:  position{line: 2108, col: 11, offset: 65285},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2111, col: 23, offset: 65415},
+							pos:   position{line: 2108, col: 23, offset: 65297},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2111, col: 28, offset: 65420},
+								pos: position{line: 2108, col: 28, offset: 65302},
 								expr: &actionExpr{
-									pos: position{line: 2111, col: 30, offset: 65422},
+									pos: position{line: 2108, col: 30, offset: 65304},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2111, col: 30, offset: 65422},
+										pos: position{line: 2108, col: 30, offset: 65304},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2111, col: 30, offset: 65422},
+												pos:  position{line: 2108, col: 30, offset: 65304},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2111, col: 33, offset: 65425},
+												pos:        position{line: 2108, col: 33, offset: 65307},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2111, col: 37, offset: 65429},
+												pos:  position{line: 2108, col: 37, offset: 65311},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2111, col: 40, offset: 65432},
+												pos:   position{line: 2108, col: 40, offset: 65314},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2111, col: 42, offset: 65434},
+													pos:  position{line: 2108, col: 42, offset: 65316},
 													name: "OrderByItem",
 												},
 											},
@@ -15153,34 +15102,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2115, col: 1, offset: 65535},
+			pos:  position{line: 2112, col: 1, offset: 65417},
 			expr: &actionExpr{
-				pos: position{line: 2116, col: 5, offset: 65551},
+				pos: position{line: 2113, col: 5, offset: 65433},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2116, col: 5, offset: 65551},
+					pos: position{line: 2113, col: 5, offset: 65433},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2116, col: 5, offset: 65551},
+							pos:   position{line: 2113, col: 5, offset: 65433},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2116, col: 7, offset: 65553},
+								pos:  position{line: 2113, col: 7, offset: 65435},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2116, col: 12, offset: 65558},
+							pos:   position{line: 2113, col: 12, offset: 65440},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2116, col: 18, offset: 65564},
+								pos:  position{line: 2113, col: 18, offset: 65446},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2116, col: 29, offset: 65575},
+							pos:   position{line: 2113, col: 29, offset: 65457},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2116, col: 35, offset: 65581},
+								pos:  position{line: 2113, col: 35, offset: 65463},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15192,49 +15141,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2127, col: 1, offset: 65831},
+			pos:  position{line: 2124, col: 1, offset: 65713},
 			expr: &choiceExpr{
-				pos: position{line: 2128, col: 5, offset: 65846},
+				pos: position{line: 2125, col: 5, offset: 65728},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2128, col: 5, offset: 65846},
+						pos: position{line: 2125, col: 5, offset: 65728},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2128, col: 5, offset: 65846},
+							pos: position{line: 2125, col: 5, offset: 65728},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 5, offset: 65846},
+									pos:  position{line: 2125, col: 5, offset: 65728},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 7, offset: 65848},
+									pos:  position{line: 2125, col: 7, offset: 65730},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2129, col: 5, offset: 65920},
+						pos: position{line: 2126, col: 5, offset: 65802},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2129, col: 5, offset: 65920},
+							pos: position{line: 2126, col: 5, offset: 65802},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 5, offset: 65920},
+									pos:  position{line: 2126, col: 5, offset: 65802},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 7, offset: 65922},
+									pos:  position{line: 2126, col: 7, offset: 65804},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2130, col: 5, offset: 65994},
+						pos: position{line: 2127, col: 5, offset: 65876},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2130, col: 5, offset: 65994},
+							pos:        position{line: 2127, col: 5, offset: 65876},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15247,65 +15196,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2132, col: 1, offset: 66026},
+			pos:  position{line: 2129, col: 1, offset: 65908},
 			expr: &choiceExpr{
-				pos: position{line: 2133, col: 5, offset: 66044},
+				pos: position{line: 2130, col: 5, offset: 65926},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2133, col: 5, offset: 66044},
+						pos: position{line: 2130, col: 5, offset: 65926},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2133, col: 5, offset: 66044},
+							pos: position{line: 2130, col: 5, offset: 65926},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2133, col: 5, offset: 66044},
+									pos:  position{line: 2130, col: 5, offset: 65926},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2133, col: 7, offset: 66046},
+									pos:  position{line: 2130, col: 7, offset: 65928},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2133, col: 13, offset: 66052},
+									pos:  position{line: 2130, col: 13, offset: 65934},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2133, col: 15, offset: 66054},
+									pos:  position{line: 2130, col: 15, offset: 65936},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2134, col: 5, offset: 66130},
+						pos: position{line: 2131, col: 5, offset: 66012},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2134, col: 5, offset: 66130},
+							pos: position{line: 2131, col: 5, offset: 66012},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2134, col: 5, offset: 66130},
+									pos:  position{line: 2131, col: 5, offset: 66012},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2134, col: 7, offset: 66132},
+									pos:  position{line: 2131, col: 7, offset: 66014},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2134, col: 13, offset: 66138},
+									pos:  position{line: 2131, col: 13, offset: 66020},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2134, col: 15, offset: 66140},
+									pos:  position{line: 2131, col: 15, offset: 66022},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2135, col: 5, offset: 66215},
+						pos: position{line: 2132, col: 5, offset: 66097},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2135, col: 5, offset: 66215},
+							pos:        position{line: 2132, col: 5, offset: 66097},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15318,29 +15267,29 @@ var g = &grammar{
 		},
 		{
 			name: "SelectLimit",
-			pos:  position{line: 2137, col: 1, offset: 66260},
+			pos:  position{line: 2134, col: 1, offset: 66142},
 			expr: &choiceExpr{
-				pos: position{line: 2138, col: 5, offset: 66276},
+				pos: position{line: 2135, col: 5, offset: 66158},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2138, col: 5, offset: 66276},
+						pos: position{line: 2135, col: 5, offset: 66158},
 						run: (*parser).callonSelectLimit2,
 						expr: &seqExpr{
-							pos: position{line: 2138, col: 5, offset: 66276},
+							pos: position{line: 2135, col: 5, offset: 66158},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2138, col: 5, offset: 66276},
+									pos:   position{line: 2135, col: 5, offset: 66158},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2138, col: 7, offset: 66278},
+										pos:  position{line: 2135, col: 7, offset: 66160},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2138, col: 19, offset: 66290},
+									pos:   position{line: 2135, col: 19, offset: 66172},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2138, col: 21, offset: 66292},
+										pos:  position{line: 2135, col: 21, offset: 66174},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15348,24 +15297,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2145, col: 5, offset: 66438},
+						pos: position{line: 2142, col: 5, offset: 66320},
 						run: (*parser).callonSelectLimit8,
 						expr: &seqExpr{
-							pos: position{line: 2145, col: 5, offset: 66438},
+							pos: position{line: 2142, col: 5, offset: 66320},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2145, col: 5, offset: 66438},
+									pos:   position{line: 2142, col: 5, offset: 66320},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2145, col: 7, offset: 66440},
+										pos:  position{line: 2142, col: 7, offset: 66322},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2145, col: 20, offset: 66453},
+									pos:   position{line: 2142, col: 20, offset: 66335},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2145, col: 22, offset: 66455},
+										pos:  position{line: 2142, col: 22, offset: 66337},
 										name: "OptLimitClause",
 									},
 								},
@@ -15379,25 +15328,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2158, col: 1, offset: 66727},
+			pos:  position{line: 2155, col: 1, offset: 66609},
 			expr: &choiceExpr{
-				pos: position{line: 2159, col: 5, offset: 66747},
+				pos: position{line: 2156, col: 5, offset: 66629},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2159, col: 5, offset: 66747},
+						pos: position{line: 2156, col: 5, offset: 66629},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2159, col: 5, offset: 66747},
+							pos: position{line: 2156, col: 5, offset: 66629},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2159, col: 5, offset: 66747},
+									pos:  position{line: 2156, col: 5, offset: 66629},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2159, col: 7, offset: 66749},
+									pos:   position{line: 2156, col: 7, offset: 66631},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2159, col: 9, offset: 66751},
+										pos:  position{line: 2156, col: 9, offset: 66633},
 										name: "LimitClause",
 									},
 								},
@@ -15405,10 +15354,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2160, col: 5, offset: 66785},
+						pos: position{line: 2157, col: 5, offset: 66667},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2160, col: 5, offset: 66785},
+							pos:        position{line: 2157, col: 5, offset: 66667},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15421,50 +15370,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2162, col: 1, offset: 66822},
+			pos:  position{line: 2159, col: 1, offset: 66704},
 			expr: &choiceExpr{
-				pos: position{line: 2163, col: 5, offset: 66839},
+				pos: position{line: 2160, col: 5, offset: 66721},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2163, col: 5, offset: 66839},
+						pos: position{line: 2160, col: 5, offset: 66721},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2163, col: 5, offset: 66839},
+							pos: position{line: 2160, col: 5, offset: 66721},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2163, col: 5, offset: 66839},
+									pos:  position{line: 2160, col: 5, offset: 66721},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2163, col: 11, offset: 66845},
+									pos:  position{line: 2160, col: 11, offset: 66727},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2163, col: 13, offset: 66847},
+									pos:  position{line: 2160, col: 13, offset: 66729},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2164, col: 5, offset: 66909},
+						pos: position{line: 2161, col: 5, offset: 66791},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2164, col: 5, offset: 66909},
+							pos: position{line: 2161, col: 5, offset: 66791},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2164, col: 5, offset: 66909},
+									pos:  position{line: 2161, col: 5, offset: 66791},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2164, col: 11, offset: 66915},
+									pos:  position{line: 2161, col: 11, offset: 66797},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2164, col: 13, offset: 66917},
+									pos:   position{line: 2161, col: 13, offset: 66799},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2164, col: 15, offset: 66919},
+										pos:  position{line: 2161, col: 15, offset: 66801},
 										name: "Expr",
 									},
 								},
@@ -15478,25 +15427,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2172, col: 1, offset: 67044},
+			pos:  position{line: 2169, col: 1, offset: 66926},
 			expr: &choiceExpr{
-				pos: position{line: 2173, col: 5, offset: 67065},
+				pos: position{line: 2170, col: 5, offset: 66947},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2173, col: 5, offset: 67065},
+						pos: position{line: 2170, col: 5, offset: 66947},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2173, col: 5, offset: 67065},
+							pos: position{line: 2170, col: 5, offset: 66947},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 5, offset: 67065},
+									pos:  position{line: 2170, col: 5, offset: 66947},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2173, col: 7, offset: 67067},
+									pos:   position{line: 2170, col: 7, offset: 66949},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2173, col: 9, offset: 67069},
+										pos:  position{line: 2170, col: 9, offset: 66951},
 										name: "OffsetClause",
 									},
 								},
@@ -15504,10 +15453,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2174, col: 5, offset: 67105},
+						pos: position{line: 2171, col: 5, offset: 66987},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2174, col: 5, offset: 67105},
+							pos:        position{line: 2171, col: 5, offset: 66987},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15520,26 +15469,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2176, col: 1, offset: 67130},
+			pos:  position{line: 2173, col: 1, offset: 67012},
 			expr: &actionExpr{
-				pos: position{line: 2177, col: 5, offset: 67148},
+				pos: position{line: 2174, col: 5, offset: 67030},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2177, col: 5, offset: 67148},
+					pos: position{line: 2174, col: 5, offset: 67030},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2177, col: 5, offset: 67148},
+							pos:  position{line: 2174, col: 5, offset: 67030},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2177, col: 12, offset: 67155},
+							pos:  position{line: 2174, col: 12, offset: 67037},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2177, col: 14, offset: 67157},
+							pos:   position{line: 2174, col: 14, offset: 67039},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2177, col: 16, offset: 67159},
+								pos:  position{line: 2174, col: 16, offset: 67041},
 								name: "Expr",
 							},
 						},
@@ -15551,108 +15500,108 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2179, col: 1, offset: 67184},
+			pos:  position{line: 2176, col: 1, offset: 67066},
 			expr: &actionExpr{
-				pos: position{line: 2180, col: 5, offset: 67201},
+				pos: position{line: 2177, col: 5, offset: 67083},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2180, col: 5, offset: 67201},
+					pos: position{line: 2177, col: 5, offset: 67083},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2180, col: 5, offset: 67201},
+							pos:   position{line: 2177, col: 5, offset: 67083},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2180, col: 10, offset: 67206},
+								pos:  position{line: 2177, col: 10, offset: 67088},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2180, col: 21, offset: 67217},
+							pos:   position{line: 2177, col: 21, offset: 67099},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2180, col: 30, offset: 67226},
+								pos:  position{line: 2177, col: 30, offset: 67108},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2180, col: 36, offset: 67232},
+							pos:  position{line: 2177, col: 36, offset: 67114},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2180, col: 38, offset: 67234},
+							pos:   position{line: 2177, col: 38, offset: 67116},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2180, col: 44, offset: 67240},
+								pos:  position{line: 2177, col: 44, offset: 67122},
 								name: "SelectExpr",
 							},
 						},
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2190, col: 1, offset: 67461},
+			pos:  position{line: 2187, col: 1, offset: 67343},
 			expr: &choiceExpr{
-				pos: position{line: 2191, col: 5, offset: 67472},
+				pos: position{line: 2188, col: 5, offset: 67354},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2191, col: 5, offset: 67472},
+						pos: position{line: 2188, col: 5, offset: 67354},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2191, col: 5, offset: 67472},
+							pos: position{line: 2188, col: 5, offset: 67354},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2191, col: 5, offset: 67472},
+									pos:  position{line: 2188, col: 5, offset: 67354},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2191, col: 7, offset: 67474},
+									pos:  position{line: 2188, col: 7, offset: 67356},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2191, col: 13, offset: 67480},
+									pos:  position{line: 2188, col: 13, offset: 67362},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2191, col: 15, offset: 67482},
+									pos:  position{line: 2188, col: 15, offset: 67364},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2192, col: 5, offset: 67518},
+						pos: position{line: 2189, col: 5, offset: 67400},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2192, col: 5, offset: 67518},
+							pos: position{line: 2189, col: 5, offset: 67400},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2192, col: 5, offset: 67518},
+									pos:  position{line: 2189, col: 5, offset: 67400},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2192, col: 7, offset: 67520},
+									pos:  position{line: 2189, col: 7, offset: 67402},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2192, col: 13, offset: 67526},
+									pos:  position{line: 2189, col: 13, offset: 67408},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2192, col: 15, offset: 67528},
+									pos:  position{line: 2189, col: 15, offset: 67410},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2193, col: 5, offset: 67563},
+						pos: position{line: 2190, col: 5, offset: 67445},
 						run: (*parser).callonSetOp14,
 						expr: &litMatcher{
-							pos:        position{line: 2193, col: 5, offset: 67563},
+							pos:        position{line: 2190, col: 5, offset: 67445},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15665,80 +15614,80 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2196, col: 1, offset: 67626},
+			pos:  position{line: 2193, col: 1, offset: 67508},
 			expr: &choiceExpr{
-				pos: position{line: 2197, col: 5, offset: 67641},
+				pos: position{line: 2194, col: 5, offset: 67523},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2197, col: 5, offset: 67641},
+						pos:  position{line: 2194, col: 5, offset: 67523},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2197, col: 12, offset: 67648},
+						pos:  position{line: 2194, col: 12, offset: 67530},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2197, col: 20, offset: 67656},
+						pos:  position{line: 2194, col: 20, offset: 67538},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2197, col: 29, offset: 67665},
+						pos:  position{line: 2194, col: 29, offset: 67547},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2197, col: 38, offset: 67674},
+						pos:  position{line: 2194, col: 38, offset: 67556},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2198, col: 5, offset: 67688},
+						pos:  position{line: 2195, col: 5, offset: 67570},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2198, col: 13, offset: 67696},
+						pos:  position{line: 2195, col: 13, offset: 67578},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2198, col: 20, offset: 67703},
+						pos:  position{line: 2195, col: 20, offset: 67585},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2198, col: 28, offset: 67711},
+						pos:  position{line: 2195, col: 28, offset: 67593},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2198, col: 36, offset: 67719},
+						pos:  position{line: 2195, col: 36, offset: 67601},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2198, col: 44, offset: 67727},
+						pos:  position{line: 2195, col: 44, offset: 67609},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2199, col: 5, offset: 67736},
+						pos:  position{line: 2196, col: 5, offset: 67618},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2200, col: 5, offset: 67746},
+						pos:  position{line: 2197, col: 5, offset: 67628},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2201, col: 5, offset: 67756},
+						pos:  position{line: 2198, col: 5, offset: 67638},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2202, col: 5, offset: 67766},
+						pos:  position{line: 2199, col: 5, offset: 67648},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2203, col: 5, offset: 67777},
+						pos:  position{line: 2200, col: 5, offset: 67659},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2204, col: 5, offset: 67786},
+						pos:  position{line: 2201, col: 5, offset: 67668},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2205, col: 5, offset: 67796},
+						pos:  position{line: 2202, col: 5, offset: 67678},
 						name: "ON",
 					},
 				},
@@ -15748,20 +15697,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2207, col: 1, offset: 67800},
+			pos:  position{line: 2204, col: 1, offset: 67682},
 			expr: &seqExpr{
-				pos: position{line: 2207, col: 14, offset: 67813},
+				pos: position{line: 2204, col: 14, offset: 67695},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2207, col: 14, offset: 67813},
+						pos:        position{line: 2204, col: 14, offset: 67695},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2207, col: 33, offset: 67832},
+						pos: position{line: 2204, col: 33, offset: 67714},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2207, col: 34, offset: 67833},
+							pos:  position{line: 2204, col: 34, offset: 67715},
 							name: "IdentifierRest",
 						},
 					},
@@ -15772,20 +15721,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2208, col: 1, offset: 67848},
+			pos:  position{line: 2205, col: 1, offset: 67730},
 			expr: &seqExpr{
-				pos: position{line: 2208, col: 14, offset: 67861},
+				pos: position{line: 2205, col: 14, offset: 67743},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2208, col: 14, offset: 67861},
+						pos:        position{line: 2205, col: 14, offset: 67743},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2208, col: 33, offset: 67880},
+						pos: position{line: 2205, col: 33, offset: 67762},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2208, col: 34, offset: 67881},
+							pos:  position{line: 2205, col: 34, offset: 67763},
 							name: "IdentifierRest",
 						},
 					},
@@ -15796,23 +15745,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2209, col: 1, offset: 67896},
+			pos:  position{line: 2206, col: 1, offset: 67778},
 			expr: &actionExpr{
-				pos: position{line: 2209, col: 14, offset: 67909},
+				pos: position{line: 2206, col: 14, offset: 67791},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2209, col: 14, offset: 67909},
+					pos: position{line: 2206, col: 14, offset: 67791},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2209, col: 14, offset: 67909},
+							pos:        position{line: 2206, col: 14, offset: 67791},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2209, col: 33, offset: 67928},
+							pos: position{line: 2206, col: 33, offset: 67810},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2209, col: 34, offset: 67929},
+								pos:  position{line: 2206, col: 34, offset: 67811},
 								name: "IdentifierRest",
 							},
 						},
@@ -15824,20 +15773,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2210, col: 1, offset: 67966},
+			pos:  position{line: 2207, col: 1, offset: 67848},
 			expr: &seqExpr{
-				pos: position{line: 2210, col: 14, offset: 67979},
+				pos: position{line: 2207, col: 14, offset: 67861},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2210, col: 14, offset: 67979},
+						pos:        position{line: 2207, col: 14, offset: 67861},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2210, col: 33, offset: 67998},
+						pos: position{line: 2207, col: 33, offset: 67880},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2210, col: 34, offset: 67999},
+							pos:  position{line: 2207, col: 34, offset: 67881},
 							name: "IdentifierRest",
 						},
 					},
@@ -15848,20 +15797,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2211, col: 1, offset: 68014},
+			pos:  position{line: 2208, col: 1, offset: 67896},
 			expr: &seqExpr{
-				pos: position{line: 2211, col: 14, offset: 68027},
+				pos: position{line: 2208, col: 14, offset: 67909},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2211, col: 14, offset: 68027},
+						pos:        position{line: 2208, col: 14, offset: 67909},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2211, col: 33, offset: 68046},
+						pos: position{line: 2208, col: 33, offset: 67928},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2211, col: 34, offset: 68047},
+							pos:  position{line: 2208, col: 34, offset: 67929},
 							name: "IdentifierRest",
 						},
 					},
@@ -15872,23 +15821,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2212, col: 1, offset: 68062},
+			pos:  position{line: 2209, col: 1, offset: 67944},
 			expr: &actionExpr{
-				pos: position{line: 2212, col: 14, offset: 68075},
+				pos: position{line: 2209, col: 14, offset: 67957},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2212, col: 14, offset: 68075},
+					pos: position{line: 2209, col: 14, offset: 67957},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2212, col: 14, offset: 68075},
+							pos:        position{line: 2209, col: 14, offset: 67957},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2212, col: 33, offset: 68094},
+							pos: position{line: 2209, col: 33, offset: 67976},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2212, col: 34, offset: 68095},
+								pos:  position{line: 2209, col: 34, offset: 67977},
 								name: "IdentifierRest",
 							},
 						},
@@ -15900,20 +15849,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2213, col: 1, offset: 68132},
+			pos:  position{line: 2210, col: 1, offset: 68014},
 			expr: &seqExpr{
-				pos: position{line: 2213, col: 14, offset: 68145},
+				pos: position{line: 2210, col: 14, offset: 68027},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2213, col: 14, offset: 68145},
+						pos:        position{line: 2210, col: 14, offset: 68027},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2213, col: 33, offset: 68164},
+						pos: position{line: 2210, col: 33, offset: 68046},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2213, col: 34, offset: 68165},
+							pos:  position{line: 2210, col: 34, offset: 68047},
 							name: "IdentifierRest",
 						},
 					},
@@ -15924,20 +15873,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2214, col: 1, offset: 68180},
+			pos:  position{line: 2211, col: 1, offset: 68062},
 			expr: &seqExpr{
-				pos: position{line: 2214, col: 14, offset: 68193},
+				pos: position{line: 2211, col: 14, offset: 68075},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2214, col: 14, offset: 68193},
+						pos:        position{line: 2211, col: 14, offset: 68075},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2214, col: 33, offset: 68212},
+						pos: position{line: 2211, col: 33, offset: 68094},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2214, col: 34, offset: 68213},
+							pos:  position{line: 2211, col: 34, offset: 68095},
 							name: "IdentifierRest",
 						},
 					},
@@ -15948,20 +15897,20 @@ var g = &grammar{
 		},
 		{
 			name: "AUTHOR",
-			pos:  position{line: 2215, col: 1, offset: 68228},
+			pos:  position{line: 2212, col: 1, offset: 68110},
 			expr: &seqExpr{
-				pos: position{line: 2215, col: 14, offset: 68241},
+				pos: position{line: 2212, col: 14, offset: 68123},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2215, col: 14, offset: 68241},
+						pos:        position{line: 2212, col: 14, offset: 68123},
 						val:        "author",
 						ignoreCase: true,
 						want:       "\"AUTHOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2215, col: 33, offset: 68260},
+						pos: position{line: 2212, col: 33, offset: 68142},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2215, col: 34, offset: 68261},
+							pos:  position{line: 2212, col: 34, offset: 68143},
 							name: "IdentifierRest",
 						},
 					},
@@ -15972,20 +15921,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2216, col: 1, offset: 68276},
+			pos:  position{line: 2213, col: 1, offset: 68158},
 			expr: &seqExpr{
-				pos: position{line: 2216, col: 14, offset: 68289},
+				pos: position{line: 2213, col: 14, offset: 68171},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2216, col: 14, offset: 68289},
+						pos:        position{line: 2213, col: 14, offset: 68171},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2216, col: 33, offset: 68308},
+						pos: position{line: 2213, col: 33, offset: 68190},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2216, col: 34, offset: 68309},
+							pos:  position{line: 2213, col: 34, offset: 68191},
 							name: "IdentifierRest",
 						},
 					},
@@ -15996,20 +15945,20 @@ var g = &grammar{
 		},
 		{
 			name: "BODY",
-			pos:  position{line: 2217, col: 1, offset: 68324},
+			pos:  position{line: 2214, col: 1, offset: 68206},
 			expr: &seqExpr{
-				pos: position{line: 2217, col: 14, offset: 68337},
+				pos: position{line: 2214, col: 14, offset: 68219},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2217, col: 14, offset: 68337},
+						pos:        position{line: 2214, col: 14, offset: 68219},
 						val:        "body",
 						ignoreCase: true,
 						want:       "\"BODY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2217, col: 33, offset: 68356},
+						pos: position{line: 2214, col: 33, offset: 68238},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2217, col: 34, offset: 68357},
+							pos:  position{line: 2214, col: 34, offset: 68239},
 							name: "IdentifierRest",
 						},
 					},
@@ -16020,20 +15969,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2218, col: 1, offset: 68372},
+			pos:  position{line: 2215, col: 1, offset: 68254},
 			expr: &seqExpr{
-				pos: position{line: 2218, col: 14, offset: 68385},
+				pos: position{line: 2215, col: 14, offset: 68267},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2218, col: 14, offset: 68385},
+						pos:        position{line: 2215, col: 14, offset: 68267},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2218, col: 33, offset: 68404},
+						pos: position{line: 2215, col: 33, offset: 68286},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2218, col: 34, offset: 68405},
+							pos:  position{line: 2215, col: 34, offset: 68287},
 							name: "IdentifierRest",
 						},
 					},
@@ -16044,20 +15993,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2219, col: 1, offset: 68420},
+			pos:  position{line: 2216, col: 1, offset: 68302},
 			expr: &seqExpr{
-				pos: position{line: 2219, col: 14, offset: 68433},
+				pos: position{line: 2216, col: 14, offset: 68315},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2219, col: 14, offset: 68433},
+						pos:        position{line: 2216, col: 14, offset: 68315},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2219, col: 33, offset: 68452},
+						pos: position{line: 2216, col: 33, offset: 68334},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2219, col: 34, offset: 68453},
+							pos:  position{line: 2216, col: 34, offset: 68335},
 							name: "IdentifierRest",
 						},
 					},
@@ -16068,20 +16017,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2220, col: 1, offset: 68468},
+			pos:  position{line: 2217, col: 1, offset: 68350},
 			expr: &seqExpr{
-				pos: position{line: 2220, col: 14, offset: 68481},
+				pos: position{line: 2217, col: 14, offset: 68363},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2220, col: 14, offset: 68481},
+						pos:        position{line: 2217, col: 14, offset: 68363},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2220, col: 33, offset: 68500},
+						pos: position{line: 2217, col: 33, offset: 68382},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2220, col: 34, offset: 68501},
+							pos:  position{line: 2217, col: 34, offset: 68383},
 							name: "IdentifierRest",
 						},
 					},
@@ -16092,20 +16041,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2221, col: 1, offset: 68516},
+			pos:  position{line: 2218, col: 1, offset: 68398},
 			expr: &seqExpr{
-				pos: position{line: 2221, col: 14, offset: 68529},
+				pos: position{line: 2218, col: 14, offset: 68411},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2221, col: 14, offset: 68529},
+						pos:        position{line: 2218, col: 14, offset: 68411},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2221, col: 33, offset: 68548},
+						pos: position{line: 2218, col: 33, offset: 68430},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2221, col: 34, offset: 68549},
+							pos:  position{line: 2218, col: 34, offset: 68431},
 							name: "IdentifierRest",
 						},
 					},
@@ -16116,20 +16065,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2222, col: 1, offset: 68564},
+			pos:  position{line: 2219, col: 1, offset: 68446},
 			expr: &seqExpr{
-				pos: position{line: 2222, col: 14, offset: 68577},
+				pos: position{line: 2219, col: 14, offset: 68459},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2222, col: 14, offset: 68577},
+						pos:        position{line: 2219, col: 14, offset: 68459},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2222, col: 33, offset: 68596},
+						pos: position{line: 2219, col: 33, offset: 68478},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2222, col: 34, offset: 68597},
+							pos:  position{line: 2219, col: 34, offset: 68479},
 							name: "IdentifierRest",
 						},
 					},
@@ -16140,20 +16089,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2223, col: 1, offset: 68612},
+			pos:  position{line: 2220, col: 1, offset: 68494},
 			expr: &seqExpr{
-				pos: position{line: 2223, col: 14, offset: 68625},
+				pos: position{line: 2220, col: 14, offset: 68507},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2223, col: 14, offset: 68625},
+						pos:        position{line: 2220, col: 14, offset: 68507},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2223, col: 33, offset: 68644},
+						pos: position{line: 2220, col: 33, offset: 68526},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2223, col: 34, offset: 68645},
+							pos:  position{line: 2220, col: 34, offset: 68527},
 							name: "IdentifierRest",
 						},
 					},
@@ -16164,20 +16113,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2224, col: 1, offset: 68660},
+			pos:  position{line: 2221, col: 1, offset: 68542},
 			expr: &seqExpr{
-				pos: position{line: 2224, col: 14, offset: 68673},
+				pos: position{line: 2221, col: 14, offset: 68555},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2224, col: 14, offset: 68673},
+						pos:        position{line: 2221, col: 14, offset: 68555},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2224, col: 33, offset: 68692},
+						pos: position{line: 2221, col: 33, offset: 68574},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2224, col: 34, offset: 68693},
+							pos:  position{line: 2221, col: 34, offset: 68575},
 							name: "IdentifierRest",
 						},
 					},
@@ -16188,23 +16137,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2225, col: 1, offset: 68708},
+			pos:  position{line: 2222, col: 1, offset: 68590},
 			expr: &actionExpr{
-				pos: position{line: 2225, col: 14, offset: 68721},
+				pos: position{line: 2222, col: 14, offset: 68603},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2225, col: 14, offset: 68721},
+					pos: position{line: 2222, col: 14, offset: 68603},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2225, col: 14, offset: 68721},
+							pos:        position{line: 2222, col: 14, offset: 68603},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2225, col: 33, offset: 68740},
+							pos: position{line: 2222, col: 33, offset: 68622},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2225, col: 34, offset: 68741},
+								pos:  position{line: 2222, col: 34, offset: 68623},
 								name: "IdentifierRest",
 							},
 						},
@@ -16216,20 +16165,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2226, col: 1, offset: 68779},
+			pos:  position{line: 2223, col: 1, offset: 68661},
 			expr: &seqExpr{
-				pos: position{line: 2226, col: 14, offset: 68792},
+				pos: position{line: 2223, col: 14, offset: 68674},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2226, col: 14, offset: 68792},
+						pos:        position{line: 2223, col: 14, offset: 68674},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2226, col: 33, offset: 68811},
+						pos: position{line: 2223, col: 33, offset: 68693},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2226, col: 34, offset: 68812},
+							pos:  position{line: 2223, col: 34, offset: 68694},
 							name: "IdentifierRest",
 						},
 					},
@@ -16240,20 +16189,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2227, col: 1, offset: 68827},
+			pos:  position{line: 2224, col: 1, offset: 68709},
 			expr: &seqExpr{
-				pos: position{line: 2227, col: 14, offset: 68840},
+				pos: position{line: 2224, col: 14, offset: 68722},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2227, col: 14, offset: 68840},
+						pos:        position{line: 2224, col: 14, offset: 68722},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2227, col: 33, offset: 68859},
+						pos: position{line: 2224, col: 33, offset: 68741},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2227, col: 34, offset: 68860},
+							pos:  position{line: 2224, col: 34, offset: 68742},
 							name: "IdentifierRest",
 						},
 					},
@@ -16264,20 +16213,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2228, col: 1, offset: 68876},
+			pos:  position{line: 2225, col: 1, offset: 68758},
 			expr: &seqExpr{
-				pos: position{line: 2228, col: 14, offset: 68889},
+				pos: position{line: 2225, col: 14, offset: 68771},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2228, col: 14, offset: 68889},
+						pos:        position{line: 2225, col: 14, offset: 68771},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2228, col: 33, offset: 68908},
+						pos: position{line: 2225, col: 33, offset: 68790},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2228, col: 34, offset: 68909},
+							pos:  position{line: 2225, col: 34, offset: 68791},
 							name: "IdentifierRest",
 						},
 					},
@@ -16288,20 +16237,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2229, col: 1, offset: 68924},
+			pos:  position{line: 2226, col: 1, offset: 68806},
 			expr: &seqExpr{
-				pos: position{line: 2229, col: 14, offset: 68937},
+				pos: position{line: 2226, col: 14, offset: 68819},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2229, col: 14, offset: 68937},
+						pos:        position{line: 2226, col: 14, offset: 68819},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2229, col: 33, offset: 68956},
+						pos: position{line: 2226, col: 33, offset: 68838},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2229, col: 34, offset: 68957},
+							pos:  position{line: 2226, col: 34, offset: 68839},
 							name: "IdentifierRest",
 						},
 					},
@@ -16312,20 +16261,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2230, col: 1, offset: 68972},
+			pos:  position{line: 2227, col: 1, offset: 68854},
 			expr: &seqExpr{
-				pos: position{line: 2230, col: 14, offset: 68985},
+				pos: position{line: 2227, col: 14, offset: 68867},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2230, col: 14, offset: 68985},
+						pos:        position{line: 2227, col: 14, offset: 68867},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2230, col: 33, offset: 69004},
+						pos: position{line: 2227, col: 33, offset: 68886},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2230, col: 34, offset: 69005},
+							pos:  position{line: 2227, col: 34, offset: 68887},
 							name: "IdentifierRest",
 						},
 					},
@@ -16336,20 +16285,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2231, col: 1, offset: 69020},
+			pos:  position{line: 2228, col: 1, offset: 68902},
 			expr: &seqExpr{
-				pos: position{line: 2231, col: 14, offset: 69033},
+				pos: position{line: 2228, col: 14, offset: 68915},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2231, col: 14, offset: 69033},
+						pos:        position{line: 2228, col: 14, offset: 68915},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2231, col: 33, offset: 69052},
+						pos: position{line: 2228, col: 33, offset: 68934},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2231, col: 34, offset: 69053},
+							pos:  position{line: 2228, col: 34, offset: 68935},
 							name: "IdentifierRest",
 						},
 					},
@@ -16360,20 +16309,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2232, col: 1, offset: 69068},
+			pos:  position{line: 2229, col: 1, offset: 68950},
 			expr: &seqExpr{
-				pos: position{line: 2232, col: 14, offset: 69081},
+				pos: position{line: 2229, col: 14, offset: 68963},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2232, col: 14, offset: 69081},
+						pos:        position{line: 2229, col: 14, offset: 68963},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2232, col: 33, offset: 69100},
+						pos: position{line: 2229, col: 33, offset: 68982},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2232, col: 34, offset: 69101},
+							pos:  position{line: 2229, col: 34, offset: 68983},
 							name: "IdentifierRest",
 						},
 					},
@@ -16384,20 +16333,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2233, col: 1, offset: 69116},
+			pos:  position{line: 2230, col: 1, offset: 68998},
 			expr: &seqExpr{
-				pos: position{line: 2233, col: 14, offset: 69129},
+				pos: position{line: 2230, col: 14, offset: 69011},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2233, col: 14, offset: 69129},
+						pos:        position{line: 2230, col: 14, offset: 69011},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2233, col: 33, offset: 69148},
+						pos: position{line: 2230, col: 33, offset: 69030},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2233, col: 34, offset: 69149},
+							pos:  position{line: 2230, col: 34, offset: 69031},
 							name: "IdentifierRest",
 						},
 					},
@@ -16408,20 +16357,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2234, col: 1, offset: 69164},
+			pos:  position{line: 2231, col: 1, offset: 69046},
 			expr: &seqExpr{
-				pos: position{line: 2234, col: 14, offset: 69177},
+				pos: position{line: 2231, col: 14, offset: 69059},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2234, col: 14, offset: 69177},
+						pos:        position{line: 2231, col: 14, offset: 69059},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2234, col: 33, offset: 69196},
+						pos: position{line: 2231, col: 33, offset: 69078},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2234, col: 34, offset: 69197},
+							pos:  position{line: 2231, col: 34, offset: 69079},
 							name: "IdentifierRest",
 						},
 					},
@@ -16432,20 +16381,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORMAT",
-			pos:  position{line: 2235, col: 1, offset: 69212},
+			pos:  position{line: 2232, col: 1, offset: 69094},
 			expr: &seqExpr{
-				pos: position{line: 2235, col: 14, offset: 69225},
+				pos: position{line: 2232, col: 14, offset: 69107},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2235, col: 14, offset: 69225},
+						pos:        position{line: 2232, col: 14, offset: 69107},
 						val:        "format",
 						ignoreCase: true,
 						want:       "\"FORMAT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2235, col: 33, offset: 69244},
+						pos: position{line: 2232, col: 33, offset: 69126},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2235, col: 34, offset: 69245},
+							pos:  position{line: 2232, col: 34, offset: 69127},
 							name: "IdentifierRest",
 						},
 					},
@@ -16456,20 +16405,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2236, col: 1, offset: 69260},
+			pos:  position{line: 2233, col: 1, offset: 69142},
 			expr: &seqExpr{
-				pos: position{line: 2236, col: 14, offset: 69273},
+				pos: position{line: 2233, col: 14, offset: 69155},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2236, col: 14, offset: 69273},
+						pos:        position{line: 2233, col: 14, offset: 69155},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2236, col: 33, offset: 69292},
+						pos: position{line: 2233, col: 33, offset: 69174},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2236, col: 34, offset: 69293},
+							pos:  position{line: 2233, col: 34, offset: 69175},
 							name: "IdentifierRest",
 						},
 					},
@@ -16480,20 +16429,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2237, col: 1, offset: 69308},
+			pos:  position{line: 2234, col: 1, offset: 69190},
 			expr: &seqExpr{
-				pos: position{line: 2237, col: 14, offset: 69321},
+				pos: position{line: 2234, col: 14, offset: 69203},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2237, col: 14, offset: 69321},
+						pos:        position{line: 2234, col: 14, offset: 69203},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2237, col: 33, offset: 69340},
+						pos: position{line: 2234, col: 33, offset: 69222},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2237, col: 34, offset: 69341},
+							pos:  position{line: 2234, col: 34, offset: 69223},
 							name: "IdentifierRest",
 						},
 					},
@@ -16504,20 +16453,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2238, col: 1, offset: 69356},
+			pos:  position{line: 2235, col: 1, offset: 69238},
 			expr: &seqExpr{
-				pos: position{line: 2238, col: 14, offset: 69369},
+				pos: position{line: 2235, col: 14, offset: 69251},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2238, col: 14, offset: 69369},
+						pos:        position{line: 2235, col: 14, offset: 69251},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2238, col: 33, offset: 69388},
+						pos: position{line: 2235, col: 33, offset: 69270},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2238, col: 34, offset: 69389},
+							pos:  position{line: 2235, col: 34, offset: 69271},
 							name: "IdentifierRest",
 						},
 					},
@@ -16528,20 +16477,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2239, col: 1, offset: 69404},
+			pos:  position{line: 2236, col: 1, offset: 69286},
 			expr: &seqExpr{
-				pos: position{line: 2239, col: 14, offset: 69417},
+				pos: position{line: 2236, col: 14, offset: 69299},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2239, col: 14, offset: 69417},
+						pos:        position{line: 2236, col: 14, offset: 69299},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2239, col: 33, offset: 69436},
+						pos: position{line: 2236, col: 33, offset: 69318},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2239, col: 34, offset: 69437},
+							pos:  position{line: 2236, col: 34, offset: 69319},
 							name: "IdentifierRest",
 						},
 					},
@@ -16552,20 +16501,20 @@ var g = &grammar{
 		},
 		{
 			name: "GREP",
-			pos:  position{line: 2240, col: 1, offset: 69452},
+			pos:  position{line: 2237, col: 1, offset: 69334},
 			expr: &seqExpr{
-				pos: position{line: 2240, col: 14, offset: 69465},
+				pos: position{line: 2237, col: 14, offset: 69347},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2240, col: 14, offset: 69465},
+						pos:        position{line: 2237, col: 14, offset: 69347},
 						val:        "grep",
 						ignoreCase: true,
 						want:       "\"GREP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2240, col: 33, offset: 69484},
+						pos: position{line: 2237, col: 33, offset: 69366},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2240, col: 34, offset: 69485},
+							pos:  position{line: 2237, col: 34, offset: 69367},
 							name: "IdentifierRest",
 						},
 					},
@@ -16576,20 +16525,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2241, col: 1, offset: 69500},
+			pos:  position{line: 2238, col: 1, offset: 69382},
 			expr: &seqExpr{
-				pos: position{line: 2241, col: 14, offset: 69513},
+				pos: position{line: 2238, col: 14, offset: 69395},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2241, col: 14, offset: 69513},
+						pos:        position{line: 2238, col: 14, offset: 69395},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2241, col: 33, offset: 69532},
+						pos: position{line: 2238, col: 33, offset: 69414},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2241, col: 34, offset: 69533},
+							pos:  position{line: 2238, col: 34, offset: 69415},
 							name: "IdentifierRest",
 						},
 					},
@@ -16600,20 +16549,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2242, col: 1, offset: 69548},
+			pos:  position{line: 2239, col: 1, offset: 69430},
 			expr: &seqExpr{
-				pos: position{line: 2242, col: 14, offset: 69561},
+				pos: position{line: 2239, col: 14, offset: 69443},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2242, col: 14, offset: 69561},
+						pos:        position{line: 2239, col: 14, offset: 69443},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2242, col: 33, offset: 69580},
+						pos: position{line: 2239, col: 33, offset: 69462},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2242, col: 34, offset: 69581},
+							pos:  position{line: 2239, col: 34, offset: 69463},
 							name: "IdentifierRest",
 						},
 					},
@@ -16624,20 +16573,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2243, col: 1, offset: 69596},
+			pos:  position{line: 2240, col: 1, offset: 69478},
 			expr: &seqExpr{
-				pos: position{line: 2243, col: 14, offset: 69609},
+				pos: position{line: 2240, col: 14, offset: 69491},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2243, col: 14, offset: 69609},
+						pos:        position{line: 2240, col: 14, offset: 69491},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2243, col: 33, offset: 69628},
+						pos: position{line: 2240, col: 33, offset: 69510},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2243, col: 34, offset: 69629},
+							pos:  position{line: 2240, col: 34, offset: 69511},
 							name: "IdentifierRest",
 						},
 					},
@@ -16648,20 +16597,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEADERS",
-			pos:  position{line: 2244, col: 1, offset: 69645},
+			pos:  position{line: 2241, col: 1, offset: 69527},
 			expr: &seqExpr{
-				pos: position{line: 2244, col: 14, offset: 69658},
+				pos: position{line: 2241, col: 14, offset: 69540},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2244, col: 14, offset: 69658},
+						pos:        position{line: 2241, col: 14, offset: 69540},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"HEADERS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2244, col: 33, offset: 69677},
+						pos: position{line: 2241, col: 33, offset: 69559},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2244, col: 34, offset: 69678},
+							pos:  position{line: 2241, col: 34, offset: 69560},
 							name: "IdentifierRest",
 						},
 					},
@@ -16672,20 +16621,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2245, col: 1, offset: 69693},
+			pos:  position{line: 2242, col: 1, offset: 69575},
 			expr: &seqExpr{
-				pos: position{line: 2245, col: 14, offset: 69706},
+				pos: position{line: 2242, col: 14, offset: 69588},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2245, col: 14, offset: 69706},
+						pos:        position{line: 2242, col: 14, offset: 69588},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2245, col: 33, offset: 69725},
+						pos: position{line: 2242, col: 33, offset: 69607},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2245, col: 34, offset: 69726},
+							pos:  position{line: 2242, col: 34, offset: 69608},
 							name: "IdentifierRest",
 						},
 					},
@@ -16696,20 +16645,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2246, col: 1, offset: 69741},
+			pos:  position{line: 2243, col: 1, offset: 69623},
 			expr: &seqExpr{
-				pos: position{line: 2246, col: 14, offset: 69754},
+				pos: position{line: 2243, col: 14, offset: 69636},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2246, col: 14, offset: 69754},
+						pos:        position{line: 2243, col: 14, offset: 69636},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2246, col: 33, offset: 69773},
+						pos: position{line: 2243, col: 33, offset: 69655},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2246, col: 34, offset: 69774},
+							pos:  position{line: 2243, col: 34, offset: 69656},
 							name: "IdentifierRest",
 						},
 					},
@@ -16720,20 +16669,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2247, col: 1, offset: 69789},
+			pos:  position{line: 2244, col: 1, offset: 69671},
 			expr: &seqExpr{
-				pos: position{line: 2247, col: 14, offset: 69802},
+				pos: position{line: 2244, col: 14, offset: 69684},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2247, col: 14, offset: 69802},
+						pos:        position{line: 2244, col: 14, offset: 69684},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2247, col: 33, offset: 69821},
+						pos: position{line: 2244, col: 33, offset: 69703},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2247, col: 34, offset: 69822},
+							pos:  position{line: 2244, col: 34, offset: 69704},
 							name: "IdentifierRest",
 						},
 					},
@@ -16744,20 +16693,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2248, col: 1, offset: 69837},
+			pos:  position{line: 2245, col: 1, offset: 69719},
 			expr: &seqExpr{
-				pos: position{line: 2248, col: 14, offset: 69850},
+				pos: position{line: 2245, col: 14, offset: 69732},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2248, col: 14, offset: 69850},
+						pos:        position{line: 2245, col: 14, offset: 69732},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2248, col: 33, offset: 69869},
+						pos: position{line: 2245, col: 33, offset: 69751},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2248, col: 34, offset: 69870},
+							pos:  position{line: 2245, col: 34, offset: 69752},
 							name: "IdentifierRest",
 						},
 					},
@@ -16768,20 +16717,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2249, col: 1, offset: 69885},
+			pos:  position{line: 2246, col: 1, offset: 69767},
 			expr: &seqExpr{
-				pos: position{line: 2249, col: 14, offset: 69898},
+				pos: position{line: 2246, col: 14, offset: 69780},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2249, col: 14, offset: 69898},
+						pos:        position{line: 2246, col: 14, offset: 69780},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2249, col: 33, offset: 69917},
+						pos: position{line: 2246, col: 33, offset: 69799},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2249, col: 34, offset: 69918},
+							pos:  position{line: 2246, col: 34, offset: 69800},
 							name: "IdentifierRest",
 						},
 					},
@@ -16792,20 +16741,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2250, col: 1, offset: 69933},
+			pos:  position{line: 2247, col: 1, offset: 69815},
 			expr: &seqExpr{
-				pos: position{line: 2250, col: 14, offset: 69946},
+				pos: position{line: 2247, col: 14, offset: 69828},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2250, col: 14, offset: 69946},
+						pos:        position{line: 2247, col: 14, offset: 69828},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2250, col: 32, offset: 69964},
+						pos: position{line: 2247, col: 32, offset: 69846},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2250, col: 33, offset: 69965},
+							pos:  position{line: 2247, col: 33, offset: 69847},
 							name: "IdentifierRest",
 						},
 					},
@@ -16816,20 +16765,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2251, col: 1, offset: 69980},
+			pos:  position{line: 2248, col: 1, offset: 69862},
 			expr: &seqExpr{
-				pos: position{line: 2251, col: 14, offset: 69993},
+				pos: position{line: 2248, col: 14, offset: 69875},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2251, col: 14, offset: 69993},
+						pos:        position{line: 2248, col: 14, offset: 69875},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2251, col: 33, offset: 70012},
+						pos: position{line: 2248, col: 33, offset: 69894},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2251, col: 34, offset: 70013},
+							pos:  position{line: 2248, col: 34, offset: 69895},
 							name: "IdentifierRest",
 						},
 					},
@@ -16840,20 +16789,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2252, col: 1, offset: 70028},
+			pos:  position{line: 2249, col: 1, offset: 69910},
 			expr: &seqExpr{
-				pos: position{line: 2252, col: 14, offset: 70041},
+				pos: position{line: 2249, col: 14, offset: 69923},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2252, col: 14, offset: 70041},
+						pos:        position{line: 2249, col: 14, offset: 69923},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2252, col: 33, offset: 70060},
+						pos: position{line: 2249, col: 33, offset: 69942},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2252, col: 34, offset: 70061},
+							pos:  position{line: 2249, col: 34, offset: 69943},
 							name: "IdentifierRest",
 						},
 					},
@@ -16864,20 +16813,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2253, col: 1, offset: 70076},
+			pos:  position{line: 2250, col: 1, offset: 69958},
 			expr: &seqExpr{
-				pos: position{line: 2253, col: 16, offset: 70091},
+				pos: position{line: 2250, col: 16, offset: 69973},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2253, col: 16, offset: 70091},
+						pos:        position{line: 2250, col: 16, offset: 69973},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2253, col: 33, offset: 70108},
+						pos: position{line: 2250, col: 33, offset: 69990},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2253, col: 34, offset: 70109},
+							pos:  position{line: 2250, col: 34, offset: 69991},
 							name: "IdentifierRest",
 						},
 					},
@@ -16888,20 +16837,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2254, col: 1, offset: 70124},
+			pos:  position{line: 2251, col: 1, offset: 70006},
 			expr: &seqExpr{
-				pos: position{line: 2254, col: 14, offset: 70137},
+				pos: position{line: 2251, col: 14, offset: 70019},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2254, col: 14, offset: 70137},
+						pos:        position{line: 2251, col: 14, offset: 70019},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2254, col: 33, offset: 70156},
+						pos: position{line: 2251, col: 33, offset: 70038},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2254, col: 34, offset: 70157},
+							pos:  position{line: 2251, col: 34, offset: 70039},
 							name: "IdentifierRest",
 						},
 					},
@@ -16912,20 +16861,20 @@ var g = &grammar{
 		},
 		{
 			name: "MESSAGE",
-			pos:  position{line: 2255, col: 1, offset: 70172},
+			pos:  position{line: 2252, col: 1, offset: 70054},
 			expr: &seqExpr{
-				pos: position{line: 2255, col: 14, offset: 70185},
+				pos: position{line: 2252, col: 14, offset: 70067},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2255, col: 14, offset: 70185},
+						pos:        position{line: 2252, col: 14, offset: 70067},
 						val:        "message",
 						ignoreCase: true,
 						want:       "\"MESSAGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2255, col: 33, offset: 70204},
+						pos: position{line: 2252, col: 33, offset: 70086},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2255, col: 34, offset: 70205},
+							pos:  position{line: 2252, col: 34, offset: 70087},
 							name: "IdentifierRest",
 						},
 					},
@@ -16936,20 +16885,20 @@ var g = &grammar{
 		},
 		{
 			name: "META",
-			pos:  position{line: 2256, col: 1, offset: 70220},
+			pos:  position{line: 2253, col: 1, offset: 70102},
 			expr: &seqExpr{
-				pos: position{line: 2256, col: 14, offset: 70233},
+				pos: position{line: 2253, col: 14, offset: 70115},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2256, col: 14, offset: 70233},
+						pos:        position{line: 2253, col: 14, offset: 70115},
 						val:        "meta",
 						ignoreCase: true,
 						want:       "\"META\"i",
 					},
 					&notExpr{
-						pos: position{line: 2256, col: 33, offset: 70252},
+						pos: position{line: 2253, col: 33, offset: 70134},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2256, col: 34, offset: 70253},
+							pos:  position{line: 2253, col: 34, offset: 70135},
 							name: "IdentifierRest",
 						},
 					},
@@ -16960,20 +16909,20 @@ var g = &grammar{
 		},
 		{
 			name: "METHOD",
-			pos:  position{line: 2257, col: 1, offset: 70268},
+			pos:  position{line: 2254, col: 1, offset: 70150},
 			expr: &seqExpr{
-				pos: position{line: 2257, col: 14, offset: 70281},
+				pos: position{line: 2254, col: 14, offset: 70163},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2257, col: 14, offset: 70281},
+						pos:        position{line: 2254, col: 14, offset: 70163},
 						val:        "method",
 						ignoreCase: true,
 						want:       "\"METHOD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2257, col: 33, offset: 70300},
+						pos: position{line: 2254, col: 33, offset: 70182},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2257, col: 34, offset: 70301},
+							pos:  position{line: 2254, col: 34, offset: 70183},
 							name: "IdentifierRest",
 						},
 					},
@@ -16984,20 +16933,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2258, col: 1, offset: 70316},
+			pos:  position{line: 2255, col: 1, offset: 70198},
 			expr: &seqExpr{
-				pos: position{line: 2258, col: 14, offset: 70329},
+				pos: position{line: 2255, col: 14, offset: 70211},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2258, col: 14, offset: 70329},
+						pos:        position{line: 2255, col: 14, offset: 70211},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2258, col: 33, offset: 70348},
+						pos: position{line: 2255, col: 33, offset: 70230},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2258, col: 34, offset: 70349},
+							pos:  position{line: 2255, col: 34, offset: 70231},
 							name: "IdentifierRest",
 						},
 					},
@@ -17008,20 +16957,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2259, col: 1, offset: 70364},
+			pos:  position{line: 2256, col: 1, offset: 70246},
 			expr: &seqExpr{
-				pos: position{line: 2259, col: 14, offset: 70377},
+				pos: position{line: 2256, col: 14, offset: 70259},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2259, col: 14, offset: 70377},
+						pos:        position{line: 2256, col: 14, offset: 70259},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2259, col: 33, offset: 70396},
+						pos: position{line: 2256, col: 33, offset: 70278},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2259, col: 34, offset: 70397},
+							pos:  position{line: 2256, col: 34, offset: 70279},
 							name: "IdentifierRest",
 						},
 					},
@@ -17032,20 +16981,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2260, col: 1, offset: 70412},
+			pos:  position{line: 2257, col: 1, offset: 70294},
 			expr: &seqExpr{
-				pos: position{line: 2260, col: 14, offset: 70425},
+				pos: position{line: 2257, col: 14, offset: 70307},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2260, col: 14, offset: 70425},
+						pos:        position{line: 2257, col: 14, offset: 70307},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2260, col: 33, offset: 70444},
+						pos: position{line: 2257, col: 33, offset: 70326},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2260, col: 34, offset: 70445},
+							pos:  position{line: 2257, col: 34, offset: 70327},
 							name: "IdentifierRest",
 						},
 					},
@@ -17056,20 +17005,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2261, col: 1, offset: 70460},
+			pos:  position{line: 2258, col: 1, offset: 70342},
 			expr: &seqExpr{
-				pos: position{line: 2261, col: 14, offset: 70473},
+				pos: position{line: 2258, col: 14, offset: 70355},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2261, col: 14, offset: 70473},
+						pos:        position{line: 2258, col: 14, offset: 70355},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2261, col: 33, offset: 70492},
+						pos: position{line: 2258, col: 33, offset: 70374},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2261, col: 34, offset: 70493},
+							pos:  position{line: 2258, col: 34, offset: 70375},
 							name: "IdentifierRest",
 						},
 					},
@@ -17080,20 +17029,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2262, col: 1, offset: 70508},
+			pos:  position{line: 2259, col: 1, offset: 70390},
 			expr: &seqExpr{
-				pos: position{line: 2262, col: 14, offset: 70521},
+				pos: position{line: 2259, col: 14, offset: 70403},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2262, col: 14, offset: 70521},
+						pos:        position{line: 2259, col: 14, offset: 70403},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2262, col: 33, offset: 70540},
+						pos: position{line: 2259, col: 33, offset: 70422},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2262, col: 34, offset: 70541},
+							pos:  position{line: 2259, col: 34, offset: 70423},
 							name: "IdentifierRest",
 						},
 					},
@@ -17104,20 +17053,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2263, col: 1, offset: 70556},
+			pos:  position{line: 2260, col: 1, offset: 70438},
 			expr: &seqExpr{
-				pos: position{line: 2263, col: 14, offset: 70569},
+				pos: position{line: 2260, col: 14, offset: 70451},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2263, col: 14, offset: 70569},
+						pos:        position{line: 2260, col: 14, offset: 70451},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2263, col: 33, offset: 70588},
+						pos: position{line: 2260, col: 33, offset: 70470},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2263, col: 34, offset: 70589},
+							pos:  position{line: 2260, col: 34, offset: 70471},
 							name: "IdentifierRest",
 						},
 					},
@@ -17128,23 +17077,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2264, col: 1, offset: 70604},
+			pos:  position{line: 2261, col: 1, offset: 70486},
 			expr: &actionExpr{
-				pos: position{line: 2264, col: 14, offset: 70617},
+				pos: position{line: 2261, col: 14, offset: 70499},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2264, col: 14, offset: 70617},
+					pos: position{line: 2261, col: 14, offset: 70499},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2264, col: 14, offset: 70617},
+							pos:        position{line: 2261, col: 14, offset: 70499},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2264, col: 33, offset: 70636},
+							pos: position{line: 2261, col: 33, offset: 70518},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2264, col: 34, offset: 70637},
+								pos:  position{line: 2261, col: 34, offset: 70519},
 								name: "IdentifierRest",
 							},
 						},
@@ -17156,20 +17105,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2265, col: 1, offset: 70673},
+			pos:  position{line: 2262, col: 1, offset: 70555},
 			expr: &seqExpr{
-				pos: position{line: 2265, col: 14, offset: 70686},
+				pos: position{line: 2262, col: 14, offset: 70568},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2265, col: 14, offset: 70686},
+						pos:        position{line: 2262, col: 14, offset: 70568},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2265, col: 33, offset: 70705},
+						pos: position{line: 2262, col: 33, offset: 70587},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2265, col: 34, offset: 70706},
+							pos:  position{line: 2262, col: 34, offset: 70588},
 							name: "IdentifierRest",
 						},
 					},
@@ -17180,20 +17129,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2266, col: 1, offset: 70721},
+			pos:  position{line: 2263, col: 1, offset: 70603},
 			expr: &seqExpr{
-				pos: position{line: 2266, col: 14, offset: 70734},
+				pos: position{line: 2263, col: 14, offset: 70616},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2266, col: 14, offset: 70734},
+						pos:        position{line: 2263, col: 14, offset: 70616},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2266, col: 33, offset: 70753},
+						pos: position{line: 2263, col: 33, offset: 70635},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2266, col: 34, offset: 70754},
+							pos:  position{line: 2263, col: 34, offset: 70636},
 							name: "IdentifierRest",
 						},
 					},
@@ -17204,20 +17153,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2267, col: 1, offset: 70769},
+			pos:  position{line: 2264, col: 1, offset: 70651},
 			expr: &seqExpr{
-				pos: position{line: 2267, col: 14, offset: 70782},
+				pos: position{line: 2264, col: 14, offset: 70664},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2267, col: 14, offset: 70782},
+						pos:        position{line: 2264, col: 14, offset: 70664},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2267, col: 33, offset: 70801},
+						pos: position{line: 2264, col: 33, offset: 70683},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2267, col: 34, offset: 70802},
+							pos:  position{line: 2264, col: 34, offset: 70684},
 							name: "IdentifierRest",
 						},
 					},
@@ -17228,20 +17177,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2268, col: 1, offset: 70817},
+			pos:  position{line: 2265, col: 1, offset: 70699},
 			expr: &seqExpr{
-				pos: position{line: 2268, col: 14, offset: 70830},
+				pos: position{line: 2265, col: 14, offset: 70712},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2268, col: 14, offset: 70830},
+						pos:        position{line: 2265, col: 14, offset: 70712},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2268, col: 33, offset: 70849},
+						pos: position{line: 2265, col: 33, offset: 70731},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2268, col: 34, offset: 70850},
+							pos:  position{line: 2265, col: 34, offset: 70732},
 							name: "IdentifierRest",
 						},
 					},
@@ -17252,20 +17201,20 @@ var g = &grammar{
 		},
 		{
 			name: "OVER",
-			pos:  position{line: 2269, col: 1, offset: 70865},
+			pos:  position{line: 2266, col: 1, offset: 70747},
 			expr: &seqExpr{
-				pos: position{line: 2269, col: 14, offset: 70878},
+				pos: position{line: 2266, col: 14, offset: 70760},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2269, col: 14, offset: 70878},
+						pos:        position{line: 2266, col: 14, offset: 70760},
 						val:        "over",
 						ignoreCase: true,
 						want:       "\"OVER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2269, col: 33, offset: 70897},
+						pos: position{line: 2266, col: 33, offset: 70779},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2269, col: 34, offset: 70898},
+							pos:  position{line: 2266, col: 34, offset: 70780},
 							name: "IdentifierRest",
 						},
 					},
@@ -17276,20 +17225,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2270, col: 1, offset: 70913},
+			pos:  position{line: 2267, col: 1, offset: 70795},
 			expr: &seqExpr{
-				pos: position{line: 2270, col: 14, offset: 70926},
+				pos: position{line: 2267, col: 14, offset: 70808},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2270, col: 14, offset: 70926},
+						pos:        position{line: 2267, col: 14, offset: 70808},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2270, col: 33, offset: 70945},
+						pos: position{line: 2267, col: 33, offset: 70827},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2270, col: 34, offset: 70946},
+							pos:  position{line: 2267, col: 34, offset: 70828},
 							name: "IdentifierRest",
 						},
 					},
@@ -17300,20 +17249,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2271, col: 1, offset: 70961},
+			pos:  position{line: 2268, col: 1, offset: 70843},
 			expr: &seqExpr{
-				pos: position{line: 2271, col: 14, offset: 70974},
+				pos: position{line: 2268, col: 14, offset: 70856},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2271, col: 14, offset: 70974},
+						pos:        position{line: 2268, col: 14, offset: 70856},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2271, col: 33, offset: 70993},
+						pos: position{line: 2268, col: 33, offset: 70875},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2271, col: 34, offset: 70994},
+							pos:  position{line: 2268, col: 34, offset: 70876},
 							name: "IdentifierRest",
 						},
 					},
@@ -17324,20 +17273,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2272, col: 1, offset: 71009},
+			pos:  position{line: 2269, col: 1, offset: 70891},
 			expr: &seqExpr{
-				pos: position{line: 2272, col: 14, offset: 71022},
+				pos: position{line: 2269, col: 14, offset: 70904},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2272, col: 14, offset: 71022},
+						pos:        position{line: 2269, col: 14, offset: 70904},
 						val:        "RECURSIVE",
 						ignoreCase: false,
 						want:       "\"RECURSIVE\"",
 					},
 					&notExpr{
-						pos: position{line: 2272, col: 33, offset: 71041},
+						pos: position{line: 2269, col: 33, offset: 70923},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2272, col: 34, offset: 71042},
+							pos:  position{line: 2269, col: 34, offset: 70924},
 							name: "IdentifierRest",
 						},
 					},
@@ -17348,20 +17297,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP",
-			pos:  position{line: 2273, col: 1, offset: 71057},
+			pos:  position{line: 2270, col: 1, offset: 70939},
 			expr: &seqExpr{
-				pos: position{line: 2273, col: 14, offset: 71070},
+				pos: position{line: 2270, col: 14, offset: 70952},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2273, col: 14, offset: 71070},
+						pos:        position{line: 2270, col: 14, offset: 70952},
 						val:        "regexp",
 						ignoreCase: true,
 						want:       "\"REGEXP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2273, col: 33, offset: 71089},
+						pos: position{line: 2270, col: 33, offset: 70971},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2273, col: 34, offset: 71090},
+							pos:  position{line: 2270, col: 34, offset: 70972},
 							name: "IdentifierRest",
 						},
 					},
@@ -17372,20 +17321,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP_REPLACE",
-			pos:  position{line: 2274, col: 1, offset: 71105},
+			pos:  position{line: 2271, col: 1, offset: 70987},
 			expr: &seqExpr{
-				pos: position{line: 2274, col: 18, offset: 71122},
+				pos: position{line: 2271, col: 18, offset: 71004},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2274, col: 18, offset: 71122},
+						pos:        position{line: 2271, col: 18, offset: 71004},
 						val:        "regexp_replace",
 						ignoreCase: true,
 						want:       "\"REGEXP_REPLACE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2274, col: 36, offset: 71140},
+						pos: position{line: 2271, col: 36, offset: 71022},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2274, col: 37, offset: 71141},
+							pos:  position{line: 2271, col: 37, offset: 71023},
 							name: "IdentifierRest",
 						},
 					},
@@ -17396,20 +17345,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2275, col: 1, offset: 71156},
+			pos:  position{line: 2272, col: 1, offset: 71038},
 			expr: &seqExpr{
-				pos: position{line: 2275, col: 14, offset: 71169},
+				pos: position{line: 2272, col: 14, offset: 71051},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2275, col: 14, offset: 71169},
+						pos:        position{line: 2272, col: 14, offset: 71051},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2275, col: 33, offset: 71188},
+						pos: position{line: 2272, col: 33, offset: 71070},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2275, col: 34, offset: 71189},
+							pos:  position{line: 2272, col: 34, offset: 71071},
 							name: "IdentifierRest",
 						},
 					},
@@ -17420,20 +17369,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2276, col: 1, offset: 71204},
+			pos:  position{line: 2273, col: 1, offset: 71086},
 			expr: &seqExpr{
-				pos: position{line: 2276, col: 14, offset: 71217},
+				pos: position{line: 2273, col: 14, offset: 71099},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2276, col: 14, offset: 71217},
+						pos:        position{line: 2273, col: 14, offset: 71099},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2276, col: 33, offset: 71236},
+						pos: position{line: 2273, col: 33, offset: 71118},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2276, col: 34, offset: 71237},
+							pos:  position{line: 2273, col: 34, offset: 71119},
 							name: "IdentifierRest",
 						},
 					},
@@ -17444,20 +17393,20 @@ var g = &grammar{
 		},
 		{
 			name: "SAMPLE",
-			pos:  position{line: 2277, col: 1, offset: 71252},
+			pos:  position{line: 2274, col: 1, offset: 71134},
 			expr: &seqExpr{
-				pos: position{line: 2277, col: 14, offset: 71265},
+				pos: position{line: 2274, col: 14, offset: 71147},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2277, col: 14, offset: 71265},
+						pos:        position{line: 2274, col: 14, offset: 71147},
 						val:        "sample",
 						ignoreCase: true,
 						want:       "\"SAMPLE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2277, col: 33, offset: 71284},
+						pos: position{line: 2274, col: 33, offset: 71166},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2277, col: 34, offset: 71285},
+							pos:  position{line: 2274, col: 34, offset: 71167},
 							name: "IdentifierRest",
 						},
 					},
@@ -17468,20 +17417,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2278, col: 1, offset: 71300},
+			pos:  position{line: 2275, col: 1, offset: 71182},
 			expr: &seqExpr{
-				pos: position{line: 2278, col: 14, offset: 71313},
+				pos: position{line: 2275, col: 14, offset: 71195},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2278, col: 14, offset: 71313},
+						pos:        position{line: 2275, col: 14, offset: 71195},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2278, col: 33, offset: 71332},
+						pos: position{line: 2275, col: 33, offset: 71214},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2278, col: 34, offset: 71333},
+							pos:  position{line: 2275, col: 34, offset: 71215},
 							name: "IdentifierRest",
 						},
 					},
@@ -17492,20 +17441,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2279, col: 1, offset: 71348},
+			pos:  position{line: 2276, col: 1, offset: 71230},
 			expr: &seqExpr{
-				pos: position{line: 2279, col: 14, offset: 71361},
+				pos: position{line: 2276, col: 14, offset: 71243},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2279, col: 14, offset: 71361},
+						pos:        position{line: 2276, col: 14, offset: 71243},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2279, col: 33, offset: 71380},
+						pos: position{line: 2276, col: 33, offset: 71262},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2279, col: 34, offset: 71381},
+							pos:  position{line: 2276, col: 34, offset: 71263},
 							name: "IdentifierRest",
 						},
 					},
@@ -17516,20 +17465,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2280, col: 1, offset: 71396},
+			pos:  position{line: 2277, col: 1, offset: 71278},
 			expr: &seqExpr{
-				pos: position{line: 2280, col: 14, offset: 71409},
+				pos: position{line: 2277, col: 14, offset: 71291},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2280, col: 14, offset: 71409},
+						pos:        position{line: 2277, col: 14, offset: 71291},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2280, col: 33, offset: 71428},
+						pos: position{line: 2277, col: 33, offset: 71310},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2280, col: 34, offset: 71429},
+							pos:  position{line: 2277, col: 34, offset: 71311},
 							name: "IdentifierRest",
 						},
 					},
@@ -17540,20 +17489,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2281, col: 1, offset: 71444},
+			pos:  position{line: 2278, col: 1, offset: 71326},
 			expr: &seqExpr{
-				pos: position{line: 2281, col: 14, offset: 71457},
+				pos: position{line: 2278, col: 14, offset: 71339},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2281, col: 14, offset: 71457},
+						pos:        position{line: 2278, col: 14, offset: 71339},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2281, col: 33, offset: 71476},
+						pos: position{line: 2278, col: 33, offset: 71358},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2281, col: 34, offset: 71477},
+							pos:  position{line: 2278, col: 34, offset: 71359},
 							name: "IdentifierRest",
 						},
 					},
@@ -17564,20 +17513,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2282, col: 1, offset: 71492},
+			pos:  position{line: 2279, col: 1, offset: 71374},
 			expr: &seqExpr{
-				pos: position{line: 2282, col: 14, offset: 71505},
+				pos: position{line: 2279, col: 14, offset: 71387},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2282, col: 14, offset: 71505},
+						pos:        position{line: 2279, col: 14, offset: 71387},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2282, col: 33, offset: 71524},
+						pos: position{line: 2279, col: 33, offset: 71406},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2282, col: 34, offset: 71525},
+							pos:  position{line: 2279, col: 34, offset: 71407},
 							name: "IdentifierRest",
 						},
 					},
@@ -17588,20 +17537,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2283, col: 1, offset: 71540},
+			pos:  position{line: 2280, col: 1, offset: 71422},
 			expr: &seqExpr{
-				pos: position{line: 2283, col: 14, offset: 71553},
+				pos: position{line: 2280, col: 14, offset: 71435},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2283, col: 14, offset: 71553},
+						pos:        position{line: 2280, col: 14, offset: 71435},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2283, col: 33, offset: 71572},
+						pos: position{line: 2280, col: 33, offset: 71454},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2283, col: 34, offset: 71573},
+							pos:  position{line: 2280, col: 34, offset: 71455},
 							name: "IdentifierRest",
 						},
 					},
@@ -17612,20 +17561,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2284, col: 1, offset: 71588},
+			pos:  position{line: 2281, col: 1, offset: 71470},
 			expr: &seqExpr{
-				pos: position{line: 2284, col: 14, offset: 71601},
+				pos: position{line: 2281, col: 14, offset: 71483},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2284, col: 14, offset: 71601},
+						pos:        position{line: 2281, col: 14, offset: 71483},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2284, col: 33, offset: 71620},
+						pos: position{line: 2281, col: 33, offset: 71502},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2284, col: 34, offset: 71621},
+							pos:  position{line: 2281, col: 34, offset: 71503},
 							name: "IdentifierRest",
 						},
 					},
@@ -17636,20 +17585,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAP",
-			pos:  position{line: 2285, col: 1, offset: 71637},
+			pos:  position{line: 2282, col: 1, offset: 71519},
 			expr: &seqExpr{
-				pos: position{line: 2285, col: 14, offset: 71650},
+				pos: position{line: 2282, col: 14, offset: 71532},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2285, col: 14, offset: 71650},
+						pos:        position{line: 2282, col: 14, offset: 71532},
 						val:        "tap",
 						ignoreCase: true,
 						want:       "\"TAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2285, col: 33, offset: 71669},
+						pos: position{line: 2282, col: 33, offset: 71551},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2285, col: 34, offset: 71670},
+							pos:  position{line: 2282, col: 34, offset: 71552},
 							name: "IdentifierRest",
 						},
 					},
@@ -17660,20 +17609,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2286, col: 1, offset: 71685},
+			pos:  position{line: 2283, col: 1, offset: 71567},
 			expr: &seqExpr{
-				pos: position{line: 2286, col: 14, offset: 71698},
+				pos: position{line: 2283, col: 14, offset: 71580},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2286, col: 14, offset: 71698},
+						pos:        position{line: 2283, col: 14, offset: 71580},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2286, col: 33, offset: 71717},
+						pos: position{line: 2283, col: 33, offset: 71599},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2286, col: 34, offset: 71718},
+							pos:  position{line: 2283, col: 34, offset: 71600},
 							name: "IdentifierRest",
 						},
 					},
@@ -17684,20 +17633,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2287, col: 1, offset: 71733},
+			pos:  position{line: 2284, col: 1, offset: 71615},
 			expr: &seqExpr{
-				pos: position{line: 2287, col: 14, offset: 71746},
+				pos: position{line: 2284, col: 14, offset: 71628},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2287, col: 14, offset: 71746},
+						pos:        position{line: 2284, col: 14, offset: 71628},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2287, col: 33, offset: 71765},
+						pos: position{line: 2284, col: 33, offset: 71647},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2287, col: 34, offset: 71766},
+							pos:  position{line: 2284, col: 34, offset: 71648},
 							name: "IdentifierRest",
 						},
 					},
@@ -17708,20 +17657,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2288, col: 1, offset: 71781},
+			pos:  position{line: 2285, col: 1, offset: 71663},
 			expr: &seqExpr{
-				pos: position{line: 2288, col: 14, offset: 71794},
+				pos: position{line: 2285, col: 14, offset: 71676},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2288, col: 14, offset: 71794},
+						pos:        position{line: 2285, col: 14, offset: 71676},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2288, col: 33, offset: 71813},
+						pos: position{line: 2285, col: 33, offset: 71695},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2288, col: 34, offset: 71814},
+							pos:  position{line: 2285, col: 34, offset: 71696},
 							name: "IdentifierRest",
 						},
 					},
@@ -17732,20 +17681,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2289, col: 1, offset: 71829},
+			pos:  position{line: 2286, col: 1, offset: 71711},
 			expr: &seqExpr{
-				pos: position{line: 2289, col: 14, offset: 71842},
+				pos: position{line: 2286, col: 14, offset: 71724},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2289, col: 14, offset: 71842},
+						pos:        position{line: 2286, col: 14, offset: 71724},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2289, col: 33, offset: 71861},
+						pos: position{line: 2286, col: 33, offset: 71743},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2289, col: 34, offset: 71862},
+							pos:  position{line: 2286, col: 34, offset: 71744},
 							name: "IdentifierRest",
 						},
 					},
@@ -17756,20 +17705,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2290, col: 1, offset: 71877},
+			pos:  position{line: 2287, col: 1, offset: 71759},
 			expr: &seqExpr{
-				pos: position{line: 2290, col: 14, offset: 71890},
+				pos: position{line: 2287, col: 14, offset: 71772},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2290, col: 14, offset: 71890},
+						pos:        position{line: 2287, col: 14, offset: 71772},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2290, col: 33, offset: 71909},
+						pos: position{line: 2287, col: 33, offset: 71791},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2290, col: 34, offset: 71910},
+							pos:  position{line: 2287, col: 34, offset: 71792},
 							name: "IdentifierRest",
 						},
 					},
@@ -17780,20 +17729,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2291, col: 1, offset: 71925},
+			pos:  position{line: 2288, col: 1, offset: 71807},
 			expr: &seqExpr{
-				pos: position{line: 2291, col: 14, offset: 71938},
+				pos: position{line: 2288, col: 14, offset: 71820},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2291, col: 14, offset: 71938},
+						pos:        position{line: 2288, col: 14, offset: 71820},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2291, col: 33, offset: 71957},
+						pos: position{line: 2288, col: 33, offset: 71839},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2291, col: 34, offset: 71958},
+							pos:  position{line: 2288, col: 34, offset: 71840},
 							name: "IdentifierRest",
 						},
 					},
@@ -17804,20 +17753,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2292, col: 1, offset: 71974},
+			pos:  position{line: 2289, col: 1, offset: 71856},
 			expr: &seqExpr{
-				pos: position{line: 2292, col: 14, offset: 71987},
+				pos: position{line: 2289, col: 14, offset: 71869},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2292, col: 14, offset: 71987},
+						pos:        position{line: 2289, col: 14, offset: 71869},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2292, col: 33, offset: 72006},
+						pos: position{line: 2289, col: 33, offset: 71888},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2292, col: 34, offset: 72007},
+							pos:  position{line: 2289, col: 34, offset: 71889},
 							name: "IdentifierRest",
 						},
 					},
@@ -17828,20 +17777,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2293, col: 1, offset: 72022},
+			pos:  position{line: 2290, col: 1, offset: 71904},
 			expr: &seqExpr{
-				pos: position{line: 2293, col: 14, offset: 72035},
+				pos: position{line: 2290, col: 14, offset: 71917},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2293, col: 14, offset: 72035},
+						pos:        position{line: 2290, col: 14, offset: 71917},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2293, col: 33, offset: 72054},
+						pos: position{line: 2290, col: 33, offset: 71936},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2293, col: 34, offset: 72055},
+							pos:  position{line: 2290, col: 34, offset: 71937},
 							name: "IdentifierRest",
 						},
 					},
@@ -17852,20 +17801,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2294, col: 1, offset: 72070},
+			pos:  position{line: 2291, col: 1, offset: 71952},
 			expr: &seqExpr{
-				pos: position{line: 2294, col: 14, offset: 72083},
+				pos: position{line: 2291, col: 14, offset: 71965},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2294, col: 14, offset: 72083},
+						pos:        position{line: 2291, col: 14, offset: 71965},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2294, col: 33, offset: 72102},
+						pos: position{line: 2291, col: 33, offset: 71984},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2294, col: 34, offset: 72103},
+							pos:  position{line: 2291, col: 34, offset: 71985},
 							name: "IdentifierRest",
 						},
 					},
@@ -17876,20 +17825,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2295, col: 1, offset: 72118},
+			pos:  position{line: 2292, col: 1, offset: 72000},
 			expr: &seqExpr{
-				pos: position{line: 2295, col: 14, offset: 72131},
+				pos: position{line: 2292, col: 14, offset: 72013},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2295, col: 14, offset: 72131},
+						pos:        position{line: 2292, col: 14, offset: 72013},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2295, col: 33, offset: 72150},
+						pos: position{line: 2292, col: 33, offset: 72032},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2295, col: 34, offset: 72151},
+							pos:  position{line: 2292, col: 34, offset: 72033},
 							name: "IdentifierRest",
 						},
 					},
@@ -17900,20 +17849,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2296, col: 1, offset: 72166},
+			pos:  position{line: 2293, col: 1, offset: 72048},
 			expr: &seqExpr{
-				pos: position{line: 2296, col: 14, offset: 72179},
+				pos: position{line: 2293, col: 14, offset: 72061},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2296, col: 14, offset: 72179},
+						pos:        position{line: 2293, col: 14, offset: 72061},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2296, col: 33, offset: 72198},
+						pos: position{line: 2293, col: 33, offset: 72080},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2296, col: 34, offset: 72199},
+							pos:  position{line: 2293, col: 34, offset: 72081},
 							name: "IdentifierRest",
 						},
 					},
@@ -17924,20 +17873,20 @@ var g = &grammar{
 		},
 		{
 			name: "YIELD",
-			pos:  position{line: 2297, col: 1, offset: 72214},
+			pos:  position{line: 2294, col: 1, offset: 72096},
 			expr: &seqExpr{
-				pos: position{line: 2297, col: 14, offset: 72227},
+				pos: position{line: 2294, col: 14, offset: 72109},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2297, col: 14, offset: 72227},
+						pos:        position{line: 2294, col: 14, offset: 72109},
 						val:        "yield",
 						ignoreCase: true,
 						want:       "\"YIELD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2297, col: 33, offset: 72246},
+						pos: position{line: 2294, col: 33, offset: 72128},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2297, col: 34, offset: 72247},
+							pos:  position{line: 2294, col: 34, offset: 72129},
 							name: "IdentifierRest",
 						},
 					},
@@ -18987,18 +18936,15 @@ func (p *parser) callonShapeOp1() (any, error) {
 	return p.cur.onShapeOp1()
 }
 
-func (c *current) onJoinOp1(style, rightInput, key, optKey, optArgs any) (any, error) {
+func (c *current) onJoinOp1(style, rightInput, e, optArgs any) (any, error) {
 	o := &ast.Join{
-		Kind:    "Join",
-		Style:   style.(string),
-		LeftKey: key.(ast.Expr),
-		Loc:     loc(c),
+		Kind:  "Join",
+		Style: style.(string),
+		Cond:  e.(ast.JoinExpr),
+		Loc:   loc(c),
 	}
 	if rightInput != nil {
 		o.RightInput = sliceOf[ast.Op](rightInput)
-	}
-	if optKey != nil {
-		o.RightKey = optKey.([]any)[3].(ast.Expr)
 	}
 	if optArgs != nil {
 		o.Args = sliceOf[ast.Assignment](optArgs.([]any)[1])
@@ -19010,7 +18956,7 @@ func (c *current) onJoinOp1(style, rightInput, key, optKey, optArgs any) (any, e
 func (p *parser) callonJoinOp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinOp1(stack["style"], stack["rightInput"], stack["key"], stack["optKey"], stack["optArgs"])
+	return p.cur.onJoinOp1(stack["style"], stack["rightInput"], stack["e"], stack["optArgs"])
 }
 
 func (c *current) onJoinStyle2() (any, error) {
@@ -19073,14 +19019,14 @@ func (p *parser) callonJoinRightInput2() (any, error) {
 	return p.cur.onJoinRightInput2(stack["s"])
 }
 
-func (c *current) onJoinRightInput12() (any, error) {
+func (c *current) onJoinRightInput11() (any, error) {
 	return nil, nil
 }
 
-func (p *parser) callonJoinRightInput12() (any, error) {
+func (p *parser) callonJoinRightInput11() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinRightInput12()
+	return p.cur.onJoinRightInput11()
 }
 
 func (c *current) onJoinKey3(expr any) (any, error) {
@@ -22173,8 +22119,8 @@ func (p *parser) callonSQLJoinStyle30() (any, error) {
 
 func (c *current) onJoinExpr2(e any) (any, error) {
 
-	return &ast.JoinOn{
-		Kind: "JoinOn",
+	return &ast.JoinOnExpr{
+		Kind: "JoinOnExpr",
 		Expr: e.(ast.Expr),
 	}, nil
 
@@ -22187,8 +22133,8 @@ func (p *parser) callonJoinExpr2() (any, error) {
 }
 
 func (c *current) onJoinExpr9(fields any) (any, error) {
-	return &ast.JoinUsing{
-		Kind:   "JoinUsing",
+	return &ast.JoinUsingExpr{
+		Kind:   "JoinUsingExpr",
 		Fields: sliceOf[ast.Expr](fields),
 	}, nil
 

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -525,18 +525,15 @@ ShapeOp
     }
 
 JoinOp
-  = style:JoinStyle JOIN rightInput:JoinRightInput ON _ key:JoinKey optKey:(__ ("==" / "=") __ JoinKey)? optArgs:(_ FlexAssignments)? {
+  = style:JoinStyle JOIN rightInput:JoinRightInput e:JoinExpr optArgs:(_ FlexAssignments)? {
       o := &ast.Join{
         Kind: "Join",
         Style: style.(string),
-        LeftKey: key.(ast.Expr),
+        Cond: e.(ast.JoinExpr),
         Loc: loc(c),
       }
       if rightInput != nil {
         o.RightInput = sliceOf[ast.Op](rightInput)
-      }
-      if optKey != nil {
-        o.RightKey = optKey.([]any)[3].(ast.Expr)
       }
       if optArgs != nil {
         o.Args = sliceOf[ast.Assignment](optArgs.([]any)[1])
@@ -552,8 +549,8 @@ JoinStyle
   / ""        { return "inner", nil }
 
 JoinRightInput
-  = __ "(" __ s:Seq __ ")" __ { return s, nil }
-  / _ { return nil, nil }
+  = __ "(" __ s:Seq __ ")" { return s, nil }
+  / "" { return nil, nil }
 
 JoinKey
   = Lval
@@ -2036,14 +2033,14 @@ SQLJoinStyle
 
 JoinExpr 
   = _ ON _ e:Expr { 
-        return &ast.JoinOn{
-            Kind: "JoinOn", 
+        return &ast.JoinOnExpr{
+            Kind: "JoinOnExpr", 
             Expr: e.(ast.Expr),
         }, nil
     }
-  / _ USING __ "(" __ fields:FieldExprs __ ")" {
-        return &ast.JoinUsing{
-            Kind: "JoinUsing",
+  / _ USING __ "(" __ fields:Lvals __ ")" {
+        return &ast.JoinUsingExpr{
+            Kind: "JoinUsingExpr",
             Fields: sliceOf[ast.Expr](fields),
         }, nil
     }

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -778,10 +778,10 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) dag.Seq {
 		return append(seq, &dag.Fuse{Kind: "Fuse"})
 	case *ast.Join:
 		rightInput := a.semSeq(o.RightInput)
-		leftKey := a.semExpr(o.LeftKey)
-		rightKey := leftKey
-		if o.RightKey != nil {
-			rightKey = a.semExpr(o.RightKey)
+		leftKey, rightKey, err := a.semJoinCond(o.Cond)
+		if err != nil {
+			a.error(o.Cond, err)
+			return append(seq, badOp())
 		}
 		join := &dag.Join{
 			Kind:     "Join",

--- a/compiler/ztests/sql/readme-query.yaml
+++ b/compiler/ztests/sql/readme-query.yaml
@@ -5,16 +5,16 @@ inputs:
   - name: query.sql
     data: |
       FROM gha.jsup
-      | SELECT union(repo.name) AS repo, actor.login AS user
+      | SELECT union(repo.name) AS repos, actor.login AS user
         GROUP BY user
-        ORDER BY len(repo) DESC
+        ORDER BY len(repos) DESC
         LIMIT 2
       | FORK (
         => FROM eval(f'{user}.jsup')
         | SELECT VALUE {user:login,created_at:time(created_at)}
         => PASS
         )
-      | JOIN USING (user)
+      | JOIN USING (user) repos
   - name: gha.jsup
     data: |
       {repo:{name:"petroav/6.828"},actor:{login:"petroav"}}
@@ -37,5 +37,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {user:"izuzero",created_at:2024-11-13T02:13:58.281661Z}
-      {user:"rspt",created_at:2024-11-13T02:14:27.813538Z}
+      {user:"izuzero",created_at:2024-11-13T02:13:58.281661Z,repos:|["zhouzhi2015/temp","izuzero/xe-module-ajaxboard"]|}
+      {user:"rspt",created_at:2024-11-13T02:14:27.813538Z,repos:|["rspt/rspt-theme","winterbe/streamjs","jdilt/jdilt.github.io"]|}

--- a/compiler/ztests/sql/readme-query.yaml
+++ b/compiler/ztests/sql/readme-query.yaml
@@ -1,0 +1,41 @@
+script: |
+  super -z -I query.sql
+
+inputs:
+  - name: query.sql
+    data: |
+      FROM gha.jsup
+      | SELECT union(repo.name) AS repo, actor.login AS user
+        GROUP BY user
+        ORDER BY len(repo) DESC
+        LIMIT 2
+      | FORK (
+        => FROM eval(f'{user}.jsup')
+        | SELECT VALUE {user:login,created_at:time(created_at)}
+        => PASS
+        )
+      | JOIN USING (user)
+  - name: gha.jsup
+    data: |
+      {repo:{name:"petroav/6.828"},actor:{login:"petroav"}}
+      {repo:{name:"rspt/rspt-theme"},actor:{login:"rspt"}}
+      {repo:{name:"izuzero/xe-module-ajaxboard"},actor:{login:"izuzero"}}
+      {repo:{name:"visionmedia/debug"},actor:{login:"SametSisartenep"}}
+      {repo:{name:"winterbe/streamjs"},actor:{login:"rspt"}}
+      {repo:{name:"hermanwahyudi/selenium"},actor:{login:"hermanwahyudi"}}
+      {repo:{name:"jdilt/jdilt.github.io"},actor:{login:"rspt"}}
+      {repo:{name:"sundaymtn/waterline"},actor:{login:"sundaymtn"}}
+      {repo:{name:"zhouzhi2015/temp"},actor:{login:"izuzero"}}
+      {repo:{name:"petrkutalek/png2pos"},actor:{login:"petrkutalek"}}
+  - name: izuzero.jsup
+    data: |
+      {login:"izuzero",created_at:"2024-11-13T02:13:58.281661Z"}
+  - name: rspt.jsup
+    data: |
+      {login:"rspt",created_at:"2024-11-13T02:14:27.813538Z"}
+
+outputs:
+  - name: stdout
+    data: |
+      {user:"izuzero",created_at:2024-11-13T02:13:58.281661Z}
+      {user:"rspt",created_at:2024-11-13T02:14:27.813538Z}

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -565,11 +565,14 @@ func (c *canon) op(p ast.Op) {
 			c.flush()
 			c.write(") ")
 		}
-		c.write("on ")
-		c.expr(p.LeftKey, "")
-		if p.RightKey != nil {
-			c.write("=")
-			c.expr(p.RightKey, "")
+		switch cond := p.Cond.(type) {
+		case *ast.JoinOnExpr:
+			c.write("on ")
+			c.expr(cond.Expr, "")
+		case *ast.JoinUsingExpr:
+			c.write("using (")
+			c.exprs(cond.Fields)
+			c.write(")")
 		}
 		if p.Args != nil {
 			c.write(" ")

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -573,6 +573,8 @@ func (c *canon) op(p ast.Op) {
 			c.write("using (")
 			c.exprs(cond.Fields)
 			c.write(")")
+		default:
+			panic(cond)
 		}
 		if p.Args != nil {
 			c.write(" ")


### PR DESCRIPTION
This commit gets the using condition for joins working and now allows the query that is now in the top-level README to work.  We unified some of the join logic between SQL and SPQ and relaxed some of the checking of group-by keys with selection, which had been too aggressive. We also added a test that emulates the README query with smaller data in local files rather than APIs.