### PR TITLE
add SQL syntactic sugar to SPQ pipe operators

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -2947,46 +2947,68 @@ var g = &grammar{
 				expr: &seqExpr{
 					pos: position{line: 387, col: 5, offset: 9418},
 					exprs: []any{
-						&ruleRefExpr{
-							pos:  position{line: 387, col: 5, offset: 9418},
-							name: "SORT",
+						&choiceExpr{
+							pos: position{line: 387, col: 6, offset: 9419},
+							alternatives: []any{
+								&ruleRefExpr{
+									pos:  position{line: 387, col: 6, offset: 9419},
+									name: "SORT",
+								},
+								&seqExpr{
+									pos: position{line: 387, col: 13, offset: 9426},
+									exprs: []any{
+										&ruleRefExpr{
+											pos:  position{line: 387, col: 13, offset: 9426},
+											name: "ORDER",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 387, col: 19, offset: 9432},
+											name: "_",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 387, col: 21, offset: 9434},
+											name: "BY",
+										},
+									},
+								},
+							},
 						},
 						&andExpr{
-							pos: position{line: 387, col: 10, offset: 9423},
+							pos: position{line: 387, col: 25, offset: 9438},
 							expr: &ruleRefExpr{
-								pos:  position{line: 387, col: 11, offset: 9424},
+								pos:  position{line: 387, col: 26, offset: 9439},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 387, col: 16, offset: 9429},
+							pos:   position{line: 387, col: 31, offset: 9444},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 387, col: 21, offset: 9434},
+								pos:  position{line: 387, col: 36, offset: 9449},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 387, col: 30, offset: 9443},
+							pos:   position{line: 387, col: 45, offset: 9458},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 387, col: 36, offset: 9449},
+								pos: position{line: 387, col: 51, offset: 9464},
 								expr: &actionExpr{
-									pos: position{line: 387, col: 37, offset: 9450},
-									run: (*parser).callonSortOp10,
+									pos: position{line: 387, col: 52, offset: 9465},
+									run: (*parser).callonSortOp15,
 									expr: &seqExpr{
-										pos: position{line: 387, col: 37, offset: 9450},
+										pos: position{line: 387, col: 52, offset: 9465},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 387, col: 37, offset: 9450},
+												pos:  position{line: 387, col: 52, offset: 9465},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 387, col: 40, offset: 9453},
+												pos:   position{line: 387, col: 55, offset: 9468},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 387, col: 42, offset: 9455},
-													name: "SortExprs",
+													pos:  position{line: 387, col: 57, offset: 9470},
+													name: "OrderByList",
 												},
 											},
 										},
@@ -3002,30 +3024,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 403, col: 1, offset: 9824},
+			pos:  position{line: 405, col: 1, offset: 9869},
 			expr: &actionExpr{
-				pos: position{line: 403, col: 12, offset: 9835},
+				pos: position{line: 405, col: 12, offset: 9880},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 403, col: 12, offset: 9835},
+					pos:   position{line: 405, col: 12, offset: 9880},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 403, col: 17, offset: 9840},
+						pos: position{line: 405, col: 17, offset: 9885},
 						expr: &actionExpr{
-							pos: position{line: 403, col: 18, offset: 9841},
+							pos: position{line: 405, col: 18, offset: 9886},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 403, col: 18, offset: 9841},
+								pos: position{line: 405, col: 18, offset: 9886},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 403, col: 18, offset: 9841},
+										pos:  position{line: 405, col: 18, offset: 9886},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 403, col: 20, offset: 9843},
+										pos:   position{line: 405, col: 20, offset: 9888},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 403, col: 22, offset: 9845},
+											pos:  position{line: 405, col: 22, offset: 9890},
 											name: "SortArg",
 										},
 									},
@@ -3040,53 +3062,53 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 405, col: 1, offset: 9902},
+			pos:  position{line: 407, col: 1, offset: 9947},
 			expr: &choiceExpr{
-				pos: position{line: 406, col: 5, offset: 9914},
+				pos: position{line: 408, col: 5, offset: 9959},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 406, col: 5, offset: 9914},
+						pos: position{line: 408, col: 5, offset: 9959},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 406, col: 5, offset: 9914},
+							pos:        position{line: 408, col: 5, offset: 9959},
 							val:        "-r",
 							ignoreCase: false,
 							want:       "\"-r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 407, col: 5, offset: 9981},
+						pos: position{line: 409, col: 5, offset: 10026},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 407, col: 5, offset: 9981},
+							pos: position{line: 409, col: 5, offset: 10026},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 407, col: 5, offset: 9981},
+									pos:        position{line: 409, col: 5, offset: 10026},
 									val:        "-nulls",
 									ignoreCase: false,
 									want:       "\"-nulls\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 407, col: 14, offset: 9990},
+									pos:  position{line: 409, col: 14, offset: 10035},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 407, col: 16, offset: 9992},
+									pos:   position{line: 409, col: 16, offset: 10037},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 407, col: 23, offset: 9999},
+										pos: position{line: 409, col: 23, offset: 10044},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 407, col: 24, offset: 10000},
+											pos: position{line: 409, col: 24, offset: 10045},
 											alternatives: []any{
 												&litMatcher{
-													pos:        position{line: 407, col: 24, offset: 10000},
+													pos:        position{line: 409, col: 24, offset: 10045},
 													val:        "first",
 													ignoreCase: false,
 													want:       "\"first\"",
 												},
 												&litMatcher{
-													pos:        position{line: 407, col: 34, offset: 10010},
+													pos:        position{line: 409, col: 34, offset: 10055},
 													val:        "last",
 													ignoreCase: false,
 													want:       "\"last\"",
@@ -3105,44 +3127,44 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 411, col: 1, offset: 10129},
+			pos:  position{line: 413, col: 1, offset: 10174},
 			expr: &actionExpr{
-				pos: position{line: 412, col: 5, offset: 10139},
+				pos: position{line: 414, col: 5, offset: 10184},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 412, col: 5, offset: 10139},
+					pos: position{line: 414, col: 5, offset: 10184},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 412, col: 5, offset: 10139},
+							pos:  position{line: 414, col: 5, offset: 10184},
 							name: "TOP",
 						},
 						&andExpr{
-							pos: position{line: 412, col: 9, offset: 10143},
+							pos: position{line: 414, col: 9, offset: 10188},
 							expr: &ruleRefExpr{
-								pos:  position{line: 412, col: 10, offset: 10144},
+								pos:  position{line: 414, col: 10, offset: 10189},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 412, col: 15, offset: 10149},
+							pos:   position{line: 414, col: 15, offset: 10194},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 412, col: 21, offset: 10155},
+								pos: position{line: 414, col: 21, offset: 10200},
 								expr: &actionExpr{
-									pos: position{line: 412, col: 22, offset: 10156},
+									pos: position{line: 414, col: 22, offset: 10201},
 									run: (*parser).callonTopOp8,
 									expr: &seqExpr{
-										pos: position{line: 412, col: 22, offset: 10156},
+										pos: position{line: 414, col: 22, offset: 10201},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 412, col: 22, offset: 10156},
+												pos:  position{line: 414, col: 22, offset: 10201},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 412, col: 24, offset: 10158},
+												pos:   position{line: 414, col: 24, offset: 10203},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 412, col: 26, offset: 10160},
+													pos:  position{line: 414, col: 26, offset: 10205},
 													name: "Expr",
 												},
 											},
@@ -3152,19 +3174,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 412, col: 51, offset: 10185},
+							pos:   position{line: 414, col: 51, offset: 10230},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 412, col: 57, offset: 10191},
+								pos: position{line: 414, col: 57, offset: 10236},
 								expr: &seqExpr{
-									pos: position{line: 412, col: 58, offset: 10192},
+									pos: position{line: 414, col: 58, offset: 10237},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 412, col: 58, offset: 10192},
+											pos:  position{line: 414, col: 58, offset: 10237},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 412, col: 60, offset: 10194},
+											pos:        position{line: 414, col: 60, offset: 10239},
 											val:        "-flush",
 											ignoreCase: false,
 											want:       "\"-flush\"",
@@ -3174,25 +3196,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 412, col: 71, offset: 10205},
+							pos:   position{line: 414, col: 71, offset: 10250},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 412, col: 78, offset: 10212},
+								pos: position{line: 414, col: 78, offset: 10257},
 								expr: &actionExpr{
-									pos: position{line: 412, col: 79, offset: 10213},
+									pos: position{line: 414, col: 79, offset: 10258},
 									run: (*parser).callonTopOp20,
 									expr: &seqExpr{
-										pos: position{line: 412, col: 79, offset: 10213},
+										pos: position{line: 414, col: 79, offset: 10258},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 412, col: 79, offset: 10213},
+												pos:  position{line: 414, col: 79, offset: 10258},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 412, col: 81, offset: 10215},
+												pos:   position{line: 414, col: 81, offset: 10260},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 412, col: 83, offset: 10217},
+													pos:  position{line: 414, col: 83, offset: 10262},
 													name: "Lvals",
 												},
 											},
@@ -3209,26 +3231,26 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 429, col: 1, offset: 10546},
+			pos:  position{line: 431, col: 1, offset: 10591},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 10556},
+				pos: position{line: 432, col: 5, offset: 10601},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 430, col: 5, offset: 10556},
+					pos: position{line: 432, col: 5, offset: 10601},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 430, col: 5, offset: 10556},
+							pos:  position{line: 432, col: 5, offset: 10601},
 							name: "CUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 430, col: 9, offset: 10560},
+							pos:  position{line: 432, col: 9, offset: 10605},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 430, col: 11, offset: 10562},
+							pos:   position{line: 432, col: 11, offset: 10607},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 430, col: 16, offset: 10567},
+								pos:  position{line: 432, col: 16, offset: 10612},
 								name: "FlexAssignments",
 							},
 						},
@@ -3240,26 +3262,26 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 438, col: 1, offset: 10715},
+			pos:  position{line: 440, col: 1, offset: 10760},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 5, offset: 10726},
+				pos: position{line: 441, col: 5, offset: 10771},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 5, offset: 10726},
+					pos: position{line: 441, col: 5, offset: 10771},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 439, col: 5, offset: 10726},
+							pos:  position{line: 441, col: 5, offset: 10771},
 							name: "DROP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 439, col: 10, offset: 10731},
+							pos:  position{line: 441, col: 10, offset: 10776},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 439, col: 12, offset: 10733},
+							pos:   position{line: 441, col: 12, offset: 10778},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 439, col: 17, offset: 10738},
+								pos:  position{line: 441, col: 17, offset: 10783},
 								name: "Lvals",
 							},
 						},
@@ -3271,36 +3293,45 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 447, col: 1, offset: 10878},
+			pos:  position{line: 449, col: 1, offset: 10923},
 			expr: &choiceExpr{
-				pos: position{line: 448, col: 5, offset: 10889},
+				pos: position{line: 450, col: 5, offset: 10934},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 448, col: 5, offset: 10889},
+						pos: position{line: 450, col: 5, offset: 10934},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 448, col: 5, offset: 10889},
+							pos: position{line: 450, col: 5, offset: 10934},
 							exprs: []any{
-								&ruleRefExpr{
-									pos:  position{line: 448, col: 5, offset: 10889},
-									name: "HEAD",
+								&choiceExpr{
+									pos: position{line: 450, col: 6, offset: 10935},
+									alternatives: []any{
+										&ruleRefExpr{
+											pos:  position{line: 450, col: 6, offset: 10935},
+											name: "HEAD",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 450, col: 13, offset: 10942},
+											name: "LIMIT",
+										},
+									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 448, col: 10, offset: 10894},
+									pos:  position{line: 450, col: 20, offset: 10949},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 448, col: 12, offset: 10896},
+									pos: position{line: 450, col: 22, offset: 10951},
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 13, offset: 10897},
+										pos:  position{line: 450, col: 23, offset: 10952},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 448, col: 21, offset: 10905},
+									pos:   position{line: 450, col: 31, offset: 10960},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 27, offset: 10911},
+										pos:  position{line: 450, col: 37, offset: 10966},
 										name: "Expr",
 									},
 								},
@@ -3308,26 +3339,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 455, col: 5, offset: 11041},
-						run: (*parser).callonHeadOp10,
+						pos: position{line: 457, col: 5, offset: 11096},
+						run: (*parser).callonHeadOp12,
 						expr: &seqExpr{
-							pos: position{line: 455, col: 5, offset: 11041},
+							pos: position{line: 457, col: 5, offset: 11096},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 455, col: 5, offset: 11041},
+									pos:  position{line: 457, col: 5, offset: 11096},
 									name: "HEAD",
 								},
 								&notExpr{
-									pos: position{line: 455, col: 10, offset: 11046},
+									pos: position{line: 457, col: 10, offset: 11101},
 									expr: &seqExpr{
-										pos: position{line: 455, col: 12, offset: 11048},
+										pos: position{line: 457, col: 12, offset: 11103},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 455, col: 12, offset: 11048},
+												pos:  position{line: 457, col: 12, offset: 11103},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 455, col: 15, offset: 11051},
+												pos:        position{line: 457, col: 15, offset: 11106},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3336,9 +3367,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 455, col: 20, offset: 11056},
+									pos: position{line: 457, col: 20, offset: 11111},
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 21, offset: 11057},
+										pos:  position{line: 457, col: 21, offset: 11112},
 										name: "EOKW",
 									},
 								},
@@ -3352,36 +3383,36 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 462, col: 1, offset: 11151},
+			pos:  position{line: 464, col: 1, offset: 11206},
 			expr: &choiceExpr{
-				pos: position{line: 463, col: 5, offset: 11162},
+				pos: position{line: 465, col: 5, offset: 11217},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 463, col: 5, offset: 11162},
+						pos: position{line: 465, col: 5, offset: 11217},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 463, col: 5, offset: 11162},
+							pos: position{line: 465, col: 5, offset: 11217},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 463, col: 5, offset: 11162},
+									pos:  position{line: 465, col: 5, offset: 11217},
 									name: "TAIL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 463, col: 10, offset: 11167},
+									pos:  position{line: 465, col: 10, offset: 11222},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 463, col: 12, offset: 11169},
+									pos: position{line: 465, col: 12, offset: 11224},
 									expr: &ruleRefExpr{
-										pos:  position{line: 463, col: 13, offset: 11170},
+										pos:  position{line: 465, col: 13, offset: 11225},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 463, col: 21, offset: 11178},
+									pos:   position{line: 465, col: 21, offset: 11233},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 463, col: 27, offset: 11184},
+										pos:  position{line: 465, col: 27, offset: 11239},
 										name: "Expr",
 									},
 								},
@@ -3389,26 +3420,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 470, col: 5, offset: 11314},
+						pos: position{line: 472, col: 5, offset: 11369},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 470, col: 5, offset: 11314},
+							pos: position{line: 472, col: 5, offset: 11369},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 470, col: 5, offset: 11314},
+									pos:  position{line: 472, col: 5, offset: 11369},
 									name: "TAIL",
 								},
 								&notExpr{
-									pos: position{line: 470, col: 10, offset: 11319},
+									pos: position{line: 472, col: 10, offset: 11374},
 									expr: &seqExpr{
-										pos: position{line: 470, col: 12, offset: 11321},
+										pos: position{line: 472, col: 12, offset: 11376},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 470, col: 12, offset: 11321},
+												pos:  position{line: 472, col: 12, offset: 11376},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 470, col: 15, offset: 11324},
+												pos:        position{line: 472, col: 15, offset: 11379},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3417,9 +3448,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 470, col: 20, offset: 11329},
+									pos: position{line: 472, col: 20, offset: 11384},
 									expr: &ruleRefExpr{
-										pos:  position{line: 470, col: 21, offset: 11330},
+										pos:  position{line: 472, col: 21, offset: 11385},
 										name: "EOKW",
 									},
 								},
@@ -3433,26 +3464,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 477, col: 1, offset: 11424},
+			pos:  position{line: 479, col: 1, offset: 11479},
 			expr: &actionExpr{
-				pos: position{line: 478, col: 5, offset: 11436},
+				pos: position{line: 480, col: 5, offset: 11491},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 478, col: 5, offset: 11436},
+					pos: position{line: 480, col: 5, offset: 11491},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 478, col: 5, offset: 11436},
+							pos:  position{line: 480, col: 5, offset: 11491},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 478, col: 11, offset: 11442},
+							pos:  position{line: 480, col: 11, offset: 11497},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 478, col: 13, offset: 11444},
+							pos:   position{line: 480, col: 13, offset: 11499},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 478, col: 18, offset: 11449},
+								pos:  position{line: 480, col: 18, offset: 11504},
 								name: "Expr",
 							},
 						},
@@ -3464,26 +3495,26 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 486, col: 1, offset: 11576},
+			pos:  position{line: 488, col: 1, offset: 11631},
 			expr: &choiceExpr{
-				pos: position{line: 487, col: 5, offset: 11587},
+				pos: position{line: 489, col: 5, offset: 11642},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 487, col: 5, offset: 11587},
+						pos: position{line: 489, col: 5, offset: 11642},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 487, col: 5, offset: 11587},
+							pos: position{line: 489, col: 5, offset: 11642},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 487, col: 5, offset: 11587},
+									pos:  position{line: 489, col: 5, offset: 11642},
 									name: "UNIQ",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 487, col: 10, offset: 11592},
+									pos:  position{line: 489, col: 10, offset: 11647},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 487, col: 12, offset: 11594},
+									pos:        position{line: 489, col: 12, offset: 11649},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3492,26 +3523,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 490, col: 5, offset: 11679},
+						pos: position{line: 492, col: 5, offset: 11734},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 490, col: 5, offset: 11679},
+							pos: position{line: 492, col: 5, offset: 11734},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 490, col: 5, offset: 11679},
+									pos:  position{line: 492, col: 5, offset: 11734},
 									name: "UNIQ",
 								},
 								&notExpr{
-									pos: position{line: 490, col: 10, offset: 11684},
+									pos: position{line: 492, col: 10, offset: 11739},
 									expr: &seqExpr{
-										pos: position{line: 490, col: 12, offset: 11686},
+										pos: position{line: 492, col: 12, offset: 11741},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 490, col: 12, offset: 11686},
+												pos:  position{line: 492, col: 12, offset: 11741},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 490, col: 15, offset: 11689},
+												pos:        position{line: 492, col: 15, offset: 11744},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3520,9 +3551,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 490, col: 20, offset: 11694},
+									pos: position{line: 492, col: 20, offset: 11749},
 									expr: &ruleRefExpr{
-										pos:  position{line: 490, col: 21, offset: 11695},
+										pos:  position{line: 492, col: 21, offset: 11750},
 										name: "EOKW",
 									},
 								},
@@ -3536,26 +3567,26 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 494, col: 1, offset: 11764},
+			pos:  position{line: 496, col: 1, offset: 11819},
 			expr: &actionExpr{
-				pos: position{line: 495, col: 5, offset: 11774},
+				pos: position{line: 497, col: 5, offset: 11829},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 495, col: 5, offset: 11774},
+					pos: position{line: 497, col: 5, offset: 11829},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 495, col: 5, offset: 11774},
+							pos:  position{line: 497, col: 5, offset: 11829},
 							name: "PUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 495, col: 9, offset: 11778},
+							pos:  position{line: 497, col: 9, offset: 11833},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 495, col: 11, offset: 11780},
+							pos:   position{line: 497, col: 11, offset: 11835},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 495, col: 16, offset: 11785},
+								pos:  position{line: 497, col: 16, offset: 11840},
 								name: "Assignments",
 							},
 						},
@@ -3567,59 +3598,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 503, col: 1, offset: 11935},
+			pos:  position{line: 505, col: 1, offset: 11990},
 			expr: &actionExpr{
-				pos: position{line: 504, col: 5, offset: 11948},
+				pos: position{line: 506, col: 5, offset: 12003},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 504, col: 5, offset: 11948},
+					pos: position{line: 506, col: 5, offset: 12003},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 504, col: 5, offset: 11948},
+							pos:  position{line: 506, col: 5, offset: 12003},
 							name: "RENAME",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 504, col: 12, offset: 11955},
+							pos:  position{line: 506, col: 12, offset: 12010},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 504, col: 14, offset: 11957},
+							pos:   position{line: 506, col: 14, offset: 12012},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 504, col: 20, offset: 11963},
+								pos:  position{line: 506, col: 20, offset: 12018},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 504, col: 31, offset: 11974},
+							pos:   position{line: 506, col: 31, offset: 12029},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 504, col: 36, offset: 11979},
+								pos: position{line: 506, col: 36, offset: 12034},
 								expr: &actionExpr{
-									pos: position{line: 504, col: 37, offset: 11980},
+									pos: position{line: 506, col: 37, offset: 12035},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 504, col: 37, offset: 11980},
+										pos: position{line: 506, col: 37, offset: 12035},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 504, col: 37, offset: 11980},
+												pos:  position{line: 506, col: 37, offset: 12035},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 504, col: 40, offset: 11983},
+												pos:        position{line: 506, col: 40, offset: 12038},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 504, col: 44, offset: 11987},
+												pos:  position{line: 506, col: 44, offset: 12042},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 504, col: 47, offset: 11990},
+												pos:   position{line: 506, col: 47, offset: 12045},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 504, col: 50, offset: 11993},
+													pos:  position{line: 506, col: 50, offset: 12048},
 													name: "Assignment",
 												},
 											},
@@ -3636,28 +3667,28 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 517, col: 1, offset: 12458},
+			pos:  position{line: 519, col: 1, offset: 12513},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 5, offset: 12469},
+				pos: position{line: 520, col: 5, offset: 12524},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 518, col: 5, offset: 12469},
+					pos: position{line: 520, col: 5, offset: 12524},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 518, col: 5, offset: 12469},
+							pos:  position{line: 520, col: 5, offset: 12524},
 							name: "FUSE",
 						},
 						&notExpr{
-							pos: position{line: 518, col: 10, offset: 12474},
+							pos: position{line: 520, col: 10, offset: 12529},
 							expr: &seqExpr{
-								pos: position{line: 518, col: 12, offset: 12476},
+								pos: position{line: 520, col: 12, offset: 12531},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 518, col: 12, offset: 12476},
+										pos:  position{line: 520, col: 12, offset: 12531},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 518, col: 15, offset: 12479},
+										pos:        position{line: 520, col: 15, offset: 12534},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3666,9 +3697,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 518, col: 20, offset: 12484},
+							pos: position{line: 520, col: 20, offset: 12539},
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 21, offset: 12485},
+								pos:  position{line: 520, col: 21, offset: 12540},
 								name: "EOKW",
 							},
 						},
@@ -3680,28 +3711,28 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 522, col: 1, offset: 12554},
+			pos:  position{line: 524, col: 1, offset: 12609},
 			expr: &actionExpr{
-				pos: position{line: 523, col: 5, offset: 12566},
+				pos: position{line: 525, col: 5, offset: 12621},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 523, col: 5, offset: 12566},
+					pos: position{line: 525, col: 5, offset: 12621},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 523, col: 5, offset: 12566},
+							pos:  position{line: 525, col: 5, offset: 12621},
 							name: "SHAPE",
 						},
 						&notExpr{
-							pos: position{line: 523, col: 11, offset: 12572},
+							pos: position{line: 525, col: 11, offset: 12627},
 							expr: &seqExpr{
-								pos: position{line: 523, col: 13, offset: 12574},
+								pos: position{line: 525, col: 13, offset: 12629},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 523, col: 13, offset: 12574},
+										pos:  position{line: 525, col: 13, offset: 12629},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 523, col: 16, offset: 12577},
+										pos:        position{line: 525, col: 16, offset: 12632},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3710,9 +3741,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 523, col: 21, offset: 12582},
+							pos: position{line: 525, col: 21, offset: 12637},
 							expr: &ruleRefExpr{
-								pos:  position{line: 523, col: 22, offset: 12583},
+								pos:  position{line: 525, col: 22, offset: 12638},
 								name: "EOKW",
 							},
 						},
@@ -3724,55 +3755,55 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 527, col: 1, offset: 12654},
+			pos:  position{line: 529, col: 1, offset: 12709},
 			expr: &actionExpr{
-				pos: position{line: 528, col: 5, offset: 12665},
+				pos: position{line: 530, col: 5, offset: 12720},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 528, col: 5, offset: 12665},
+					pos: position{line: 530, col: 5, offset: 12720},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 528, col: 5, offset: 12665},
+							pos:   position{line: 530, col: 5, offset: 12720},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 11, offset: 12671},
+								pos:  position{line: 530, col: 11, offset: 12726},
 								name: "JoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 528, col: 21, offset: 12681},
+							pos:  position{line: 530, col: 21, offset: 12736},
 							name: "JOIN",
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 26, offset: 12686},
+							pos:   position{line: 530, col: 26, offset: 12741},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 37, offset: 12697},
+								pos:  position{line: 530, col: 37, offset: 12752},
 								name: "JoinRightInput",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 52, offset: 12712},
+							pos:   position{line: 530, col: 52, offset: 12767},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 54, offset: 12714},
+								pos:  position{line: 530, col: 54, offset: 12769},
 								name: "JoinExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 63, offset: 12723},
+							pos:   position{line: 530, col: 63, offset: 12778},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 528, col: 71, offset: 12731},
+								pos: position{line: 530, col: 71, offset: 12786},
 								expr: &seqExpr{
-									pos: position{line: 528, col: 72, offset: 12732},
+									pos: position{line: 530, col: 72, offset: 12787},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 528, col: 72, offset: 12732},
+											pos:  position{line: 530, col: 72, offset: 12787},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 528, col: 74, offset: 12734},
+											pos:  position{line: 530, col: 74, offset: 12789},
 											name: "FlexAssignments",
 										},
 									},
@@ -3787,83 +3818,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 544, col: 1, offset: 13100},
+			pos:  position{line: 546, col: 1, offset: 13155},
 			expr: &choiceExpr{
-				pos: position{line: 545, col: 5, offset: 13114},
+				pos: position{line: 547, col: 5, offset: 13169},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 545, col: 5, offset: 13114},
+						pos: position{line: 547, col: 5, offset: 13169},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 545, col: 5, offset: 13114},
+							pos: position{line: 547, col: 5, offset: 13169},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 5, offset: 13114},
+									pos:  position{line: 547, col: 5, offset: 13169},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 10, offset: 13119},
+									pos:  position{line: 547, col: 10, offset: 13174},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 546, col: 5, offset: 13149},
+						pos: position{line: 548, col: 5, offset: 13204},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 546, col: 5, offset: 13149},
+							pos: position{line: 548, col: 5, offset: 13204},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 5, offset: 13149},
+									pos:  position{line: 548, col: 5, offset: 13204},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 11, offset: 13155},
+									pos:  position{line: 548, col: 11, offset: 13210},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 13185},
+						pos: position{line: 549, col: 5, offset: 13240},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 5, offset: 13185},
+							pos: position{line: 549, col: 5, offset: 13240},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 5, offset: 13185},
+									pos:  position{line: 549, col: 5, offset: 13240},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 11, offset: 13191},
+									pos:  position{line: 549, col: 11, offset: 13246},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 13220},
+						pos: position{line: 550, col: 5, offset: 13275},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 548, col: 5, offset: 13220},
+							pos: position{line: 550, col: 5, offset: 13275},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 5, offset: 13220},
+									pos:  position{line: 550, col: 5, offset: 13275},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 11, offset: 13226},
+									pos:  position{line: 550, col: 11, offset: 13281},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 549, col: 5, offset: 13256},
+						pos: position{line: 551, col: 5, offset: 13311},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 549, col: 5, offset: 13256},
+							pos:        position{line: 551, col: 5, offset: 13311},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3876,44 +3907,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 551, col: 1, offset: 13291},
+			pos:  position{line: 553, col: 1, offset: 13346},
 			expr: &choiceExpr{
-				pos: position{line: 552, col: 5, offset: 13310},
+				pos: position{line: 554, col: 5, offset: 13365},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 552, col: 5, offset: 13310},
+						pos: position{line: 554, col: 5, offset: 13365},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 552, col: 5, offset: 13310},
+							pos: position{line: 554, col: 5, offset: 13365},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 552, col: 5, offset: 13310},
+									pos:  position{line: 554, col: 5, offset: 13365},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 552, col: 8, offset: 13313},
+									pos:        position{line: 554, col: 8, offset: 13368},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 552, col: 12, offset: 13317},
+									pos:  position{line: 554, col: 12, offset: 13372},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 552, col: 15, offset: 13320},
+									pos:   position{line: 554, col: 15, offset: 13375},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 552, col: 17, offset: 13322},
+										pos:  position{line: 554, col: 17, offset: 13377},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 552, col: 21, offset: 13326},
+									pos:  position{line: 554, col: 21, offset: 13381},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 552, col: 24, offset: 13329},
+									pos:        position{line: 554, col: 24, offset: 13384},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3922,10 +3953,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 553, col: 5, offset: 13355},
+						pos: position{line: 555, col: 5, offset: 13410},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 553, col: 5, offset: 13355},
+							pos:        position{line: 555, col: 5, offset: 13410},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3938,36 +3969,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 555, col: 1, offset: 13379},
+			pos:  position{line: 557, col: 1, offset: 13434},
 			expr: &choiceExpr{
-				pos: position{line: 556, col: 5, offset: 13391},
+				pos: position{line: 558, col: 5, offset: 13446},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 556, col: 5, offset: 13391},
+						pos:  position{line: 558, col: 5, offset: 13446},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 557, col: 5, offset: 13400},
+						pos: position{line: 559, col: 5, offset: 13455},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 557, col: 5, offset: 13400},
+							pos: position{line: 559, col: 5, offset: 13455},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 557, col: 5, offset: 13400},
+									pos:        position{line: 559, col: 5, offset: 13455},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 557, col: 9, offset: 13404},
+									pos:   position{line: 559, col: 9, offset: 13459},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 557, col: 14, offset: 13409},
+										pos:  position{line: 559, col: 14, offset: 13464},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 557, col: 19, offset: 13414},
+									pos:        position{line: 559, col: 19, offset: 13469},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3982,44 +4013,44 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 559, col: 1, offset: 13440},
+			pos:  position{line: 561, col: 1, offset: 13495},
 			expr: &actionExpr{
-				pos: position{line: 560, col: 5, offset: 13453},
+				pos: position{line: 562, col: 5, offset: 13508},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 560, col: 5, offset: 13453},
+					pos: position{line: 562, col: 5, offset: 13508},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 560, col: 5, offset: 13453},
+							pos:  position{line: 562, col: 5, offset: 13508},
 							name: "SAMPLE",
 						},
 						&andExpr{
-							pos: position{line: 560, col: 12, offset: 13460},
+							pos: position{line: 562, col: 12, offset: 13515},
 							expr: &ruleRefExpr{
-								pos:  position{line: 560, col: 13, offset: 13461},
+								pos:  position{line: 562, col: 13, offset: 13516},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 560, col: 18, offset: 13466},
+							pos:   position{line: 562, col: 18, offset: 13521},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 560, col: 23, offset: 13471},
+								pos: position{line: 562, col: 23, offset: 13526},
 								expr: &actionExpr{
-									pos: position{line: 560, col: 24, offset: 13472},
+									pos: position{line: 562, col: 24, offset: 13527},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 560, col: 24, offset: 13472},
+										pos: position{line: 562, col: 24, offset: 13527},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 560, col: 24, offset: 13472},
+												pos:  position{line: 562, col: 24, offset: 13527},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 560, col: 26, offset: 13474},
+												pos:   position{line: 562, col: 26, offset: 13529},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 560, col: 28, offset: 13476},
+													pos:  position{line: 562, col: 28, offset: 13531},
 													name: "Lval",
 												},
 											},
@@ -4036,15 +4067,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 573, col: 1, offset: 13914},
+			pos:  position{line: 575, col: 1, offset: 13969},
 			expr: &actionExpr{
-				pos: position{line: 574, col: 5, offset: 13931},
+				pos: position{line: 576, col: 5, offset: 13986},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 574, col: 5, offset: 13931},
+					pos:   position{line: 576, col: 5, offset: 13986},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 574, col: 7, offset: 13933},
+						pos:  position{line: 576, col: 7, offset: 13988},
 						name: "Assignments",
 					},
 				},
@@ -4054,69 +4085,69 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 582, col: 1, offset: 14105},
+			pos:  position{line: 584, col: 1, offset: 14160},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 5, offset: 14116},
+				pos: position{line: 585, col: 5, offset: 14171},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 583, col: 5, offset: 14116},
+					pos: position{line: 585, col: 5, offset: 14171},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 5, offset: 14116},
+							pos:  position{line: 585, col: 5, offset: 14171},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 10, offset: 14121},
+							pos:  position{line: 585, col: 10, offset: 14176},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 12, offset: 14123},
+							pos:   position{line: 585, col: 12, offset: 14178},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 17, offset: 14128},
+								pos:  position{line: 585, col: 17, offset: 14183},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 22, offset: 14133},
+							pos:   position{line: 585, col: 22, offset: 14188},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 583, col: 29, offset: 14140},
+								pos: position{line: 585, col: 29, offset: 14195},
 								expr: &ruleRefExpr{
-									pos:  position{line: 583, col: 29, offset: 14140},
+									pos:  position{line: 585, col: 29, offset: 14195},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 41, offset: 14152},
+							pos:   position{line: 585, col: 41, offset: 14207},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 583, col: 48, offset: 14159},
+								pos: position{line: 585, col: 48, offset: 14214},
 								expr: &ruleRefExpr{
-									pos:  position{line: 583, col: 48, offset: 14159},
+									pos:  position{line: 585, col: 48, offset: 14214},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 59, offset: 14170},
+							pos:   position{line: 585, col: 59, offset: 14225},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 583, col: 67, offset: 14178},
+								pos: position{line: 585, col: 67, offset: 14233},
 								expr: &ruleRefExpr{
-									pos:  position{line: 583, col: 67, offset: 14178},
+									pos:  position{line: 585, col: 67, offset: 14233},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 79, offset: 14190},
+							pos:   position{line: 585, col: 79, offset: 14245},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 583, col: 84, offset: 14195},
+								pos: position{line: 585, col: 84, offset: 14250},
 								expr: &ruleRefExpr{
-									pos:  position{line: 583, col: 84, offset: 14195},
+									pos:  position{line: 585, col: 84, offset: 14250},
 									name: "MetaArg",
 								},
 							},
@@ -4129,30 +4160,30 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 595, col: 1, offset: 14477},
+			pos:  position{line: 597, col: 1, offset: 14532},
 			expr: &actionExpr{
-				pos: position{line: 596, col: 5, offset: 14491},
+				pos: position{line: 598, col: 5, offset: 14546},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 596, col: 5, offset: 14491},
+					pos: position{line: 598, col: 5, offset: 14546},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 596, col: 5, offset: 14491},
+							pos:  position{line: 598, col: 5, offset: 14546},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 596, col: 7, offset: 14493},
+							pos:  position{line: 598, col: 7, offset: 14548},
 							name: "AUTHOR",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 596, col: 14, offset: 14500},
+							pos:  position{line: 598, col: 14, offset: 14555},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 596, col: 16, offset: 14502},
+							pos:   position{line: 598, col: 16, offset: 14557},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 596, col: 18, offset: 14504},
+								pos:  position{line: 598, col: 18, offset: 14559},
 								name: "Name",
 							},
 						},
@@ -4164,30 +4195,30 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 598, col: 1, offset: 14528},
+			pos:  position{line: 600, col: 1, offset: 14583},
 			expr: &actionExpr{
-				pos: position{line: 599, col: 5, offset: 14543},
+				pos: position{line: 601, col: 5, offset: 14598},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 599, col: 5, offset: 14543},
+					pos: position{line: 601, col: 5, offset: 14598},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 5, offset: 14543},
+							pos:  position{line: 601, col: 5, offset: 14598},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 7, offset: 14545},
+							pos:  position{line: 601, col: 7, offset: 14600},
 							name: "MESSAGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 599, col: 15, offset: 14553},
+							pos:  position{line: 601, col: 15, offset: 14608},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 599, col: 17, offset: 14555},
+							pos:   position{line: 601, col: 17, offset: 14610},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 599, col: 19, offset: 14557},
+								pos:  position{line: 601, col: 19, offset: 14612},
 								name: "Name",
 							},
 						},
@@ -4199,30 +4230,30 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 601, col: 1, offset: 14581},
+			pos:  position{line: 603, col: 1, offset: 14636},
 			expr: &actionExpr{
-				pos: position{line: 602, col: 5, offset: 14593},
+				pos: position{line: 604, col: 5, offset: 14648},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 602, col: 5, offset: 14593},
+					pos: position{line: 604, col: 5, offset: 14648},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 602, col: 5, offset: 14593},
+							pos:  position{line: 604, col: 5, offset: 14648},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 602, col: 7, offset: 14595},
+							pos:  position{line: 604, col: 7, offset: 14650},
 							name: "META",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 602, col: 12, offset: 14600},
+							pos:  position{line: 604, col: 12, offset: 14655},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 602, col: 14, offset: 14602},
+							pos:   position{line: 604, col: 14, offset: 14657},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 602, col: 16, offset: 14604},
+								pos:  position{line: 604, col: 16, offset: 14659},
 								name: "Name",
 							},
 						},
@@ -4234,24 +4265,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 604, col: 1, offset: 14628},
+			pos:  position{line: 606, col: 1, offset: 14683},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 5, offset: 14643},
+				pos: position{line: 607, col: 5, offset: 14698},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 5, offset: 14643},
+					pos: position{line: 607, col: 5, offset: 14698},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 605, col: 5, offset: 14643},
+							pos:        position{line: 607, col: 5, offset: 14698},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 605, col: 9, offset: 14647},
+							pos:   position{line: 607, col: 9, offset: 14702},
 							label: "branch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 605, col: 16, offset: 14654},
+								pos:  position{line: 607, col: 16, offset: 14709},
 								name: "Name",
 							},
 						},
@@ -4263,26 +4294,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 607, col: 1, offset: 14683},
+			pos:  position{line: 609, col: 1, offset: 14738},
 			expr: &actionExpr{
-				pos: position{line: 608, col: 5, offset: 14696},
+				pos: position{line: 610, col: 5, offset: 14751},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 608, col: 5, offset: 14696},
+					pos: position{line: 610, col: 5, offset: 14751},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 608, col: 5, offset: 14696},
+							pos:  position{line: 610, col: 5, offset: 14751},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 608, col: 12, offset: 14703},
+							pos:  position{line: 610, col: 12, offset: 14758},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 608, col: 14, offset: 14705},
+							pos:   position{line: 610, col: 14, offset: 14760},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 608, col: 19, offset: 14710},
+								pos:  position{line: 610, col: 19, offset: 14765},
 								name: "Identifier",
 							},
 						},
@@ -4294,44 +4325,44 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 616, col: 1, offset: 14844},
+			pos:  position{line: 618, col: 1, offset: 14899},
 			expr: &actionExpr{
-				pos: position{line: 617, col: 5, offset: 14856},
+				pos: position{line: 619, col: 5, offset: 14911},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 617, col: 5, offset: 14856},
+					pos: position{line: 619, col: 5, offset: 14911},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 5, offset: 14856},
+							pos:  position{line: 619, col: 5, offset: 14911},
 							name: "DEBUG",
 						},
 						&andExpr{
-							pos: position{line: 617, col: 11, offset: 14862},
+							pos: position{line: 619, col: 11, offset: 14917},
 							expr: &ruleRefExpr{
-								pos:  position{line: 617, col: 12, offset: 14863},
+								pos:  position{line: 619, col: 12, offset: 14918},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 617, col: 17, offset: 14868},
+							pos:   position{line: 619, col: 17, offset: 14923},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 617, col: 22, offset: 14873},
+								pos: position{line: 619, col: 22, offset: 14928},
 								expr: &actionExpr{
-									pos: position{line: 617, col: 23, offset: 14874},
+									pos: position{line: 619, col: 23, offset: 14929},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 617, col: 23, offset: 14874},
+										pos: position{line: 619, col: 23, offset: 14929},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 617, col: 23, offset: 14874},
+												pos:  position{line: 619, col: 23, offset: 14929},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 617, col: 25, offset: 14876},
+												pos:   position{line: 619, col: 25, offset: 14931},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 617, col: 27, offset: 14878},
+													pos:  position{line: 619, col: 27, offset: 14933},
 													name: "Expr",
 												},
 											},
@@ -4348,26 +4379,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 628, col: 1, offset: 15071},
+			pos:  position{line: 630, col: 1, offset: 15126},
 			expr: &actionExpr{
-				pos: position{line: 629, col: 5, offset: 15082},
+				pos: position{line: 631, col: 5, offset: 15137},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 629, col: 5, offset: 15082},
+					pos: position{line: 631, col: 5, offset: 15137},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 629, col: 5, offset: 15082},
+							pos:  position{line: 631, col: 5, offset: 15137},
 							name: "FromKeyWord",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 629, col: 17, offset: 15094},
+							pos:  position{line: 631, col: 17, offset: 15149},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 19, offset: 15096},
+							pos:   position{line: 631, col: 19, offset: 15151},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 629, col: 25, offset: 15102},
+								pos:  position{line: 631, col: 25, offset: 15157},
 								name: "FromElems",
 							},
 						},
@@ -4379,16 +4410,16 @@ var g = &grammar{
 		},
 		{
 			name: "FromKeyWord",
-			pos:  position{line: 637, col: 1, offset: 15245},
+			pos:  position{line: 639, col: 1, offset: 15300},
 			expr: &choiceExpr{
-				pos: position{line: 638, col: 5, offset: 15261},
+				pos: position{line: 640, col: 5, offset: 15316},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 638, col: 5, offset: 15261},
+						pos:  position{line: 640, col: 5, offset: 15316},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 639, col: 5, offset: 15270},
+						pos:  position{line: 641, col: 5, offset: 15325},
 						name: "DeprecatedFroms",
 					},
 				},
@@ -4398,24 +4429,24 @@ var g = &grammar{
 		},
 		{
 			name: "DeprecatedFroms",
-			pos:  position{line: 641, col: 1, offset: 15287},
+			pos:  position{line: 643, col: 1, offset: 15342},
 			expr: &choiceExpr{
-				pos: position{line: 641, col: 19, offset: 15305},
+				pos: position{line: 643, col: 19, offset: 15360},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 641, col: 19, offset: 15305},
+						pos:        position{line: 643, col: 19, offset: 15360},
 						val:        "get",
 						ignoreCase: false,
 						want:       "\"get\"",
 					},
 					&litMatcher{
-						pos:        position{line: 641, col: 27, offset: 15313},
+						pos:        position{line: 643, col: 27, offset: 15368},
 						val:        "file",
 						ignoreCase: false,
 						want:       "\"file\"",
 					},
 					&litMatcher{
-						pos:        position{line: 641, col: 36, offset: 15322},
+						pos:        position{line: 643, col: 36, offset: 15377},
 						val:        "pool",
 						ignoreCase: false,
 						want:       "\"pool\"",
@@ -4427,51 +4458,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 643, col: 1, offset: 15330},
+			pos:  position{line: 645, col: 1, offset: 15385},
 			expr: &actionExpr{
-				pos: position{line: 644, col: 5, offset: 15344},
+				pos: position{line: 646, col: 5, offset: 15399},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 644, col: 5, offset: 15344},
+					pos: position{line: 646, col: 5, offset: 15399},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 644, col: 5, offset: 15344},
+							pos:   position{line: 646, col: 5, offset: 15399},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 644, col: 11, offset: 15350},
+								pos:  position{line: 646, col: 11, offset: 15405},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 644, col: 20, offset: 15359},
+							pos:   position{line: 646, col: 20, offset: 15414},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 644, col: 25, offset: 15364},
+								pos: position{line: 646, col: 25, offset: 15419},
 								expr: &actionExpr{
-									pos: position{line: 644, col: 27, offset: 15366},
+									pos: position{line: 646, col: 27, offset: 15421},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 644, col: 27, offset: 15366},
+										pos: position{line: 646, col: 27, offset: 15421},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 644, col: 27, offset: 15366},
+												pos:  position{line: 646, col: 27, offset: 15421},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 644, col: 30, offset: 15369},
+												pos:        position{line: 646, col: 30, offset: 15424},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 644, col: 34, offset: 15373},
+												pos:  position{line: 646, col: 34, offset: 15428},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 644, col: 37, offset: 15376},
+												pos:   position{line: 646, col: 37, offset: 15431},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 644, col: 42, offset: 15381},
+													pos:  position{line: 646, col: 42, offset: 15436},
 													name: "FromElem",
 												},
 											},
@@ -4488,42 +4519,42 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 648, col: 1, offset: 15465},
+			pos:  position{line: 650, col: 1, offset: 15520},
 			expr: &actionExpr{
-				pos: position{line: 649, col: 5, offset: 15478},
+				pos: position{line: 651, col: 5, offset: 15533},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 649, col: 5, offset: 15478},
+					pos: position{line: 651, col: 5, offset: 15533},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 649, col: 5, offset: 15478},
+							pos:   position{line: 651, col: 5, offset: 15533},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 12, offset: 15485},
+								pos:  position{line: 651, col: 12, offset: 15540},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 23, offset: 15496},
+							pos:   position{line: 651, col: 23, offset: 15551},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 28, offset: 15501},
+								pos:  position{line: 651, col: 28, offset: 15556},
 								name: "FromArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 37, offset: 15510},
+							pos:   position{line: 651, col: 37, offset: 15565},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 39, offset: 15512},
+								pos:  position{line: 651, col: 39, offset: 15567},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 53, offset: 15526},
+							pos:   position{line: 651, col: 53, offset: 15581},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 59, offset: 15532},
+								pos:  position{line: 651, col: 59, offset: 15587},
 								name: "OptAlias",
 							},
 						},
@@ -4535,46 +4566,46 @@ var g = &grammar{
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 667, col: 1, offset: 15920},
+			pos:  position{line: 669, col: 1, offset: 15975},
 			expr: &choiceExpr{
-				pos: position{line: 668, col: 5, offset: 15935},
+				pos: position{line: 670, col: 5, offset: 15990},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 15935},
+						pos: position{line: 670, col: 5, offset: 15990},
 						run: (*parser).callonFromEntity2,
 						expr: &labeledExpr{
-							pos:   position{line: 668, col: 5, offset: 15935},
+							pos:   position{line: 670, col: 5, offset: 15990},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 668, col: 9, offset: 15939},
+								pos:  position{line: 670, col: 9, offset: 15994},
 								name: "UnquotedURL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 675, col: 5, offset: 16071},
+						pos:  position{line: 677, col: 5, offset: 16126},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 676, col: 5, offset: 16082},
+						pos:  position{line: 678, col: 5, offset: 16137},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 677, col: 5, offset: 16091},
+						pos: position{line: 679, col: 5, offset: 16146},
 						run: (*parser).callonFromEntity7,
 						expr: &seqExpr{
-							pos: position{line: 677, col: 5, offset: 16091},
+							pos: position{line: 679, col: 5, offset: 16146},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 677, col: 5, offset: 16091},
+									pos:        position{line: 679, col: 5, offset: 16146},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 677, col: 9, offset: 16095},
+									pos: position{line: 679, col: 9, offset: 16150},
 									expr: &ruleRefExpr{
-										pos:  position{line: 677, col: 10, offset: 16096},
+										pos:  position{line: 679, col: 10, offset: 16151},
 										name: "ExprGuard",
 									},
 								},
@@ -4582,43 +4613,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 678, col: 5, offset: 16177},
+						pos: position{line: 680, col: 5, offset: 16232},
 						run: (*parser).callonFromEntity12,
 						expr: &seqExpr{
-							pos: position{line: 678, col: 5, offset: 16177},
+							pos: position{line: 680, col: 5, offset: 16232},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 678, col: 5, offset: 16177},
+									pos:  position{line: 680, col: 5, offset: 16232},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 678, col: 10, offset: 16182},
+									pos:  position{line: 680, col: 10, offset: 16237},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 678, col: 13, offset: 16185},
+									pos:        position{line: 680, col: 13, offset: 16240},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 678, col: 17, offset: 16189},
+									pos:  position{line: 680, col: 17, offset: 16244},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 678, col: 20, offset: 16192},
+									pos:   position{line: 680, col: 20, offset: 16247},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 678, col: 22, offset: 16194},
+										pos:  position{line: 680, col: 22, offset: 16249},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 678, col: 27, offset: 16199},
+									pos:  position{line: 680, col: 27, offset: 16254},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 678, col: 30, offset: 16202},
+									pos:        position{line: 680, col: 30, offset: 16257},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4627,35 +4658,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 685, col: 5, offset: 16338},
+						pos: position{line: 687, col: 5, offset: 16393},
 						run: (*parser).callonFromEntity22,
 						expr: &labeledExpr{
-							pos:   position{line: 685, col: 5, offset: 16338},
+							pos:   position{line: 687, col: 5, offset: 16393},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 685, col: 10, offset: 16343},
+								pos:  position{line: 687, col: 10, offset: 16398},
 								name: "PoolMeta",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 692, col: 5, offset: 16486},
+						pos: position{line: 694, col: 5, offset: 16541},
 						run: (*parser).callonFromEntity25,
 						expr: &seqExpr{
-							pos: position{line: 692, col: 5, offset: 16486},
+							pos: position{line: 694, col: 5, offset: 16541},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 692, col: 5, offset: 16486},
+									pos:   position{line: 694, col: 5, offset: 16541},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 10, offset: 16491},
+										pos:  position{line: 694, col: 10, offset: 16546},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 692, col: 24, offset: 16505},
+									pos: position{line: 694, col: 24, offset: 16560},
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 25, offset: 16506},
+										pos:  position{line: 694, col: 25, offset: 16561},
 										name: "AliasClause",
 									},
 								},
@@ -4663,35 +4694,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 693, col: 5, offset: 16541},
+						pos: position{line: 695, col: 5, offset: 16596},
 						run: (*parser).callonFromEntity31,
 						expr: &seqExpr{
-							pos: position{line: 693, col: 5, offset: 16541},
+							pos: position{line: 695, col: 5, offset: 16596},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 693, col: 5, offset: 16541},
+									pos:        position{line: 695, col: 5, offset: 16596},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 693, col: 9, offset: 16545},
+									pos:  position{line: 695, col: 9, offset: 16600},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 693, col: 12, offset: 16548},
+									pos:   position{line: 695, col: 12, offset: 16603},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 693, col: 17, offset: 16553},
+										pos:  position{line: 695, col: 17, offset: 16608},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 693, col: 31, offset: 16567},
+									pos:  position{line: 695, col: 31, offset: 16622},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 693, col: 34, offset: 16570},
+									pos:        position{line: 695, col: 34, offset: 16625},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4700,35 +4731,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 694, col: 5, offset: 16599},
+						pos: position{line: 696, col: 5, offset: 16654},
 						run: (*parser).callonFromEntity39,
 						expr: &seqExpr{
-							pos: position{line: 694, col: 5, offset: 16599},
+							pos: position{line: 696, col: 5, offset: 16654},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 694, col: 5, offset: 16599},
+									pos:        position{line: 696, col: 5, offset: 16654},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 694, col: 9, offset: 16603},
+									pos:  position{line: 696, col: 9, offset: 16658},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 694, col: 12, offset: 16606},
+									pos:   position{line: 696, col: 12, offset: 16661},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 14, offset: 16608},
+										pos:  position{line: 696, col: 14, offset: 16663},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 694, col: 22, offset: 16616},
+									pos:  position{line: 696, col: 22, offset: 16671},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 694, col: 25, offset: 16619},
+									pos:        position{line: 696, col: 25, offset: 16674},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4737,13 +4768,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 697, col: 6, offset: 16656},
+						pos: position{line: 699, col: 6, offset: 16711},
 						run: (*parser).callonFromEntity47,
 						expr: &labeledExpr{
-							pos:   position{line: 697, col: 6, offset: 16656},
+							pos:   position{line: 699, col: 6, offset: 16711},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 697, col: 11, offset: 16661},
+								pos:  position{line: 699, col: 11, offset: 16716},
 								name: "Name",
 							},
 						},
@@ -4755,40 +4786,40 @@ var g = &grammar{
 		},
 		{
 			name: "FromArgs",
-			pos:  position{line: 700, col: 1, offset: 16759},
+			pos:  position{line: 702, col: 1, offset: 16814},
 			expr: &choiceExpr{
-				pos: position{line: 701, col: 5, offset: 16772},
+				pos: position{line: 703, col: 5, offset: 16827},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 16772},
+						pos: position{line: 703, col: 5, offset: 16827},
 						run: (*parser).callonFromArgs2,
 						expr: &seqExpr{
-							pos: position{line: 701, col: 5, offset: 16772},
+							pos: position{line: 703, col: 5, offset: 16827},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 701, col: 5, offset: 16772},
+									pos:   position{line: 703, col: 5, offset: 16827},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 12, offset: 16779},
+										pos:  position{line: 703, col: 12, offset: 16834},
 										name: "PoolCommit",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 701, col: 23, offset: 16790},
+									pos:   position{line: 703, col: 23, offset: 16845},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 701, col: 28, offset: 16795},
+										pos: position{line: 703, col: 28, offset: 16850},
 										expr: &ruleRefExpr{
-											pos:  position{line: 701, col: 28, offset: 16795},
+											pos:  position{line: 703, col: 28, offset: 16850},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 701, col: 38, offset: 16805},
+									pos:   position{line: 703, col: 38, offset: 16860},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 42, offset: 16809},
+										pos:  position{line: 703, col: 42, offset: 16864},
 										name: "TapArg",
 									},
 								},
@@ -4796,24 +4827,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 710, col: 5, offset: 17013},
+						pos: position{line: 712, col: 5, offset: 17068},
 						run: (*parser).callonFromArgs11,
 						expr: &seqExpr{
-							pos: position{line: 710, col: 5, offset: 17013},
+							pos: position{line: 712, col: 5, offset: 17068},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 710, col: 5, offset: 17013},
+									pos:   position{line: 712, col: 5, offset: 17068},
 									label: "meta",
 									expr: &ruleRefExpr{
-										pos:  position{line: 710, col: 10, offset: 17018},
+										pos:  position{line: 712, col: 10, offset: 17073},
 										name: "PoolMeta",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 710, col: 19, offset: 17027},
+									pos:   position{line: 712, col: 19, offset: 17082},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 710, col: 23, offset: 17031},
+										pos:  position{line: 712, col: 23, offset: 17086},
 										name: "TapArg",
 									},
 								},
@@ -4821,41 +4852,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 718, col: 5, offset: 17197},
+						pos: position{line: 720, col: 5, offset: 17252},
 						run: (*parser).callonFromArgs17,
 						expr: &seqExpr{
-							pos: position{line: 718, col: 5, offset: 17197},
+							pos: position{line: 720, col: 5, offset: 17252},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 718, col: 5, offset: 17197},
+									pos:   position{line: 720, col: 5, offset: 17252},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 718, col: 12, offset: 17204},
+										pos:  position{line: 720, col: 12, offset: 17259},
 										name: "FormatArg",
 									},
 								},
 								&notExpr{
-									pos: position{line: 718, col: 22, offset: 17214},
+									pos: position{line: 720, col: 22, offset: 17269},
 									expr: &seqExpr{
-										pos: position{line: 718, col: 24, offset: 17216},
+										pos: position{line: 720, col: 24, offset: 17271},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 718, col: 24, offset: 17216},
+												pos:  position{line: 720, col: 24, offset: 17271},
 												name: "_",
 											},
 											&choiceExpr{
-												pos: position{line: 718, col: 27, offset: 17219},
+												pos: position{line: 720, col: 27, offset: 17274},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 718, col: 27, offset: 17219},
+														pos:  position{line: 720, col: 27, offset: 17274},
 														name: "METHOD",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 718, col: 36, offset: 17228},
+														pos:  position{line: 720, col: 36, offset: 17283},
 														name: "HEADERS",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 718, col: 46, offset: 17238},
+														pos:  position{line: 720, col: 46, offset: 17293},
 														name: "BODY",
 													},
 												},
@@ -4867,51 +4898,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 725, col: 5, offset: 17383},
+						pos: position{line: 727, col: 5, offset: 17438},
 						run: (*parser).callonFromArgs28,
 						expr: &seqExpr{
-							pos: position{line: 725, col: 5, offset: 17383},
+							pos: position{line: 727, col: 5, offset: 17438},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 725, col: 5, offset: 17383},
+									pos:   position{line: 727, col: 5, offset: 17438},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 725, col: 12, offset: 17390},
+										pos: position{line: 727, col: 12, offset: 17445},
 										expr: &ruleRefExpr{
-											pos:  position{line: 725, col: 12, offset: 17390},
+											pos:  position{line: 727, col: 12, offset: 17445},
 											name: "FormatArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 725, col: 23, offset: 17401},
+									pos:   position{line: 727, col: 23, offset: 17456},
 									label: "method",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 725, col: 30, offset: 17408},
+										pos: position{line: 727, col: 30, offset: 17463},
 										expr: &ruleRefExpr{
-											pos:  position{line: 725, col: 30, offset: 17408},
+											pos:  position{line: 727, col: 30, offset: 17463},
 											name: "MethodArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 725, col: 41, offset: 17419},
+									pos:   position{line: 727, col: 41, offset: 17474},
 									label: "headers",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 725, col: 49, offset: 17427},
+										pos: position{line: 727, col: 49, offset: 17482},
 										expr: &ruleRefExpr{
-											pos:  position{line: 725, col: 49, offset: 17427},
+											pos:  position{line: 727, col: 49, offset: 17482},
 											name: "HeadersArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 725, col: 61, offset: 17439},
+									pos:   position{line: 727, col: 61, offset: 17494},
 									label: "body",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 725, col: 66, offset: 17444},
+										pos: position{line: 727, col: 66, offset: 17499},
 										expr: &ruleRefExpr{
-											pos:  position{line: 725, col: 66, offset: 17444},
+											pos:  position{line: 727, col: 66, offset: 17499},
 											name: "BodyArg",
 										},
 									},
@@ -4926,30 +4957,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 742, col: 1, offset: 17860},
+			pos:  position{line: 744, col: 1, offset: 17915},
 			expr: &actionExpr{
-				pos: position{line: 742, col: 13, offset: 17872},
+				pos: position{line: 744, col: 13, offset: 17927},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 742, col: 13, offset: 17872},
+					pos: position{line: 744, col: 13, offset: 17927},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 742, col: 13, offset: 17872},
+							pos:  position{line: 744, col: 13, offset: 17927},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 742, col: 15, offset: 17874},
+							pos:  position{line: 744, col: 15, offset: 17929},
 							name: "FORMAT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 742, col: 22, offset: 17881},
+							pos:  position{line: 744, col: 22, offset: 17936},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 742, col: 24, offset: 17883},
+							pos:   position{line: 744, col: 24, offset: 17938},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 742, col: 26, offset: 17885},
+								pos:  position{line: 744, col: 26, offset: 17940},
 								name: "Name",
 							},
 						},
@@ -4961,30 +4992,30 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 744, col: 1, offset: 17909},
+			pos:  position{line: 746, col: 1, offset: 17964},
 			expr: &actionExpr{
-				pos: position{line: 744, col: 13, offset: 17921},
+				pos: position{line: 746, col: 13, offset: 17976},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 744, col: 13, offset: 17921},
+					pos: position{line: 746, col: 13, offset: 17976},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 13, offset: 17921},
+							pos:  position{line: 746, col: 13, offset: 17976},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 15, offset: 17923},
+							pos:  position{line: 746, col: 15, offset: 17978},
 							name: "METHOD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 22, offset: 17930},
+							pos:  position{line: 746, col: 22, offset: 17985},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 744, col: 24, offset: 17932},
+							pos:   position{line: 746, col: 24, offset: 17987},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 744, col: 26, offset: 17934},
+								pos:  position{line: 746, col: 26, offset: 17989},
 								name: "Name",
 							},
 						},
@@ -4996,30 +5027,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 746, col: 1, offset: 17958},
+			pos:  position{line: 748, col: 1, offset: 18013},
 			expr: &actionExpr{
-				pos: position{line: 746, col: 14, offset: 17971},
+				pos: position{line: 748, col: 14, offset: 18026},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 746, col: 14, offset: 17971},
+					pos: position{line: 748, col: 14, offset: 18026},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 14, offset: 17971},
+							pos:  position{line: 748, col: 14, offset: 18026},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 16, offset: 17973},
+							pos:  position{line: 748, col: 16, offset: 18028},
 							name: "HEADERS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 24, offset: 17981},
+							pos:  position{line: 748, col: 24, offset: 18036},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 746, col: 26, offset: 17983},
+							pos:   position{line: 748, col: 26, offset: 18038},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 746, col: 28, offset: 17985},
+								pos:  position{line: 748, col: 28, offset: 18040},
 								name: "Record",
 							},
 						},
@@ -5031,30 +5062,30 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 748, col: 1, offset: 18011},
+			pos:  position{line: 750, col: 1, offset: 18066},
 			expr: &actionExpr{
-				pos: position{line: 748, col: 11, offset: 18021},
+				pos: position{line: 750, col: 11, offset: 18076},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 748, col: 11, offset: 18021},
+					pos: position{line: 750, col: 11, offset: 18076},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 11, offset: 18021},
+							pos:  position{line: 750, col: 11, offset: 18076},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 13, offset: 18023},
+							pos:  position{line: 750, col: 13, offset: 18078},
 							name: "BODY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 18, offset: 18028},
+							pos:  position{line: 750, col: 18, offset: 18083},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 748, col: 20, offset: 18030},
+							pos:   position{line: 750, col: 20, offset: 18085},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 748, col: 22, offset: 18032},
+								pos:  position{line: 750, col: 22, offset: 18087},
 								name: "Name",
 							},
 						},
@@ -5066,24 +5097,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 750, col: 1, offset: 18056},
+			pos:  position{line: 752, col: 1, offset: 18111},
 			expr: &actionExpr{
-				pos: position{line: 750, col: 15, offset: 18070},
+				pos: position{line: 752, col: 15, offset: 18125},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 750, col: 15, offset: 18070},
+					pos: position{line: 752, col: 15, offset: 18125},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 750, col: 16, offset: 18071},
+							pos: position{line: 752, col: 16, offset: 18126},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 750, col: 16, offset: 18071},
+									pos:        position{line: 752, col: 16, offset: 18126},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 750, col: 28, offset: 18083},
+									pos:        position{line: 752, col: 28, offset: 18138},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
@@ -5091,9 +5122,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 750, col: 40, offset: 18095},
+							pos: position{line: 752, col: 40, offset: 18150},
 							expr: &ruleRefExpr{
-								pos:  position{line: 750, col: 40, offset: 18095},
+								pos:  position{line: 752, col: 40, offset: 18150},
 								name: "URLChar",
 							},
 						},
@@ -5105,9 +5136,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 752, col: 1, offset: 18136},
+			pos:  position{line: 754, col: 1, offset: 18191},
 			expr: &charClassMatcher{
-				pos:        position{line: 752, col: 11, offset: 18146},
+				pos:        position{line: 754, col: 11, offset: 18201},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -5119,30 +5150,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 755, col: 1, offset: 18210},
+			pos:  position{line: 757, col: 1, offset: 18265},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 18221},
+				pos: position{line: 758, col: 5, offset: 18276},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 756, col: 5, offset: 18221},
+					pos: position{line: 758, col: 5, offset: 18276},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 5, offset: 18221},
+							pos:  position{line: 758, col: 5, offset: 18276},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 7, offset: 18223},
+							pos:  position{line: 758, col: 7, offset: 18278},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 10, offset: 18226},
+							pos:  position{line: 758, col: 10, offset: 18281},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 12, offset: 18228},
+							pos:   position{line: 758, col: 12, offset: 18283},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 15, offset: 18231},
+								pos:  position{line: 758, col: 15, offset: 18286},
 								name: "KSUID",
 							},
 						},
@@ -5154,14 +5185,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 759, col: 1, offset: 18297},
+			pos:  position{line: 761, col: 1, offset: 18352},
 			expr: &actionExpr{
-				pos: position{line: 759, col: 9, offset: 18305},
+				pos: position{line: 761, col: 9, offset: 18360},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 759, col: 9, offset: 18305},
+					pos: position{line: 761, col: 9, offset: 18360},
 					expr: &charClassMatcher{
-						pos:        position{line: 759, col: 10, offset: 18306},
+						pos:        position{line: 761, col: 10, offset: 18361},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -5174,24 +5205,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 761, col: 1, offset: 18352},
+			pos:  position{line: 763, col: 1, offset: 18407},
 			expr: &actionExpr{
-				pos: position{line: 762, col: 5, offset: 18367},
+				pos: position{line: 764, col: 5, offset: 18422},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 762, col: 5, offset: 18367},
+					pos: position{line: 764, col: 5, offset: 18422},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 762, col: 5, offset: 18367},
+							pos:        position{line: 764, col: 5, offset: 18422},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 762, col: 9, offset: 18371},
+							pos:   position{line: 764, col: 9, offset: 18426},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 762, col: 11, offset: 18373},
+								pos:  position{line: 764, col: 11, offset: 18428},
 								name: "Name",
 							},
 						},
@@ -5203,24 +5234,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 764, col: 1, offset: 18397},
+			pos:  position{line: 766, col: 1, offset: 18452},
 			expr: &actionExpr{
-				pos: position{line: 765, col: 5, offset: 18410},
+				pos: position{line: 767, col: 5, offset: 18465},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 765, col: 5, offset: 18410},
+					pos: position{line: 767, col: 5, offset: 18465},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 765, col: 5, offset: 18410},
+							pos:        position{line: 767, col: 5, offset: 18465},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 9, offset: 18414},
+							pos:   position{line: 767, col: 9, offset: 18469},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 765, col: 11, offset: 18416},
+								pos:  position{line: 767, col: 11, offset: 18471},
 								name: "Name",
 							},
 						},
@@ -5231,172 +5262,33 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "SortExprs",
-			pos:  position{line: 767, col: 1, offset: 18440},
-			expr: &actionExpr{
-				pos: position{line: 768, col: 5, offset: 18454},
-				run: (*parser).callonSortExprs1,
-				expr: &seqExpr{
-					pos: position{line: 768, col: 5, offset: 18454},
-					exprs: []any{
-						&labeledExpr{
-							pos:   position{line: 768, col: 5, offset: 18454},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 11, offset: 18460},
-								name: "SortExpr",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 768, col: 20, offset: 18469},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 768, col: 25, offset: 18474},
-								expr: &actionExpr{
-									pos: position{line: 768, col: 26, offset: 18475},
-									run: (*parser).callonSortExprs7,
-									expr: &seqExpr{
-										pos: position{line: 768, col: 26, offset: 18475},
-										exprs: []any{
-											&ruleRefExpr{
-												pos:  position{line: 768, col: 26, offset: 18475},
-												name: "__",
-											},
-											&litMatcher{
-												pos:        position{line: 768, col: 29, offset: 18478},
-												val:        ",",
-												ignoreCase: false,
-												want:       "\",\"",
-											},
-											&ruleRefExpr{
-												pos:  position{line: 768, col: 33, offset: 18482},
-												name: "__",
-											},
-											&labeledExpr{
-												pos:   position{line: 768, col: 36, offset: 18485},
-												label: "s",
-												expr: &ruleRefExpr{
-													pos:  position{line: 768, col: 38, offset: 18487},
-													name: "SortExpr",
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
-			name: "SortExpr",
-			pos:  position{line: 772, col: 1, offset: 18564},
-			expr: &actionExpr{
-				pos: position{line: 773, col: 5, offset: 18577},
-				run: (*parser).callonSortExpr1,
-				expr: &seqExpr{
-					pos: position{line: 773, col: 5, offset: 18577},
-					exprs: []any{
-						&labeledExpr{
-							pos:   position{line: 773, col: 5, offset: 18577},
-							label: "e",
-							expr: &ruleRefExpr{
-								pos:  position{line: 773, col: 7, offset: 18579},
-								name: "Expr",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 773, col: 12, offset: 18584},
-							label: "order",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 773, col: 18, offset: 18590},
-								expr: &actionExpr{
-									pos: position{line: 773, col: 19, offset: 18591},
-									run: (*parser).callonSortExpr7,
-									expr: &seqExpr{
-										pos: position{line: 773, col: 19, offset: 18591},
-										exprs: []any{
-											&ruleRefExpr{
-												pos:  position{line: 773, col: 19, offset: 18591},
-												name: "_",
-											},
-											&labeledExpr{
-												pos:   position{line: 773, col: 21, offset: 18593},
-												label: "o",
-												expr: &ruleRefExpr{
-													pos:  position{line: 773, col: 23, offset: 18595},
-													name: "OrderSpec",
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
-			name: "OrderSpec",
-			pos:  position{line: 781, col: 1, offset: 18794},
-			expr: &actionExpr{
-				pos: position{line: 782, col: 5, offset: 18808},
-				run: (*parser).callonOrderSpec1,
-				expr: &labeledExpr{
-					pos:   position{line: 782, col: 5, offset: 18808},
-					label: "o",
-					expr: &choiceExpr{
-						pos: position{line: 782, col: 8, offset: 18811},
-						alternatives: []any{
-							&ruleRefExpr{
-								pos:  position{line: 782, col: 8, offset: 18811},
-								name: "ASC",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 782, col: 14, offset: 18817},
-								name: "DESC",
-							},
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
 			name: "TapArg",
-			pos:  position{line: 786, col: 1, offset: 18901},
+			pos:  position{line: 769, col: 1, offset: 18495},
 			expr: &choiceExpr{
-				pos: position{line: 787, col: 5, offset: 18912},
+				pos: position{line: 770, col: 5, offset: 18506},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 787, col: 5, offset: 18912},
+						pos: position{line: 770, col: 5, offset: 18506},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 787, col: 5, offset: 18912},
+							pos: position{line: 770, col: 5, offset: 18506},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 787, col: 5, offset: 18912},
+									pos:  position{line: 770, col: 5, offset: 18506},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 787, col: 7, offset: 18914},
+									pos:  position{line: 770, col: 7, offset: 18508},
 									name: "TAP",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 788, col: 5, offset: 18943},
+						pos: position{line: 771, col: 5, offset: 18537},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 788, col: 5, offset: 18943},
+							pos:        position{line: 771, col: 5, offset: 18537},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -5409,28 +5301,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 790, col: 1, offset: 18969},
+			pos:  position{line: 773, col: 1, offset: 18563},
 			expr: &actionExpr{
-				pos: position{line: 791, col: 5, offset: 18980},
+				pos: position{line: 774, col: 5, offset: 18574},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 791, col: 5, offset: 18980},
+					pos: position{line: 774, col: 5, offset: 18574},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 791, col: 5, offset: 18980},
+							pos:  position{line: 774, col: 5, offset: 18574},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 791, col: 10, offset: 18985},
+							pos: position{line: 774, col: 10, offset: 18579},
 							expr: &seqExpr{
-								pos: position{line: 791, col: 12, offset: 18987},
+								pos: position{line: 774, col: 12, offset: 18581},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 791, col: 12, offset: 18987},
+										pos:  position{line: 774, col: 12, offset: 18581},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 791, col: 15, offset: 18990},
+										pos:        position{line: 774, col: 15, offset: 18584},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5439,9 +5331,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 791, col: 20, offset: 18995},
+							pos: position{line: 774, col: 20, offset: 18589},
 							expr: &ruleRefExpr{
-								pos:  position{line: 791, col: 21, offset: 18996},
+								pos:  position{line: 774, col: 21, offset: 18590},
 								name: "EOKW",
 							},
 						},
@@ -5453,44 +5345,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 797, col: 1, offset: 19187},
+			pos:  position{line: 780, col: 1, offset: 18781},
 			expr: &actionExpr{
-				pos: position{line: 798, col: 5, offset: 19201},
+				pos: position{line: 781, col: 5, offset: 18795},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 798, col: 5, offset: 19201},
+					pos: position{line: 781, col: 5, offset: 18795},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 798, col: 5, offset: 19201},
+							pos:  position{line: 781, col: 5, offset: 18795},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 798, col: 13, offset: 19209},
+							pos:  position{line: 781, col: 13, offset: 18803},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 15, offset: 19211},
+							pos:   position{line: 781, col: 15, offset: 18805},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 798, col: 20, offset: 19216},
+								pos:  position{line: 781, col: 20, offset: 18810},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 26, offset: 19222},
+							pos:   position{line: 781, col: 26, offset: 18816},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 798, col: 30, offset: 19226},
+								pos:  position{line: 781, col: 30, offset: 18820},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 38, offset: 19234},
+							pos:   position{line: 781, col: 38, offset: 18828},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 798, col: 41, offset: 19237},
+								pos: position{line: 781, col: 41, offset: 18831},
 								expr: &ruleRefExpr{
-									pos:  position{line: 798, col: 41, offset: 19237},
+									pos:  position{line: 781, col: 41, offset: 18831},
 									name: "AsArg",
 								},
 							},
@@ -5503,26 +5395,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 811, col: 1, offset: 19479},
+			pos:  position{line: 794, col: 1, offset: 19073},
 			expr: &actionExpr{
-				pos: position{line: 812, col: 5, offset: 19491},
+				pos: position{line: 795, col: 5, offset: 19085},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 812, col: 5, offset: 19491},
+					pos: position{line: 795, col: 5, offset: 19085},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 812, col: 5, offset: 19491},
+							pos:  position{line: 795, col: 5, offset: 19085},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 812, col: 11, offset: 19497},
+							pos:  position{line: 795, col: 11, offset: 19091},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 812, col: 13, offset: 19499},
+							pos:   position{line: 795, col: 13, offset: 19093},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 812, col: 18, offset: 19504},
+								pos:  position{line: 795, col: 18, offset: 19098},
 								name: "Expr",
 							},
 						},
@@ -5534,47 +5426,56 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 820, col: 1, offset: 19631},
+			pos:  position{line: 803, col: 1, offset: 19225},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 5, offset: 19642},
+				pos: position{line: 804, col: 5, offset: 19236},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 821, col: 5, offset: 19642},
+					pos: position{line: 804, col: 5, offset: 19236},
 					exprs: []any{
-						&ruleRefExpr{
-							pos:  position{line: 821, col: 5, offset: 19642},
-							name: "OVER",
+						&choiceExpr{
+							pos: position{line: 804, col: 6, offset: 19237},
+							alternatives: []any{
+								&ruleRefExpr{
+									pos:  position{line: 804, col: 6, offset: 19237},
+									name: "OVER",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 804, col: 13, offset: 19244},
+									name: "UNNEST",
+								},
+							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 10, offset: 19647},
+							pos:  position{line: 804, col: 21, offset: 19252},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 12, offset: 19649},
+							pos:   position{line: 804, col: 23, offset: 19254},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 821, col: 18, offset: 19655},
+								pos:  position{line: 804, col: 29, offset: 19260},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 24, offset: 19661},
+							pos:   position{line: 804, col: 35, offset: 19266},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 821, col: 31, offset: 19668},
+								pos: position{line: 804, col: 42, offset: 19273},
 								expr: &ruleRefExpr{
-									pos:  position{line: 821, col: 31, offset: 19668},
+									pos:  position{line: 804, col: 42, offset: 19273},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 39, offset: 19676},
+							pos:   position{line: 804, col: 50, offset: 19281},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 821, col: 44, offset: 19681},
+								pos: position{line: 804, col: 55, offset: 19286},
 								expr: &ruleRefExpr{
-									pos:  position{line: 821, col: 44, offset: 19681},
+									pos:  position{line: 804, col: 55, offset: 19286},
 									name: "Lateral",
 								},
 							},
@@ -5587,54 +5488,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 836, col: 1, offset: 20006},
+			pos:  position{line: 819, col: 1, offset: 19611},
 			expr: &choiceExpr{
-				pos: position{line: 837, col: 5, offset: 20018},
+				pos: position{line: 820, col: 5, offset: 19623},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 837, col: 5, offset: 20018},
+						pos: position{line: 820, col: 5, offset: 19623},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 837, col: 5, offset: 20018},
+							pos: position{line: 820, col: 5, offset: 19623},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 837, col: 5, offset: 20018},
+									pos:  position{line: 820, col: 5, offset: 19623},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 837, col: 8, offset: 20021},
+									pos:        position{line: 820, col: 8, offset: 19626},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 837, col: 13, offset: 20026},
+									pos:  position{line: 820, col: 13, offset: 19631},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 837, col: 16, offset: 20029},
+									pos:        position{line: 820, col: 16, offset: 19634},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 837, col: 20, offset: 20033},
+									pos:  position{line: 820, col: 20, offset: 19638},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 837, col: 23, offset: 20036},
+									pos:   position{line: 820, col: 23, offset: 19641},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 837, col: 29, offset: 20042},
+										pos:  position{line: 820, col: 29, offset: 19647},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 837, col: 35, offset: 20048},
+									pos:  position{line: 820, col: 35, offset: 19653},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 837, col: 38, offset: 20051},
+									pos:        position{line: 820, col: 38, offset: 19656},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5643,49 +5544,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 840, col: 5, offset: 20132},
+						pos: position{line: 823, col: 5, offset: 19737},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 840, col: 5, offset: 20132},
+							pos: position{line: 823, col: 5, offset: 19737},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 840, col: 5, offset: 20132},
+									pos:  position{line: 823, col: 5, offset: 19737},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 840, col: 8, offset: 20135},
+									pos:        position{line: 823, col: 8, offset: 19740},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 840, col: 13, offset: 20140},
+									pos:  position{line: 823, col: 13, offset: 19745},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 840, col: 16, offset: 20143},
+									pos:        position{line: 823, col: 16, offset: 19748},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 840, col: 20, offset: 20147},
+									pos:  position{line: 823, col: 20, offset: 19752},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 840, col: 23, offset: 20150},
+									pos:   position{line: 823, col: 23, offset: 19755},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 840, col: 27, offset: 20154},
+										pos:  position{line: 823, col: 27, offset: 19759},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 840, col: 31, offset: 20158},
+									pos:  position{line: 823, col: 31, offset: 19763},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 840, col: 34, offset: 20161},
+									pos:        position{line: 823, col: 34, offset: 19766},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5700,63 +5601,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 844, col: 1, offset: 20217},
+			pos:  position{line: 827, col: 1, offset: 19822},
 			expr: &actionExpr{
-				pos: position{line: 845, col: 5, offset: 20228},
+				pos: position{line: 828, col: 5, offset: 19833},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 845, col: 5, offset: 20228},
+					pos: position{line: 828, col: 5, offset: 19833},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 845, col: 5, offset: 20228},
+							pos:  position{line: 828, col: 5, offset: 19833},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 845, col: 7, offset: 20230},
+							pos:  position{line: 828, col: 7, offset: 19835},
 							name: "WITH",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 845, col: 12, offset: 20235},
+							pos:  position{line: 828, col: 12, offset: 19840},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 845, col: 14, offset: 20237},
+							pos:   position{line: 828, col: 14, offset: 19842},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 845, col: 20, offset: 20243},
+								pos:  position{line: 828, col: 20, offset: 19848},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 845, col: 37, offset: 20260},
+							pos:   position{line: 828, col: 37, offset: 19865},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 845, col: 42, offset: 20265},
+								pos: position{line: 828, col: 42, offset: 19870},
 								expr: &actionExpr{
-									pos: position{line: 845, col: 43, offset: 20266},
+									pos: position{line: 828, col: 43, offset: 19871},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 845, col: 43, offset: 20266},
+										pos: position{line: 828, col: 43, offset: 19871},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 845, col: 43, offset: 20266},
+												pos:  position{line: 828, col: 43, offset: 19871},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 845, col: 46, offset: 20269},
+												pos:        position{line: 828, col: 46, offset: 19874},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 845, col: 50, offset: 20273},
+												pos:  position{line: 828, col: 50, offset: 19878},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 845, col: 53, offset: 20276},
+												pos:   position{line: 828, col: 53, offset: 19881},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 845, col: 55, offset: 20278},
+													pos:  position{line: 828, col: 55, offset: 19883},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5773,45 +5674,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 849, col: 1, offset: 20363},
+			pos:  position{line: 832, col: 1, offset: 19968},
 			expr: &actionExpr{
-				pos: position{line: 850, col: 5, offset: 20384},
+				pos: position{line: 833, col: 5, offset: 19989},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 850, col: 5, offset: 20384},
+					pos: position{line: 833, col: 5, offset: 19989},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 850, col: 5, offset: 20384},
+							pos:   position{line: 833, col: 5, offset: 19989},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 850, col: 10, offset: 20389},
+								pos:  position{line: 833, col: 10, offset: 19994},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 850, col: 21, offset: 20400},
+							pos:   position{line: 833, col: 21, offset: 20005},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 850, col: 25, offset: 20404},
+								pos: position{line: 833, col: 25, offset: 20009},
 								expr: &seqExpr{
-									pos: position{line: 850, col: 26, offset: 20405},
+									pos: position{line: 833, col: 26, offset: 20010},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 850, col: 26, offset: 20405},
+											pos:  position{line: 833, col: 26, offset: 20010},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 850, col: 29, offset: 20408},
+											pos:        position{line: 833, col: 29, offset: 20013},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 850, col: 33, offset: 20412},
+											pos:  position{line: 833, col: 33, offset: 20017},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 850, col: 36, offset: 20415},
+											pos:  position{line: 833, col: 36, offset: 20020},
 											name: "Expr",
 										},
 									},
@@ -5826,26 +5727,26 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 862, col: 1, offset: 20639},
+			pos:  position{line: 845, col: 1, offset: 20244},
 			expr: &actionExpr{
-				pos: position{line: 863, col: 5, offset: 20651},
+				pos: position{line: 846, col: 5, offset: 20256},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 863, col: 5, offset: 20651},
+					pos: position{line: 846, col: 5, offset: 20256},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 863, col: 5, offset: 20651},
+							pos:  position{line: 846, col: 5, offset: 20256},
 							name: "YIELD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 863, col: 11, offset: 20657},
+							pos:  position{line: 846, col: 11, offset: 20262},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 863, col: 13, offset: 20659},
+							pos:   position{line: 846, col: 13, offset: 20264},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 863, col: 19, offset: 20665},
+								pos:  position{line: 846, col: 19, offset: 20270},
 								name: "Exprs",
 							},
 						},
@@ -5857,30 +5758,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 871, col: 1, offset: 20809},
+			pos:  position{line: 854, col: 1, offset: 20414},
 			expr: &actionExpr{
-				pos: position{line: 872, col: 5, offset: 20821},
+				pos: position{line: 855, col: 5, offset: 20426},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 872, col: 5, offset: 20821},
+					pos: position{line: 855, col: 5, offset: 20426},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 872, col: 5, offset: 20821},
+							pos:  position{line: 855, col: 5, offset: 20426},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 872, col: 7, offset: 20823},
+							pos:  position{line: 855, col: 7, offset: 20428},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 872, col: 10, offset: 20826},
+							pos:  position{line: 855, col: 10, offset: 20431},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 872, col: 12, offset: 20828},
+							pos:   position{line: 855, col: 12, offset: 20433},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 872, col: 16, offset: 20832},
+								pos:  position{line: 855, col: 16, offset: 20437},
 								name: "Type",
 							},
 						},
@@ -5892,30 +5793,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 874, col: 1, offset: 20858},
+			pos:  position{line: 857, col: 1, offset: 20463},
 			expr: &actionExpr{
-				pos: position{line: 875, col: 5, offset: 20868},
+				pos: position{line: 858, col: 5, offset: 20473},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 875, col: 5, offset: 20868},
+					pos: position{line: 858, col: 5, offset: 20473},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 875, col: 5, offset: 20868},
+							pos:  position{line: 858, col: 5, offset: 20473},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 875, col: 7, offset: 20870},
+							pos:  position{line: 858, col: 7, offset: 20475},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 875, col: 10, offset: 20873},
+							pos:  position{line: 858, col: 10, offset: 20478},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 875, col: 12, offset: 20875},
+							pos:   position{line: 858, col: 12, offset: 20480},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 875, col: 16, offset: 20879},
+								pos:  position{line: 858, col: 16, offset: 20484},
 								name: "Lval",
 							},
 						},
@@ -5927,9 +5828,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 879, col: 1, offset: 20930},
+			pos:  position{line: 862, col: 1, offset: 20535},
 			expr: &ruleRefExpr{
-				pos:  position{line: 879, col: 8, offset: 20937},
+				pos:  position{line: 862, col: 8, offset: 20542},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5937,51 +5838,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 881, col: 1, offset: 20948},
+			pos:  position{line: 864, col: 1, offset: 20553},
 			expr: &actionExpr{
-				pos: position{line: 882, col: 5, offset: 20958},
+				pos: position{line: 865, col: 5, offset: 20563},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 882, col: 5, offset: 20958},
+					pos: position{line: 865, col: 5, offset: 20563},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 882, col: 5, offset: 20958},
+							pos:   position{line: 865, col: 5, offset: 20563},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 882, col: 11, offset: 20964},
+								pos:  position{line: 865, col: 11, offset: 20569},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 882, col: 16, offset: 20969},
+							pos:   position{line: 865, col: 16, offset: 20574},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 882, col: 21, offset: 20974},
+								pos: position{line: 865, col: 21, offset: 20579},
 								expr: &actionExpr{
-									pos: position{line: 882, col: 22, offset: 20975},
+									pos: position{line: 865, col: 22, offset: 20580},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 882, col: 22, offset: 20975},
+										pos: position{line: 865, col: 22, offset: 20580},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 882, col: 22, offset: 20975},
+												pos:  position{line: 865, col: 22, offset: 20580},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 882, col: 25, offset: 20978},
+												pos:        position{line: 865, col: 25, offset: 20583},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 882, col: 29, offset: 20982},
+												pos:  position{line: 865, col: 29, offset: 20587},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 882, col: 32, offset: 20985},
+												pos:   position{line: 865, col: 32, offset: 20590},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 882, col: 37, offset: 20990},
+													pos:  position{line: 865, col: 37, offset: 20595},
 													name: "Lval",
 												},
 											},
@@ -5998,51 +5899,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 886, col: 1, offset: 21066},
+			pos:  position{line: 869, col: 1, offset: 20671},
 			expr: &actionExpr{
-				pos: position{line: 887, col: 5, offset: 21082},
+				pos: position{line: 870, col: 5, offset: 20687},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 887, col: 5, offset: 21082},
+					pos: position{line: 870, col: 5, offset: 20687},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 887, col: 5, offset: 21082},
+							pos:   position{line: 870, col: 5, offset: 20687},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 887, col: 11, offset: 21088},
+								pos:  position{line: 870, col: 11, offset: 20693},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 887, col: 22, offset: 21099},
+							pos:   position{line: 870, col: 22, offset: 20704},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 887, col: 27, offset: 21104},
+								pos: position{line: 870, col: 27, offset: 20709},
 								expr: &actionExpr{
-									pos: position{line: 887, col: 28, offset: 21105},
+									pos: position{line: 870, col: 28, offset: 20710},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 887, col: 28, offset: 21105},
+										pos: position{line: 870, col: 28, offset: 20710},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 887, col: 28, offset: 21105},
+												pos:  position{line: 870, col: 28, offset: 20710},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 887, col: 31, offset: 21108},
+												pos:        position{line: 870, col: 31, offset: 20713},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 887, col: 35, offset: 21112},
+												pos:  position{line: 870, col: 35, offset: 20717},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 887, col: 38, offset: 21115},
+												pos:   position{line: 870, col: 38, offset: 20720},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 887, col: 40, offset: 21117},
+													pos:  position{line: 870, col: 40, offset: 20722},
 													name: "Assignment",
 												},
 											},
@@ -6059,40 +5960,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 891, col: 1, offset: 21192},
+			pos:  position{line: 874, col: 1, offset: 20797},
 			expr: &actionExpr{
-				pos: position{line: 892, col: 5, offset: 21207},
+				pos: position{line: 875, col: 5, offset: 20812},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 892, col: 5, offset: 21207},
+					pos: position{line: 875, col: 5, offset: 20812},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 892, col: 5, offset: 21207},
+							pos:   position{line: 875, col: 5, offset: 20812},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 892, col: 9, offset: 21211},
+								pos:  position{line: 875, col: 9, offset: 20816},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 892, col: 14, offset: 21216},
+							pos:  position{line: 875, col: 14, offset: 20821},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 892, col: 17, offset: 21219},
+							pos:        position{line: 875, col: 17, offset: 20824},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 892, col: 22, offset: 21224},
+							pos:  position{line: 875, col: 22, offset: 20829},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 892, col: 25, offset: 21227},
+							pos:   position{line: 875, col: 25, offset: 20832},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 892, col: 29, offset: 21231},
+								pos:  position{line: 875, col: 29, offset: 20836},
 								name: "Expr",
 							},
 						},
@@ -6104,9 +6005,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 901, col: 1, offset: 21402},
+			pos:  position{line: 884, col: 1, offset: 21007},
 			expr: &ruleRefExpr{
-				pos:  position{line: 901, col: 8, offset: 21409},
+				pos:  position{line: 884, col: 8, offset: 21014},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -6114,63 +6015,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 903, col: 1, offset: 21426},
+			pos:  position{line: 886, col: 1, offset: 21031},
 			expr: &actionExpr{
-				pos: position{line: 904, col: 5, offset: 21446},
+				pos: position{line: 887, col: 5, offset: 21051},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 904, col: 5, offset: 21446},
+					pos: position{line: 887, col: 5, offset: 21051},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 904, col: 5, offset: 21446},
+							pos:   position{line: 887, col: 5, offset: 21051},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 904, col: 10, offset: 21451},
+								pos:  position{line: 887, col: 10, offset: 21056},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 904, col: 24, offset: 21465},
+							pos:   position{line: 887, col: 24, offset: 21070},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 904, col: 28, offset: 21469},
+								pos: position{line: 887, col: 28, offset: 21074},
 								expr: &seqExpr{
-									pos: position{line: 904, col: 29, offset: 21470},
+									pos: position{line: 887, col: 29, offset: 21075},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 904, col: 29, offset: 21470},
+											pos:  position{line: 887, col: 29, offset: 21075},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 904, col: 32, offset: 21473},
+											pos:        position{line: 887, col: 32, offset: 21078},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 904, col: 36, offset: 21477},
+											pos:  position{line: 887, col: 36, offset: 21082},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 904, col: 39, offset: 21480},
+											pos:  position{line: 887, col: 39, offset: 21085},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 904, col: 44, offset: 21485},
+											pos:  position{line: 887, col: 44, offset: 21090},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 904, col: 47, offset: 21488},
+											pos:        position{line: 887, col: 47, offset: 21093},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 904, col: 51, offset: 21492},
+											pos:  position{line: 887, col: 51, offset: 21097},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 904, col: 54, offset: 21495},
+											pos:  position{line: 887, col: 54, offset: 21100},
 											name: "Expr",
 										},
 									},
@@ -6185,53 +6086,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 918, col: 1, offset: 21816},
+			pos:  position{line: 901, col: 1, offset: 21421},
 			expr: &actionExpr{
-				pos: position{line: 919, col: 5, offset: 21834},
+				pos: position{line: 902, col: 5, offset: 21439},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 919, col: 5, offset: 21834},
+					pos: position{line: 902, col: 5, offset: 21439},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 919, col: 5, offset: 21834},
+							pos:   position{line: 902, col: 5, offset: 21439},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 919, col: 11, offset: 21840},
+								pos:  position{line: 902, col: 11, offset: 21445},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 920, col: 5, offset: 21859},
+							pos:   position{line: 903, col: 5, offset: 21464},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 920, col: 10, offset: 21864},
+								pos: position{line: 903, col: 10, offset: 21469},
 								expr: &actionExpr{
-									pos: position{line: 920, col: 11, offset: 21865},
+									pos: position{line: 903, col: 11, offset: 21470},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 920, col: 11, offset: 21865},
+										pos: position{line: 903, col: 11, offset: 21470},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 920, col: 11, offset: 21865},
+												pos:  position{line: 903, col: 11, offset: 21470},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 920, col: 14, offset: 21868},
+												pos:   position{line: 903, col: 14, offset: 21473},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 920, col: 17, offset: 21871},
+													pos:  position{line: 903, col: 17, offset: 21476},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 920, col: 20, offset: 21874},
+												pos:  position{line: 903, col: 20, offset: 21479},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 920, col: 23, offset: 21877},
+												pos:   position{line: 903, col: 23, offset: 21482},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 920, col: 28, offset: 21882},
+													pos:  position{line: 903, col: 28, offset: 21487},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6248,53 +6149,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 924, col: 1, offset: 21996},
+			pos:  position{line: 907, col: 1, offset: 21601},
 			expr: &actionExpr{
-				pos: position{line: 925, col: 5, offset: 22015},
+				pos: position{line: 908, col: 5, offset: 21620},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 925, col: 5, offset: 22015},
+					pos: position{line: 908, col: 5, offset: 21620},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 925, col: 5, offset: 22015},
+							pos:   position{line: 908, col: 5, offset: 21620},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 925, col: 11, offset: 22021},
+								pos:  position{line: 908, col: 11, offset: 21626},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 926, col: 5, offset: 22033},
+							pos:   position{line: 909, col: 5, offset: 21638},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 926, col: 10, offset: 22038},
+								pos: position{line: 909, col: 10, offset: 21643},
 								expr: &actionExpr{
-									pos: position{line: 926, col: 11, offset: 22039},
+									pos: position{line: 909, col: 11, offset: 21644},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 926, col: 11, offset: 22039},
+										pos: position{line: 909, col: 11, offset: 21644},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 926, col: 11, offset: 22039},
+												pos:  position{line: 909, col: 11, offset: 21644},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 926, col: 14, offset: 22042},
+												pos:   position{line: 909, col: 14, offset: 21647},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 926, col: 17, offset: 22045},
+													pos:  position{line: 909, col: 17, offset: 21650},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 926, col: 21, offset: 22049},
+												pos:  position{line: 909, col: 21, offset: 21654},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 926, col: 24, offset: 22052},
+												pos:   position{line: 909, col: 24, offset: 21657},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 926, col: 29, offset: 22057},
+													pos:  position{line: 909, col: 29, offset: 21662},
 													name: "NotExpr",
 												},
 											},
@@ -6311,43 +6212,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 930, col: 1, offset: 22164},
+			pos:  position{line: 913, col: 1, offset: 21769},
 			expr: &choiceExpr{
-				pos: position{line: 931, col: 5, offset: 22176},
+				pos: position{line: 914, col: 5, offset: 21781},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 931, col: 5, offset: 22176},
+						pos: position{line: 914, col: 5, offset: 21781},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 931, col: 5, offset: 22176},
+							pos: position{line: 914, col: 5, offset: 21781},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 931, col: 6, offset: 22177},
+									pos: position{line: 914, col: 6, offset: 21782},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 931, col: 6, offset: 22177},
+											pos: position{line: 914, col: 6, offset: 21782},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 931, col: 6, offset: 22177},
+													pos:  position{line: 914, col: 6, offset: 21782},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 931, col: 10, offset: 22181},
+													pos:  position{line: 914, col: 10, offset: 21786},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 931, col: 14, offset: 22185},
+											pos: position{line: 914, col: 14, offset: 21790},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 931, col: 14, offset: 22185},
+													pos:        position{line: 914, col: 14, offset: 21790},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 931, col: 18, offset: 22189},
+													pos:  position{line: 914, col: 18, offset: 21794},
 													name: "__",
 												},
 											},
@@ -6355,10 +6256,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 931, col: 22, offset: 22193},
+									pos:   position{line: 914, col: 22, offset: 21798},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 931, col: 24, offset: 22195},
+										pos:  position{line: 914, col: 24, offset: 21800},
 										name: "NotExpr",
 									},
 								},
@@ -6366,7 +6267,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 939, col: 5, offset: 22361},
+						pos:  position{line: 922, col: 5, offset: 21966},
 						name: "BetweenExpr",
 					},
 				},
@@ -6376,61 +6277,61 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 941, col: 1, offset: 22376},
+			pos:  position{line: 924, col: 1, offset: 21981},
 			expr: &choiceExpr{
-				pos: position{line: 942, col: 5, offset: 22392},
+				pos: position{line: 925, col: 5, offset: 21997},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 942, col: 5, offset: 22392},
+						pos: position{line: 925, col: 5, offset: 21997},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 942, col: 5, offset: 22392},
+							pos: position{line: 925, col: 5, offset: 21997},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 942, col: 5, offset: 22392},
+									pos:   position{line: 925, col: 5, offset: 21997},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 10, offset: 22397},
+										pos:  position{line: 925, col: 10, offset: 22002},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 25, offset: 22412},
+									pos:  position{line: 925, col: 25, offset: 22017},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 27, offset: 22414},
+									pos:  position{line: 925, col: 27, offset: 22019},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 35, offset: 22422},
+									pos:  position{line: 925, col: 35, offset: 22027},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 942, col: 37, offset: 22424},
+									pos:   position{line: 925, col: 37, offset: 22029},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 43, offset: 22430},
+										pos:  position{line: 925, col: 43, offset: 22035},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 55, offset: 22442},
+									pos:  position{line: 925, col: 55, offset: 22047},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 57, offset: 22444},
+									pos:  position{line: 925, col: 57, offset: 22049},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 61, offset: 22448},
+									pos:  position{line: 925, col: 61, offset: 22053},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 942, col: 63, offset: 22450},
+									pos:   position{line: 925, col: 63, offset: 22055},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 69, offset: 22456},
+										pos:  position{line: 925, col: 69, offset: 22061},
 										name: "BetweenExpr",
 									},
 								},
@@ -6438,7 +6339,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 950, col: 5, offset: 22642},
+						pos:  position{line: 933, col: 5, offset: 22247},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6448,78 +6349,173 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 952, col: 1, offset: 22658},
-			expr: &actionExpr{
-				pos: position{line: 953, col: 5, offset: 22677},
-				run: (*parser).callonComparisonExpr1,
-				expr: &seqExpr{
-					pos: position{line: 953, col: 5, offset: 22677},
-					exprs: []any{
-						&labeledExpr{
-							pos:   position{line: 953, col: 5, offset: 22677},
-							label: "lhs",
-							expr: &ruleRefExpr{
-								pos:  position{line: 953, col: 9, offset: 22681},
-								name: "AdditiveExpr",
+			pos:  position{line: 935, col: 1, offset: 22263},
+			expr: &choiceExpr{
+				pos: position{line: 936, col: 5, offset: 22282},
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 936, col: 5, offset: 22282},
+						run: (*parser).callonComparisonExpr2,
+						expr: &seqExpr{
+							pos: position{line: 936, col: 5, offset: 22282},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 936, col: 5, offset: 22282},
+									label: "lhs",
+									expr: &ruleRefExpr{
+										pos:  position{line: 936, col: 9, offset: 22286},
+										name: "AdditiveExpr",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 936, col: 22, offset: 22299},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 936, col: 24, offset: 22301},
+									label: "op",
+									expr: &ruleRefExpr{
+										pos:  position{line: 936, col: 27, offset: 22304},
+										name: "IsNull",
+									},
+								},
 							},
 						},
-						&labeledExpr{
-							pos:   position{line: 953, col: 22, offset: 22694},
-							label: "opAndRHS",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 953, col: 31, offset: 22703},
-								expr: &choiceExpr{
-									pos: position{line: 953, col: 32, offset: 22704},
-									alternatives: []any{
-										&seqExpr{
-											pos: position{line: 953, col: 32, offset: 22704},
-											exprs: []any{
-												&ruleRefExpr{
-													pos:  position{line: 953, col: 32, offset: 22704},
-													name: "__",
-												},
-												&ruleRefExpr{
-													pos:  position{line: 953, col: 35, offset: 22707},
-													name: "Comparator",
-												},
-												&ruleRefExpr{
-													pos:  position{line: 953, col: 46, offset: 22718},
-													name: "__",
-												},
-												&ruleRefExpr{
-													pos:  position{line: 953, col: 49, offset: 22721},
-													name: "AdditiveExpr",
-												},
-											},
-										},
-										&seqExpr{
-											pos: position{line: 953, col: 64, offset: 22736},
-											exprs: []any{
-												&ruleRefExpr{
-													pos:  position{line: 953, col: 64, offset: 22736},
-													name: "__",
-												},
-												&actionExpr{
-													pos: position{line: 953, col: 68, offset: 22740},
-													run: (*parser).callonComparisonExpr15,
-													expr: &litMatcher{
-														pos:        position{line: 953, col: 68, offset: 22740},
-														val:        "~",
-														ignoreCase: false,
-														want:       "\"~\"",
+					},
+					&actionExpr{
+						pos: position{line: 945, col: 5, offset: 22514},
+						run: (*parser).callonComparisonExpr9,
+						expr: &seqExpr{
+							pos: position{line: 945, col: 5, offset: 22514},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 945, col: 5, offset: 22514},
+									label: "lhs",
+									expr: &ruleRefExpr{
+										pos:  position{line: 945, col: 9, offset: 22518},
+										name: "AdditiveExpr",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 945, col: 22, offset: 22531},
+									label: "opAndRHS",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 945, col: 31, offset: 22540},
+										expr: &choiceExpr{
+											pos: position{line: 945, col: 32, offset: 22541},
+											alternatives: []any{
+												&seqExpr{
+													pos: position{line: 945, col: 32, offset: 22541},
+													exprs: []any{
+														&ruleRefExpr{
+															pos:  position{line: 945, col: 32, offset: 22541},
+															name: "__",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 945, col: 35, offset: 22544},
+															name: "Comparator",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 945, col: 46, offset: 22555},
+															name: "__",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 945, col: 49, offset: 22558},
+															name: "AdditiveExpr",
+														},
 													},
 												},
-												&ruleRefExpr{
-													pos:  position{line: 953, col: 104, offset: 22776},
-													name: "__",
-												},
-												&ruleRefExpr{
-													pos:  position{line: 953, col: 107, offset: 22779},
-													name: "Regexp",
+												&seqExpr{
+													pos: position{line: 945, col: 64, offset: 22573},
+													exprs: []any{
+														&ruleRefExpr{
+															pos:  position{line: 945, col: 64, offset: 22573},
+															name: "__",
+														},
+														&actionExpr{
+															pos: position{line: 945, col: 68, offset: 22577},
+															run: (*parser).callonComparisonExpr23,
+															expr: &litMatcher{
+																pos:        position{line: 945, col: 68, offset: 22577},
+																val:        "~",
+																ignoreCase: false,
+																want:       "\"~\"",
+															},
+														},
+														&ruleRefExpr{
+															pos:  position{line: 945, col: 104, offset: 22613},
+															name: "__",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 945, col: 107, offset: 22616},
+															name: "Regexp",
+														},
+													},
 												},
 											},
 										},
 									},
+								},
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "IsNull",
+			pos:  position{line: 958, col: 2, offset: 22903},
+			expr: &choiceExpr{
+				pos: position{line: 959, col: 5, offset: 22914},
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 959, col: 5, offset: 22914},
+						run: (*parser).callonIsNull2,
+						expr: &seqExpr{
+							pos: position{line: 959, col: 5, offset: 22914},
+							exprs: []any{
+								&ruleRefExpr{
+									pos:  position{line: 959, col: 5, offset: 22914},
+									name: "IS",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 959, col: 8, offset: 22917},
+									name: "_",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 959, col: 10, offset: 22919},
+									name: "NULL",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 960, col: 5, offset: 22949},
+						run: (*parser).callonIsNull7,
+						expr: &seqExpr{
+							pos: position{line: 960, col: 5, offset: 22949},
+							exprs: []any{
+								&ruleRefExpr{
+									pos:  position{line: 960, col: 5, offset: 22949},
+									name: "IS",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 960, col: 8, offset: 22952},
+									name: "_",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 960, col: 10, offset: 22954},
+									name: "NOT",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 960, col: 14, offset: 22958},
+									name: "_",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 960, col: 16, offset: 22960},
+									name: "NULL",
 								},
 							},
 						},
@@ -6531,53 +6527,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 966, col: 1, offset: 23064},
+			pos:  position{line: 962, col: 1, offset: 22987},
 			expr: &actionExpr{
-				pos: position{line: 967, col: 5, offset: 23081},
+				pos: position{line: 963, col: 5, offset: 23004},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 967, col: 5, offset: 23081},
+					pos: position{line: 963, col: 5, offset: 23004},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 967, col: 5, offset: 23081},
+							pos:   position{line: 963, col: 5, offset: 23004},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 967, col: 11, offset: 23087},
+								pos:  position{line: 963, col: 11, offset: 23010},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 968, col: 5, offset: 23110},
+							pos:   position{line: 964, col: 5, offset: 23033},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 968, col: 10, offset: 23115},
+								pos: position{line: 964, col: 10, offset: 23038},
 								expr: &actionExpr{
-									pos: position{line: 968, col: 11, offset: 23116},
+									pos: position{line: 964, col: 11, offset: 23039},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 968, col: 11, offset: 23116},
+										pos: position{line: 964, col: 11, offset: 23039},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 968, col: 11, offset: 23116},
+												pos:  position{line: 964, col: 11, offset: 23039},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 968, col: 14, offset: 23119},
+												pos:   position{line: 964, col: 14, offset: 23042},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 968, col: 17, offset: 23122},
+													pos:  position{line: 964, col: 17, offset: 23045},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 968, col: 34, offset: 23139},
+												pos:  position{line: 964, col: 34, offset: 23062},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 968, col: 37, offset: 23142},
+												pos:   position{line: 964, col: 37, offset: 23065},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 968, col: 42, offset: 23147},
+													pos:  position{line: 964, col: 42, offset: 23070},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6594,21 +6590,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 972, col: 1, offset: 23265},
+			pos:  position{line: 968, col: 1, offset: 23188},
 			expr: &actionExpr{
-				pos: position{line: 972, col: 20, offset: 23284},
+				pos: position{line: 968, col: 20, offset: 23207},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 972, col: 21, offset: 23285},
+					pos: position{line: 968, col: 21, offset: 23208},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 972, col: 21, offset: 23285},
+							pos:        position{line: 968, col: 21, offset: 23208},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 972, col: 27, offset: 23291},
+							pos:        position{line: 968, col: 27, offset: 23214},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6621,53 +6617,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 974, col: 1, offset: 23328},
+			pos:  position{line: 970, col: 1, offset: 23251},
 			expr: &actionExpr{
-				pos: position{line: 975, col: 5, offset: 23351},
+				pos: position{line: 971, col: 5, offset: 23274},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 975, col: 5, offset: 23351},
+					pos: position{line: 971, col: 5, offset: 23274},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 975, col: 5, offset: 23351},
+							pos:   position{line: 971, col: 5, offset: 23274},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 975, col: 11, offset: 23357},
+								pos:  position{line: 971, col: 11, offset: 23280},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 976, col: 5, offset: 23372},
+							pos:   position{line: 972, col: 5, offset: 23295},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 976, col: 10, offset: 23377},
+								pos: position{line: 972, col: 10, offset: 23300},
 								expr: &actionExpr{
-									pos: position{line: 976, col: 11, offset: 23378},
+									pos: position{line: 972, col: 11, offset: 23301},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 976, col: 11, offset: 23378},
+										pos: position{line: 972, col: 11, offset: 23301},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 976, col: 11, offset: 23378},
+												pos:  position{line: 972, col: 11, offset: 23301},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 976, col: 14, offset: 23381},
+												pos:   position{line: 972, col: 14, offset: 23304},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 976, col: 17, offset: 23384},
+													pos:  position{line: 972, col: 17, offset: 23307},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 976, col: 40, offset: 23407},
+												pos:  position{line: 972, col: 40, offset: 23330},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 976, col: 43, offset: 23410},
+												pos:   position{line: 972, col: 43, offset: 23333},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 976, col: 48, offset: 23415},
+													pos:  position{line: 972, col: 48, offset: 23338},
 													name: "ConcatExpr",
 												},
 											},
@@ -6684,27 +6680,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 980, col: 1, offset: 23525},
+			pos:  position{line: 976, col: 1, offset: 23448},
 			expr: &actionExpr{
-				pos: position{line: 980, col: 26, offset: 23550},
+				pos: position{line: 976, col: 26, offset: 23473},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 980, col: 27, offset: 23551},
+					pos: position{line: 976, col: 27, offset: 23474},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 980, col: 27, offset: 23551},
+							pos:        position{line: 976, col: 27, offset: 23474},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 980, col: 33, offset: 23557},
+							pos:        position{line: 976, col: 33, offset: 23480},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 980, col: 39, offset: 23563},
+							pos:        position{line: 976, col: 39, offset: 23486},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6717,51 +6713,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 982, col: 1, offset: 23600},
+			pos:  position{line: 978, col: 1, offset: 23523},
 			expr: &actionExpr{
-				pos: position{line: 983, col: 5, offset: 23616},
+				pos: position{line: 979, col: 5, offset: 23539},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 983, col: 5, offset: 23616},
+					pos: position{line: 979, col: 5, offset: 23539},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 983, col: 5, offset: 23616},
+							pos:   position{line: 979, col: 5, offset: 23539},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 983, col: 11, offset: 23622},
+								pos:  position{line: 979, col: 11, offset: 23545},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 984, col: 5, offset: 23643},
+							pos:   position{line: 980, col: 5, offset: 23566},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 984, col: 10, offset: 23648},
+								pos: position{line: 980, col: 10, offset: 23571},
 								expr: &actionExpr{
-									pos: position{line: 984, col: 11, offset: 23649},
+									pos: position{line: 980, col: 11, offset: 23572},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 984, col: 11, offset: 23649},
+										pos: position{line: 980, col: 11, offset: 23572},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 984, col: 11, offset: 23649},
+												pos:  position{line: 980, col: 11, offset: 23572},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 984, col: 14, offset: 23652},
+												pos:        position{line: 980, col: 14, offset: 23575},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 984, col: 19, offset: 23657},
+												pos:  position{line: 980, col: 19, offset: 23580},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 984, col: 22, offset: 23660},
+												pos:   position{line: 980, col: 22, offset: 23583},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 984, col: 27, offset: 23665},
+													pos:  position{line: 980, col: 27, offset: 23588},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6778,40 +6774,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 988, col: 1, offset: 23783},
+			pos:  position{line: 984, col: 1, offset: 23706},
 			expr: &choiceExpr{
-				pos: position{line: 989, col: 5, offset: 23804},
+				pos: position{line: 985, col: 5, offset: 23727},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 989, col: 5, offset: 23804},
+						pos: position{line: 985, col: 5, offset: 23727},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 989, col: 5, offset: 23804},
+							pos: position{line: 985, col: 5, offset: 23727},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 989, col: 5, offset: 23804},
+									pos: position{line: 985, col: 5, offset: 23727},
 									expr: &ruleRefExpr{
-										pos:  position{line: 989, col: 6, offset: 23805},
+										pos:  position{line: 985, col: 6, offset: 23728},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 989, col: 14, offset: 23813},
+									pos:   position{line: 985, col: 14, offset: 23736},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 989, col: 17, offset: 23816},
+										pos:  position{line: 985, col: 17, offset: 23739},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 31, offset: 23830},
+									pos:  position{line: 985, col: 31, offset: 23753},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 989, col: 34, offset: 23833},
+									pos:   position{line: 985, col: 34, offset: 23756},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 989, col: 36, offset: 23835},
+										pos:  position{line: 985, col: 36, offset: 23758},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6819,7 +6815,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 998, col: 5, offset: 24019},
+						pos:  position{line: 994, col: 5, offset: 23942},
 						name: "DerefExpr",
 					},
 				},
@@ -6829,21 +6825,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 1000, col: 1, offset: 24030},
+			pos:  position{line: 996, col: 1, offset: 23953},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 17, offset: 24046},
+				pos: position{line: 996, col: 17, offset: 23969},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 1000, col: 18, offset: 24047},
+					pos: position{line: 996, col: 18, offset: 23970},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1000, col: 18, offset: 24047},
+							pos:        position{line: 996, col: 18, offset: 23970},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1000, col: 24, offset: 24053},
+							pos:        position{line: 996, col: 24, offset: 23976},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6856,73 +6852,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 1002, col: 1, offset: 24090},
+			pos:  position{line: 998, col: 1, offset: 24013},
 			expr: &choiceExpr{
-				pos: position{line: 1003, col: 5, offset: 24104},
+				pos: position{line: 999, col: 5, offset: 24027},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1003, col: 5, offset: 24104},
+						pos: position{line: 999, col: 5, offset: 24027},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1003, col: 5, offset: 24104},
+							pos: position{line: 999, col: 5, offset: 24027},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1003, col: 5, offset: 24104},
+									pos:   position{line: 999, col: 5, offset: 24027},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1003, col: 10, offset: 24109},
+										pos:  position{line: 999, col: 10, offset: 24032},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1003, col: 20, offset: 24119},
+									pos:        position{line: 999, col: 20, offset: 24042},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 24, offset: 24123},
+									pos:  position{line: 999, col: 24, offset: 24046},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1003, col: 27, offset: 24126},
+									pos:   position{line: 999, col: 27, offset: 24049},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1003, col: 32, offset: 24131},
+										pos:  position{line: 999, col: 32, offset: 24054},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 45, offset: 24144},
+									pos:  position{line: 999, col: 45, offset: 24067},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1003, col: 48, offset: 24147},
+									pos:        position{line: 999, col: 48, offset: 24070},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 52, offset: 24151},
+									pos:  position{line: 999, col: 52, offset: 24074},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1003, col: 55, offset: 24154},
+									pos:   position{line: 999, col: 55, offset: 24077},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1003, col: 58, offset: 24157},
+										pos: position{line: 999, col: 58, offset: 24080},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1003, col: 58, offset: 24157},
+											pos:  position{line: 999, col: 58, offset: 24080},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 72, offset: 24171},
+									pos:  position{line: 999, col: 72, offset: 24094},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1003, col: 75, offset: 24174},
+									pos:        position{line: 999, col: 75, offset: 24097},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6931,49 +6927,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1015, col: 5, offset: 24413},
+						pos: position{line: 1011, col: 5, offset: 24336},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1015, col: 5, offset: 24413},
+							pos: position{line: 1011, col: 5, offset: 24336},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1015, col: 5, offset: 24413},
+									pos:   position{line: 1011, col: 5, offset: 24336},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1015, col: 10, offset: 24418},
+										pos:  position{line: 1011, col: 10, offset: 24341},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1015, col: 20, offset: 24428},
+									pos:        position{line: 1011, col: 20, offset: 24351},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1015, col: 24, offset: 24432},
+									pos:  position{line: 1011, col: 24, offset: 24355},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1015, col: 27, offset: 24435},
+									pos:        position{line: 1011, col: 27, offset: 24358},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1015, col: 31, offset: 24439},
+									pos:  position{line: 1011, col: 31, offset: 24362},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1015, col: 34, offset: 24442},
+									pos:   position{line: 1011, col: 34, offset: 24365},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1015, col: 37, offset: 24445},
+										pos:  position{line: 1011, col: 37, offset: 24368},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1015, col: 50, offset: 24458},
+									pos:        position{line: 1011, col: 50, offset: 24381},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6982,35 +6978,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 24622},
+						pos: position{line: 1019, col: 5, offset: 24545},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 24622},
+							pos: position{line: 1019, col: 5, offset: 24545},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1023, col: 5, offset: 24622},
+									pos:   position{line: 1019, col: 5, offset: 24545},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 10, offset: 24627},
+										pos:  position{line: 1019, col: 10, offset: 24550},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 20, offset: 24637},
+									pos:        position{line: 1019, col: 20, offset: 24560},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 24, offset: 24641},
+									pos:   position{line: 1019, col: 24, offset: 24564},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 30, offset: 24647},
+										pos:  position{line: 1019, col: 30, offset: 24570},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 35, offset: 24652},
+									pos:        position{line: 1019, col: 35, offset: 24575},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7019,30 +7015,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1031, col: 5, offset: 24822},
+						pos: position{line: 1027, col: 5, offset: 24745},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1031, col: 5, offset: 24822},
+							pos: position{line: 1027, col: 5, offset: 24745},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1031, col: 5, offset: 24822},
+									pos:   position{line: 1027, col: 5, offset: 24745},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1031, col: 10, offset: 24827},
+										pos:  position{line: 1027, col: 10, offset: 24750},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1031, col: 20, offset: 24837},
+									pos:        position{line: 1027, col: 20, offset: 24760},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1031, col: 24, offset: 24841},
+									pos:   position{line: 1027, col: 24, offset: 24764},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1031, col: 27, offset: 24844},
+										pos:  position{line: 1027, col: 27, offset: 24767},
 										name: "Identifier",
 									},
 								},
@@ -7050,11 +7046,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1040, col: 5, offset: 25034},
+						pos:  position{line: 1036, col: 5, offset: 24957},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1041, col: 5, offset: 25047},
+						pos:  position{line: 1037, col: 5, offset: 24970},
 						name: "Primary",
 					},
 				},
@@ -7064,16 +7060,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 1043, col: 1, offset: 25056},
+			pos:  position{line: 1039, col: 1, offset: 24979},
 			expr: &choiceExpr{
-				pos: position{line: 1044, col: 5, offset: 25069},
+				pos: position{line: 1040, col: 5, offset: 24992},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 25069},
+						pos:  position{line: 1040, col: 5, offset: 24992},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1045, col: 5, offset: 25078},
+						pos:  position{line: 1041, col: 5, offset: 25001},
 						name: "Function",
 					},
 				},
@@ -7083,20 +7079,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1047, col: 1, offset: 25088},
+			pos:  position{line: 1043, col: 1, offset: 25011},
 			expr: &seqExpr{
-				pos: position{line: 1047, col: 13, offset: 25100},
+				pos: position{line: 1043, col: 13, offset: 25023},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 13, offset: 25100},
+						pos:  position{line: 1043, col: 13, offset: 25023},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 22, offset: 25109},
+						pos:  position{line: 1043, col: 22, offset: 25032},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1047, col: 25, offset: 25112},
+						pos:        position{line: 1043, col: 25, offset: 25035},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -7108,16 +7104,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1049, col: 1, offset: 25117},
+			pos:  position{line: 1045, col: 1, offset: 25040},
 			expr: &choiceExpr{
-				pos: position{line: 1050, col: 5, offset: 25130},
+				pos: position{line: 1046, col: 5, offset: 25053},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1050, col: 5, offset: 25130},
+						pos:  position{line: 1046, col: 5, offset: 25053},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1051, col: 5, offset: 25138},
+						pos:  position{line: 1047, col: 5, offset: 25061},
 						name: "SELECT",
 					},
 				},
@@ -7127,58 +7123,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1053, col: 1, offset: 25146},
+			pos:  position{line: 1049, col: 1, offset: 25069},
 			expr: &actionExpr{
-				pos: position{line: 1054, col: 5, offset: 25155},
+				pos: position{line: 1050, col: 5, offset: 25078},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1054, col: 5, offset: 25155},
+					pos: position{line: 1050, col: 5, offset: 25078},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1054, col: 5, offset: 25155},
+							pos:   position{line: 1050, col: 5, offset: 25078},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1054, col: 9, offset: 25159},
+								pos:  position{line: 1050, col: 9, offset: 25082},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1054, col: 21, offset: 25171},
+							pos:  position{line: 1050, col: 21, offset: 25094},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1054, col: 24, offset: 25174},
+							pos:        position{line: 1050, col: 24, offset: 25097},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1054, col: 28, offset: 25178},
+							pos:  position{line: 1050, col: 28, offset: 25101},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1054, col: 31, offset: 25181},
+							pos:   position{line: 1050, col: 31, offset: 25104},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1054, col: 37, offset: 25187},
+								pos: position{line: 1050, col: 37, offset: 25110},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1054, col: 37, offset: 25187},
+										pos:  position{line: 1050, col: 37, offset: 25110},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1054, col: 48, offset: 25198},
+										pos:  position{line: 1050, col: 48, offset: 25121},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1054, col: 54, offset: 25204},
+							pos:  position{line: 1050, col: 54, offset: 25127},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1054, col: 57, offset: 25207},
+							pos:        position{line: 1050, col: 57, offset: 25130},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7191,85 +7187,85 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1058, col: 1, offset: 25320},
+			pos:  position{line: 1054, col: 1, offset: 25243},
 			expr: &choiceExpr{
-				pos: position{line: 1059, col: 5, offset: 25333},
+				pos: position{line: 1055, col: 5, offset: 25256},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1059, col: 5, offset: 25333},
+						pos:  position{line: 1055, col: 5, offset: 25256},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1061, col: 5, offset: 25420},
+						pos: position{line: 1057, col: 5, offset: 25343},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1061, col: 5, offset: 25420},
+							pos: position{line: 1057, col: 5, offset: 25343},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 5, offset: 25420},
+									pos:  position{line: 1057, col: 5, offset: 25343},
 									name: "REGEXP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 12, offset: 25427},
+									pos:  position{line: 1057, col: 12, offset: 25350},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 15, offset: 25430},
+									pos:        position{line: 1057, col: 15, offset: 25353},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 19, offset: 25434},
+									pos:  position{line: 1057, col: 19, offset: 25357},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 22, offset: 25437},
+									pos:   position{line: 1057, col: 22, offset: 25360},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1061, col: 27, offset: 25442},
+										pos:  position{line: 1057, col: 27, offset: 25365},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 43, offset: 25458},
+									pos:  position{line: 1057, col: 43, offset: 25381},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 46, offset: 25461},
+									pos:        position{line: 1057, col: 46, offset: 25384},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 50, offset: 25465},
+									pos:  position{line: 1057, col: 50, offset: 25388},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 53, offset: 25468},
+									pos:   position{line: 1057, col: 53, offset: 25391},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1061, col: 58, offset: 25473},
+										pos:  position{line: 1057, col: 58, offset: 25396},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 63, offset: 25478},
+									pos:  position{line: 1057, col: 63, offset: 25401},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 66, offset: 25481},
+									pos:        position{line: 1057, col: 66, offset: 25404},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 70, offset: 25485},
+									pos:   position{line: 1057, col: 70, offset: 25408},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1061, col: 76, offset: 25491},
+										pos: position{line: 1057, col: 76, offset: 25414},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1061, col: 76, offset: 25491},
+											pos:  position{line: 1057, col: 76, offset: 25414},
 											name: "WhereClause",
 										},
 									},
@@ -7278,98 +7274,98 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 5, offset: 25670},
+						pos: position{line: 1061, col: 5, offset: 25593},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1065, col: 5, offset: 25670},
+							pos: position{line: 1061, col: 5, offset: 25593},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 5, offset: 25670},
+									pos:  position{line: 1061, col: 5, offset: 25593},
 									name: "REGEXP_REPLACE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 20, offset: 25685},
+									pos:  position{line: 1061, col: 20, offset: 25608},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1065, col: 23, offset: 25688},
+									pos:        position{line: 1061, col: 23, offset: 25611},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 27, offset: 25692},
+									pos:  position{line: 1061, col: 27, offset: 25615},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 30, offset: 25695},
+									pos:   position{line: 1061, col: 30, offset: 25618},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 35, offset: 25700},
+										pos:  position{line: 1061, col: 35, offset: 25623},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 40, offset: 25705},
+									pos:  position{line: 1061, col: 40, offset: 25628},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1065, col: 43, offset: 25708},
+									pos:        position{line: 1061, col: 43, offset: 25631},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 47, offset: 25712},
+									pos:  position{line: 1061, col: 47, offset: 25635},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 50, offset: 25715},
+									pos:   position{line: 1061, col: 50, offset: 25638},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 55, offset: 25720},
+										pos:  position{line: 1061, col: 55, offset: 25643},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 71, offset: 25736},
+									pos:  position{line: 1061, col: 71, offset: 25659},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1065, col: 74, offset: 25739},
+									pos:        position{line: 1061, col: 74, offset: 25662},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 78, offset: 25743},
+									pos:  position{line: 1061, col: 78, offset: 25666},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 81, offset: 25746},
+									pos:   position{line: 1061, col: 81, offset: 25669},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 86, offset: 25751},
+										pos:  position{line: 1061, col: 86, offset: 25674},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 91, offset: 25756},
+									pos:  position{line: 1061, col: 91, offset: 25679},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1065, col: 94, offset: 25759},
+									pos:        position{line: 1061, col: 94, offset: 25682},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 98, offset: 25763},
+									pos:   position{line: 1061, col: 98, offset: 25686},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1065, col: 104, offset: 25769},
+										pos: position{line: 1061, col: 104, offset: 25692},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1065, col: 104, offset: 25769},
+											pos:  position{line: 1061, col: 104, offset: 25692},
 											name: "WhereClause",
 										},
 									},
@@ -7378,65 +7374,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 25963},
+						pos: position{line: 1065, col: 5, offset: 25886},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1069, col: 5, offset: 25963},
+							pos: position{line: 1065, col: 5, offset: 25886},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1069, col: 5, offset: 25963},
+									pos: position{line: 1065, col: 5, offset: 25886},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 6, offset: 25964},
+										pos:  position{line: 1065, col: 6, offset: 25887},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 16, offset: 25974},
+									pos:   position{line: 1065, col: 16, offset: 25897},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 19, offset: 25977},
+										pos:  position{line: 1065, col: 19, offset: 25900},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 30, offset: 25988},
+									pos:  position{line: 1065, col: 30, offset: 25911},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 33, offset: 25991},
+									pos:        position{line: 1065, col: 33, offset: 25914},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 37, offset: 25995},
+									pos:  position{line: 1065, col: 37, offset: 25918},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 40, offset: 25998},
+									pos:   position{line: 1065, col: 40, offset: 25921},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 45, offset: 26003},
+										pos:  position{line: 1065, col: 45, offset: 25926},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 58, offset: 26016},
+									pos:  position{line: 1065, col: 58, offset: 25939},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 61, offset: 26019},
+									pos:        position{line: 1065, col: 61, offset: 25942},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 65, offset: 26023},
+									pos:   position{line: 1065, col: 65, offset: 25946},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1069, col: 71, offset: 26029},
+										pos: position{line: 1065, col: 71, offset: 25952},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1069, col: 71, offset: 26029},
+											pos:  position{line: 1065, col: 71, offset: 25952},
 											name: "WhereClause",
 										},
 									},
@@ -7451,15 +7447,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1073, col: 1, offset: 26097},
+			pos:  position{line: 1069, col: 1, offset: 26020},
 			expr: &actionExpr{
-				pos: position{line: 1074, col: 5, offset: 26117},
+				pos: position{line: 1070, col: 5, offset: 26040},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1074, col: 5, offset: 26117},
+					pos:   position{line: 1070, col: 5, offset: 26040},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1074, col: 9, offset: 26121},
+						pos:  position{line: 1070, col: 9, offset: 26044},
 						name: "RegexpPattern",
 					},
 				},
@@ -7469,24 +7465,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1076, col: 1, offset: 26192},
+			pos:  position{line: 1072, col: 1, offset: 26115},
 			expr: &choiceExpr{
-				pos: position{line: 1077, col: 5, offset: 26209},
+				pos: position{line: 1073, col: 5, offset: 26132},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 26209},
+						pos: position{line: 1073, col: 5, offset: 26132},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1077, col: 5, offset: 26209},
+							pos:   position{line: 1073, col: 5, offset: 26132},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1077, col: 7, offset: 26211},
+								pos:  position{line: 1073, col: 7, offset: 26134},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 5, offset: 26249},
+						pos:  position{line: 1074, col: 5, offset: 26172},
 						name: "OptionalExprs",
 					},
 				},
@@ -7496,96 +7492,96 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1080, col: 1, offset: 26264},
+			pos:  position{line: 1076, col: 1, offset: 26187},
 			expr: &actionExpr{
-				pos: position{line: 1081, col: 5, offset: 26273},
+				pos: position{line: 1077, col: 5, offset: 26196},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1081, col: 5, offset: 26273},
+					pos: position{line: 1077, col: 5, offset: 26196},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1081, col: 5, offset: 26273},
+							pos:  position{line: 1077, col: 5, offset: 26196},
 							name: "GREP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1081, col: 10, offset: 26278},
+							pos:  position{line: 1077, col: 10, offset: 26201},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1081, col: 13, offset: 26281},
+							pos:        position{line: 1077, col: 13, offset: 26204},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1081, col: 17, offset: 26285},
+							pos:  position{line: 1077, col: 17, offset: 26208},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1081, col: 20, offset: 26288},
+							pos:   position{line: 1077, col: 20, offset: 26211},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1081, col: 29, offset: 26297},
+								pos: position{line: 1077, col: 29, offset: 26220},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1081, col: 29, offset: 26297},
+										pos:  position{line: 1077, col: 29, offset: 26220},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1081, col: 38, offset: 26306},
+										pos:  position{line: 1077, col: 38, offset: 26229},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1081, col: 45, offset: 26313},
+										pos:  position{line: 1077, col: 45, offset: 26236},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1081, col: 51, offset: 26319},
+							pos:  position{line: 1077, col: 51, offset: 26242},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1081, col: 54, offset: 26322},
+							pos:   position{line: 1077, col: 54, offset: 26245},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1081, col: 58, offset: 26326},
+								pos: position{line: 1077, col: 58, offset: 26249},
 								expr: &actionExpr{
-									pos: position{line: 1081, col: 59, offset: 26327},
+									pos: position{line: 1077, col: 59, offset: 26250},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1081, col: 59, offset: 26327},
+										pos: position{line: 1077, col: 59, offset: 26250},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1081, col: 59, offset: 26327},
+												pos:        position{line: 1077, col: 59, offset: 26250},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1081, col: 63, offset: 26331},
+												pos:  position{line: 1077, col: 63, offset: 26254},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1081, col: 66, offset: 26334},
+												pos:   position{line: 1077, col: 66, offset: 26257},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1081, col: 69, offset: 26337},
+													pos: position{line: 1077, col: 69, offset: 26260},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1081, col: 69, offset: 26337},
+															pos:  position{line: 1077, col: 69, offset: 26260},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1081, col: 80, offset: 26348},
+															pos:  position{line: 1077, col: 80, offset: 26271},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1081, col: 86, offset: 26354},
+												pos:  position{line: 1077, col: 86, offset: 26277},
 												name: "__",
 											},
 										},
@@ -7594,7 +7590,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1081, col: 109, offset: 26377},
+							pos:        position{line: 1077, col: 109, offset: 26300},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7607,19 +7603,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1093, col: 1, offset: 26590},
+			pos:  position{line: 1089, col: 1, offset: 26513},
 			expr: &choiceExpr{
-				pos: position{line: 1094, col: 5, offset: 26608},
+				pos: position{line: 1090, col: 5, offset: 26531},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1094, col: 5, offset: 26608},
+						pos:  position{line: 1090, col: 5, offset: 26531},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1095, col: 5, offset: 26618},
+						pos: position{line: 1091, col: 5, offset: 26541},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1095, col: 5, offset: 26618},
+							pos:  position{line: 1091, col: 5, offset: 26541},
 							name: "__",
 						},
 					},
@@ -7630,51 +7626,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1097, col: 1, offset: 26646},
+			pos:  position{line: 1093, col: 1, offset: 26569},
 			expr: &actionExpr{
-				pos: position{line: 1098, col: 5, offset: 26656},
+				pos: position{line: 1094, col: 5, offset: 26579},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1098, col: 5, offset: 26656},
+					pos: position{line: 1094, col: 5, offset: 26579},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1098, col: 5, offset: 26656},
+							pos:   position{line: 1094, col: 5, offset: 26579},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1098, col: 11, offset: 26662},
+								pos:  position{line: 1094, col: 11, offset: 26585},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1098, col: 16, offset: 26667},
+							pos:   position{line: 1094, col: 16, offset: 26590},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1098, col: 21, offset: 26672},
+								pos: position{line: 1094, col: 21, offset: 26595},
 								expr: &actionExpr{
-									pos: position{line: 1098, col: 22, offset: 26673},
+									pos: position{line: 1094, col: 22, offset: 26596},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1098, col: 22, offset: 26673},
+										pos: position{line: 1094, col: 22, offset: 26596},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1098, col: 22, offset: 26673},
+												pos:  position{line: 1094, col: 22, offset: 26596},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1098, col: 25, offset: 26676},
+												pos:        position{line: 1094, col: 25, offset: 26599},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1098, col: 29, offset: 26680},
+												pos:  position{line: 1094, col: 29, offset: 26603},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1098, col: 32, offset: 26683},
+												pos:   position{line: 1094, col: 32, offset: 26606},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1098, col: 34, offset: 26685},
+													pos:  position{line: 1094, col: 34, offset: 26608},
 													name: "Expr",
 												},
 											},
@@ -7691,52 +7687,52 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1102, col: 1, offset: 26758},
+			pos:  position{line: 1098, col: 1, offset: 26681},
 			expr: &choiceExpr{
-				pos: position{line: 1103, col: 5, offset: 26770},
+				pos: position{line: 1099, col: 5, offset: 26693},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1103, col: 5, offset: 26770},
+						pos:  position{line: 1099, col: 5, offset: 26693},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1104, col: 5, offset: 26783},
+						pos:  position{line: 1100, col: 5, offset: 26706},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1105, col: 5, offset: 26794},
+						pos:  position{line: 1101, col: 5, offset: 26717},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1106, col: 5, offset: 26804},
+						pos:  position{line: 1102, col: 5, offset: 26727},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1107, col: 5, offset: 26812},
+						pos:  position{line: 1103, col: 5, offset: 26735},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1108, col: 5, offset: 26820},
+						pos:  position{line: 1104, col: 5, offset: 26743},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1109, col: 5, offset: 26832},
+						pos: position{line: 1105, col: 5, offset: 26755},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1109, col: 5, offset: 26832},
+							pos: position{line: 1105, col: 5, offset: 26755},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1109, col: 5, offset: 26832},
+									pos: position{line: 1105, col: 5, offset: 26755},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1109, col: 6, offset: 26833},
+										pos:  position{line: 1105, col: 6, offset: 26756},
 										name: "PipeKeyword",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1109, col: 18, offset: 26845},
+									pos:   position{line: 1105, col: 18, offset: 26768},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1109, col: 21, offset: 26848},
+										pos:  position{line: 1105, col: 21, offset: 26771},
 										name: "Identifier",
 									},
 								},
@@ -7744,39 +7740,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1110, col: 5, offset: 26882},
+						pos:  position{line: 1106, col: 5, offset: 26805},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1111, col: 5, offset: 26892},
+						pos: position{line: 1107, col: 5, offset: 26815},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 1111, col: 5, offset: 26892},
+							pos: position{line: 1107, col: 5, offset: 26815},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1111, col: 5, offset: 26892},
+									pos:        position{line: 1107, col: 5, offset: 26815},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 9, offset: 26896},
+									pos:  position{line: 1107, col: 9, offset: 26819},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 12, offset: 26899},
+									pos:   position{line: 1107, col: 12, offset: 26822},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 17, offset: 26904},
+										pos:  position{line: 1107, col: 17, offset: 26827},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 26, offset: 26913},
+									pos:  position{line: 1107, col: 26, offset: 26836},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 29, offset: 26916},
+									pos:        position{line: 1107, col: 29, offset: 26839},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7785,35 +7781,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1112, col: 5, offset: 26945},
+						pos: position{line: 1108, col: 5, offset: 26868},
 						run: (*parser).callonPrimary23,
 						expr: &seqExpr{
-							pos: position{line: 1112, col: 5, offset: 26945},
+							pos: position{line: 1108, col: 5, offset: 26868},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1112, col: 5, offset: 26945},
+									pos:        position{line: 1108, col: 5, offset: 26868},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1112, col: 9, offset: 26949},
+									pos:  position{line: 1108, col: 9, offset: 26872},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1112, col: 12, offset: 26952},
+									pos:   position{line: 1108, col: 12, offset: 26875},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1112, col: 17, offset: 26957},
+										pos:  position{line: 1108, col: 17, offset: 26880},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1112, col: 22, offset: 26962},
+									pos:  position{line: 1108, col: 22, offset: 26885},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1112, col: 25, offset: 26965},
+									pos:        position{line: 1108, col: 25, offset: 26888},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7828,55 +7824,55 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1114, col: 1, offset: 26991},
+			pos:  position{line: 1110, col: 1, offset: 26914},
 			expr: &choiceExpr{
-				pos: position{line: 1115, col: 5, offset: 27004},
+				pos: position{line: 1111, col: 5, offset: 26927},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1115, col: 5, offset: 27004},
+						pos: position{line: 1111, col: 5, offset: 26927},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1115, col: 5, offset: 27004},
+							pos: position{line: 1111, col: 5, offset: 26927},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1115, col: 5, offset: 27004},
+									pos:  position{line: 1111, col: 5, offset: 26927},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1115, col: 10, offset: 27009},
+									pos:   position{line: 1111, col: 10, offset: 26932},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1115, col: 16, offset: 27015},
+										pos: position{line: 1111, col: 16, offset: 26938},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1115, col: 16, offset: 27015},
+											pos:  position{line: 1111, col: 16, offset: 26938},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1115, col: 22, offset: 27021},
+									pos:   position{line: 1111, col: 22, offset: 26944},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1115, col: 28, offset: 27027},
+										pos: position{line: 1111, col: 28, offset: 26950},
 										expr: &seqExpr{
-											pos: position{line: 1115, col: 29, offset: 27028},
+											pos: position{line: 1111, col: 29, offset: 26951},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1115, col: 29, offset: 27028},
+													pos:  position{line: 1111, col: 29, offset: 26951},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 1115, col: 31, offset: 27030},
+													pos:        position{line: 1111, col: 31, offset: 26953},
 													val:        "else",
 													ignoreCase: false,
 													want:       "\"else\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1115, col: 38, offset: 27037},
+													pos:  position{line: 1111, col: 38, offset: 26960},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1115, col: 40, offset: 27039},
+													pos:  position{line: 1111, col: 40, offset: 26962},
 													name: "Expr",
 												},
 											},
@@ -7884,24 +7880,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1115, col: 47, offset: 27046},
+									pos:  position{line: 1111, col: 47, offset: 26969},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1115, col: 49, offset: 27048},
+									pos:  position{line: 1111, col: 49, offset: 26971},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1115, col: 53, offset: 27052},
+									pos: position{line: 1111, col: 53, offset: 26975},
 									expr: &seqExpr{
-										pos: position{line: 1115, col: 54, offset: 27053},
+										pos: position{line: 1111, col: 54, offset: 26976},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1115, col: 54, offset: 27053},
+												pos:  position{line: 1111, col: 54, offset: 26976},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1115, col: 56, offset: 27055},
+												pos:  position{line: 1111, col: 56, offset: 26978},
 												name: "CASE",
 											},
 										},
@@ -7911,62 +7907,62 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1139, col: 5, offset: 27704},
+						pos: position{line: 1135, col: 5, offset: 27627},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1139, col: 5, offset: 27704},
+							pos: position{line: 1135, col: 5, offset: 27627},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1139, col: 5, offset: 27704},
+									pos:  position{line: 1135, col: 5, offset: 27627},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1139, col: 10, offset: 27709},
+									pos:  position{line: 1135, col: 10, offset: 27632},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 12, offset: 27711},
+									pos:   position{line: 1135, col: 12, offset: 27634},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1139, col: 17, offset: 27716},
+										pos:  position{line: 1135, col: 17, offset: 27639},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 22, offset: 27721},
+									pos:   position{line: 1135, col: 22, offset: 27644},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1139, col: 28, offset: 27727},
+										pos: position{line: 1135, col: 28, offset: 27650},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1139, col: 28, offset: 27727},
+											pos:  position{line: 1135, col: 28, offset: 27650},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 34, offset: 27733},
+									pos:   position{line: 1135, col: 34, offset: 27656},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1139, col: 40, offset: 27739},
+										pos: position{line: 1135, col: 40, offset: 27662},
 										expr: &seqExpr{
-											pos: position{line: 1139, col: 41, offset: 27740},
+											pos: position{line: 1135, col: 41, offset: 27663},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1139, col: 41, offset: 27740},
+													pos:  position{line: 1135, col: 41, offset: 27663},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 1139, col: 43, offset: 27742},
+													pos:        position{line: 1135, col: 43, offset: 27665},
 													val:        "else",
 													ignoreCase: false,
 													want:       "\"else\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1139, col: 50, offset: 27749},
+													pos:  position{line: 1135, col: 50, offset: 27672},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1139, col: 52, offset: 27751},
+													pos:  position{line: 1135, col: 52, offset: 27674},
 													name: "Expr",
 												},
 											},
@@ -7974,24 +7970,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1139, col: 59, offset: 27758},
+									pos:  position{line: 1135, col: 59, offset: 27681},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1139, col: 61, offset: 27760},
+									pos:  position{line: 1135, col: 61, offset: 27683},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1139, col: 65, offset: 27764},
+									pos: position{line: 1135, col: 65, offset: 27687},
 									expr: &seqExpr{
-										pos: position{line: 1139, col: 66, offset: 27765},
+										pos: position{line: 1135, col: 66, offset: 27688},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1139, col: 66, offset: 27765},
+												pos:  position{line: 1135, col: 66, offset: 27688},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1139, col: 68, offset: 27767},
+												pos:  position{line: 1135, col: 68, offset: 27690},
 												name: "CASE",
 											},
 										},
@@ -8007,50 +8003,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1152, col: 1, offset: 28073},
+			pos:  position{line: 1148, col: 1, offset: 27996},
 			expr: &actionExpr{
-				pos: position{line: 1153, col: 5, offset: 28082},
+				pos: position{line: 1149, col: 5, offset: 28005},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1153, col: 5, offset: 28082},
+					pos: position{line: 1149, col: 5, offset: 28005},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1153, col: 5, offset: 28082},
+							pos:  position{line: 1149, col: 5, offset: 28005},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1153, col: 7, offset: 28084},
+							pos:  position{line: 1149, col: 7, offset: 28007},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1153, col: 12, offset: 28089},
+							pos:  position{line: 1149, col: 12, offset: 28012},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1153, col: 14, offset: 28091},
+							pos:   position{line: 1149, col: 14, offset: 28014},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1153, col: 19, offset: 28096},
+								pos:  position{line: 1149, col: 19, offset: 28019},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1153, col: 24, offset: 28101},
+							pos:  position{line: 1149, col: 24, offset: 28024},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1153, col: 26, offset: 28103},
+							pos:  position{line: 1149, col: 26, offset: 28026},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1153, col: 31, offset: 28108},
+							pos:  position{line: 1149, col: 31, offset: 28031},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1153, col: 33, offset: 28110},
+							pos:   position{line: 1149, col: 33, offset: 28033},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1153, col: 38, offset: 28115},
+								pos:  position{line: 1149, col: 38, offset: 28038},
 								name: "Expr",
 							},
 						},
@@ -8062,57 +8058,57 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1162, col: 1, offset: 28274},
+			pos:  position{line: 1158, col: 1, offset: 28197},
 			expr: &actionExpr{
-				pos: position{line: 1163, col: 5, offset: 28287},
+				pos: position{line: 1159, col: 5, offset: 28210},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1163, col: 5, offset: 28287},
+					pos: position{line: 1159, col: 5, offset: 28210},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1163, col: 5, offset: 28287},
+							pos:  position{line: 1159, col: 5, offset: 28210},
 							name: "OVER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1163, col: 10, offset: 28292},
+							pos:  position{line: 1159, col: 10, offset: 28215},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1163, col: 12, offset: 28294},
+							pos:   position{line: 1159, col: 12, offset: 28217},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1163, col: 18, offset: 28300},
+								pos:  position{line: 1159, col: 18, offset: 28223},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1163, col: 24, offset: 28306},
+							pos:   position{line: 1159, col: 24, offset: 28229},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1163, col: 31, offset: 28313},
+								pos: position{line: 1159, col: 31, offset: 28236},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1163, col: 31, offset: 28313},
+									pos:  position{line: 1159, col: 31, offset: 28236},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1163, col: 39, offset: 28321},
+							pos:  position{line: 1159, col: 39, offset: 28244},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1163, col: 42, offset: 28324},
+							pos:  position{line: 1159, col: 42, offset: 28247},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1163, col: 47, offset: 28329},
+							pos:  position{line: 1159, col: 47, offset: 28252},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1163, col: 50, offset: 28332},
+							pos:   position{line: 1159, col: 50, offset: 28255},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1163, col: 55, offset: 28337},
+								pos:  position{line: 1159, col: 55, offset: 28260},
 								name: "Seq",
 							},
 						},
@@ -8124,37 +8120,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1173, col: 1, offset: 28568},
+			pos:  position{line: 1169, col: 1, offset: 28491},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 5, offset: 28579},
+				pos: position{line: 1170, col: 5, offset: 28502},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1174, col: 5, offset: 28579},
+					pos: position{line: 1170, col: 5, offset: 28502},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1174, col: 5, offset: 28579},
+							pos:        position{line: 1170, col: 5, offset: 28502},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 9, offset: 28583},
+							pos:  position{line: 1170, col: 9, offset: 28506},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1174, col: 12, offset: 28586},
+							pos:   position{line: 1170, col: 12, offset: 28509},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1174, col: 18, offset: 28592},
+								pos:  position{line: 1170, col: 18, offset: 28515},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 30, offset: 28604},
+							pos:  position{line: 1170, col: 30, offset: 28527},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1174, col: 33, offset: 28607},
+							pos:        position{line: 1170, col: 33, offset: 28530},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8167,31 +8163,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1182, col: 1, offset: 28765},
+			pos:  position{line: 1178, col: 1, offset: 28688},
 			expr: &choiceExpr{
-				pos: position{line: 1183, col: 5, offset: 28781},
+				pos: position{line: 1179, col: 5, offset: 28704},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1183, col: 5, offset: 28781},
+						pos: position{line: 1179, col: 5, offset: 28704},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1183, col: 5, offset: 28781},
+							pos: position{line: 1179, col: 5, offset: 28704},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1183, col: 5, offset: 28781},
+									pos:   position{line: 1179, col: 5, offset: 28704},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1183, col: 11, offset: 28787},
+										pos:  position{line: 1179, col: 11, offset: 28710},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1183, col: 22, offset: 28798},
+									pos:   position{line: 1179, col: 22, offset: 28721},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1183, col: 27, offset: 28803},
+										pos: position{line: 1179, col: 27, offset: 28726},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1183, col: 27, offset: 28803},
+											pos:  position{line: 1179, col: 27, offset: 28726},
 											name: "RecordElemTail",
 										},
 									},
@@ -8200,10 +8196,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1186, col: 5, offset: 28866},
+						pos: position{line: 1182, col: 5, offset: 28789},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1186, col: 5, offset: 28866},
+							pos:  position{line: 1182, col: 5, offset: 28789},
 							name: "__",
 						},
 					},
@@ -8214,32 +8210,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1188, col: 1, offset: 28890},
+			pos:  position{line: 1184, col: 1, offset: 28813},
 			expr: &actionExpr{
-				pos: position{line: 1188, col: 18, offset: 28907},
+				pos: position{line: 1184, col: 18, offset: 28830},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1188, col: 18, offset: 28907},
+					pos: position{line: 1184, col: 18, offset: 28830},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1188, col: 18, offset: 28907},
+							pos:  position{line: 1184, col: 18, offset: 28830},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1188, col: 21, offset: 28910},
+							pos:        position{line: 1184, col: 21, offset: 28833},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1188, col: 25, offset: 28914},
+							pos:  position{line: 1184, col: 25, offset: 28837},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1188, col: 28, offset: 28917},
+							pos:   position{line: 1184, col: 28, offset: 28840},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1188, col: 33, offset: 28922},
+								pos:  position{line: 1184, col: 33, offset: 28845},
 								name: "RecordElem",
 							},
 						},
@@ -8251,20 +8247,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1190, col: 1, offset: 28955},
+			pos:  position{line: 1186, col: 1, offset: 28878},
 			expr: &choiceExpr{
-				pos: position{line: 1191, col: 5, offset: 28970},
+				pos: position{line: 1187, col: 5, offset: 28893},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1191, col: 5, offset: 28970},
+						pos:  position{line: 1187, col: 5, offset: 28893},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1192, col: 5, offset: 28981},
+						pos:  position{line: 1188, col: 5, offset: 28904},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1193, col: 5, offset: 28995},
+						pos:  position{line: 1189, col: 5, offset: 28918},
 						name: "Identifier",
 					},
 				},
@@ -8274,28 +8270,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1195, col: 1, offset: 29007},
+			pos:  position{line: 1191, col: 1, offset: 28930},
 			expr: &actionExpr{
-				pos: position{line: 1196, col: 5, offset: 29018},
+				pos: position{line: 1192, col: 5, offset: 28941},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1196, col: 5, offset: 29018},
+					pos: position{line: 1192, col: 5, offset: 28941},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1196, col: 5, offset: 29018},
+							pos:        position{line: 1192, col: 5, offset: 28941},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1196, col: 11, offset: 29024},
+							pos:  position{line: 1192, col: 11, offset: 28947},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1196, col: 14, offset: 29027},
+							pos:   position{line: 1192, col: 14, offset: 28950},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1196, col: 19, offset: 29032},
+								pos:  position{line: 1192, col: 19, offset: 28955},
 								name: "Expr",
 							},
 						},
@@ -8307,40 +8303,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1200, col: 1, offset: 29128},
+			pos:  position{line: 1196, col: 1, offset: 29051},
 			expr: &actionExpr{
-				pos: position{line: 1201, col: 5, offset: 29142},
+				pos: position{line: 1197, col: 5, offset: 29065},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1201, col: 5, offset: 29142},
+					pos: position{line: 1197, col: 5, offset: 29065},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1201, col: 5, offset: 29142},
+							pos:   position{line: 1197, col: 5, offset: 29065},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1201, col: 10, offset: 29147},
+								pos:  position{line: 1197, col: 10, offset: 29070},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1201, col: 15, offset: 29152},
+							pos:  position{line: 1197, col: 15, offset: 29075},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1201, col: 18, offset: 29155},
+							pos:        position{line: 1197, col: 18, offset: 29078},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1201, col: 22, offset: 29159},
+							pos:  position{line: 1197, col: 22, offset: 29082},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1201, col: 25, offset: 29162},
+							pos:   position{line: 1197, col: 25, offset: 29085},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1201, col: 31, offset: 29168},
+								pos:  position{line: 1197, col: 31, offset: 29091},
 								name: "Expr",
 							},
 						},
@@ -8352,37 +8348,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1210, col: 1, offset: 29337},
+			pos:  position{line: 1206, col: 1, offset: 29260},
 			expr: &actionExpr{
-				pos: position{line: 1211, col: 5, offset: 29347},
+				pos: position{line: 1207, col: 5, offset: 29270},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1211, col: 5, offset: 29347},
+					pos: position{line: 1207, col: 5, offset: 29270},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1211, col: 5, offset: 29347},
+							pos:        position{line: 1207, col: 5, offset: 29270},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1211, col: 9, offset: 29351},
+							pos:  position{line: 1207, col: 9, offset: 29274},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1211, col: 12, offset: 29354},
+							pos:   position{line: 1207, col: 12, offset: 29277},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1211, col: 18, offset: 29360},
+								pos:  position{line: 1207, col: 18, offset: 29283},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1211, col: 30, offset: 29372},
+							pos:  position{line: 1207, col: 30, offset: 29295},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1211, col: 33, offset: 29375},
+							pos:        position{line: 1207, col: 33, offset: 29298},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8395,37 +8391,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1219, col: 1, offset: 29531},
+			pos:  position{line: 1215, col: 1, offset: 29454},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 5, offset: 29539},
+				pos: position{line: 1216, col: 5, offset: 29462},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 5, offset: 29539},
+					pos: position{line: 1216, col: 5, offset: 29462},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1220, col: 5, offset: 29539},
+							pos:        position{line: 1216, col: 5, offset: 29462},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 10, offset: 29544},
+							pos:  position{line: 1216, col: 10, offset: 29467},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1220, col: 13, offset: 29547},
+							pos:   position{line: 1216, col: 13, offset: 29470},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 19, offset: 29553},
+								pos:  position{line: 1216, col: 19, offset: 29476},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 31, offset: 29565},
+							pos:  position{line: 1216, col: 31, offset: 29488},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1220, col: 34, offset: 29568},
+							pos:        position{line: 1216, col: 34, offset: 29491},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8438,54 +8434,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1228, col: 1, offset: 29721},
+			pos:  position{line: 1224, col: 1, offset: 29644},
 			expr: &choiceExpr{
-				pos: position{line: 1229, col: 5, offset: 29737},
+				pos: position{line: 1225, col: 5, offset: 29660},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1229, col: 5, offset: 29737},
+						pos: position{line: 1225, col: 5, offset: 29660},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1229, col: 5, offset: 29737},
+							pos: position{line: 1225, col: 5, offset: 29660},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1229, col: 5, offset: 29737},
+									pos:   position{line: 1225, col: 5, offset: 29660},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1229, col: 11, offset: 29743},
+										pos:  position{line: 1225, col: 11, offset: 29666},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1229, col: 22, offset: 29754},
+									pos:   position{line: 1225, col: 22, offset: 29677},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1229, col: 27, offset: 29759},
+										pos: position{line: 1225, col: 27, offset: 29682},
 										expr: &actionExpr{
-											pos: position{line: 1229, col: 28, offset: 29760},
+											pos: position{line: 1225, col: 28, offset: 29683},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1229, col: 28, offset: 29760},
+												pos: position{line: 1225, col: 28, offset: 29683},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1229, col: 28, offset: 29760},
+														pos:  position{line: 1225, col: 28, offset: 29683},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1229, col: 31, offset: 29763},
+														pos:        position{line: 1225, col: 31, offset: 29686},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1229, col: 35, offset: 29767},
+														pos:  position{line: 1225, col: 35, offset: 29690},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1229, col: 38, offset: 29770},
+														pos:   position{line: 1225, col: 38, offset: 29693},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1229, col: 40, offset: 29772},
+															pos:  position{line: 1225, col: 40, offset: 29695},
 															name: "VectorElem",
 														},
 													},
@@ -8498,10 +8494,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1232, col: 5, offset: 29854},
+						pos: position{line: 1228, col: 5, offset: 29777},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1232, col: 5, offset: 29854},
+							pos:  position{line: 1228, col: 5, offset: 29777},
 							name: "__",
 						},
 					},
@@ -8512,22 +8508,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1234, col: 1, offset: 29878},
+			pos:  position{line: 1230, col: 1, offset: 29801},
 			expr: &choiceExpr{
-				pos: position{line: 1235, col: 5, offset: 29893},
+				pos: position{line: 1231, col: 5, offset: 29816},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1235, col: 5, offset: 29893},
+						pos:  position{line: 1231, col: 5, offset: 29816},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1236, col: 5, offset: 29904},
+						pos: position{line: 1232, col: 5, offset: 29827},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1236, col: 5, offset: 29904},
+							pos:   position{line: 1232, col: 5, offset: 29827},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1236, col: 7, offset: 29906},
+								pos:  position{line: 1232, col: 7, offset: 29829},
 								name: "Expr",
 							},
 						},
@@ -8539,37 +8535,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1238, col: 1, offset: 29997},
+			pos:  position{line: 1234, col: 1, offset: 29920},
 			expr: &actionExpr{
-				pos: position{line: 1239, col: 5, offset: 30005},
+				pos: position{line: 1235, col: 5, offset: 29928},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1239, col: 5, offset: 30005},
+					pos: position{line: 1235, col: 5, offset: 29928},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1239, col: 5, offset: 30005},
+							pos:        position{line: 1235, col: 5, offset: 29928},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1239, col: 10, offset: 30010},
+							pos:  position{line: 1235, col: 10, offset: 29933},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1239, col: 13, offset: 30013},
+							pos:   position{line: 1235, col: 13, offset: 29936},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1239, col: 19, offset: 30019},
+								pos:  position{line: 1235, col: 19, offset: 29942},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1239, col: 27, offset: 30027},
+							pos:  position{line: 1235, col: 27, offset: 29950},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1239, col: 30, offset: 30030},
+							pos:        position{line: 1235, col: 30, offset: 29953},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8582,31 +8578,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1247, col: 1, offset: 30184},
+			pos:  position{line: 1243, col: 1, offset: 30107},
 			expr: &choiceExpr{
-				pos: position{line: 1248, col: 5, offset: 30196},
+				pos: position{line: 1244, col: 5, offset: 30119},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1248, col: 5, offset: 30196},
+						pos: position{line: 1244, col: 5, offset: 30119},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1248, col: 5, offset: 30196},
+							pos: position{line: 1244, col: 5, offset: 30119},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1248, col: 5, offset: 30196},
+									pos:   position{line: 1244, col: 5, offset: 30119},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1248, col: 11, offset: 30202},
+										pos:  position{line: 1244, col: 11, offset: 30125},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1248, col: 17, offset: 30208},
+									pos:   position{line: 1244, col: 17, offset: 30131},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1248, col: 22, offset: 30213},
+										pos: position{line: 1244, col: 22, offset: 30136},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1248, col: 22, offset: 30213},
+											pos:  position{line: 1244, col: 22, offset: 30136},
 											name: "EntryTail",
 										},
 									},
@@ -8615,10 +8611,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1251, col: 5, offset: 30271},
+						pos: position{line: 1247, col: 5, offset: 30194},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1251, col: 5, offset: 30271},
+							pos:  position{line: 1247, col: 5, offset: 30194},
 							name: "__",
 						},
 					},
@@ -8629,32 +8625,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1254, col: 1, offset: 30296},
+			pos:  position{line: 1250, col: 1, offset: 30219},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 13, offset: 30308},
+				pos: position{line: 1250, col: 13, offset: 30231},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1254, col: 13, offset: 30308},
+					pos: position{line: 1250, col: 13, offset: 30231},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1254, col: 13, offset: 30308},
+							pos:  position{line: 1250, col: 13, offset: 30231},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1254, col: 16, offset: 30311},
+							pos:        position{line: 1250, col: 16, offset: 30234},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1254, col: 20, offset: 30315},
+							pos:  position{line: 1250, col: 20, offset: 30238},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1254, col: 23, offset: 30318},
+							pos:   position{line: 1250, col: 23, offset: 30241},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1254, col: 25, offset: 30320},
+								pos:  position{line: 1250, col: 25, offset: 30243},
 								name: "Entry",
 							},
 						},
@@ -8666,40 +8662,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1256, col: 1, offset: 30345},
+			pos:  position{line: 1252, col: 1, offset: 30268},
 			expr: &actionExpr{
-				pos: position{line: 1257, col: 5, offset: 30355},
+				pos: position{line: 1253, col: 5, offset: 30278},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1257, col: 5, offset: 30355},
+					pos: position{line: 1253, col: 5, offset: 30278},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1257, col: 5, offset: 30355},
+							pos:   position{line: 1253, col: 5, offset: 30278},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1257, col: 9, offset: 30359},
+								pos:  position{line: 1253, col: 9, offset: 30282},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1257, col: 14, offset: 30364},
+							pos:  position{line: 1253, col: 14, offset: 30287},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1257, col: 17, offset: 30367},
+							pos:        position{line: 1253, col: 17, offset: 30290},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1257, col: 21, offset: 30371},
+							pos:  position{line: 1253, col: 21, offset: 30294},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1257, col: 24, offset: 30374},
+							pos:   position{line: 1253, col: 24, offset: 30297},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1257, col: 30, offset: 30380},
+								pos:  position{line: 1253, col: 30, offset: 30303},
 								name: "Expr",
 							},
 						},
@@ -8711,61 +8707,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1261, col: 1, offset: 30483},
+			pos:  position{line: 1257, col: 1, offset: 30406},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 5, offset: 30493},
+				pos: position{line: 1258, col: 5, offset: 30416},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1262, col: 5, offset: 30493},
+					pos: position{line: 1258, col: 5, offset: 30416},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1262, col: 5, offset: 30493},
+							pos:        position{line: 1258, col: 5, offset: 30416},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1262, col: 9, offset: 30497},
+							pos:  position{line: 1258, col: 9, offset: 30420},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1262, col: 12, offset: 30500},
+							pos:   position{line: 1258, col: 12, offset: 30423},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1262, col: 18, offset: 30506},
+								pos:  position{line: 1258, col: 18, offset: 30429},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1262, col: 23, offset: 30511},
+							pos:   position{line: 1258, col: 23, offset: 30434},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1262, col: 28, offset: 30516},
+								pos: position{line: 1258, col: 28, offset: 30439},
 								expr: &actionExpr{
-									pos: position{line: 1262, col: 29, offset: 30517},
+									pos: position{line: 1258, col: 29, offset: 30440},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1262, col: 29, offset: 30517},
+										pos: position{line: 1258, col: 29, offset: 30440},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1262, col: 29, offset: 30517},
+												pos:  position{line: 1258, col: 29, offset: 30440},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1262, col: 32, offset: 30520},
+												pos:        position{line: 1258, col: 32, offset: 30443},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1262, col: 36, offset: 30524},
+												pos:  position{line: 1258, col: 36, offset: 30447},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1262, col: 39, offset: 30527},
+												pos:   position{line: 1258, col: 39, offset: 30450},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1262, col: 41, offset: 30529},
+													pos:  position{line: 1258, col: 41, offset: 30452},
 													name: "Expr",
 												},
 											},
@@ -8775,11 +8771,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1262, col: 66, offset: 30554},
+							pos:  position{line: 1258, col: 66, offset: 30477},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1262, col: 69, offset: 30557},
+							pos:        position{line: 1258, col: 69, offset: 30480},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8792,56 +8788,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1272, col: 1, offset: 30738},
+			pos:  position{line: 1268, col: 1, offset: 30661},
 			expr: &choiceExpr{
-				pos: position{line: 1273, col: 5, offset: 30750},
+				pos: position{line: 1269, col: 5, offset: 30673},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 30750},
+						pos:  position{line: 1269, col: 5, offset: 30673},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1274, col: 5, offset: 30766},
+						pos:  position{line: 1270, col: 5, offset: 30689},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1275, col: 5, offset: 30784},
+						pos:  position{line: 1271, col: 5, offset: 30707},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1276, col: 5, offset: 30796},
+						pos:  position{line: 1272, col: 5, offset: 30719},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1277, col: 5, offset: 30814},
+						pos:  position{line: 1273, col: 5, offset: 30737},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 30833},
+						pos:  position{line: 1274, col: 5, offset: 30756},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 5, offset: 30850},
+						pos:  position{line: 1275, col: 5, offset: 30773},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1280, col: 5, offset: 30863},
+						pos:  position{line: 1276, col: 5, offset: 30786},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1281, col: 5, offset: 30872},
+						pos:  position{line: 1277, col: 5, offset: 30795},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1282, col: 5, offset: 30889},
+						pos:  position{line: 1278, col: 5, offset: 30812},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1283, col: 5, offset: 30908},
+						pos:  position{line: 1279, col: 5, offset: 30831},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1284, col: 5, offset: 30927},
+						pos:  position{line: 1280, col: 5, offset: 30850},
 						name: "NullLiteral",
 					},
 				},
@@ -8851,28 +8847,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1286, col: 1, offset: 30940},
+			pos:  position{line: 1282, col: 1, offset: 30863},
 			expr: &choiceExpr{
-				pos: position{line: 1287, col: 5, offset: 30958},
+				pos: position{line: 1283, col: 5, offset: 30881},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1287, col: 5, offset: 30958},
+						pos: position{line: 1283, col: 5, offset: 30881},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1287, col: 5, offset: 30958},
+							pos: position{line: 1283, col: 5, offset: 30881},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1287, col: 5, offset: 30958},
+									pos:   position{line: 1283, col: 5, offset: 30881},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1287, col: 7, offset: 30960},
+										pos:  position{line: 1283, col: 7, offset: 30883},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1287, col: 14, offset: 30967},
+									pos: position{line: 1283, col: 14, offset: 30890},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1287, col: 15, offset: 30968},
+										pos:  position{line: 1283, col: 15, offset: 30891},
 										name: "IdentifierRest",
 									},
 								},
@@ -8880,13 +8876,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 31048},
+						pos: position{line: 1286, col: 5, offset: 30971},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1290, col: 5, offset: 31048},
+							pos:   position{line: 1286, col: 5, offset: 30971},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1290, col: 7, offset: 31050},
+								pos:  position{line: 1286, col: 7, offset: 30973},
 								name: "IP4Net",
 							},
 						},
@@ -8898,28 +8894,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1294, col: 1, offset: 31119},
+			pos:  position{line: 1290, col: 1, offset: 31042},
 			expr: &choiceExpr{
-				pos: position{line: 1295, col: 5, offset: 31138},
+				pos: position{line: 1291, col: 5, offset: 31061},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1295, col: 5, offset: 31138},
+						pos: position{line: 1291, col: 5, offset: 31061},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1295, col: 5, offset: 31138},
+							pos: position{line: 1291, col: 5, offset: 31061},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1295, col: 5, offset: 31138},
+									pos:   position{line: 1291, col: 5, offset: 31061},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1295, col: 7, offset: 31140},
+										pos:  position{line: 1291, col: 7, offset: 31063},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1295, col: 11, offset: 31144},
+									pos: position{line: 1291, col: 11, offset: 31067},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1295, col: 12, offset: 31145},
+										pos:  position{line: 1291, col: 12, offset: 31068},
 										name: "IdentifierRest",
 									},
 								},
@@ -8927,13 +8923,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1298, col: 5, offset: 31224},
+						pos: position{line: 1294, col: 5, offset: 31147},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1298, col: 5, offset: 31224},
+							pos:   position{line: 1294, col: 5, offset: 31147},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1298, col: 7, offset: 31226},
+								pos:  position{line: 1294, col: 7, offset: 31149},
 								name: "IP",
 							},
 						},
@@ -8945,15 +8941,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1302, col: 1, offset: 31290},
+			pos:  position{line: 1298, col: 1, offset: 31213},
 			expr: &actionExpr{
-				pos: position{line: 1303, col: 5, offset: 31307},
+				pos: position{line: 1299, col: 5, offset: 31230},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1303, col: 5, offset: 31307},
+					pos:   position{line: 1299, col: 5, offset: 31230},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1303, col: 7, offset: 31309},
+						pos:  position{line: 1299, col: 7, offset: 31232},
 						name: "FloatString",
 					},
 				},
@@ -8963,15 +8959,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1307, col: 1, offset: 31387},
+			pos:  position{line: 1303, col: 1, offset: 31310},
 			expr: &actionExpr{
-				pos: position{line: 1308, col: 5, offset: 31406},
+				pos: position{line: 1304, col: 5, offset: 31329},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1308, col: 5, offset: 31406},
+					pos:   position{line: 1304, col: 5, offset: 31329},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1308, col: 7, offset: 31408},
+						pos:  position{line: 1304, col: 7, offset: 31331},
 						name: "IntString",
 					},
 				},
@@ -8981,23 +8977,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1312, col: 1, offset: 31482},
+			pos:  position{line: 1308, col: 1, offset: 31405},
 			expr: &choiceExpr{
-				pos: position{line: 1313, col: 5, offset: 31501},
+				pos: position{line: 1309, col: 5, offset: 31424},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 31501},
+						pos: position{line: 1309, col: 5, offset: 31424},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1313, col: 5, offset: 31501},
+							pos:  position{line: 1309, col: 5, offset: 31424},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 31559},
+						pos: position{line: 1310, col: 5, offset: 31482},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1314, col: 5, offset: 31559},
+							pos:  position{line: 1310, col: 5, offset: 31482},
 							name: "FALSE",
 						},
 					},
@@ -9008,12 +9004,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1316, col: 1, offset: 31615},
+			pos:  position{line: 1312, col: 1, offset: 31538},
 			expr: &actionExpr{
-				pos: position{line: 1317, col: 5, offset: 31631},
+				pos: position{line: 1313, col: 5, offset: 31554},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1317, col: 5, offset: 31631},
+					pos:  position{line: 1313, col: 5, offset: 31554},
 					name: "NULL",
 				},
 			},
@@ -9022,23 +9018,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1319, col: 1, offset: 31681},
+			pos:  position{line: 1315, col: 1, offset: 31604},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 5, offset: 31698},
+				pos: position{line: 1316, col: 5, offset: 31621},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1320, col: 5, offset: 31698},
+					pos: position{line: 1316, col: 5, offset: 31621},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1320, col: 5, offset: 31698},
+							pos:        position{line: 1316, col: 5, offset: 31621},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1320, col: 10, offset: 31703},
+							pos: position{line: 1316, col: 10, offset: 31626},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1320, col: 10, offset: 31703},
+								pos:  position{line: 1316, col: 10, offset: 31626},
 								name: "HexDigit",
 							},
 						},
@@ -9050,29 +9046,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1324, col: 1, offset: 31777},
+			pos:  position{line: 1320, col: 1, offset: 31700},
 			expr: &actionExpr{
-				pos: position{line: 1325, col: 5, offset: 31793},
+				pos: position{line: 1321, col: 5, offset: 31716},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1325, col: 5, offset: 31793},
+					pos: position{line: 1321, col: 5, offset: 31716},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1325, col: 5, offset: 31793},
+							pos:        position{line: 1321, col: 5, offset: 31716},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1325, col: 9, offset: 31797},
+							pos:   position{line: 1321, col: 9, offset: 31720},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1325, col: 13, offset: 31801},
+								pos:  position{line: 1321, col: 13, offset: 31724},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1325, col: 18, offset: 31806},
+							pos:        position{line: 1321, col: 18, offset: 31729},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -9085,16 +9081,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1333, col: 1, offset: 31939},
+			pos:  position{line: 1329, col: 1, offset: 31862},
 			expr: &choiceExpr{
-				pos: position{line: 1334, col: 5, offset: 31948},
+				pos: position{line: 1330, col: 5, offset: 31871},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1334, col: 5, offset: 31948},
+						pos:  position{line: 1330, col: 5, offset: 31871},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1335, col: 5, offset: 31966},
+						pos:  position{line: 1331, col: 5, offset: 31889},
 						name: "ComplexType",
 					},
 				},
@@ -9104,28 +9100,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1337, col: 1, offset: 31979},
+			pos:  position{line: 1333, col: 1, offset: 31902},
 			expr: &choiceExpr{
-				pos: position{line: 1338, col: 5, offset: 31997},
+				pos: position{line: 1334, col: 5, offset: 31920},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1338, col: 5, offset: 31997},
+						pos: position{line: 1334, col: 5, offset: 31920},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1338, col: 5, offset: 31997},
+							pos: position{line: 1334, col: 5, offset: 31920},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1338, col: 5, offset: 31997},
+									pos:   position{line: 1334, col: 5, offset: 31920},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1338, col: 10, offset: 32002},
+										pos:  position{line: 1334, col: 10, offset: 31925},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1338, col: 24, offset: 32016},
+									pos: position{line: 1334, col: 24, offset: 31939},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1338, col: 25, offset: 32017},
+										pos:  position{line: 1334, col: 25, offset: 31940},
 										name: "IdentifierRest",
 									},
 								},
@@ -9133,43 +9129,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1339, col: 5, offset: 32057},
+						pos: position{line: 1335, col: 5, offset: 31980},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1339, col: 5, offset: 32057},
+							pos: position{line: 1335, col: 5, offset: 31980},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1339, col: 5, offset: 32057},
+									pos:  position{line: 1335, col: 5, offset: 31980},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1339, col: 11, offset: 32063},
+									pos:  position{line: 1335, col: 11, offset: 31986},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1339, col: 14, offset: 32066},
+									pos:        position{line: 1335, col: 14, offset: 31989},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1339, col: 18, offset: 32070},
+									pos:  position{line: 1335, col: 18, offset: 31993},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1339, col: 21, offset: 32073},
+									pos:   position{line: 1335, col: 21, offset: 31996},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1339, col: 23, offset: 32075},
+										pos:  position{line: 1335, col: 23, offset: 31998},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1339, col: 28, offset: 32080},
+									pos:  position{line: 1335, col: 28, offset: 32003},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1339, col: 31, offset: 32083},
+									pos:        position{line: 1335, col: 31, offset: 32006},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9178,43 +9174,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1346, col: 5, offset: 32223},
+						pos: position{line: 1342, col: 5, offset: 32146},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1346, col: 5, offset: 32223},
+							pos: position{line: 1342, col: 5, offset: 32146},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1346, col: 5, offset: 32223},
+									pos:   position{line: 1342, col: 5, offset: 32146},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1346, col: 10, offset: 32228},
+										pos:  position{line: 1342, col: 10, offset: 32151},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1346, col: 15, offset: 32233},
+									pos:   position{line: 1342, col: 15, offset: 32156},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1346, col: 19, offset: 32237},
+										pos: position{line: 1342, col: 19, offset: 32160},
 										expr: &seqExpr{
-											pos: position{line: 1346, col: 20, offset: 32238},
+											pos: position{line: 1342, col: 20, offset: 32161},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1346, col: 20, offset: 32238},
+													pos:  position{line: 1342, col: 20, offset: 32161},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1346, col: 23, offset: 32241},
+													pos:        position{line: 1342, col: 23, offset: 32164},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1346, col: 27, offset: 32245},
+													pos:  position{line: 1342, col: 27, offset: 32168},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1346, col: 30, offset: 32248},
+													pos:  position{line: 1342, col: 30, offset: 32171},
 													name: "Type",
 												},
 											},
@@ -9225,31 +9221,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1357, col: 5, offset: 32573},
+						pos: position{line: 1353, col: 5, offset: 32496},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1357, col: 5, offset: 32573},
+							pos: position{line: 1353, col: 5, offset: 32496},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1357, col: 5, offset: 32573},
+									pos:        position{line: 1353, col: 5, offset: 32496},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1357, col: 9, offset: 32577},
+									pos:  position{line: 1353, col: 9, offset: 32500},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1357, col: 12, offset: 32580},
+									pos:   position{line: 1353, col: 12, offset: 32503},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1357, col: 18, offset: 32586},
+										pos:  position{line: 1353, col: 18, offset: 32509},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1357, col: 27, offset: 32595},
+									pos:        position{line: 1353, col: 27, offset: 32518},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9264,28 +9260,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1365, col: 1, offset: 32739},
+			pos:  position{line: 1361, col: 1, offset: 32662},
 			expr: &actionExpr{
-				pos: position{line: 1366, col: 5, offset: 32752},
+				pos: position{line: 1362, col: 5, offset: 32675},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1366, col: 5, offset: 32752},
+					pos: position{line: 1362, col: 5, offset: 32675},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1366, col: 5, offset: 32752},
+							pos:   position{line: 1362, col: 5, offset: 32675},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1366, col: 11, offset: 32758},
+								pos:  position{line: 1362, col: 11, offset: 32681},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1366, col: 16, offset: 32763},
+							pos:   position{line: 1362, col: 16, offset: 32686},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1366, col: 21, offset: 32768},
+								pos: position{line: 1362, col: 21, offset: 32691},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1366, col: 21, offset: 32768},
+									pos:  position{line: 1362, col: 21, offset: 32691},
 									name: "TypeListTail",
 								},
 							},
@@ -9298,32 +9294,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1370, col: 1, offset: 32826},
+			pos:  position{line: 1366, col: 1, offset: 32749},
 			expr: &actionExpr{
-				pos: position{line: 1370, col: 16, offset: 32841},
+				pos: position{line: 1366, col: 16, offset: 32764},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1370, col: 16, offset: 32841},
+					pos: position{line: 1366, col: 16, offset: 32764},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1370, col: 16, offset: 32841},
+							pos:  position{line: 1366, col: 16, offset: 32764},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1370, col: 19, offset: 32844},
+							pos:        position{line: 1366, col: 19, offset: 32767},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1370, col: 23, offset: 32848},
+							pos:  position{line: 1366, col: 23, offset: 32771},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1370, col: 26, offset: 32851},
+							pos:   position{line: 1366, col: 26, offset: 32774},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1370, col: 30, offset: 32855},
+								pos:  position{line: 1366, col: 30, offset: 32778},
 								name: "Type",
 							},
 						},
@@ -9335,40 +9331,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1372, col: 1, offset: 32881},
+			pos:  position{line: 1368, col: 1, offset: 32804},
 			expr: &choiceExpr{
-				pos: position{line: 1373, col: 5, offset: 32897},
+				pos: position{line: 1369, col: 5, offset: 32820},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1373, col: 5, offset: 32897},
+						pos: position{line: 1369, col: 5, offset: 32820},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1373, col: 5, offset: 32897},
+							pos: position{line: 1369, col: 5, offset: 32820},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1373, col: 5, offset: 32897},
+									pos:        position{line: 1369, col: 5, offset: 32820},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1373, col: 9, offset: 32901},
+									pos:  position{line: 1369, col: 9, offset: 32824},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1373, col: 12, offset: 32904},
+									pos:   position{line: 1369, col: 12, offset: 32827},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1373, col: 19, offset: 32911},
+										pos:  position{line: 1369, col: 19, offset: 32834},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1373, col: 33, offset: 32925},
+									pos:  position{line: 1369, col: 33, offset: 32848},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1373, col: 36, offset: 32928},
+									pos:        position{line: 1369, col: 36, offset: 32851},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9377,35 +9373,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1380, col: 5, offset: 33090},
+						pos: position{line: 1376, col: 5, offset: 33013},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1380, col: 5, offset: 33090},
+							pos: position{line: 1376, col: 5, offset: 33013},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1380, col: 5, offset: 33090},
+									pos:        position{line: 1376, col: 5, offset: 33013},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1380, col: 9, offset: 33094},
+									pos:  position{line: 1376, col: 9, offset: 33017},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1380, col: 12, offset: 33097},
+									pos:   position{line: 1376, col: 12, offset: 33020},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1380, col: 16, offset: 33101},
+										pos:  position{line: 1376, col: 16, offset: 33024},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1380, col: 21, offset: 33106},
+									pos:  position{line: 1376, col: 21, offset: 33029},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1380, col: 24, offset: 33109},
+									pos:        position{line: 1376, col: 24, offset: 33032},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9414,35 +9410,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1387, col: 5, offset: 33251},
+						pos: position{line: 1383, col: 5, offset: 33174},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1387, col: 5, offset: 33251},
+							pos: position{line: 1383, col: 5, offset: 33174},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1387, col: 5, offset: 33251},
+									pos:        position{line: 1383, col: 5, offset: 33174},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1387, col: 10, offset: 33256},
+									pos:  position{line: 1383, col: 10, offset: 33179},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1387, col: 13, offset: 33259},
+									pos:   position{line: 1383, col: 13, offset: 33182},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1387, col: 17, offset: 33263},
+										pos:  position{line: 1383, col: 17, offset: 33186},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1387, col: 22, offset: 33268},
+									pos:  position{line: 1383, col: 22, offset: 33191},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1387, col: 25, offset: 33271},
+									pos:        position{line: 1383, col: 25, offset: 33194},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9451,57 +9447,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1394, col: 5, offset: 33410},
+						pos: position{line: 1390, col: 5, offset: 33333},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1394, col: 5, offset: 33410},
+							pos: position{line: 1390, col: 5, offset: 33333},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1394, col: 5, offset: 33410},
+									pos:        position{line: 1390, col: 5, offset: 33333},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1394, col: 10, offset: 33415},
+									pos:  position{line: 1390, col: 10, offset: 33338},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1394, col: 13, offset: 33418},
+									pos:   position{line: 1390, col: 13, offset: 33341},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1394, col: 21, offset: 33426},
+										pos:  position{line: 1390, col: 21, offset: 33349},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1394, col: 26, offset: 33431},
+									pos:  position{line: 1390, col: 26, offset: 33354},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1394, col: 29, offset: 33434},
+									pos:        position{line: 1390, col: 29, offset: 33357},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1394, col: 33, offset: 33438},
+									pos:  position{line: 1390, col: 33, offset: 33361},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1394, col: 36, offset: 33441},
+									pos:   position{line: 1390, col: 36, offset: 33364},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1394, col: 44, offset: 33449},
+										pos:  position{line: 1390, col: 44, offset: 33372},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1394, col: 49, offset: 33454},
+									pos:  position{line: 1390, col: 49, offset: 33377},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1394, col: 52, offset: 33457},
+									pos:        position{line: 1390, col: 52, offset: 33380},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9516,35 +9512,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1403, col: 1, offset: 33631},
+			pos:  position{line: 1399, col: 1, offset: 33554},
 			expr: &choiceExpr{
-				pos: position{line: 1404, col: 5, offset: 33649},
+				pos: position{line: 1400, col: 5, offset: 33572},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1404, col: 5, offset: 33649},
+						pos: position{line: 1400, col: 5, offset: 33572},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1404, col: 5, offset: 33649},
+							pos: position{line: 1400, col: 5, offset: 33572},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1404, col: 5, offset: 33649},
+									pos:        position{line: 1400, col: 5, offset: 33572},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1404, col: 9, offset: 33653},
+									pos:   position{line: 1400, col: 9, offset: 33576},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1404, col: 11, offset: 33655},
+										pos: position{line: 1400, col: 11, offset: 33578},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1404, col: 11, offset: 33655},
+											pos:  position{line: 1400, col: 11, offset: 33578},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1404, col: 29, offset: 33673},
+									pos:        position{line: 1400, col: 29, offset: 33596},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9553,30 +9549,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1405, col: 5, offset: 33737},
+						pos: position{line: 1401, col: 5, offset: 33660},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1405, col: 5, offset: 33737},
+							pos: position{line: 1401, col: 5, offset: 33660},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1405, col: 5, offset: 33737},
+									pos:        position{line: 1401, col: 5, offset: 33660},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1405, col: 9, offset: 33741},
+									pos:   position{line: 1401, col: 9, offset: 33664},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1405, col: 11, offset: 33743},
+										pos: position{line: 1401, col: 11, offset: 33666},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1405, col: 11, offset: 33743},
+											pos:  position{line: 1401, col: 11, offset: 33666},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1405, col: 29, offset: 33761},
+									pos:        position{line: 1401, col: 29, offset: 33684},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9591,35 +9587,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1407, col: 1, offset: 33822},
+			pos:  position{line: 1403, col: 1, offset: 33745},
 			expr: &choiceExpr{
-				pos: position{line: 1408, col: 5, offset: 33834},
+				pos: position{line: 1404, col: 5, offset: 33757},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1408, col: 5, offset: 33834},
+						pos: position{line: 1404, col: 5, offset: 33757},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1408, col: 5, offset: 33834},
+							pos: position{line: 1404, col: 5, offset: 33757},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1408, col: 5, offset: 33834},
+									pos:        position{line: 1404, col: 5, offset: 33757},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1408, col: 11, offset: 33840},
+									pos:   position{line: 1404, col: 11, offset: 33763},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1408, col: 13, offset: 33842},
+										pos: position{line: 1404, col: 13, offset: 33765},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1408, col: 13, offset: 33842},
+											pos:  position{line: 1404, col: 13, offset: 33765},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1408, col: 38, offset: 33867},
+									pos:        position{line: 1404, col: 38, offset: 33790},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9628,30 +9624,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1415, col: 5, offset: 34013},
+						pos: position{line: 1411, col: 5, offset: 33936},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1415, col: 5, offset: 34013},
+							pos: position{line: 1411, col: 5, offset: 33936},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1415, col: 5, offset: 34013},
+									pos:        position{line: 1411, col: 5, offset: 33936},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1415, col: 10, offset: 34018},
+									pos:   position{line: 1411, col: 10, offset: 33941},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1415, col: 12, offset: 34020},
+										pos: position{line: 1411, col: 12, offset: 33943},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1415, col: 12, offset: 34020},
+											pos:  position{line: 1411, col: 12, offset: 33943},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1415, col: 37, offset: 34045},
+									pos:        position{line: 1411, col: 37, offset: 33968},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9666,24 +9662,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1423, col: 1, offset: 34188},
+			pos:  position{line: 1419, col: 1, offset: 34111},
 			expr: &choiceExpr{
-				pos: position{line: 1424, col: 5, offset: 34216},
+				pos: position{line: 1420, col: 5, offset: 34139},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1424, col: 5, offset: 34216},
+						pos:  position{line: 1420, col: 5, offset: 34139},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1425, col: 5, offset: 34232},
+						pos: position{line: 1421, col: 5, offset: 34155},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1425, col: 5, offset: 34232},
+							pos:   position{line: 1421, col: 5, offset: 34155},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1425, col: 7, offset: 34234},
+								pos: position{line: 1421, col: 7, offset: 34157},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1425, col: 7, offset: 34234},
+									pos:  position{line: 1421, col: 7, offset: 34157},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9696,27 +9692,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1429, col: 1, offset: 34357},
+			pos:  position{line: 1425, col: 1, offset: 34280},
 			expr: &choiceExpr{
-				pos: position{line: 1430, col: 5, offset: 34385},
+				pos: position{line: 1426, col: 5, offset: 34308},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1430, col: 5, offset: 34385},
+						pos: position{line: 1426, col: 5, offset: 34308},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1430, col: 5, offset: 34385},
+							pos: position{line: 1426, col: 5, offset: 34308},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1430, col: 5, offset: 34385},
+									pos:        position{line: 1426, col: 5, offset: 34308},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1430, col: 10, offset: 34390},
+									pos:   position{line: 1426, col: 10, offset: 34313},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1430, col: 12, offset: 34392},
+										pos:        position{line: 1426, col: 12, offset: 34315},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9726,25 +9722,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1431, col: 5, offset: 34418},
+						pos: position{line: 1427, col: 5, offset: 34341},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1431, col: 5, offset: 34418},
+							pos: position{line: 1427, col: 5, offset: 34341},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1431, col: 5, offset: 34418},
+									pos: position{line: 1427, col: 5, offset: 34341},
 									expr: &litMatcher{
-										pos:        position{line: 1431, col: 7, offset: 34420},
+										pos:        position{line: 1427, col: 7, offset: 34343},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1431, col: 12, offset: 34425},
+									pos:   position{line: 1427, col: 12, offset: 34348},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1431, col: 14, offset: 34427},
+										pos:  position{line: 1427, col: 14, offset: 34350},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9758,24 +9754,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1433, col: 1, offset: 34463},
+			pos:  position{line: 1429, col: 1, offset: 34386},
 			expr: &choiceExpr{
-				pos: position{line: 1434, col: 5, offset: 34491},
+				pos: position{line: 1430, col: 5, offset: 34414},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1434, col: 5, offset: 34491},
+						pos:  position{line: 1430, col: 5, offset: 34414},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1435, col: 5, offset: 34507},
+						pos: position{line: 1431, col: 5, offset: 34430},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1435, col: 5, offset: 34507},
+							pos:   position{line: 1431, col: 5, offset: 34430},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1435, col: 7, offset: 34509},
+								pos: position{line: 1431, col: 7, offset: 34432},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1435, col: 7, offset: 34509},
+									pos:  position{line: 1431, col: 7, offset: 34432},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9788,27 +9784,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1439, col: 1, offset: 34632},
+			pos:  position{line: 1435, col: 1, offset: 34555},
 			expr: &choiceExpr{
-				pos: position{line: 1440, col: 5, offset: 34660},
+				pos: position{line: 1436, col: 5, offset: 34583},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1440, col: 5, offset: 34660},
+						pos: position{line: 1436, col: 5, offset: 34583},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1440, col: 5, offset: 34660},
+							pos: position{line: 1436, col: 5, offset: 34583},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1440, col: 5, offset: 34660},
+									pos:        position{line: 1436, col: 5, offset: 34583},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1440, col: 10, offset: 34665},
+									pos:   position{line: 1436, col: 10, offset: 34588},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1440, col: 12, offset: 34667},
+										pos:        position{line: 1436, col: 12, offset: 34590},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9818,25 +9814,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1441, col: 5, offset: 34693},
+						pos: position{line: 1437, col: 5, offset: 34616},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1441, col: 5, offset: 34693},
+							pos: position{line: 1437, col: 5, offset: 34616},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1441, col: 5, offset: 34693},
+									pos: position{line: 1437, col: 5, offset: 34616},
 									expr: &litMatcher{
-										pos:        position{line: 1441, col: 7, offset: 34695},
+										pos:        position{line: 1437, col: 7, offset: 34618},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1441, col: 12, offset: 34700},
+									pos:   position{line: 1437, col: 12, offset: 34623},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1441, col: 14, offset: 34702},
+										pos:  position{line: 1437, col: 14, offset: 34625},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9850,37 +9846,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1443, col: 1, offset: 34738},
+			pos:  position{line: 1439, col: 1, offset: 34661},
 			expr: &actionExpr{
-				pos: position{line: 1444, col: 5, offset: 34754},
+				pos: position{line: 1440, col: 5, offset: 34677},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1444, col: 5, offset: 34754},
+					pos: position{line: 1440, col: 5, offset: 34677},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1444, col: 5, offset: 34754},
+							pos:        position{line: 1440, col: 5, offset: 34677},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1444, col: 9, offset: 34758},
+							pos:  position{line: 1440, col: 9, offset: 34681},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1444, col: 12, offset: 34761},
+							pos:   position{line: 1440, col: 12, offset: 34684},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1444, col: 14, offset: 34763},
+								pos:  position{line: 1440, col: 14, offset: 34686},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1444, col: 19, offset: 34768},
+							pos:  position{line: 1440, col: 19, offset: 34691},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1444, col: 22, offset: 34771},
+							pos:        position{line: 1440, col: 22, offset: 34694},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9893,129 +9889,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1452, col: 1, offset: 34906},
+			pos:  position{line: 1448, col: 1, offset: 34829},
 			expr: &actionExpr{
-				pos: position{line: 1453, col: 5, offset: 34924},
+				pos: position{line: 1449, col: 5, offset: 34847},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1453, col: 9, offset: 34928},
+					pos: position{line: 1449, col: 9, offset: 34851},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1453, col: 9, offset: 34928},
+							pos:        position{line: 1449, col: 9, offset: 34851},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1453, col: 19, offset: 34938},
+							pos:        position{line: 1449, col: 19, offset: 34861},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1453, col: 30, offset: 34949},
+							pos:        position{line: 1449, col: 30, offset: 34872},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1453, col: 41, offset: 34960},
+							pos:        position{line: 1449, col: 41, offset: 34883},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 9, offset: 34977},
+							pos:        position{line: 1450, col: 9, offset: 34900},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 18, offset: 34986},
+							pos:        position{line: 1450, col: 18, offset: 34909},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 28, offset: 34996},
+							pos:        position{line: 1450, col: 28, offset: 34919},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 38, offset: 35006},
+							pos:        position{line: 1450, col: 38, offset: 34929},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 9, offset: 35022},
+							pos:        position{line: 1451, col: 9, offset: 34945},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 21, offset: 35034},
+							pos:        position{line: 1451, col: 21, offset: 34957},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 33, offset: 35046},
+							pos:        position{line: 1451, col: 33, offset: 34969},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1456, col: 9, offset: 35064},
+							pos:        position{line: 1452, col: 9, offset: 34987},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1456, col: 18, offset: 35073},
+							pos:        position{line: 1452, col: 18, offset: 34996},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1457, col: 9, offset: 35090},
+							pos:        position{line: 1453, col: 9, offset: 35013},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1457, col: 22, offset: 35103},
+							pos:        position{line: 1453, col: 22, offset: 35026},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1458, col: 9, offset: 35118},
+							pos:        position{line: 1454, col: 9, offset: 35041},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1459, col: 9, offset: 35134},
+							pos:        position{line: 1455, col: 9, offset: 35057},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1459, col: 16, offset: 35141},
+							pos:        position{line: 1455, col: 16, offset: 35064},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1460, col: 9, offset: 35155},
+							pos:        position{line: 1456, col: 9, offset: 35078},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1460, col: 18, offset: 35164},
+							pos:        position{line: 1456, col: 18, offset: 35087},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -10028,31 +10024,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1468, col: 1, offset: 35349},
+			pos:  position{line: 1464, col: 1, offset: 35272},
 			expr: &choiceExpr{
-				pos: position{line: 1469, col: 5, offset: 35367},
+				pos: position{line: 1465, col: 5, offset: 35290},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1469, col: 5, offset: 35367},
+						pos: position{line: 1465, col: 5, offset: 35290},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1469, col: 5, offset: 35367},
+							pos: position{line: 1465, col: 5, offset: 35290},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1469, col: 5, offset: 35367},
+									pos:   position{line: 1465, col: 5, offset: 35290},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1469, col: 11, offset: 35373},
+										pos:  position{line: 1465, col: 11, offset: 35296},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1469, col: 21, offset: 35383},
+									pos:   position{line: 1465, col: 21, offset: 35306},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1469, col: 26, offset: 35388},
+										pos: position{line: 1465, col: 26, offset: 35311},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1469, col: 26, offset: 35388},
+											pos:  position{line: 1465, col: 26, offset: 35311},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10061,10 +10057,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1472, col: 5, offset: 35454},
+						pos: position{line: 1468, col: 5, offset: 35377},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1472, col: 5, offset: 35454},
+							pos:        position{line: 1468, col: 5, offset: 35377},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10077,32 +10073,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1474, col: 1, offset: 35478},
+			pos:  position{line: 1470, col: 1, offset: 35401},
 			expr: &actionExpr{
-				pos: position{line: 1474, col: 21, offset: 35498},
+				pos: position{line: 1470, col: 21, offset: 35421},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1474, col: 21, offset: 35498},
+					pos: position{line: 1470, col: 21, offset: 35421},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1474, col: 21, offset: 35498},
+							pos:  position{line: 1470, col: 21, offset: 35421},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1474, col: 24, offset: 35501},
+							pos:        position{line: 1470, col: 24, offset: 35424},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1474, col: 28, offset: 35505},
+							pos:  position{line: 1470, col: 28, offset: 35428},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1474, col: 31, offset: 35508},
+							pos:   position{line: 1470, col: 31, offset: 35431},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1474, col: 35, offset: 35512},
+								pos:  position{line: 1470, col: 35, offset: 35435},
 								name: "TypeField",
 							},
 						},
@@ -10114,40 +10110,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1476, col: 1, offset: 35543},
+			pos:  position{line: 1472, col: 1, offset: 35466},
 			expr: &actionExpr{
-				pos: position{line: 1477, col: 5, offset: 35557},
+				pos: position{line: 1473, col: 5, offset: 35480},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1477, col: 5, offset: 35557},
+					pos: position{line: 1473, col: 5, offset: 35480},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1477, col: 5, offset: 35557},
+							pos:   position{line: 1473, col: 5, offset: 35480},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1477, col: 10, offset: 35562},
+								pos:  position{line: 1473, col: 10, offset: 35485},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1477, col: 15, offset: 35567},
+							pos:  position{line: 1473, col: 15, offset: 35490},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1477, col: 18, offset: 35570},
+							pos:        position{line: 1473, col: 18, offset: 35493},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1477, col: 22, offset: 35574},
+							pos:  position{line: 1473, col: 22, offset: 35497},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1477, col: 25, offset: 35577},
+							pos:   position{line: 1473, col: 25, offset: 35500},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1477, col: 29, offset: 35581},
+								pos:  position{line: 1473, col: 29, offset: 35504},
 								name: "Type",
 							},
 						},
@@ -10159,54 +10155,54 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1485, col: 1, offset: 35730},
+			pos:  position{line: 1481, col: 1, offset: 35653},
 			expr: &choiceExpr{
-				pos: position{line: 1486, col: 5, offset: 35739},
+				pos: position{line: 1482, col: 5, offset: 35662},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1486, col: 5, offset: 35739},
+						pos: position{line: 1482, col: 5, offset: 35662},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1486, col: 5, offset: 35739},
+							pos:   position{line: 1482, col: 5, offset: 35662},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1486, col: 7, offset: 35741},
+								pos:  position{line: 1482, col: 7, offset: 35664},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1487, col: 5, offset: 35830},
+						pos: position{line: 1483, col: 5, offset: 35753},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1487, col: 5, offset: 35830},
+							pos:   position{line: 1483, col: 5, offset: 35753},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1487, col: 7, offset: 35832},
+								pos:  position{line: 1483, col: 7, offset: 35755},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1488, col: 5, offset: 35921},
+						pos: position{line: 1484, col: 5, offset: 35844},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1488, col: 5, offset: 35921},
+							pos:   position{line: 1484, col: 5, offset: 35844},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1488, col: 7, offset: 35923},
+								pos:  position{line: 1484, col: 7, offset: 35846},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1489, col: 5, offset: 36012},
+						pos: position{line: 1485, col: 5, offset: 35935},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1489, col: 5, offset: 36012},
+							pos:   position{line: 1485, col: 5, offset: 35935},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1489, col: 7, offset: 36014},
+								pos:  position{line: 1485, col: 7, offset: 35937},
 								name: "KSUID",
 							},
 						},
@@ -10218,22 +10214,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1491, col: 1, offset: 36100},
+			pos:  position{line: 1487, col: 1, offset: 36023},
 			expr: &actionExpr{
-				pos: position{line: 1492, col: 5, offset: 36114},
+				pos: position{line: 1488, col: 5, offset: 36037},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1492, col: 5, offset: 36114},
+					pos: position{line: 1488, col: 5, offset: 36037},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1492, col: 6, offset: 36115},
+							pos: position{line: 1488, col: 6, offset: 36038},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1492, col: 6, offset: 36115},
+									pos:  position{line: 1488, col: 6, offset: 36038},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1492, col: 24, offset: 36133},
+									pos:        position{line: 1488, col: 24, offset: 36056},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -10241,16 +10237,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1492, col: 29, offset: 36138},
+							pos: position{line: 1488, col: 29, offset: 36061},
 							expr: &choiceExpr{
-								pos: position{line: 1492, col: 30, offset: 36139},
+								pos: position{line: 1488, col: 30, offset: 36062},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1492, col: 30, offset: 36139},
+										pos:  position{line: 1488, col: 30, offset: 36062},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1492, col: 47, offset: 36156},
+										pos:        position{line: 1488, col: 47, offset: 36079},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -10266,15 +10262,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1494, col: 1, offset: 36194},
+			pos:  position{line: 1490, col: 1, offset: 36117},
 			expr: &actionExpr{
-				pos: position{line: 1495, col: 5, offset: 36209},
+				pos: position{line: 1491, col: 5, offset: 36132},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1495, col: 5, offset: 36209},
+					pos:   position{line: 1491, col: 5, offset: 36132},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1495, col: 8, offset: 36212},
+						pos:  position{line: 1491, col: 8, offset: 36135},
 						name: "IdentifierName",
 					},
 				},
@@ -10284,51 +10280,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1503, col: 1, offset: 36345},
+			pos:  position{line: 1499, col: 1, offset: 36268},
 			expr: &actionExpr{
-				pos: position{line: 1504, col: 5, offset: 36361},
+				pos: position{line: 1500, col: 5, offset: 36284},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1504, col: 5, offset: 36361},
+					pos: position{line: 1500, col: 5, offset: 36284},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1504, col: 5, offset: 36361},
+							pos:   position{line: 1500, col: 5, offset: 36284},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1504, col: 11, offset: 36367},
+								pos:  position{line: 1500, col: 11, offset: 36290},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1504, col: 22, offset: 36378},
+							pos:   position{line: 1500, col: 22, offset: 36301},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1504, col: 27, offset: 36383},
+								pos: position{line: 1500, col: 27, offset: 36306},
 								expr: &actionExpr{
-									pos: position{line: 1504, col: 28, offset: 36384},
+									pos: position{line: 1500, col: 28, offset: 36307},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1504, col: 28, offset: 36384},
+										pos: position{line: 1500, col: 28, offset: 36307},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1504, col: 28, offset: 36384},
+												pos:  position{line: 1500, col: 28, offset: 36307},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1504, col: 31, offset: 36387},
+												pos:        position{line: 1500, col: 31, offset: 36310},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1504, col: 35, offset: 36391},
+												pos:  position{line: 1500, col: 35, offset: 36314},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1504, col: 38, offset: 36394},
+												pos:   position{line: 1500, col: 38, offset: 36317},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1504, col: 43, offset: 36399},
+													pos:  position{line: 1500, col: 43, offset: 36322},
 													name: "Identifier",
 												},
 											},
@@ -10345,29 +10341,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1508, col: 1, offset: 36477},
+			pos:  position{line: 1504, col: 1, offset: 36400},
 			expr: &choiceExpr{
-				pos: position{line: 1509, col: 5, offset: 36496},
+				pos: position{line: 1505, col: 5, offset: 36419},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1509, col: 5, offset: 36496},
+						pos: position{line: 1505, col: 5, offset: 36419},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1509, col: 5, offset: 36496},
+							pos: position{line: 1505, col: 5, offset: 36419},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1509, col: 5, offset: 36496},
+									pos: position{line: 1505, col: 5, offset: 36419},
 									expr: &seqExpr{
-										pos: position{line: 1509, col: 7, offset: 36498},
+										pos: position{line: 1505, col: 7, offset: 36421},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1509, col: 7, offset: 36498},
+												pos:  position{line: 1505, col: 7, offset: 36421},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1509, col: 15, offset: 36506},
+												pos: position{line: 1505, col: 15, offset: 36429},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1509, col: 16, offset: 36507},
+													pos:  position{line: 1505, col: 16, offset: 36430},
 													name: "IdentifierRest",
 												},
 											},
@@ -10375,13 +10371,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1509, col: 32, offset: 36523},
+									pos:  position{line: 1505, col: 32, offset: 36446},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1509, col: 48, offset: 36539},
+									pos: position{line: 1505, col: 48, offset: 36462},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1509, col: 48, offset: 36539},
+										pos:  position{line: 1505, col: 48, offset: 36462},
 										name: "IdentifierRest",
 									},
 								},
@@ -10389,32 +10385,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1510, col: 5, offset: 36590},
+						pos: position{line: 1506, col: 5, offset: 36513},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1510, col: 5, offset: 36590},
+							pos:        position{line: 1506, col: 5, offset: 36513},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1511, col: 5, offset: 36629},
+						pos: position{line: 1507, col: 5, offset: 36552},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1511, col: 5, offset: 36629},
+							pos: position{line: 1507, col: 5, offset: 36552},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1511, col: 5, offset: 36629},
+									pos:        position{line: 1507, col: 5, offset: 36552},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1511, col: 10, offset: 36634},
+									pos:   position{line: 1507, col: 10, offset: 36557},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1511, col: 13, offset: 36637},
+										pos:  position{line: 1507, col: 13, offset: 36560},
 										name: "IDGuard",
 									},
 								},
@@ -10422,17 +10418,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1513, col: 5, offset: 36728},
+						pos: position{line: 1509, col: 5, offset: 36651},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1513, col: 5, offset: 36728},
+							pos:        position{line: 1509, col: 5, offset: 36651},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1514, col: 5, offset: 36770},
+						pos:  position{line: 1510, col: 5, offset: 36693},
 						name: "BacktickString",
 					},
 				},
@@ -10442,22 +10438,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1516, col: 1, offset: 36787},
+			pos:  position{line: 1512, col: 1, offset: 36710},
 			expr: &choiceExpr{
-				pos: position{line: 1517, col: 5, offset: 36807},
+				pos: position{line: 1513, col: 5, offset: 36730},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1517, col: 5, offset: 36807},
+						pos:  position{line: 1513, col: 5, offset: 36730},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1518, col: 5, offset: 36825},
+						pos:        position{line: 1514, col: 5, offset: 36748},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1519, col: 5, offset: 36833},
+						pos:        position{line: 1515, col: 5, offset: 36756},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10469,24 +10465,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1521, col: 1, offset: 36838},
+			pos:  position{line: 1517, col: 1, offset: 36761},
 			expr: &choiceExpr{
-				pos: position{line: 1522, col: 5, offset: 36857},
+				pos: position{line: 1518, col: 5, offset: 36780},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1522, col: 5, offset: 36857},
+						pos:  position{line: 1518, col: 5, offset: 36780},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1523, col: 5, offset: 36877},
+						pos:  position{line: 1519, col: 5, offset: 36800},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1524, col: 5, offset: 36902},
+						pos:  position{line: 1520, col: 5, offset: 36825},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1525, col: 5, offset: 36919},
+						pos:  position{line: 1521, col: 5, offset: 36842},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10496,24 +10492,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1527, col: 1, offset: 36948},
+			pos:  position{line: 1523, col: 1, offset: 36871},
 			expr: &choiceExpr{
-				pos: position{line: 1528, col: 5, offset: 36960},
+				pos: position{line: 1524, col: 5, offset: 36883},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1528, col: 5, offset: 36960},
+						pos:  position{line: 1524, col: 5, offset: 36883},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1529, col: 5, offset: 36979},
+						pos:  position{line: 1525, col: 5, offset: 36902},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1530, col: 5, offset: 36995},
+						pos:  position{line: 1526, col: 5, offset: 36918},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1531, col: 5, offset: 37003},
+						pos:  position{line: 1527, col: 5, offset: 36926},
 						name: "Infinity",
 					},
 				},
@@ -10523,25 +10519,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1533, col: 1, offset: 37013},
+			pos:  position{line: 1529, col: 1, offset: 36936},
 			expr: &actionExpr{
-				pos: position{line: 1534, col: 5, offset: 37022},
+				pos: position{line: 1530, col: 5, offset: 36945},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1534, col: 5, offset: 37022},
+					pos: position{line: 1530, col: 5, offset: 36945},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1534, col: 5, offset: 37022},
+							pos:  position{line: 1530, col: 5, offset: 36945},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1534, col: 14, offset: 37031},
+							pos:        position{line: 1530, col: 14, offset: 36954},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1534, col: 18, offset: 37035},
+							pos:  position{line: 1530, col: 18, offset: 36958},
 							name: "FullTime",
 						},
 					},
@@ -10552,32 +10548,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1538, col: 1, offset: 37111},
+			pos:  position{line: 1534, col: 1, offset: 37034},
 			expr: &seqExpr{
-				pos: position{line: 1538, col: 12, offset: 37122},
+				pos: position{line: 1534, col: 12, offset: 37045},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1538, col: 12, offset: 37122},
+						pos:  position{line: 1534, col: 12, offset: 37045},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1538, col: 15, offset: 37125},
+						pos:        position{line: 1534, col: 15, offset: 37048},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1538, col: 19, offset: 37129},
+						pos:  position{line: 1534, col: 19, offset: 37052},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1538, col: 22, offset: 37132},
+						pos:        position{line: 1534, col: 22, offset: 37055},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1538, col: 26, offset: 37136},
+						pos:  position{line: 1534, col: 26, offset: 37059},
 						name: "D2",
 					},
 				},
@@ -10587,33 +10583,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1540, col: 1, offset: 37140},
+			pos:  position{line: 1536, col: 1, offset: 37063},
 			expr: &seqExpr{
-				pos: position{line: 1540, col: 6, offset: 37145},
+				pos: position{line: 1536, col: 6, offset: 37068},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1540, col: 6, offset: 37145},
+						pos:        position{line: 1536, col: 6, offset: 37068},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1540, col: 11, offset: 37150},
+						pos:        position{line: 1536, col: 11, offset: 37073},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1540, col: 16, offset: 37155},
+						pos:        position{line: 1536, col: 16, offset: 37078},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1540, col: 21, offset: 37160},
+						pos:        position{line: 1536, col: 21, offset: 37083},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10626,19 +10622,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1541, col: 1, offset: 37166},
+			pos:  position{line: 1537, col: 1, offset: 37089},
 			expr: &seqExpr{
-				pos: position{line: 1541, col: 6, offset: 37171},
+				pos: position{line: 1537, col: 6, offset: 37094},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1541, col: 6, offset: 37171},
+						pos:        position{line: 1537, col: 6, offset: 37094},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1541, col: 11, offset: 37176},
+						pos:        position{line: 1537, col: 11, offset: 37099},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10651,16 +10647,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1543, col: 1, offset: 37183},
+			pos:  position{line: 1539, col: 1, offset: 37106},
 			expr: &seqExpr{
-				pos: position{line: 1543, col: 12, offset: 37194},
+				pos: position{line: 1539, col: 12, offset: 37117},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1543, col: 12, offset: 37194},
+						pos:  position{line: 1539, col: 12, offset: 37117},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1543, col: 24, offset: 37206},
+						pos:  position{line: 1539, col: 24, offset: 37129},
 						name: "TimeOffset",
 					},
 				},
@@ -10670,49 +10666,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1545, col: 1, offset: 37218},
+			pos:  position{line: 1541, col: 1, offset: 37141},
 			expr: &seqExpr{
-				pos: position{line: 1545, col: 15, offset: 37232},
+				pos: position{line: 1541, col: 15, offset: 37155},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1545, col: 15, offset: 37232},
+						pos:  position{line: 1541, col: 15, offset: 37155},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1545, col: 18, offset: 37235},
+						pos:        position{line: 1541, col: 18, offset: 37158},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1545, col: 22, offset: 37239},
+						pos:  position{line: 1541, col: 22, offset: 37162},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1545, col: 25, offset: 37242},
+						pos:        position{line: 1541, col: 25, offset: 37165},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1545, col: 29, offset: 37246},
+						pos:  position{line: 1541, col: 29, offset: 37169},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1545, col: 32, offset: 37249},
+						pos: position{line: 1541, col: 32, offset: 37172},
 						expr: &seqExpr{
-							pos: position{line: 1545, col: 33, offset: 37250},
+							pos: position{line: 1541, col: 33, offset: 37173},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1545, col: 33, offset: 37250},
+									pos:        position{line: 1541, col: 33, offset: 37173},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1545, col: 37, offset: 37254},
+									pos: position{line: 1541, col: 37, offset: 37177},
 									expr: &charClassMatcher{
-										pos:        position{line: 1545, col: 37, offset: 37254},
+										pos:        position{line: 1541, col: 37, offset: 37177},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10729,30 +10725,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1547, col: 1, offset: 37264},
+			pos:  position{line: 1543, col: 1, offset: 37187},
 			expr: &choiceExpr{
-				pos: position{line: 1548, col: 5, offset: 37279},
+				pos: position{line: 1544, col: 5, offset: 37202},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1548, col: 5, offset: 37279},
+						pos:        position{line: 1544, col: 5, offset: 37202},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1549, col: 5, offset: 37287},
+						pos: position{line: 1545, col: 5, offset: 37210},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1549, col: 6, offset: 37288},
+								pos: position{line: 1545, col: 6, offset: 37211},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1549, col: 6, offset: 37288},
+										pos:        position{line: 1545, col: 6, offset: 37211},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1549, col: 12, offset: 37294},
+										pos:        position{line: 1545, col: 12, offset: 37217},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10760,34 +10756,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1549, col: 17, offset: 37299},
+								pos:  position{line: 1545, col: 17, offset: 37222},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1549, col: 20, offset: 37302},
+								pos:        position{line: 1545, col: 20, offset: 37225},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1549, col: 24, offset: 37306},
+								pos:  position{line: 1545, col: 24, offset: 37229},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1549, col: 27, offset: 37309},
+								pos: position{line: 1545, col: 27, offset: 37232},
 								expr: &seqExpr{
-									pos: position{line: 1549, col: 28, offset: 37310},
+									pos: position{line: 1545, col: 28, offset: 37233},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1549, col: 28, offset: 37310},
+											pos:        position{line: 1545, col: 28, offset: 37233},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1549, col: 32, offset: 37314},
+											pos: position{line: 1545, col: 32, offset: 37237},
 											expr: &charClassMatcher{
-												pos:        position{line: 1549, col: 32, offset: 37314},
+												pos:        position{line: 1545, col: 32, offset: 37237},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10806,33 +10802,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1551, col: 1, offset: 37324},
+			pos:  position{line: 1547, col: 1, offset: 37247},
 			expr: &actionExpr{
-				pos: position{line: 1552, col: 5, offset: 37337},
+				pos: position{line: 1548, col: 5, offset: 37260},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1552, col: 5, offset: 37337},
+					pos: position{line: 1548, col: 5, offset: 37260},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1552, col: 5, offset: 37337},
+							pos: position{line: 1548, col: 5, offset: 37260},
 							expr: &litMatcher{
-								pos:        position{line: 1552, col: 5, offset: 37337},
+								pos:        position{line: 1548, col: 5, offset: 37260},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1552, col: 10, offset: 37342},
+							pos: position{line: 1548, col: 10, offset: 37265},
 							expr: &seqExpr{
-								pos: position{line: 1552, col: 11, offset: 37343},
+								pos: position{line: 1548, col: 11, offset: 37266},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1552, col: 11, offset: 37343},
+										pos:  position{line: 1548, col: 11, offset: 37266},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1552, col: 19, offset: 37351},
+										pos:  position{line: 1548, col: 19, offset: 37274},
 										name: "TimeUnit",
 									},
 								},
@@ -10846,27 +10842,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1556, col: 1, offset: 37433},
+			pos:  position{line: 1552, col: 1, offset: 37356},
 			expr: &seqExpr{
-				pos: position{line: 1556, col: 11, offset: 37443},
+				pos: position{line: 1552, col: 11, offset: 37366},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1556, col: 11, offset: 37443},
+						pos:  position{line: 1552, col: 11, offset: 37366},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1556, col: 16, offset: 37448},
+						pos: position{line: 1552, col: 16, offset: 37371},
 						expr: &seqExpr{
-							pos: position{line: 1556, col: 17, offset: 37449},
+							pos: position{line: 1552, col: 17, offset: 37372},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1556, col: 17, offset: 37449},
+									pos:        position{line: 1552, col: 17, offset: 37372},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1556, col: 21, offset: 37453},
+									pos:  position{line: 1552, col: 21, offset: 37376},
 									name: "UInt",
 								},
 							},
@@ -10879,60 +10875,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1558, col: 1, offset: 37461},
+			pos:  position{line: 1554, col: 1, offset: 37384},
 			expr: &choiceExpr{
-				pos: position{line: 1559, col: 5, offset: 37474},
+				pos: position{line: 1555, col: 5, offset: 37397},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1559, col: 5, offset: 37474},
+						pos:        position{line: 1555, col: 5, offset: 37397},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1560, col: 5, offset: 37483},
+						pos:        position{line: 1556, col: 5, offset: 37406},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1561, col: 5, offset: 37492},
+						pos:        position{line: 1557, col: 5, offset: 37415},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1562, col: 5, offset: 37501},
+						pos:        position{line: 1558, col: 5, offset: 37424},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1563, col: 5, offset: 37509},
+						pos:        position{line: 1559, col: 5, offset: 37432},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 5, offset: 37517},
+						pos:        position{line: 1560, col: 5, offset: 37440},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1565, col: 5, offset: 37525},
+						pos:        position{line: 1561, col: 5, offset: 37448},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1566, col: 5, offset: 37533},
+						pos:        position{line: 1562, col: 5, offset: 37456},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1567, col: 5, offset: 37541},
+						pos:        position{line: 1563, col: 5, offset: 37464},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10944,45 +10940,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1569, col: 1, offset: 37546},
+			pos:  position{line: 1565, col: 1, offset: 37469},
 			expr: &actionExpr{
-				pos: position{line: 1570, col: 5, offset: 37553},
+				pos: position{line: 1566, col: 5, offset: 37476},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1570, col: 5, offset: 37553},
+					pos: position{line: 1566, col: 5, offset: 37476},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1570, col: 5, offset: 37553},
+							pos:  position{line: 1566, col: 5, offset: 37476},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1570, col: 10, offset: 37558},
+							pos:        position{line: 1566, col: 10, offset: 37481},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1570, col: 14, offset: 37562},
+							pos:  position{line: 1566, col: 14, offset: 37485},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1570, col: 19, offset: 37567},
+							pos:        position{line: 1566, col: 19, offset: 37490},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1570, col: 23, offset: 37571},
+							pos:  position{line: 1566, col: 23, offset: 37494},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1570, col: 28, offset: 37576},
+							pos:        position{line: 1566, col: 28, offset: 37499},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1570, col: 32, offset: 37580},
+							pos:  position{line: 1566, col: 32, offset: 37503},
 							name: "UInt",
 						},
 					},
@@ -10993,43 +10989,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1572, col: 1, offset: 37617},
+			pos:  position{line: 1568, col: 1, offset: 37540},
 			expr: &actionExpr{
-				pos: position{line: 1573, col: 5, offset: 37625},
+				pos: position{line: 1569, col: 5, offset: 37548},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1573, col: 5, offset: 37625},
+					pos: position{line: 1569, col: 5, offset: 37548},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1573, col: 5, offset: 37625},
+							pos: position{line: 1569, col: 5, offset: 37548},
 							expr: &seqExpr{
-								pos: position{line: 1573, col: 7, offset: 37627},
+								pos: position{line: 1569, col: 7, offset: 37550},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1573, col: 7, offset: 37627},
+										pos:  position{line: 1569, col: 7, offset: 37550},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1573, col: 11, offset: 37631},
+										pos:        position{line: 1569, col: 11, offset: 37554},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1573, col: 15, offset: 37635},
+										pos:  position{line: 1569, col: 15, offset: 37558},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1573, col: 19, offset: 37639},
+										pos: position{line: 1569, col: 19, offset: 37562},
 										expr: &choiceExpr{
-											pos: position{line: 1573, col: 21, offset: 37641},
+											pos: position{line: 1569, col: 21, offset: 37564},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1573, col: 21, offset: 37641},
+													pos:  position{line: 1569, col: 21, offset: 37564},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1573, col: 32, offset: 37652},
+													pos:        position{line: 1569, col: 32, offset: 37575},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11041,10 +11037,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1573, col: 38, offset: 37658},
+							pos:   position{line: 1569, col: 38, offset: 37581},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1573, col: 40, offset: 37660},
+								pos:  position{line: 1569, col: 40, offset: 37583},
 								name: "IP6Variations",
 							},
 						},
@@ -11056,32 +11052,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1577, col: 1, offset: 37824},
+			pos:  position{line: 1573, col: 1, offset: 37747},
 			expr: &choiceExpr{
-				pos: position{line: 1578, col: 5, offset: 37842},
+				pos: position{line: 1574, col: 5, offset: 37765},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1578, col: 5, offset: 37842},
+						pos: position{line: 1574, col: 5, offset: 37765},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1578, col: 5, offset: 37842},
+							pos: position{line: 1574, col: 5, offset: 37765},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1578, col: 5, offset: 37842},
+									pos:   position{line: 1574, col: 5, offset: 37765},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1578, col: 7, offset: 37844},
+										pos: position{line: 1574, col: 7, offset: 37767},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1578, col: 7, offset: 37844},
+											pos:  position{line: 1574, col: 7, offset: 37767},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1578, col: 17, offset: 37854},
+									pos:   position{line: 1574, col: 17, offset: 37777},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1578, col: 19, offset: 37856},
+										pos:  position{line: 1574, col: 19, offset: 37779},
 										name: "IP6Tail",
 									},
 								},
@@ -11089,52 +11085,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1581, col: 5, offset: 37920},
+						pos: position{line: 1577, col: 5, offset: 37843},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1581, col: 5, offset: 37920},
+							pos: position{line: 1577, col: 5, offset: 37843},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1581, col: 5, offset: 37920},
+									pos:   position{line: 1577, col: 5, offset: 37843},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1581, col: 7, offset: 37922},
+										pos:  position{line: 1577, col: 7, offset: 37845},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1581, col: 11, offset: 37926},
+									pos:   position{line: 1577, col: 11, offset: 37849},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1581, col: 13, offset: 37928},
+										pos: position{line: 1577, col: 13, offset: 37851},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1581, col: 13, offset: 37928},
+											pos:  position{line: 1577, col: 13, offset: 37851},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1581, col: 23, offset: 37938},
+									pos:        position{line: 1577, col: 23, offset: 37861},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1581, col: 28, offset: 37943},
+									pos:   position{line: 1577, col: 28, offset: 37866},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1581, col: 30, offset: 37945},
+										pos: position{line: 1577, col: 30, offset: 37868},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1581, col: 30, offset: 37945},
+											pos:  position{line: 1577, col: 30, offset: 37868},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1581, col: 40, offset: 37955},
+									pos:   position{line: 1577, col: 40, offset: 37878},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1581, col: 42, offset: 37957},
+										pos:  position{line: 1577, col: 42, offset: 37880},
 										name: "IP6Tail",
 									},
 								},
@@ -11142,33 +11138,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1584, col: 5, offset: 38056},
+						pos: position{line: 1580, col: 5, offset: 37979},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1584, col: 5, offset: 38056},
+							pos: position{line: 1580, col: 5, offset: 37979},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1584, col: 5, offset: 38056},
+									pos:        position{line: 1580, col: 5, offset: 37979},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1584, col: 10, offset: 38061},
+									pos:   position{line: 1580, col: 10, offset: 37984},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1584, col: 12, offset: 38063},
+										pos: position{line: 1580, col: 12, offset: 37986},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1584, col: 12, offset: 38063},
+											pos:  position{line: 1580, col: 12, offset: 37986},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1584, col: 22, offset: 38073},
+									pos:   position{line: 1580, col: 22, offset: 37996},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1584, col: 24, offset: 38075},
+										pos:  position{line: 1580, col: 24, offset: 37998},
 										name: "IP6Tail",
 									},
 								},
@@ -11176,32 +11172,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1587, col: 5, offset: 38146},
+						pos: position{line: 1583, col: 5, offset: 38069},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1587, col: 5, offset: 38146},
+							pos: position{line: 1583, col: 5, offset: 38069},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1587, col: 5, offset: 38146},
+									pos:   position{line: 1583, col: 5, offset: 38069},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1587, col: 7, offset: 38148},
+										pos:  position{line: 1583, col: 7, offset: 38071},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1587, col: 11, offset: 38152},
+									pos:   position{line: 1583, col: 11, offset: 38075},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1587, col: 13, offset: 38154},
+										pos: position{line: 1583, col: 13, offset: 38077},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1587, col: 13, offset: 38154},
+											pos:  position{line: 1583, col: 13, offset: 38077},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1587, col: 23, offset: 38164},
+									pos:        position{line: 1583, col: 23, offset: 38087},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -11210,10 +11206,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1590, col: 5, offset: 38232},
+						pos: position{line: 1586, col: 5, offset: 38155},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1590, col: 5, offset: 38232},
+							pos:        position{line: 1586, col: 5, offset: 38155},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11226,16 +11222,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1594, col: 1, offset: 38269},
+			pos:  position{line: 1590, col: 1, offset: 38192},
 			expr: &choiceExpr{
-				pos: position{line: 1595, col: 5, offset: 38281},
+				pos: position{line: 1591, col: 5, offset: 38204},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1595, col: 5, offset: 38281},
+						pos:  position{line: 1591, col: 5, offset: 38204},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1596, col: 5, offset: 38288},
+						pos:  position{line: 1592, col: 5, offset: 38211},
 						name: "Hex",
 					},
 				},
@@ -11245,24 +11241,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1598, col: 1, offset: 38293},
+			pos:  position{line: 1594, col: 1, offset: 38216},
 			expr: &actionExpr{
-				pos: position{line: 1598, col: 12, offset: 38304},
+				pos: position{line: 1594, col: 12, offset: 38227},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1598, col: 12, offset: 38304},
+					pos: position{line: 1594, col: 12, offset: 38227},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1598, col: 12, offset: 38304},
+							pos:        position{line: 1594, col: 12, offset: 38227},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1598, col: 16, offset: 38308},
+							pos:   position{line: 1594, col: 16, offset: 38231},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1598, col: 18, offset: 38310},
+								pos:  position{line: 1594, col: 18, offset: 38233},
 								name: "Hex",
 							},
 						},
@@ -11274,23 +11270,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1600, col: 1, offset: 38348},
+			pos:  position{line: 1596, col: 1, offset: 38271},
 			expr: &actionExpr{
-				pos: position{line: 1600, col: 12, offset: 38359},
+				pos: position{line: 1596, col: 12, offset: 38282},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1600, col: 12, offset: 38359},
+					pos: position{line: 1596, col: 12, offset: 38282},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1600, col: 12, offset: 38359},
+							pos:   position{line: 1596, col: 12, offset: 38282},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1600, col: 14, offset: 38361},
+								pos:  position{line: 1596, col: 14, offset: 38284},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1600, col: 18, offset: 38365},
+							pos:        position{line: 1596, col: 18, offset: 38288},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11303,32 +11299,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1602, col: 1, offset: 38403},
+			pos:  position{line: 1598, col: 1, offset: 38326},
 			expr: &actionExpr{
-				pos: position{line: 1603, col: 5, offset: 38414},
+				pos: position{line: 1599, col: 5, offset: 38337},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1603, col: 5, offset: 38414},
+					pos: position{line: 1599, col: 5, offset: 38337},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1603, col: 5, offset: 38414},
+							pos:   position{line: 1599, col: 5, offset: 38337},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1603, col: 7, offset: 38416},
+								pos:  position{line: 1599, col: 7, offset: 38339},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1603, col: 10, offset: 38419},
+							pos:        position{line: 1599, col: 10, offset: 38342},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1603, col: 14, offset: 38423},
+							pos:   position{line: 1599, col: 14, offset: 38346},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1603, col: 16, offset: 38425},
+								pos:  position{line: 1599, col: 16, offset: 38348},
 								name: "UIntString",
 							},
 						},
@@ -11340,32 +11336,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1607, col: 1, offset: 38493},
+			pos:  position{line: 1603, col: 1, offset: 38416},
 			expr: &actionExpr{
-				pos: position{line: 1608, col: 5, offset: 38504},
+				pos: position{line: 1604, col: 5, offset: 38427},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1608, col: 5, offset: 38504},
+					pos: position{line: 1604, col: 5, offset: 38427},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1608, col: 5, offset: 38504},
+							pos:   position{line: 1604, col: 5, offset: 38427},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1608, col: 7, offset: 38506},
+								pos:  position{line: 1604, col: 7, offset: 38429},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1608, col: 11, offset: 38510},
+							pos:        position{line: 1604, col: 11, offset: 38433},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1608, col: 15, offset: 38514},
+							pos:   position{line: 1604, col: 15, offset: 38437},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1608, col: 17, offset: 38516},
+								pos:  position{line: 1604, col: 17, offset: 38439},
 								name: "UIntString",
 							},
 						},
@@ -11377,15 +11373,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1612, col: 1, offset: 38584},
+			pos:  position{line: 1608, col: 1, offset: 38507},
 			expr: &actionExpr{
-				pos: position{line: 1613, col: 4, offset: 38592},
+				pos: position{line: 1609, col: 4, offset: 38515},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1613, col: 4, offset: 38592},
+					pos:   position{line: 1609, col: 4, offset: 38515},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1613, col: 6, offset: 38594},
+						pos:  position{line: 1609, col: 6, offset: 38517},
 						name: "UIntString",
 					},
 				},
@@ -11395,16 +11391,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1615, col: 1, offset: 38634},
+			pos:  position{line: 1611, col: 1, offset: 38557},
 			expr: &choiceExpr{
-				pos: position{line: 1616, col: 5, offset: 38648},
+				pos: position{line: 1612, col: 5, offset: 38571},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1616, col: 5, offset: 38648},
+						pos:  position{line: 1612, col: 5, offset: 38571},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1617, col: 5, offset: 38663},
+						pos:  position{line: 1613, col: 5, offset: 38586},
 						name: "MinusIntString",
 					},
 				},
@@ -11414,14 +11410,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1619, col: 1, offset: 38679},
+			pos:  position{line: 1615, col: 1, offset: 38602},
 			expr: &actionExpr{
-				pos: position{line: 1619, col: 14, offset: 38692},
+				pos: position{line: 1615, col: 14, offset: 38615},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1619, col: 14, offset: 38692},
+					pos: position{line: 1615, col: 14, offset: 38615},
 					expr: &charClassMatcher{
-						pos:        position{line: 1619, col: 14, offset: 38692},
+						pos:        position{line: 1615, col: 14, offset: 38615},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11434,21 +11430,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1621, col: 1, offset: 38731},
+			pos:  position{line: 1617, col: 1, offset: 38654},
 			expr: &actionExpr{
-				pos: position{line: 1622, col: 5, offset: 38750},
+				pos: position{line: 1618, col: 5, offset: 38673},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1622, col: 5, offset: 38750},
+					pos: position{line: 1618, col: 5, offset: 38673},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1622, col: 5, offset: 38750},
+							pos:        position{line: 1618, col: 5, offset: 38673},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1622, col: 9, offset: 38754},
+							pos:  position{line: 1618, col: 9, offset: 38677},
 							name: "UIntString",
 						},
 					},
@@ -11459,29 +11455,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1624, col: 1, offset: 38797},
+			pos:  position{line: 1620, col: 1, offset: 38720},
 			expr: &choiceExpr{
-				pos: position{line: 1625, col: 5, offset: 38813},
+				pos: position{line: 1621, col: 5, offset: 38736},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1625, col: 5, offset: 38813},
+						pos: position{line: 1621, col: 5, offset: 38736},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1625, col: 5, offset: 38813},
+							pos: position{line: 1621, col: 5, offset: 38736},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1625, col: 5, offset: 38813},
+									pos: position{line: 1621, col: 5, offset: 38736},
 									expr: &litMatcher{
-										pos:        position{line: 1625, col: 5, offset: 38813},
+										pos:        position{line: 1621, col: 5, offset: 38736},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1625, col: 10, offset: 38818},
+									pos: position{line: 1621, col: 10, offset: 38741},
 									expr: &charClassMatcher{
-										pos:        position{line: 1625, col: 10, offset: 38818},
+										pos:        position{line: 1621, col: 10, offset: 38741},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11489,15 +11485,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1625, col: 17, offset: 38825},
+									pos:        position{line: 1621, col: 17, offset: 38748},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1625, col: 21, offset: 38829},
+									pos: position{line: 1621, col: 21, offset: 38752},
 									expr: &charClassMatcher{
-										pos:        position{line: 1625, col: 21, offset: 38829},
+										pos:        position{line: 1621, col: 21, offset: 38752},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11505,9 +11501,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1625, col: 28, offset: 38836},
+									pos: position{line: 1621, col: 28, offset: 38759},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1625, col: 28, offset: 38836},
+										pos:  position{line: 1621, col: 28, offset: 38759},
 										name: "ExponentPart",
 									},
 								},
@@ -11515,30 +11511,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1626, col: 5, offset: 38885},
+						pos: position{line: 1622, col: 5, offset: 38808},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1626, col: 5, offset: 38885},
+							pos: position{line: 1622, col: 5, offset: 38808},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1626, col: 5, offset: 38885},
+									pos: position{line: 1622, col: 5, offset: 38808},
 									expr: &litMatcher{
-										pos:        position{line: 1626, col: 5, offset: 38885},
+										pos:        position{line: 1622, col: 5, offset: 38808},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1626, col: 10, offset: 38890},
+									pos:        position{line: 1622, col: 10, offset: 38813},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1626, col: 14, offset: 38894},
+									pos: position{line: 1622, col: 14, offset: 38817},
 									expr: &charClassMatcher{
-										pos:        position{line: 1626, col: 14, offset: 38894},
+										pos:        position{line: 1622, col: 14, offset: 38817},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11546,9 +11542,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1626, col: 21, offset: 38901},
+									pos: position{line: 1622, col: 21, offset: 38824},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1626, col: 21, offset: 38901},
+										pos:  position{line: 1622, col: 21, offset: 38824},
 										name: "ExponentPart",
 									},
 								},
@@ -11556,17 +11552,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1627, col: 5, offset: 38950},
+						pos: position{line: 1623, col: 5, offset: 38873},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1627, col: 6, offset: 38951},
+							pos: position{line: 1623, col: 6, offset: 38874},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1627, col: 6, offset: 38951},
+									pos:  position{line: 1623, col: 6, offset: 38874},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1627, col: 12, offset: 38957},
+									pos:  position{line: 1623, col: 12, offset: 38880},
 									name: "Infinity",
 								},
 							},
@@ -11579,20 +11575,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1630, col: 1, offset: 39000},
+			pos:  position{line: 1626, col: 1, offset: 38923},
 			expr: &seqExpr{
-				pos: position{line: 1630, col: 16, offset: 39015},
+				pos: position{line: 1626, col: 16, offset: 38938},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1630, col: 16, offset: 39015},
+						pos:        position{line: 1626, col: 16, offset: 38938},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1630, col: 21, offset: 39020},
+						pos: position{line: 1626, col: 21, offset: 38943},
 						expr: &charClassMatcher{
-							pos:        position{line: 1630, col: 21, offset: 39020},
+							pos:        position{line: 1626, col: 21, offset: 38943},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11600,7 +11596,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1630, col: 27, offset: 39026},
+						pos:  position{line: 1626, col: 27, offset: 38949},
 						name: "UIntString",
 					},
 				},
@@ -11610,9 +11606,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1632, col: 1, offset: 39038},
+			pos:  position{line: 1628, col: 1, offset: 38961},
 			expr: &litMatcher{
-				pos:        position{line: 1632, col: 7, offset: 39044},
+				pos:        position{line: 1628, col: 7, offset: 38967},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11622,23 +11618,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1634, col: 1, offset: 39051},
+			pos:  position{line: 1630, col: 1, offset: 38974},
 			expr: &seqExpr{
-				pos: position{line: 1634, col: 12, offset: 39062},
+				pos: position{line: 1630, col: 12, offset: 38985},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1634, col: 12, offset: 39062},
+						pos: position{line: 1630, col: 12, offset: 38985},
 						expr: &choiceExpr{
-							pos: position{line: 1634, col: 13, offset: 39063},
+							pos: position{line: 1630, col: 13, offset: 38986},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1634, col: 13, offset: 39063},
+									pos:        position{line: 1630, col: 13, offset: 38986},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1634, col: 19, offset: 39069},
+									pos:        position{line: 1630, col: 19, offset: 38992},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11647,7 +11643,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1634, col: 25, offset: 39075},
+						pos:        position{line: 1630, col: 25, offset: 38998},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11659,14 +11655,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1636, col: 1, offset: 39082},
+			pos:  position{line: 1632, col: 1, offset: 39005},
 			expr: &actionExpr{
-				pos: position{line: 1636, col: 7, offset: 39088},
+				pos: position{line: 1632, col: 7, offset: 39011},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1636, col: 7, offset: 39088},
+					pos: position{line: 1632, col: 7, offset: 39011},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1636, col: 7, offset: 39088},
+						pos:  position{line: 1632, col: 7, offset: 39011},
 						name: "HexDigit",
 					},
 				},
@@ -11676,9 +11672,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1638, col: 1, offset: 39130},
+			pos:  position{line: 1634, col: 1, offset: 39053},
 			expr: &charClassMatcher{
-				pos:        position{line: 1638, col: 12, offset: 39141},
+				pos:        position{line: 1634, col: 12, offset: 39064},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11689,35 +11685,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1640, col: 1, offset: 39154},
+			pos:  position{line: 1636, col: 1, offset: 39077},
 			expr: &choiceExpr{
-				pos: position{line: 1641, col: 5, offset: 39171},
+				pos: position{line: 1637, col: 5, offset: 39094},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1641, col: 5, offset: 39171},
+						pos: position{line: 1637, col: 5, offset: 39094},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1641, col: 5, offset: 39171},
+							pos: position{line: 1637, col: 5, offset: 39094},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1641, col: 5, offset: 39171},
+									pos:        position{line: 1637, col: 5, offset: 39094},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1641, col: 9, offset: 39175},
+									pos:   position{line: 1637, col: 9, offset: 39098},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1641, col: 11, offset: 39177},
+										pos: position{line: 1637, col: 11, offset: 39100},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1641, col: 11, offset: 39177},
+											pos:  position{line: 1637, col: 11, offset: 39100},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1641, col: 29, offset: 39195},
+									pos:        position{line: 1637, col: 29, offset: 39118},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11726,30 +11722,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1642, col: 5, offset: 39232},
+						pos: position{line: 1638, col: 5, offset: 39155},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1642, col: 5, offset: 39232},
+							pos: position{line: 1638, col: 5, offset: 39155},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1642, col: 5, offset: 39232},
+									pos:        position{line: 1638, col: 5, offset: 39155},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1642, col: 9, offset: 39236},
+									pos:   position{line: 1638, col: 9, offset: 39159},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1642, col: 11, offset: 39238},
+										pos: position{line: 1638, col: 11, offset: 39161},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1642, col: 11, offset: 39238},
+											pos:  position{line: 1638, col: 11, offset: 39161},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1642, col: 29, offset: 39256},
+									pos:        position{line: 1638, col: 29, offset: 39179},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11764,57 +11760,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1644, col: 1, offset: 39290},
+			pos:  position{line: 1640, col: 1, offset: 39213},
 			expr: &choiceExpr{
-				pos: position{line: 1645, col: 5, offset: 39311},
+				pos: position{line: 1641, col: 5, offset: 39234},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1645, col: 5, offset: 39311},
+						pos: position{line: 1641, col: 5, offset: 39234},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1645, col: 5, offset: 39311},
+							pos: position{line: 1641, col: 5, offset: 39234},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1645, col: 5, offset: 39311},
+									pos: position{line: 1641, col: 5, offset: 39234},
 									expr: &choiceExpr{
-										pos: position{line: 1645, col: 7, offset: 39313},
+										pos: position{line: 1641, col: 7, offset: 39236},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1645, col: 7, offset: 39313},
+												pos:        position{line: 1641, col: 7, offset: 39236},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1645, col: 13, offset: 39319},
+												pos:  position{line: 1641, col: 13, offset: 39242},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1645, col: 26, offset: 39332,
+									line: 1641, col: 26, offset: 39255,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1646, col: 5, offset: 39369},
+						pos: position{line: 1642, col: 5, offset: 39292},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1646, col: 5, offset: 39369},
+							pos: position{line: 1642, col: 5, offset: 39292},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1646, col: 5, offset: 39369},
+									pos:        position{line: 1642, col: 5, offset: 39292},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1646, col: 10, offset: 39374},
+									pos:   position{line: 1642, col: 10, offset: 39297},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1646, col: 12, offset: 39376},
+										pos:  position{line: 1642, col: 12, offset: 39299},
 										name: "EscapeSequence",
 									},
 								},
@@ -11828,32 +11824,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1648, col: 1, offset: 39410},
+			pos:  position{line: 1644, col: 1, offset: 39333},
 			expr: &actionExpr{
-				pos: position{line: 1649, col: 5, offset: 39429},
+				pos: position{line: 1645, col: 5, offset: 39352},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1649, col: 5, offset: 39429},
+					pos: position{line: 1645, col: 5, offset: 39352},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1649, col: 5, offset: 39429},
+							pos:        position{line: 1645, col: 5, offset: 39352},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1649, col: 9, offset: 39433},
+							pos:   position{line: 1645, col: 9, offset: 39356},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1649, col: 11, offset: 39435},
+								pos: position{line: 1645, col: 11, offset: 39358},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1649, col: 11, offset: 39435},
+									pos:  position{line: 1645, col: 11, offset: 39358},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1649, col: 25, offset: 39449},
+							pos:        position{line: 1645, col: 25, offset: 39372},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11866,57 +11862,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1651, col: 1, offset: 39483},
+			pos:  position{line: 1647, col: 1, offset: 39406},
 			expr: &choiceExpr{
-				pos: position{line: 1652, col: 5, offset: 39500},
+				pos: position{line: 1648, col: 5, offset: 39423},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1652, col: 5, offset: 39500},
+						pos: position{line: 1648, col: 5, offset: 39423},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1652, col: 5, offset: 39500},
+							pos: position{line: 1648, col: 5, offset: 39423},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1652, col: 5, offset: 39500},
+									pos: position{line: 1648, col: 5, offset: 39423},
 									expr: &choiceExpr{
-										pos: position{line: 1652, col: 7, offset: 39502},
+										pos: position{line: 1648, col: 7, offset: 39425},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1652, col: 7, offset: 39502},
+												pos:        position{line: 1648, col: 7, offset: 39425},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1652, col: 13, offset: 39508},
+												pos:  position{line: 1648, col: 13, offset: 39431},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1652, col: 26, offset: 39521,
+									line: 1648, col: 26, offset: 39444,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1653, col: 5, offset: 39558},
+						pos: position{line: 1649, col: 5, offset: 39481},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1653, col: 5, offset: 39558},
+							pos: position{line: 1649, col: 5, offset: 39481},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1653, col: 5, offset: 39558},
+									pos:        position{line: 1649, col: 5, offset: 39481},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1653, col: 10, offset: 39563},
+									pos:   position{line: 1649, col: 10, offset: 39486},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1653, col: 12, offset: 39565},
+										pos:  position{line: 1649, col: 12, offset: 39488},
 										name: "EscapeSequence",
 									},
 								},
@@ -11930,28 +11926,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1655, col: 1, offset: 39599},
+			pos:  position{line: 1651, col: 1, offset: 39522},
 			expr: &actionExpr{
-				pos: position{line: 1656, col: 5, offset: 39611},
+				pos: position{line: 1652, col: 5, offset: 39534},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1656, col: 5, offset: 39611},
+					pos: position{line: 1652, col: 5, offset: 39534},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1656, col: 5, offset: 39611},
+							pos:   position{line: 1652, col: 5, offset: 39534},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1656, col: 10, offset: 39616},
+								pos:  position{line: 1652, col: 10, offset: 39539},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1656, col: 23, offset: 39629},
+							pos:   position{line: 1652, col: 23, offset: 39552},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1656, col: 28, offset: 39634},
+								pos: position{line: 1652, col: 28, offset: 39557},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1656, col: 28, offset: 39634},
+									pos:  position{line: 1652, col: 28, offset: 39557},
 									name: "KeyWordRest",
 								},
 							},
@@ -11964,16 +11960,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1658, col: 1, offset: 39696},
+			pos:  position{line: 1654, col: 1, offset: 39619},
 			expr: &choiceExpr{
-				pos: position{line: 1659, col: 5, offset: 39713},
+				pos: position{line: 1655, col: 5, offset: 39636},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1659, col: 5, offset: 39713},
+						pos:  position{line: 1655, col: 5, offset: 39636},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1660, col: 5, offset: 39730},
+						pos:  position{line: 1656, col: 5, offset: 39653},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11983,16 +11979,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1662, col: 1, offset: 39742},
+			pos:  position{line: 1658, col: 1, offset: 39665},
 			expr: &choiceExpr{
-				pos: position{line: 1663, col: 5, offset: 39758},
+				pos: position{line: 1659, col: 5, offset: 39681},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1663, col: 5, offset: 39758},
+						pos:  position{line: 1659, col: 5, offset: 39681},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1664, col: 5, offset: 39775},
+						pos:        position{line: 1660, col: 5, offset: 39698},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12005,19 +12001,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1666, col: 1, offset: 39782},
+			pos:  position{line: 1662, col: 1, offset: 39705},
 			expr: &actionExpr{
-				pos: position{line: 1666, col: 16, offset: 39797},
+				pos: position{line: 1662, col: 16, offset: 39720},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1666, col: 17, offset: 39798},
+					pos: position{line: 1662, col: 17, offset: 39721},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1666, col: 17, offset: 39798},
+							pos:  position{line: 1662, col: 17, offset: 39721},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1666, col: 33, offset: 39814},
+							pos:        position{line: 1662, col: 33, offset: 39737},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12031,31 +12027,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1668, col: 1, offset: 39858},
+			pos:  position{line: 1664, col: 1, offset: 39781},
 			expr: &actionExpr{
-				pos: position{line: 1668, col: 14, offset: 39871},
+				pos: position{line: 1664, col: 14, offset: 39794},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1668, col: 14, offset: 39871},
+					pos: position{line: 1664, col: 14, offset: 39794},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1668, col: 14, offset: 39871},
+							pos:        position{line: 1664, col: 14, offset: 39794},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1668, col: 19, offset: 39876},
+							pos:   position{line: 1664, col: 19, offset: 39799},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1668, col: 22, offset: 39879},
+								pos: position{line: 1664, col: 22, offset: 39802},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1668, col: 22, offset: 39879},
+										pos:  position{line: 1664, col: 22, offset: 39802},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1668, col: 38, offset: 39895},
+										pos:  position{line: 1664, col: 38, offset: 39818},
 										name: "EscapeSequence",
 									},
 								},
@@ -12069,42 +12065,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1670, col: 1, offset: 39930},
+			pos:  position{line: 1666, col: 1, offset: 39853},
 			expr: &actionExpr{
-				pos: position{line: 1671, col: 5, offset: 39946},
+				pos: position{line: 1667, col: 5, offset: 39869},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1671, col: 5, offset: 39946},
+					pos: position{line: 1667, col: 5, offset: 39869},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1671, col: 5, offset: 39946},
+							pos: position{line: 1667, col: 5, offset: 39869},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1671, col: 6, offset: 39947},
+								pos:  position{line: 1667, col: 6, offset: 39870},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1671, col: 22, offset: 39963},
+							pos: position{line: 1667, col: 22, offset: 39886},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1671, col: 23, offset: 39964},
+								pos:  position{line: 1667, col: 23, offset: 39887},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1671, col: 35, offset: 39976},
+							pos:   position{line: 1667, col: 35, offset: 39899},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1671, col: 40, offset: 39981},
+								pos:  position{line: 1667, col: 40, offset: 39904},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1671, col: 50, offset: 39991},
+							pos:   position{line: 1667, col: 50, offset: 39914},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1671, col: 55, offset: 39996},
+								pos: position{line: 1667, col: 55, offset: 39919},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1671, col: 55, offset: 39996},
+									pos:  position{line: 1667, col: 55, offset: 39919},
 									name: "GlobRest",
 								},
 							},
@@ -12117,28 +12113,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1675, col: 1, offset: 40065},
+			pos:  position{line: 1671, col: 1, offset: 39988},
 			expr: &choiceExpr{
-				pos: position{line: 1675, col: 19, offset: 40083},
+				pos: position{line: 1671, col: 19, offset: 40006},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1675, col: 19, offset: 40083},
+						pos:  position{line: 1671, col: 19, offset: 40006},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1675, col: 34, offset: 40098},
+						pos: position{line: 1671, col: 34, offset: 40021},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1675, col: 34, offset: 40098},
+								pos: position{line: 1671, col: 34, offset: 40021},
 								expr: &litMatcher{
-									pos:        position{line: 1675, col: 34, offset: 40098},
+									pos:        position{line: 1671, col: 34, offset: 40021},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1675, col: 39, offset: 40103},
+								pos:  position{line: 1671, col: 39, offset: 40026},
 								name: "KeyWordRest",
 							},
 						},
@@ -12150,19 +12146,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1676, col: 1, offset: 40115},
+			pos:  position{line: 1672, col: 1, offset: 40038},
 			expr: &seqExpr{
-				pos: position{line: 1676, col: 15, offset: 40129},
+				pos: position{line: 1672, col: 15, offset: 40052},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1676, col: 15, offset: 40129},
+						pos: position{line: 1672, col: 15, offset: 40052},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1676, col: 15, offset: 40129},
+							pos:  position{line: 1672, col: 15, offset: 40052},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1676, col: 28, offset: 40142},
+						pos:        position{line: 1672, col: 28, offset: 40065},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12174,23 +12170,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1678, col: 1, offset: 40147},
+			pos:  position{line: 1674, col: 1, offset: 40070},
 			expr: &choiceExpr{
-				pos: position{line: 1679, col: 5, offset: 40161},
+				pos: position{line: 1675, col: 5, offset: 40084},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1679, col: 5, offset: 40161},
+						pos:  position{line: 1675, col: 5, offset: 40084},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1680, col: 5, offset: 40178},
+						pos:  position{line: 1676, col: 5, offset: 40101},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1681, col: 5, offset: 40190},
+						pos: position{line: 1677, col: 5, offset: 40113},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1681, col: 5, offset: 40190},
+							pos:        position{line: 1677, col: 5, offset: 40113},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12203,16 +12199,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1683, col: 1, offset: 40215},
+			pos:  position{line: 1679, col: 1, offset: 40138},
 			expr: &choiceExpr{
-				pos: position{line: 1684, col: 5, offset: 40228},
+				pos: position{line: 1680, col: 5, offset: 40151},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1684, col: 5, offset: 40228},
+						pos:  position{line: 1680, col: 5, offset: 40151},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1685, col: 5, offset: 40242},
+						pos:        position{line: 1681, col: 5, offset: 40165},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12225,31 +12221,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1687, col: 1, offset: 40249},
+			pos:  position{line: 1683, col: 1, offset: 40172},
 			expr: &actionExpr{
-				pos: position{line: 1687, col: 11, offset: 40259},
+				pos: position{line: 1683, col: 11, offset: 40182},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1687, col: 11, offset: 40259},
+					pos: position{line: 1683, col: 11, offset: 40182},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1687, col: 11, offset: 40259},
+							pos:        position{line: 1683, col: 11, offset: 40182},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1687, col: 16, offset: 40264},
+							pos:   position{line: 1683, col: 16, offset: 40187},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1687, col: 19, offset: 40267},
+								pos: position{line: 1683, col: 19, offset: 40190},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1687, col: 19, offset: 40267},
+										pos:  position{line: 1683, col: 19, offset: 40190},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1687, col: 32, offset: 40280},
+										pos:  position{line: 1683, col: 32, offset: 40203},
 										name: "EscapeSequence",
 									},
 								},
@@ -12263,32 +12259,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1689, col: 1, offset: 40315},
+			pos:  position{line: 1685, col: 1, offset: 40238},
 			expr: &choiceExpr{
-				pos: position{line: 1690, col: 5, offset: 40330},
+				pos: position{line: 1686, col: 5, offset: 40253},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1690, col: 5, offset: 40330},
+						pos: position{line: 1686, col: 5, offset: 40253},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1690, col: 5, offset: 40330},
+							pos:        position{line: 1686, col: 5, offset: 40253},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1691, col: 5, offset: 40358},
+						pos: position{line: 1687, col: 5, offset: 40281},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1691, col: 5, offset: 40358},
+							pos:        position{line: 1687, col: 5, offset: 40281},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1692, col: 5, offset: 40388},
+						pos:        position{line: 1688, col: 5, offset: 40311},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12301,57 +12297,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1694, col: 1, offset: 40394},
+			pos:  position{line: 1690, col: 1, offset: 40317},
 			expr: &choiceExpr{
-				pos: position{line: 1695, col: 5, offset: 40415},
+				pos: position{line: 1691, col: 5, offset: 40338},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1695, col: 5, offset: 40415},
+						pos: position{line: 1691, col: 5, offset: 40338},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1695, col: 5, offset: 40415},
+							pos: position{line: 1691, col: 5, offset: 40338},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1695, col: 5, offset: 40415},
+									pos: position{line: 1691, col: 5, offset: 40338},
 									expr: &choiceExpr{
-										pos: position{line: 1695, col: 7, offset: 40417},
+										pos: position{line: 1691, col: 7, offset: 40340},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1695, col: 7, offset: 40417},
+												pos:        position{line: 1691, col: 7, offset: 40340},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1695, col: 13, offset: 40423},
+												pos:  position{line: 1691, col: 13, offset: 40346},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1695, col: 26, offset: 40436,
+									line: 1691, col: 26, offset: 40359,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1696, col: 5, offset: 40473},
+						pos: position{line: 1692, col: 5, offset: 40396},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1696, col: 5, offset: 40473},
+							pos: position{line: 1692, col: 5, offset: 40396},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1696, col: 5, offset: 40473},
+									pos:        position{line: 1692, col: 5, offset: 40396},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1696, col: 10, offset: 40478},
+									pos:   position{line: 1692, col: 10, offset: 40401},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1696, col: 12, offset: 40480},
+										pos:  position{line: 1692, col: 12, offset: 40403},
 										name: "EscapeSequence",
 									},
 								},
@@ -12365,16 +12361,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1698, col: 1, offset: 40514},
+			pos:  position{line: 1694, col: 1, offset: 40437},
 			expr: &choiceExpr{
-				pos: position{line: 1699, col: 5, offset: 40533},
+				pos: position{line: 1695, col: 5, offset: 40456},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1699, col: 5, offset: 40533},
+						pos:  position{line: 1695, col: 5, offset: 40456},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1700, col: 5, offset: 40554},
+						pos:  position{line: 1696, col: 5, offset: 40477},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12384,87 +12380,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1702, col: 1, offset: 40569},
+			pos:  position{line: 1698, col: 1, offset: 40492},
 			expr: &choiceExpr{
-				pos: position{line: 1703, col: 5, offset: 40590},
+				pos: position{line: 1699, col: 5, offset: 40513},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1703, col: 5, offset: 40590},
+						pos:        position{line: 1699, col: 5, offset: 40513},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1704, col: 5, offset: 40598},
+						pos: position{line: 1700, col: 5, offset: 40521},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1704, col: 5, offset: 40598},
+							pos:        position{line: 1700, col: 5, offset: 40521},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1705, col: 5, offset: 40638},
+						pos:        position{line: 1701, col: 5, offset: 40561},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1706, col: 5, offset: 40647},
+						pos: position{line: 1702, col: 5, offset: 40570},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1706, col: 5, offset: 40647},
+							pos:        position{line: 1702, col: 5, offset: 40570},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1707, col: 5, offset: 40676},
+						pos: position{line: 1703, col: 5, offset: 40599},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1707, col: 5, offset: 40676},
+							pos:        position{line: 1703, col: 5, offset: 40599},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1708, col: 5, offset: 40705},
+						pos: position{line: 1704, col: 5, offset: 40628},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1708, col: 5, offset: 40705},
+							pos:        position{line: 1704, col: 5, offset: 40628},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1709, col: 5, offset: 40734},
+						pos: position{line: 1705, col: 5, offset: 40657},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1709, col: 5, offset: 40734},
+							pos:        position{line: 1705, col: 5, offset: 40657},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1710, col: 5, offset: 40763},
+						pos: position{line: 1706, col: 5, offset: 40686},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1710, col: 5, offset: 40763},
+							pos:        position{line: 1706, col: 5, offset: 40686},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1711, col: 5, offset: 40792},
+						pos: position{line: 1707, col: 5, offset: 40715},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1711, col: 5, offset: 40792},
+							pos:        position{line: 1707, col: 5, offset: 40715},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12477,32 +12473,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1713, col: 1, offset: 40818},
+			pos:  position{line: 1709, col: 1, offset: 40741},
 			expr: &choiceExpr{
-				pos: position{line: 1714, col: 5, offset: 40836},
+				pos: position{line: 1710, col: 5, offset: 40759},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1714, col: 5, offset: 40836},
+						pos: position{line: 1710, col: 5, offset: 40759},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1714, col: 5, offset: 40836},
+							pos:        position{line: 1710, col: 5, offset: 40759},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1715, col: 5, offset: 40864},
+						pos: position{line: 1711, col: 5, offset: 40787},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1715, col: 5, offset: 40864},
+							pos:        position{line: 1711, col: 5, offset: 40787},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1716, col: 5, offset: 40892},
+						pos:        position{line: 1712, col: 5, offset: 40815},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12515,42 +12511,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1718, col: 1, offset: 40898},
+			pos:  position{line: 1714, col: 1, offset: 40821},
 			expr: &choiceExpr{
-				pos: position{line: 1719, col: 5, offset: 40916},
+				pos: position{line: 1715, col: 5, offset: 40839},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1719, col: 5, offset: 40916},
+						pos: position{line: 1715, col: 5, offset: 40839},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1719, col: 5, offset: 40916},
+							pos: position{line: 1715, col: 5, offset: 40839},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1719, col: 5, offset: 40916},
+									pos:        position{line: 1715, col: 5, offset: 40839},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1719, col: 9, offset: 40920},
+									pos:   position{line: 1715, col: 9, offset: 40843},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1719, col: 16, offset: 40927},
+										pos: position{line: 1715, col: 16, offset: 40850},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1719, col: 16, offset: 40927},
+												pos:  position{line: 1715, col: 16, offset: 40850},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1719, col: 25, offset: 40936},
+												pos:  position{line: 1715, col: 25, offset: 40859},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1719, col: 34, offset: 40945},
+												pos:  position{line: 1715, col: 34, offset: 40868},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1719, col: 43, offset: 40954},
+												pos:  position{line: 1715, col: 43, offset: 40877},
 												name: "HexDigit",
 											},
 										},
@@ -12560,65 +12556,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1722, col: 5, offset: 41017},
+						pos: position{line: 1718, col: 5, offset: 40940},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1722, col: 5, offset: 41017},
+							pos: position{line: 1718, col: 5, offset: 40940},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1722, col: 5, offset: 41017},
+									pos:        position{line: 1718, col: 5, offset: 40940},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1722, col: 9, offset: 41021},
+									pos:        position{line: 1718, col: 9, offset: 40944},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1722, col: 13, offset: 41025},
+									pos:   position{line: 1718, col: 13, offset: 40948},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1722, col: 20, offset: 41032},
+										pos: position{line: 1718, col: 20, offset: 40955},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1722, col: 20, offset: 41032},
+												pos:  position{line: 1718, col: 20, offset: 40955},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1722, col: 29, offset: 41041},
+												pos: position{line: 1718, col: 29, offset: 40964},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1722, col: 29, offset: 41041},
+													pos:  position{line: 1718, col: 29, offset: 40964},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1722, col: 39, offset: 41051},
+												pos: position{line: 1718, col: 39, offset: 40974},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1722, col: 39, offset: 41051},
+													pos:  position{line: 1718, col: 39, offset: 40974},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1722, col: 49, offset: 41061},
+												pos: position{line: 1718, col: 49, offset: 40984},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1722, col: 49, offset: 41061},
+													pos:  position{line: 1718, col: 49, offset: 40984},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1722, col: 59, offset: 41071},
+												pos: position{line: 1718, col: 59, offset: 40994},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1722, col: 59, offset: 41071},
+													pos:  position{line: 1718, col: 59, offset: 40994},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1722, col: 69, offset: 41081},
+												pos: position{line: 1718, col: 69, offset: 41004},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1722, col: 69, offset: 41081},
+													pos:  position{line: 1718, col: 69, offset: 41004},
 													name: "HexDigit",
 												},
 											},
@@ -12626,7 +12622,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1722, col: 80, offset: 41092},
+									pos:        position{line: 1718, col: 80, offset: 41015},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12641,37 +12637,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1726, col: 1, offset: 41146},
+			pos:  position{line: 1722, col: 1, offset: 41069},
 			expr: &actionExpr{
-				pos: position{line: 1727, col: 5, offset: 41164},
+				pos: position{line: 1723, col: 5, offset: 41087},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1727, col: 5, offset: 41164},
+					pos: position{line: 1723, col: 5, offset: 41087},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1727, col: 5, offset: 41164},
+							pos:        position{line: 1723, col: 5, offset: 41087},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1727, col: 9, offset: 41168},
+							pos:   position{line: 1723, col: 9, offset: 41091},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1727, col: 14, offset: 41173},
+								pos:  position{line: 1723, col: 14, offset: 41096},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1727, col: 25, offset: 41184},
+							pos:        position{line: 1723, col: 25, offset: 41107},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1727, col: 29, offset: 41188},
+							pos: position{line: 1723, col: 29, offset: 41111},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1727, col: 30, offset: 41189},
+								pos:  position{line: 1723, col: 30, offset: 41112},
 								name: "KeyWordStart",
 							},
 						},
@@ -12683,33 +12679,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1729, col: 1, offset: 41224},
+			pos:  position{line: 1725, col: 1, offset: 41147},
 			expr: &actionExpr{
-				pos: position{line: 1730, col: 5, offset: 41239},
+				pos: position{line: 1726, col: 5, offset: 41162},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1730, col: 5, offset: 41239},
+					pos: position{line: 1726, col: 5, offset: 41162},
 					expr: &choiceExpr{
-						pos: position{line: 1730, col: 6, offset: 41240},
+						pos: position{line: 1726, col: 6, offset: 41163},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1730, col: 6, offset: 41240},
+								pos:        position{line: 1726, col: 6, offset: 41163},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1730, col: 15, offset: 41249},
+								pos: position{line: 1726, col: 15, offset: 41172},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1730, col: 15, offset: 41249},
+										pos:        position{line: 1726, col: 15, offset: 41172},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1730, col: 20, offset: 41254,
+										line: 1726, col: 20, offset: 41177,
 									},
 								},
 							},
@@ -12722,9 +12718,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1732, col: 1, offset: 41290},
+			pos:  position{line: 1728, col: 1, offset: 41213},
 			expr: &charClassMatcher{
-				pos:        position{line: 1733, col: 5, offset: 41306},
+				pos:        position{line: 1729, col: 5, offset: 41229},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12736,11 +12732,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1735, col: 1, offset: 41321},
+			pos:  position{line: 1731, col: 1, offset: 41244},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1735, col: 5, offset: 41325},
+				pos: position{line: 1731, col: 5, offset: 41248},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1735, col: 5, offset: 41325},
+					pos:  position{line: 1731, col: 5, offset: 41248},
 					name: "AnySpace",
 				},
 			},
@@ -12749,11 +12745,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1737, col: 1, offset: 41336},
+			pos:  position{line: 1733, col: 1, offset: 41259},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1737, col: 6, offset: 41341},
+				pos: position{line: 1733, col: 6, offset: 41264},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1737, col: 6, offset: 41341},
+					pos:  position{line: 1733, col: 6, offset: 41264},
 					name: "AnySpace",
 				},
 			},
@@ -12762,20 +12758,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1739, col: 1, offset: 41352},
+			pos:  position{line: 1735, col: 1, offset: 41275},
 			expr: &choiceExpr{
-				pos: position{line: 1740, col: 5, offset: 41365},
+				pos: position{line: 1736, col: 5, offset: 41288},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1740, col: 5, offset: 41365},
+						pos:  position{line: 1736, col: 5, offset: 41288},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1741, col: 5, offset: 41380},
+						pos:  position{line: 1737, col: 5, offset: 41303},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1742, col: 5, offset: 41399},
+						pos:  position{line: 1738, col: 5, offset: 41322},
 						name: "Comment",
 					},
 				},
@@ -12785,32 +12781,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1744, col: 1, offset: 41408},
+			pos:  position{line: 1740, col: 1, offset: 41331},
 			expr: &choiceExpr{
-				pos: position{line: 1745, col: 5, offset: 41426},
+				pos: position{line: 1741, col: 5, offset: 41349},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1745, col: 5, offset: 41426},
+						pos:  position{line: 1741, col: 5, offset: 41349},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1746, col: 5, offset: 41433},
+						pos:  position{line: 1742, col: 5, offset: 41356},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1747, col: 5, offset: 41440},
+						pos:  position{line: 1743, col: 5, offset: 41363},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1748, col: 5, offset: 41447},
+						pos:  position{line: 1744, col: 5, offset: 41370},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1749, col: 5, offset: 41454},
+						pos:  position{line: 1745, col: 5, offset: 41377},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1750, col: 5, offset: 41461},
+						pos:  position{line: 1746, col: 5, offset: 41384},
 						name: "Nl",
 					},
 				},
@@ -12820,16 +12816,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1752, col: 1, offset: 41465},
+			pos:  position{line: 1748, col: 1, offset: 41388},
 			expr: &choiceExpr{
-				pos: position{line: 1753, col: 5, offset: 41490},
+				pos: position{line: 1749, col: 5, offset: 41413},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1753, col: 5, offset: 41490},
+						pos:  position{line: 1749, col: 5, offset: 41413},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1754, col: 5, offset: 41497},
+						pos:  position{line: 1750, col: 5, offset: 41420},
 						name: "Mc",
 					},
 				},
@@ -12839,9 +12835,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1756, col: 1, offset: 41501},
+			pos:  position{line: 1752, col: 1, offset: 41424},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1757, col: 5, offset: 41518},
+				pos:  position{line: 1753, col: 5, offset: 41441},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12849,9 +12845,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1759, col: 1, offset: 41522},
+			pos:  position{line: 1755, col: 1, offset: 41445},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1760, col: 5, offset: 41554},
+				pos:  position{line: 1756, col: 5, offset: 41477},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12859,9 +12855,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1766, col: 1, offset: 41735},
+			pos:  position{line: 1762, col: 1, offset: 41658},
 			expr: &charClassMatcher{
-				pos:        position{line: 1766, col: 6, offset: 41740},
+				pos:        position{line: 1762, col: 6, offset: 41663},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12873,9 +12869,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1769, col: 1, offset: 45892},
+			pos:  position{line: 1765, col: 1, offset: 45815},
 			expr: &charClassMatcher{
-				pos:        position{line: 1769, col: 6, offset: 45897},
+				pos:        position{line: 1765, col: 6, offset: 45820},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12887,9 +12883,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1772, col: 1, offset: 46382},
+			pos:  position{line: 1768, col: 1, offset: 46305},
 			expr: &charClassMatcher{
-				pos:        position{line: 1772, col: 6, offset: 46387},
+				pos:        position{line: 1768, col: 6, offset: 46310},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12901,9 +12897,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1775, col: 1, offset: 49834},
+			pos:  position{line: 1771, col: 1, offset: 49757},
 			expr: &charClassMatcher{
-				pos:        position{line: 1775, col: 6, offset: 49839},
+				pos:        position{line: 1771, col: 6, offset: 49762},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12915,9 +12911,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1778, col: 1, offset: 49945},
+			pos:  position{line: 1774, col: 1, offset: 49868},
 			expr: &charClassMatcher{
-				pos:        position{line: 1778, col: 6, offset: 49950},
+				pos:        position{line: 1774, col: 6, offset: 49873},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12929,9 +12925,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1781, col: 1, offset: 53951},
+			pos:  position{line: 1777, col: 1, offset: 53874},
 			expr: &charClassMatcher{
-				pos:        position{line: 1781, col: 6, offset: 53956},
+				pos:        position{line: 1777, col: 6, offset: 53879},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12943,9 +12939,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1784, col: 1, offset: 55144},
+			pos:  position{line: 1780, col: 1, offset: 55067},
 			expr: &charClassMatcher{
-				pos:        position{line: 1784, col: 6, offset: 55149},
+				pos:        position{line: 1780, col: 6, offset: 55072},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12957,9 +12953,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1787, col: 1, offset: 57329},
+			pos:  position{line: 1783, col: 1, offset: 57252},
 			expr: &charClassMatcher{
-				pos:        position{line: 1787, col: 6, offset: 57334},
+				pos:        position{line: 1783, col: 6, offset: 57257},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12970,9 +12966,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1790, col: 1, offset: 57837},
+			pos:  position{line: 1786, col: 1, offset: 57760},
 			expr: &charClassMatcher{
-				pos:        position{line: 1790, col: 6, offset: 57842},
+				pos:        position{line: 1786, col: 6, offset: 57765},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12984,9 +12980,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1793, col: 1, offset: 57956},
+			pos:  position{line: 1789, col: 1, offset: 57879},
 			expr: &charClassMatcher{
-				pos:        position{line: 1793, col: 6, offset: 57961},
+				pos:        position{line: 1789, col: 6, offset: 57884},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12998,9 +12994,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1796, col: 1, offset: 58042},
+			pos:  position{line: 1792, col: 1, offset: 57965},
 			expr: &charClassMatcher{
-				pos:        position{line: 1796, col: 6, offset: 58047},
+				pos:        position{line: 1792, col: 6, offset: 57970},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13012,9 +13008,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1798, col: 1, offset: 58100},
+			pos:  position{line: 1794, col: 1, offset: 58023},
 			expr: &anyMatcher{
-				line: 1799, col: 5, offset: 58120,
+				line: 1795, col: 5, offset: 58043,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13022,48 +13018,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1801, col: 1, offset: 58123},
+			pos:         position{line: 1797, col: 1, offset: 58046},
 			expr: &choiceExpr{
-				pos: position{line: 1802, col: 5, offset: 58151},
+				pos: position{line: 1798, col: 5, offset: 58074},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1802, col: 5, offset: 58151},
+						pos:        position{line: 1798, col: 5, offset: 58074},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1803, col: 5, offset: 58160},
+						pos:        position{line: 1799, col: 5, offset: 58083},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1804, col: 5, offset: 58169},
+						pos:        position{line: 1800, col: 5, offset: 58092},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1805, col: 5, offset: 58178},
+						pos:        position{line: 1801, col: 5, offset: 58101},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1806, col: 5, offset: 58186},
+						pos:        position{line: 1802, col: 5, offset: 58109},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1807, col: 5, offset: 58199},
+						pos:        position{line: 1803, col: 5, offset: 58122},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1808, col: 5, offset: 58212},
+						pos:  position{line: 1804, col: 5, offset: 58135},
 						name: "Zs",
 					},
 				},
@@ -13073,9 +13069,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1810, col: 1, offset: 58216},
+			pos:  position{line: 1806, col: 1, offset: 58139},
 			expr: &charClassMatcher{
-				pos:        position{line: 1811, col: 5, offset: 58235},
+				pos:        position{line: 1807, col: 5, offset: 58158},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13087,9 +13083,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1817, col: 1, offset: 58565},
+			pos:         position{line: 1813, col: 1, offset: 58488},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1820, col: 5, offset: 58636},
+				pos:  position{line: 1816, col: 5, offset: 58559},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -13097,39 +13093,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1822, col: 1, offset: 58655},
+			pos:  position{line: 1818, col: 1, offset: 58578},
 			expr: &seqExpr{
-				pos: position{line: 1823, col: 5, offset: 58676},
+				pos: position{line: 1819, col: 5, offset: 58599},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1823, col: 5, offset: 58676},
+						pos:        position{line: 1819, col: 5, offset: 58599},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1823, col: 10, offset: 58681},
+						pos: position{line: 1819, col: 10, offset: 58604},
 						expr: &seqExpr{
-							pos: position{line: 1823, col: 11, offset: 58682},
+							pos: position{line: 1819, col: 11, offset: 58605},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1823, col: 11, offset: 58682},
+									pos: position{line: 1819, col: 11, offset: 58605},
 									expr: &litMatcher{
-										pos:        position{line: 1823, col: 12, offset: 58683},
+										pos:        position{line: 1819, col: 12, offset: 58606},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1823, col: 17, offset: 58688},
+									pos:  position{line: 1819, col: 17, offset: 58611},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1823, col: 35, offset: 58706},
+						pos:        position{line: 1819, col: 35, offset: 58629},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13141,33 +13137,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1825, col: 1, offset: 58712},
+			pos:  position{line: 1821, col: 1, offset: 58635},
 			expr: &choiceExpr{
-				pos: position{line: 1826, col: 5, offset: 58734},
+				pos: position{line: 1822, col: 5, offset: 58657},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1826, col: 5, offset: 58734},
+						pos: position{line: 1822, col: 5, offset: 58657},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1826, col: 5, offset: 58734},
+								pos:        position{line: 1822, col: 5, offset: 58657},
 								val:        "//",
 								ignoreCase: false,
 								want:       "\"//\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1826, col: 10, offset: 58739},
+								pos: position{line: 1822, col: 10, offset: 58662},
 								expr: &seqExpr{
-									pos: position{line: 1826, col: 11, offset: 58740},
+									pos: position{line: 1822, col: 11, offset: 58663},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1826, col: 11, offset: 58740},
+											pos: position{line: 1822, col: 11, offset: 58663},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1826, col: 12, offset: 58741},
+												pos:  position{line: 1822, col: 12, offset: 58664},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1826, col: 27, offset: 58756},
+											pos:  position{line: 1822, col: 27, offset: 58679},
 											name: "SourceCharacter",
 										},
 									},
@@ -13176,28 +13172,28 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1827, col: 5, offset: 58778},
+						pos: position{line: 1823, col: 5, offset: 58701},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1827, col: 5, offset: 58778},
+								pos:        position{line: 1823, col: 5, offset: 58701},
 								val:        "--",
 								ignoreCase: false,
 								want:       "\"--\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1827, col: 10, offset: 58783},
+								pos: position{line: 1823, col: 10, offset: 58706},
 								expr: &seqExpr{
-									pos: position{line: 1827, col: 11, offset: 58784},
+									pos: position{line: 1823, col: 11, offset: 58707},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1827, col: 11, offset: 58784},
+											pos: position{line: 1823, col: 11, offset: 58707},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1827, col: 12, offset: 58785},
+												pos:  position{line: 1823, col: 12, offset: 58708},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1827, col: 27, offset: 58800},
+											pos:  position{line: 1823, col: 27, offset: 58723},
 											name: "SourceCharacter",
 										},
 									},
@@ -13212,19 +13208,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1829, col: 1, offset: 58819},
+			pos:  position{line: 1825, col: 1, offset: 58742},
 			expr: &seqExpr{
-				pos: position{line: 1829, col: 7, offset: 58825},
+				pos: position{line: 1825, col: 7, offset: 58748},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1829, col: 7, offset: 58825},
+						pos: position{line: 1825, col: 7, offset: 58748},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1829, col: 7, offset: 58825},
+							pos:  position{line: 1825, col: 7, offset: 58748},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1829, col: 19, offset: 58837},
+						pos:  position{line: 1825, col: 19, offset: 58760},
 						name: "LineTerminator",
 					},
 				},
@@ -13234,16 +13230,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1831, col: 1, offset: 58853},
+			pos:  position{line: 1827, col: 1, offset: 58776},
 			expr: &choiceExpr{
-				pos: position{line: 1831, col: 7, offset: 58859},
+				pos: position{line: 1827, col: 7, offset: 58782},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1831, col: 7, offset: 58859},
+						pos:  position{line: 1827, col: 7, offset: 58782},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1831, col: 11, offset: 58863},
+						pos:  position{line: 1827, col: 11, offset: 58786},
 						name: "EOF",
 					},
 				},
@@ -13253,11 +13249,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1833, col: 1, offset: 58868},
+			pos:  position{line: 1829, col: 1, offset: 58791},
 			expr: &notExpr{
-				pos: position{line: 1833, col: 7, offset: 58874},
+				pos: position{line: 1829, col: 7, offset: 58797},
 				expr: &anyMatcher{
-					line: 1833, col: 8, offset: 58875,
+					line: 1829, col: 8, offset: 58798,
 				},
 			},
 			leader:        false,
@@ -13265,11 +13261,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1835, col: 1, offset: 58878},
+			pos:  position{line: 1831, col: 1, offset: 58801},
 			expr: &notExpr{
-				pos: position{line: 1835, col: 8, offset: 58885},
+				pos: position{line: 1831, col: 8, offset: 58808},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1835, col: 9, offset: 58886},
+					pos:  position{line: 1831, col: 9, offset: 58809},
 					name: "KeyWordChars",
 				},
 			},
@@ -13278,15 +13274,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1839, col: 1, offset: 58922},
+			pos:  position{line: 1835, col: 1, offset: 58845},
 			expr: &actionExpr{
-				pos: position{line: 1840, col: 5, offset: 58935},
+				pos: position{line: 1836, col: 5, offset: 58858},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1840, col: 5, offset: 58935},
+					pos:   position{line: 1836, col: 5, offset: 58858},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1840, col: 7, offset: 58937},
+						pos:  position{line: 1836, col: 7, offset: 58860},
 						name: "Seq",
 					},
 				},
@@ -13296,27 +13292,27 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1848, col: 1, offset: 59083},
+			pos:  position{line: 1844, col: 1, offset: 59006},
 			expr: &actionExpr{
-				pos: position{line: 1848, col: 12, offset: 59094},
+				pos: position{line: 1844, col: 12, offset: 59017},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1848, col: 12, offset: 59094},
+					pos: position{line: 1844, col: 12, offset: 59017},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1848, col: 12, offset: 59094},
+							pos: position{line: 1844, col: 12, offset: 59017},
 							expr: &litMatcher{
-								pos:        position{line: 1848, col: 13, offset: 59095},
+								pos:        position{line: 1844, col: 13, offset: 59018},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1848, col: 17, offset: 59099},
+							pos:   position{line: 1844, col: 17, offset: 59022},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1848, col: 20, offset: 59102},
+								pos:  position{line: 1844, col: 20, offset: 59025},
 								name: "SelectExpr",
 							},
 						},
@@ -13328,65 +13324,65 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1850, col: 1, offset: 59132},
+			pos:  position{line: 1846, col: 1, offset: 59055},
 			expr: &actionExpr{
-				pos: position{line: 1851, col: 5, offset: 59148},
+				pos: position{line: 1847, col: 5, offset: 59071},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1851, col: 5, offset: 59148},
+					pos: position{line: 1847, col: 5, offset: 59071},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1851, col: 5, offset: 59148},
+							pos:   position{line: 1847, col: 5, offset: 59071},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1851, col: 10, offset: 59153},
+								pos:  position{line: 1847, col: 10, offset: 59076},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1852, col: 5, offset: 59171},
+							pos:   position{line: 1848, col: 5, offset: 59094},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1853, col: 9, offset: 59186},
+								pos: position{line: 1849, col: 9, offset: 59109},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1853, col: 9, offset: 59186},
+										pos:  position{line: 1849, col: 9, offset: 59109},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1854, col: 9, offset: 59207},
+										pos:  position{line: 1850, col: 9, offset: 59130},
 										name: "Select",
 									},
 									&actionExpr{
-										pos: position{line: 1855, col: 9, offset: 59222},
+										pos: position{line: 1851, col: 9, offset: 59145},
 										run: (*parser).callonSelectExpr9,
 										expr: &seqExpr{
-											pos: position{line: 1855, col: 9, offset: 59222},
+											pos: position{line: 1851, col: 9, offset: 59145},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1855, col: 9, offset: 59222},
+													pos:        position{line: 1851, col: 9, offset: 59145},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1855, col: 13, offset: 59226},
+													pos:  position{line: 1851, col: 13, offset: 59149},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1855, col: 16, offset: 59229},
+													pos:   position{line: 1851, col: 16, offset: 59152},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1855, col: 18, offset: 59231},
+														pos:  position{line: 1851, col: 18, offset: 59154},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1855, col: 26, offset: 59239},
+													pos:  position{line: 1851, col: 26, offset: 59162},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1855, col: 28, offset: 59241},
+													pos:        position{line: 1851, col: 28, offset: 59164},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13398,18 +13394,18 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1857, col: 5, offset: 59278},
+							pos:   position{line: 1853, col: 5, offset: 59201},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1857, col: 13, offset: 59286},
+								pos:  position{line: 1853, col: 13, offset: 59209},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1858, col: 5, offset: 59307},
+							pos:   position{line: 1854, col: 5, offset: 59230},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1858, col: 11, offset: 59313},
+								pos:  position{line: 1854, col: 11, offset: 59236},
 								name: "OptLimitClause",
 							},
 						},
@@ -13421,74 +13417,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1878, col: 1, offset: 59699},
+			pos:  position{line: 1874, col: 1, offset: 59622},
 			expr: &actionExpr{
-				pos: position{line: 1879, col: 5, offset: 59711},
+				pos: position{line: 1875, col: 5, offset: 59634},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1879, col: 5, offset: 59711},
+					pos: position{line: 1875, col: 5, offset: 59634},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1879, col: 5, offset: 59711},
+							pos:  position{line: 1875, col: 5, offset: 59634},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1880, col: 5, offset: 59723},
+							pos:   position{line: 1876, col: 5, offset: 59646},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1880, col: 14, offset: 59732},
+								pos:  position{line: 1876, col: 14, offset: 59655},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1881, col: 5, offset: 59748},
+							pos:   position{line: 1877, col: 5, offset: 59671},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1881, col: 11, offset: 59754},
+								pos:  position{line: 1877, col: 11, offset: 59677},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1884, col: 5, offset: 59894},
+							pos:  position{line: 1880, col: 5, offset: 59817},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1884, col: 7, offset: 59896},
+							pos:   position{line: 1880, col: 7, offset: 59819},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1884, col: 17, offset: 59906},
+								pos:  position{line: 1880, col: 17, offset: 59829},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1885, col: 5, offset: 59920},
+							pos:   position{line: 1881, col: 5, offset: 59843},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1885, col: 10, offset: 59925},
+								pos:  position{line: 1881, col: 10, offset: 59848},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1886, col: 5, offset: 59943},
+							pos:   position{line: 1882, col: 5, offset: 59866},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1886, col: 11, offset: 59949},
+								pos:  position{line: 1882, col: 11, offset: 59872},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 5, offset: 59968},
+							pos:   position{line: 1883, col: 5, offset: 59891},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1887, col: 11, offset: 59974},
+								pos:  position{line: 1883, col: 11, offset: 59897},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1888, col: 5, offset: 59993},
+							pos:   position{line: 1884, col: 5, offset: 59916},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1888, col: 12, offset: 60000},
+								pos:  position{line: 1884, col: 12, offset: 59923},
 								name: "OptHavingClause",
 							},
 						},
@@ -13500,49 +13496,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 1914, col: 1, offset: 60606},
+			pos:  position{line: 1910, col: 1, offset: 60529},
 			expr: &choiceExpr{
-				pos: position{line: 1915, col: 5, offset: 60622},
+				pos: position{line: 1911, col: 5, offset: 60545},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1915, col: 5, offset: 60622},
+						pos: position{line: 1911, col: 5, offset: 60545},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 1915, col: 5, offset: 60622},
+							pos: position{line: 1911, col: 5, offset: 60545},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1915, col: 5, offset: 60622},
+									pos:  position{line: 1911, col: 5, offset: 60545},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1915, col: 7, offset: 60624},
+									pos:  position{line: 1911, col: 7, offset: 60547},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1916, col: 5, offset: 60661},
+						pos: position{line: 1912, col: 5, offset: 60584},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 1916, col: 5, offset: 60661},
+							pos: position{line: 1912, col: 5, offset: 60584},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1916, col: 5, offset: 60661},
+									pos:  position{line: 1912, col: 5, offset: 60584},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1916, col: 7, offset: 60663},
+									pos:  position{line: 1912, col: 7, offset: 60586},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1917, col: 5, offset: 60699},
+						pos: position{line: 1913, col: 5, offset: 60622},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 1917, col: 5, offset: 60699},
+							pos:        position{line: 1913, col: 5, offset: 60622},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13555,57 +13551,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 1919, col: 1, offset: 60738},
+			pos:  position{line: 1915, col: 1, offset: 60661},
 			expr: &choiceExpr{
-				pos: position{line: 1920, col: 5, offset: 60757},
+				pos: position{line: 1916, col: 5, offset: 60680},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1920, col: 5, offset: 60757},
+						pos: position{line: 1916, col: 5, offset: 60680},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 1920, col: 5, offset: 60757},
+							pos: position{line: 1916, col: 5, offset: 60680},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1920, col: 5, offset: 60757},
+									pos:  position{line: 1916, col: 5, offset: 60680},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1920, col: 7, offset: 60759},
+									pos:  position{line: 1916, col: 7, offset: 60682},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1920, col: 10, offset: 60762},
+									pos:  position{line: 1916, col: 10, offset: 60685},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1920, col: 12, offset: 60764},
+									pos:  position{line: 1916, col: 12, offset: 60687},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1921, col: 5, offset: 60796},
+						pos: position{line: 1917, col: 5, offset: 60719},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 1921, col: 5, offset: 60796},
+							pos: position{line: 1917, col: 5, offset: 60719},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1921, col: 5, offset: 60796},
+									pos:  position{line: 1917, col: 5, offset: 60719},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1921, col: 7, offset: 60798},
+									pos:  position{line: 1917, col: 7, offset: 60721},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1922, col: 5, offset: 60869},
+						pos: position{line: 1918, col: 5, offset: 60792},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 1922, col: 5, offset: 60869},
+							pos:        position{line: 1918, col: 5, offset: 60792},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13618,19 +13614,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 1924, col: 1, offset: 60912},
+			pos:  position{line: 1920, col: 1, offset: 60835},
 			expr: &choiceExpr{
-				pos: position{line: 1925, col: 5, offset: 60931},
+				pos: position{line: 1921, col: 5, offset: 60854},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1925, col: 5, offset: 60931},
+						pos:  position{line: 1921, col: 5, offset: 60854},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 1926, col: 5, offset: 60947},
+						pos: position{line: 1922, col: 5, offset: 60870},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 1926, col: 5, offset: 60947},
+							pos:        position{line: 1922, col: 5, offset: 60870},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13643,38 +13639,38 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 1928, col: 1, offset: 60980},
+			pos:  position{line: 1924, col: 1, offset: 60903},
 			expr: &actionExpr{
-				pos: position{line: 1929, col: 5, offset: 60996},
+				pos: position{line: 1925, col: 5, offset: 60919},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 1929, col: 5, offset: 60996},
+					pos: position{line: 1925, col: 5, offset: 60919},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1929, col: 5, offset: 60996},
+							pos:  position{line: 1925, col: 5, offset: 60919},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1929, col: 7, offset: 60998},
+							pos:  position{line: 1925, col: 7, offset: 60921},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 1929, col: 12, offset: 61003},
+							pos:   position{line: 1925, col: 12, offset: 60926},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1929, col: 14, offset: 61005},
+								pos:  position{line: 1925, col: 14, offset: 60928},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1929, col: 27, offset: 61018},
+							pos:  position{line: 1925, col: 27, offset: 60941},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1929, col: 29, offset: 61020},
+							pos:   position{line: 1925, col: 29, offset: 60943},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1929, col: 34, offset: 61025},
+								pos:  position{line: 1925, col: 34, offset: 60948},
 								name: "CteList",
 							},
 						},
@@ -13686,32 +13682,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 1938, col: 1, offset: 61210},
+			pos:  position{line: 1934, col: 1, offset: 61133},
 			expr: &choiceExpr{
-				pos: position{line: 1939, col: 5, offset: 61228},
+				pos: position{line: 1935, col: 5, offset: 61151},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1939, col: 5, offset: 61228},
+						pos: position{line: 1935, col: 5, offset: 61151},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 1939, col: 5, offset: 61228},
+							pos: position{line: 1935, col: 5, offset: 61151},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1939, col: 5, offset: 61228},
+									pos:  position{line: 1935, col: 5, offset: 61151},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1939, col: 7, offset: 61230},
+									pos:  position{line: 1935, col: 7, offset: 61153},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1940, col: 5, offset: 61266},
+						pos: position{line: 1936, col: 5, offset: 61189},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 1940, col: 5, offset: 61266},
+							pos:        position{line: 1936, col: 5, offset: 61189},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13724,51 +13720,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 1942, col: 1, offset: 61305},
+			pos:  position{line: 1938, col: 1, offset: 61228},
 			expr: &actionExpr{
-				pos: position{line: 1942, col: 11, offset: 61315},
+				pos: position{line: 1938, col: 11, offset: 61238},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 1942, col: 11, offset: 61315},
+					pos: position{line: 1938, col: 11, offset: 61238},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1942, col: 11, offset: 61315},
+							pos:   position{line: 1938, col: 11, offset: 61238},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1942, col: 17, offset: 61321},
+								pos:  position{line: 1938, col: 17, offset: 61244},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1942, col: 21, offset: 61325},
+							pos:   position{line: 1938, col: 21, offset: 61248},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1942, col: 26, offset: 61330},
+								pos: position{line: 1938, col: 26, offset: 61253},
 								expr: &actionExpr{
-									pos: position{line: 1942, col: 28, offset: 61332},
+									pos: position{line: 1938, col: 28, offset: 61255},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 1942, col: 28, offset: 61332},
+										pos: position{line: 1938, col: 28, offset: 61255},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1942, col: 28, offset: 61332},
+												pos:  position{line: 1938, col: 28, offset: 61255},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1942, col: 31, offset: 61335},
+												pos:        position{line: 1938, col: 31, offset: 61258},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1942, col: 35, offset: 61339},
+												pos:  position{line: 1938, col: 35, offset: 61262},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1942, col: 38, offset: 61342},
+												pos:   position{line: 1938, col: 38, offset: 61265},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1942, col: 42, offset: 61346},
+													pos:  position{line: 1938, col: 42, offset: 61269},
 													name: "Cte",
 												},
 											},
@@ -13785,65 +13781,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 1946, col: 1, offset: 61415},
+			pos:  position{line: 1942, col: 1, offset: 61338},
 			expr: &actionExpr{
-				pos: position{line: 1947, col: 5, offset: 61423},
+				pos: position{line: 1943, col: 5, offset: 61346},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 1947, col: 5, offset: 61423},
+					pos: position{line: 1943, col: 5, offset: 61346},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1947, col: 5, offset: 61423},
+							pos:   position{line: 1943, col: 5, offset: 61346},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 10, offset: 61428},
+								pos:  position{line: 1943, col: 10, offset: 61351},
 								name: "AliasName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 20, offset: 61438},
+							pos:  position{line: 1943, col: 20, offset: 61361},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 22, offset: 61440},
+							pos:  position{line: 1943, col: 22, offset: 61363},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 1947, col: 25, offset: 61443},
+							pos:   position{line: 1943, col: 25, offset: 61366},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 27, offset: 61445},
+								pos:  position{line: 1943, col: 27, offset: 61368},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 43, offset: 61461},
+							pos:  position{line: 1943, col: 43, offset: 61384},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1947, col: 46, offset: 61464},
+							pos:        position{line: 1943, col: 46, offset: 61387},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 50, offset: 61468},
+							pos:  position{line: 1943, col: 50, offset: 61391},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1947, col: 53, offset: 61471},
+							pos:   position{line: 1943, col: 53, offset: 61394},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 55, offset: 61473},
+								pos:  position{line: 1943, col: 55, offset: 61396},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 63, offset: 61481},
+							pos:  position{line: 1943, col: 63, offset: 61404},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1947, col: 66, offset: 61484},
+							pos:        position{line: 1943, col: 66, offset: 61407},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13856,9 +13852,9 @@ var g = &grammar{
 		},
 		{
 			name: "AliasName",
-			pos:  position{line: 1956, col: 1, offset: 61659},
+			pos:  position{line: 1952, col: 1, offset: 61582},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1956, col: 13, offset: 61671},
+				pos:  position{line: 1952, col: 13, offset: 61594},
 				name: "Identifier",
 			},
 			leader:        false,
@@ -13866,65 +13862,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 1958, col: 1, offset: 61683},
+			pos:  position{line: 1954, col: 1, offset: 61606},
 			expr: &choiceExpr{
-				pos: position{line: 1959, col: 5, offset: 61704},
+				pos: position{line: 1955, col: 5, offset: 61627},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1959, col: 5, offset: 61704},
+						pos: position{line: 1955, col: 5, offset: 61627},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 1959, col: 5, offset: 61704},
+							pos: position{line: 1955, col: 5, offset: 61627},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1959, col: 5, offset: 61704},
+									pos:  position{line: 1955, col: 5, offset: 61627},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1959, col: 7, offset: 61706},
+									pos:  position{line: 1955, col: 7, offset: 61629},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1959, col: 20, offset: 61719},
+									pos:  position{line: 1955, col: 20, offset: 61642},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1960, col: 5, offset: 61758},
+						pos: position{line: 1956, col: 5, offset: 61681},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 1960, col: 5, offset: 61758},
+							pos: position{line: 1956, col: 5, offset: 61681},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1960, col: 5, offset: 61758},
+									pos:  position{line: 1956, col: 5, offset: 61681},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1960, col: 7, offset: 61760},
+									pos:  position{line: 1956, col: 7, offset: 61683},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1960, col: 11, offset: 61764},
+									pos:  position{line: 1956, col: 11, offset: 61687},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1960, col: 13, offset: 61766},
+									pos:  position{line: 1956, col: 13, offset: 61689},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1960, col: 26, offset: 61779},
+									pos:  position{line: 1956, col: 26, offset: 61702},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1961, col: 5, offset: 61810},
+						pos: position{line: 1957, col: 5, offset: 61733},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 1961, col: 5, offset: 61810},
+							pos:        position{line: 1957, col: 5, offset: 61733},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13937,25 +13933,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 1963, col: 1, offset: 61865},
+			pos:  position{line: 1959, col: 1, offset: 61788},
 			expr: &choiceExpr{
-				pos: position{line: 1964, col: 5, offset: 61882},
+				pos: position{line: 1960, col: 5, offset: 61805},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1964, col: 5, offset: 61882},
+						pos: position{line: 1960, col: 5, offset: 61805},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1964, col: 5, offset: 61882},
+								pos:  position{line: 1960, col: 5, offset: 61805},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1964, col: 7, offset: 61884},
+								pos:  position{line: 1960, col: 7, offset: 61807},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1965, col: 5, offset: 61893},
+						pos:        position{line: 1961, col: 5, offset: 61816},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -13967,25 +13963,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 1967, col: 1, offset: 61897},
+			pos:  position{line: 1963, col: 1, offset: 61820},
 			expr: &choiceExpr{
-				pos: position{line: 1968, col: 5, offset: 61915},
+				pos: position{line: 1964, col: 5, offset: 61838},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1968, col: 5, offset: 61915},
+						pos: position{line: 1964, col: 5, offset: 61838},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 1968, col: 5, offset: 61915},
+							pos: position{line: 1964, col: 5, offset: 61838},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1968, col: 5, offset: 61915},
+									pos:  position{line: 1964, col: 5, offset: 61838},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1968, col: 7, offset: 61917},
+									pos:   position{line: 1964, col: 7, offset: 61840},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1968, col: 12, offset: 61922},
+										pos:  position{line: 1964, col: 12, offset: 61845},
 										name: "FromOp",
 									},
 								},
@@ -13993,10 +13989,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1971, col: 5, offset: 61964},
+						pos: position{line: 1967, col: 5, offset: 61887},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1971, col: 5, offset: 61964},
+							pos:        position{line: 1967, col: 5, offset: 61887},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14009,27 +14005,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 1973, col: 1, offset: 62005},
+			pos:  position{line: 1969, col: 1, offset: 61928},
 			expr: &choiceExpr{
-				pos: position{line: 1974, col: 5, offset: 62024},
+				pos: position{line: 1970, col: 5, offset: 61947},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1974, col: 5, offset: 62024},
+						pos: position{line: 1970, col: 5, offset: 61947},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 1974, col: 5, offset: 62024},
+							pos:   position{line: 1970, col: 5, offset: 61947},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1974, col: 11, offset: 62030},
+								pos:  position{line: 1970, col: 11, offset: 61953},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1975, col: 5, offset: 62072},
+						pos: position{line: 1971, col: 5, offset: 61995},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 1975, col: 5, offset: 62072},
+							pos:        position{line: 1971, col: 5, offset: 61995},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14042,25 +14038,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 1977, col: 1, offset: 62117},
+			pos:  position{line: 1973, col: 1, offset: 62040},
 			expr: &choiceExpr{
-				pos: position{line: 1978, col: 5, offset: 62136},
+				pos: position{line: 1974, col: 5, offset: 62059},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1978, col: 5, offset: 62136},
+						pos: position{line: 1974, col: 5, offset: 62059},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 1978, col: 5, offset: 62136},
+							pos: position{line: 1974, col: 5, offset: 62059},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1978, col: 5, offset: 62136},
+									pos:  position{line: 1974, col: 5, offset: 62059},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1978, col: 7, offset: 62138},
+									pos:   position{line: 1974, col: 7, offset: 62061},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1978, col: 13, offset: 62144},
+										pos:  position{line: 1974, col: 13, offset: 62067},
 										name: "GroupClause",
 									},
 								},
@@ -14068,10 +14064,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1979, col: 5, offset: 62182},
+						pos: position{line: 1975, col: 5, offset: 62105},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1979, col: 5, offset: 62182},
+							pos:        position{line: 1975, col: 5, offset: 62105},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14084,34 +14080,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 1981, col: 1, offset: 62223},
+			pos:  position{line: 1977, col: 1, offset: 62146},
 			expr: &actionExpr{
-				pos: position{line: 1982, col: 5, offset: 62239},
+				pos: position{line: 1978, col: 5, offset: 62162},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 1982, col: 5, offset: 62239},
+					pos: position{line: 1978, col: 5, offset: 62162},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 5, offset: 62239},
+							pos:  position{line: 1978, col: 5, offset: 62162},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 11, offset: 62245},
+							pos:  position{line: 1978, col: 11, offset: 62168},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 13, offset: 62247},
+							pos:  position{line: 1978, col: 13, offset: 62170},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 16, offset: 62250},
+							pos:  position{line: 1978, col: 16, offset: 62173},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 18, offset: 62252},
+							pos:   position{line: 1978, col: 18, offset: 62175},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 23, offset: 62257},
+								pos:  position{line: 1978, col: 23, offset: 62180},
 								name: "GroupByList",
 							},
 						},
@@ -14123,51 +14119,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 1984, col: 1, offset: 62291},
+			pos:  position{line: 1980, col: 1, offset: 62214},
 			expr: &actionExpr{
-				pos: position{line: 1985, col: 5, offset: 62308},
+				pos: position{line: 1981, col: 5, offset: 62231},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 1985, col: 5, offset: 62308},
+					pos: position{line: 1981, col: 5, offset: 62231},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1985, col: 5, offset: 62308},
+							pos:   position{line: 1981, col: 5, offset: 62231},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1985, col: 11, offset: 62314},
+								pos:  position{line: 1981, col: 11, offset: 62237},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1985, col: 23, offset: 62326},
+							pos:   position{line: 1981, col: 23, offset: 62249},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1985, col: 28, offset: 62331},
+								pos: position{line: 1981, col: 28, offset: 62254},
 								expr: &actionExpr{
-									pos: position{line: 1985, col: 30, offset: 62333},
+									pos: position{line: 1981, col: 30, offset: 62256},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 1985, col: 30, offset: 62333},
+										pos: position{line: 1981, col: 30, offset: 62256},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1985, col: 30, offset: 62333},
+												pos:  position{line: 1981, col: 30, offset: 62256},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1985, col: 33, offset: 62336},
+												pos:        position{line: 1981, col: 33, offset: 62259},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1985, col: 37, offset: 62340},
+												pos:  position{line: 1981, col: 37, offset: 62263},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1985, col: 40, offset: 62343},
+												pos:   position{line: 1981, col: 40, offset: 62266},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1985, col: 42, offset: 62345},
+													pos:  position{line: 1981, col: 42, offset: 62268},
 													name: "GroupByItem",
 												},
 											},
@@ -14184,9 +14180,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 1989, col: 1, offset: 62426},
+			pos:  position{line: 1985, col: 1, offset: 62349},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1989, col: 15, offset: 62440},
+				pos:  position{line: 1985, col: 15, offset: 62363},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14194,25 +14190,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 1991, col: 1, offset: 62446},
+			pos:  position{line: 1987, col: 1, offset: 62369},
 			expr: &choiceExpr{
-				pos: position{line: 1992, col: 5, offset: 62466},
+				pos: position{line: 1988, col: 5, offset: 62389},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1992, col: 5, offset: 62466},
+						pos: position{line: 1988, col: 5, offset: 62389},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 1992, col: 5, offset: 62466},
+							pos: position{line: 1988, col: 5, offset: 62389},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1992, col: 5, offset: 62466},
+									pos:  position{line: 1988, col: 5, offset: 62389},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1992, col: 7, offset: 62468},
+									pos:   position{line: 1988, col: 7, offset: 62391},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1992, col: 9, offset: 62470},
+										pos:  position{line: 1988, col: 9, offset: 62393},
 										name: "HavingClause",
 									},
 								},
@@ -14220,10 +14216,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1993, col: 5, offset: 62505},
+						pos: position{line: 1989, col: 5, offset: 62428},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1993, col: 5, offset: 62505},
+							pos:        position{line: 1989, col: 5, offset: 62428},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14236,26 +14232,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 1995, col: 1, offset: 62529},
+			pos:  position{line: 1991, col: 1, offset: 62452},
 			expr: &actionExpr{
-				pos: position{line: 1996, col: 5, offset: 62546},
+				pos: position{line: 1992, col: 5, offset: 62469},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 1996, col: 5, offset: 62546},
+					pos: position{line: 1992, col: 5, offset: 62469},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1996, col: 5, offset: 62546},
+							pos:  position{line: 1992, col: 5, offset: 62469},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1996, col: 12, offset: 62553},
+							pos:  position{line: 1992, col: 12, offset: 62476},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1996, col: 14, offset: 62555},
+							pos:   position{line: 1992, col: 14, offset: 62478},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1996, col: 16, offset: 62557},
+								pos:  position{line: 1992, col: 16, offset: 62480},
 								name: "Expr",
 							},
 						},
@@ -14267,16 +14263,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 1998, col: 1, offset: 62581},
+			pos:  position{line: 1994, col: 1, offset: 62504},
 			expr: &choiceExpr{
-				pos: position{line: 1999, col: 5, offset: 62599},
+				pos: position{line: 1995, col: 5, offset: 62522},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1999, col: 5, offset: 62599},
+						pos:  position{line: 1995, col: 5, offset: 62522},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2000, col: 5, offset: 62613},
+						pos:  position{line: 1996, col: 5, offset: 62536},
 						name: "ConditionJoin",
 					},
 				},
@@ -14286,30 +14282,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2002, col: 1, offset: 62628},
+			pos:  position{line: 1998, col: 1, offset: 62551},
 			expr: &actionExpr{
-				pos: position{line: 2003, col: 5, offset: 62642},
+				pos: position{line: 1999, col: 5, offset: 62565},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2003, col: 5, offset: 62642},
+					pos: position{line: 1999, col: 5, offset: 62565},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2003, col: 5, offset: 62642},
+							pos:   position{line: 1999, col: 5, offset: 62565},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2003, col: 10, offset: 62647},
+								pos:  position{line: 1999, col: 10, offset: 62570},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2003, col: 19, offset: 62656},
+							pos:  position{line: 1999, col: 19, offset: 62579},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2003, col: 31, offset: 62668},
+							pos:   position{line: 1999, col: 31, offset: 62591},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2003, col: 37, offset: 62674},
+								pos:  position{line: 1999, col: 37, offset: 62597},
 								name: "FromElem",
 							},
 						},
@@ -14321,50 +14317,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2012, col: 1, offset: 62876},
+			pos:  position{line: 2008, col: 1, offset: 62799},
 			expr: &choiceExpr{
-				pos: position{line: 2013, col: 5, offset: 62893},
+				pos: position{line: 2009, col: 5, offset: 62816},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2013, col: 5, offset: 62893},
+						pos: position{line: 2009, col: 5, offset: 62816},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2013, col: 5, offset: 62893},
+								pos:  position{line: 2009, col: 5, offset: 62816},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2013, col: 8, offset: 62896},
+								pos:        position{line: 2009, col: 8, offset: 62819},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2013, col: 12, offset: 62900},
+								pos:  position{line: 2009, col: 12, offset: 62823},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2014, col: 5, offset: 62908},
+						pos: position{line: 2010, col: 5, offset: 62831},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2014, col: 5, offset: 62908},
+								pos:  position{line: 2010, col: 5, offset: 62831},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2014, col: 7, offset: 62910},
+								pos:  position{line: 2010, col: 7, offset: 62833},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2014, col: 13, offset: 62916},
+								pos:  position{line: 2010, col: 13, offset: 62839},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2014, col: 15, offset: 62918},
+								pos:  position{line: 2010, col: 15, offset: 62841},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2014, col: 20, offset: 62923},
+								pos:  position{line: 2010, col: 20, offset: 62846},
 								name: "_",
 							},
 						},
@@ -14376,46 +14372,46 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2016, col: 1, offset: 62927},
+			pos:  position{line: 2012, col: 1, offset: 62850},
 			expr: &actionExpr{
-				pos: position{line: 2017, col: 5, offset: 62945},
+				pos: position{line: 2013, col: 5, offset: 62868},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2017, col: 5, offset: 62945},
+					pos: position{line: 2013, col: 5, offset: 62868},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2017, col: 5, offset: 62945},
+							pos:   position{line: 2013, col: 5, offset: 62868},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2017, col: 10, offset: 62950},
+								pos:  position{line: 2013, col: 10, offset: 62873},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2017, col: 19, offset: 62959},
+							pos:   position{line: 2013, col: 19, offset: 62882},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2017, col: 25, offset: 62965},
+								pos:  position{line: 2013, col: 25, offset: 62888},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2017, col: 38, offset: 62978},
+							pos:  position{line: 2013, col: 38, offset: 62901},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2017, col: 40, offset: 62980},
+							pos:   position{line: 2013, col: 40, offset: 62903},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2017, col: 46, offset: 62986},
+								pos:  position{line: 2013, col: 46, offset: 62909},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2017, col: 55, offset: 62995},
+							pos:   position{line: 2013, col: 55, offset: 62918},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2017, col: 57, offset: 62997},
+								pos:  position{line: 2013, col: 57, offset: 62920},
 								name: "JoinExpr",
 							},
 						},
@@ -14427,161 +14423,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2028, col: 1, offset: 63266},
+			pos:  position{line: 2024, col: 1, offset: 63189},
 			expr: &choiceExpr{
-				pos: position{line: 2029, col: 5, offset: 63284},
+				pos: position{line: 2025, col: 5, offset: 63207},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2029, col: 5, offset: 63284},
+						pos: position{line: 2025, col: 5, offset: 63207},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2029, col: 5, offset: 63284},
+							pos: position{line: 2025, col: 5, offset: 63207},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2029, col: 5, offset: 63284},
+									pos: position{line: 2025, col: 5, offset: 63207},
 									expr: &seqExpr{
-										pos: position{line: 2029, col: 6, offset: 63285},
+										pos: position{line: 2025, col: 6, offset: 63208},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2029, col: 6, offset: 63285},
+												pos:  position{line: 2025, col: 6, offset: 63208},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2029, col: 8, offset: 63287},
+												pos:  position{line: 2025, col: 8, offset: 63210},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2029, col: 16, offset: 63295},
+									pos:  position{line: 2025, col: 16, offset: 63218},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2029, col: 18, offset: 63297},
+									pos:  position{line: 2025, col: 18, offset: 63220},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2030, col: 5, offset: 63342},
+						pos: position{line: 2026, col: 5, offset: 63265},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2030, col: 5, offset: 63342},
+							pos: position{line: 2026, col: 5, offset: 63265},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2030, col: 5, offset: 63342},
+									pos:  position{line: 2026, col: 5, offset: 63265},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2030, col: 7, offset: 63344},
+									pos:  position{line: 2026, col: 7, offset: 63267},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2030, col: 12, offset: 63349},
+									pos: position{line: 2026, col: 12, offset: 63272},
 									expr: &seqExpr{
-										pos: position{line: 2030, col: 13, offset: 63350},
+										pos: position{line: 2026, col: 13, offset: 63273},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2030, col: 13, offset: 63350},
+												pos:  position{line: 2026, col: 13, offset: 63273},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2030, col: 15, offset: 63352},
+												pos:  position{line: 2026, col: 15, offset: 63275},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2030, col: 23, offset: 63360},
+									pos:  position{line: 2026, col: 23, offset: 63283},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2030, col: 25, offset: 63362},
+									pos:  position{line: 2026, col: 25, offset: 63285},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2031, col: 5, offset: 63396},
+						pos: position{line: 2027, col: 5, offset: 63319},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2031, col: 5, offset: 63396},
+							pos: position{line: 2027, col: 5, offset: 63319},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 5, offset: 63396},
+									pos:  position{line: 2027, col: 5, offset: 63319},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 7, offset: 63398},
+									pos:  position{line: 2027, col: 7, offset: 63321},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2031, col: 12, offset: 63403},
+									pos: position{line: 2027, col: 12, offset: 63326},
 									expr: &seqExpr{
-										pos: position{line: 2031, col: 13, offset: 63404},
+										pos: position{line: 2027, col: 13, offset: 63327},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2031, col: 13, offset: 63404},
+												pos:  position{line: 2027, col: 13, offset: 63327},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2031, col: 15, offset: 63406},
+												pos:  position{line: 2027, col: 15, offset: 63329},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 23, offset: 63414},
+									pos:  position{line: 2027, col: 23, offset: 63337},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 25, offset: 63416},
+									pos:  position{line: 2027, col: 25, offset: 63339},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2032, col: 5, offset: 63450},
+						pos: position{line: 2028, col: 5, offset: 63373},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2032, col: 5, offset: 63450},
+							pos: position{line: 2028, col: 5, offset: 63373},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2032, col: 5, offset: 63450},
+									pos:  position{line: 2028, col: 5, offset: 63373},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2032, col: 7, offset: 63452},
+									pos:  position{line: 2028, col: 7, offset: 63375},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2032, col: 13, offset: 63458},
+									pos: position{line: 2028, col: 13, offset: 63381},
 									expr: &seqExpr{
-										pos: position{line: 2032, col: 14, offset: 63459},
+										pos: position{line: 2028, col: 14, offset: 63382},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2032, col: 14, offset: 63459},
+												pos:  position{line: 2028, col: 14, offset: 63382},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2032, col: 16, offset: 63461},
+												pos:  position{line: 2028, col: 16, offset: 63384},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2032, col: 24, offset: 63469},
+									pos:  position{line: 2028, col: 24, offset: 63392},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2032, col: 26, offset: 63471},
+									pos:  position{line: 2028, col: 26, offset: 63394},
 									name: "JOIN",
 								},
 							},
@@ -14594,33 +14590,33 @@ var g = &grammar{
 		},
 		{
 			name: "JoinExpr",
-			pos:  position{line: 2034, col: 1, offset: 63503},
+			pos:  position{line: 2030, col: 1, offset: 63426},
 			expr: &choiceExpr{
-				pos: position{line: 2035, col: 5, offset: 63517},
+				pos: position{line: 2031, col: 5, offset: 63440},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2035, col: 5, offset: 63517},
+						pos: position{line: 2031, col: 5, offset: 63440},
 						run: (*parser).callonJoinExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2035, col: 5, offset: 63517},
+							pos: position{line: 2031, col: 5, offset: 63440},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 5, offset: 63517},
+									pos:  position{line: 2031, col: 5, offset: 63440},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 7, offset: 63519},
+									pos:  position{line: 2031, col: 7, offset: 63442},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 10, offset: 63522},
+									pos:  position{line: 2031, col: 10, offset: 63445},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2035, col: 12, offset: 63524},
+									pos:   position{line: 2031, col: 12, offset: 63447},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2035, col: 14, offset: 63526},
+										pos:  position{line: 2031, col: 14, offset: 63449},
 										name: "Expr",
 									},
 								},
@@ -14628,47 +14624,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2041, col: 5, offset: 63656},
+						pos: position{line: 2037, col: 5, offset: 63579},
 						run: (*parser).callonJoinExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2041, col: 5, offset: 63656},
+							pos: position{line: 2037, col: 5, offset: 63579},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2041, col: 5, offset: 63656},
+									pos:  position{line: 2037, col: 5, offset: 63579},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2041, col: 7, offset: 63658},
+									pos:  position{line: 2037, col: 7, offset: 63581},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2041, col: 13, offset: 63664},
+									pos:  position{line: 2037, col: 13, offset: 63587},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2041, col: 16, offset: 63667},
+									pos:        position{line: 2037, col: 16, offset: 63590},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2041, col: 20, offset: 63671},
+									pos:  position{line: 2037, col: 20, offset: 63594},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2041, col: 23, offset: 63674},
+									pos:   position{line: 2037, col: 23, offset: 63597},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2041, col: 30, offset: 63681},
+										pos:  position{line: 2037, col: 30, offset: 63604},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2041, col: 36, offset: 63687},
+									pos:  position{line: 2037, col: 36, offset: 63610},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2041, col: 39, offset: 63690},
+									pos:        position{line: 2037, col: 39, offset: 63613},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14683,40 +14679,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2048, col: 1, offset: 63835},
+			pos:  position{line: 2044, col: 1, offset: 63758},
 			expr: &choiceExpr{
-				pos: position{line: 2049, col: 5, offset: 63854},
+				pos: position{line: 2045, col: 5, offset: 63777},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2049, col: 5, offset: 63854},
+						pos: position{line: 2045, col: 5, offset: 63777},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2049, col: 5, offset: 63854},
+							pos: position{line: 2045, col: 5, offset: 63777},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 5, offset: 63854},
+									pos:  position{line: 2045, col: 5, offset: 63777},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 7, offset: 63856},
+									pos:  position{line: 2045, col: 7, offset: 63779},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 12, offset: 63861},
+									pos:  position{line: 2045, col: 12, offset: 63784},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 14, offset: 63863},
+									pos:  position{line: 2045, col: 14, offset: 63786},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2055, col: 5, offset: 63992},
+						pos: position{line: 2051, col: 5, offset: 63915},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2055, col: 5, offset: 63992},
+							pos:        position{line: 2051, col: 5, offset: 63915},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14729,25 +14725,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2057, col: 1, offset: 64041},
+			pos:  position{line: 2053, col: 1, offset: 63964},
 			expr: &choiceExpr{
-				pos: position{line: 2058, col: 5, offset: 64054},
+				pos: position{line: 2054, col: 5, offset: 63977},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2058, col: 5, offset: 64054},
+						pos: position{line: 2054, col: 5, offset: 63977},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2058, col: 5, offset: 64054},
+							pos: position{line: 2054, col: 5, offset: 63977},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2058, col: 5, offset: 64054},
+									pos:  position{line: 2054, col: 5, offset: 63977},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2058, col: 7, offset: 64056},
+									pos:   position{line: 2054, col: 7, offset: 63979},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2058, col: 9, offset: 64058},
+										pos:  position{line: 2054, col: 9, offset: 63981},
 										name: "AliasClause",
 									},
 								},
@@ -14755,10 +14751,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2059, col: 5, offset: 64092},
+						pos: position{line: 2055, col: 5, offset: 64015},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2059, col: 5, offset: 64092},
+							pos:        position{line: 2055, col: 5, offset: 64015},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14771,50 +14767,50 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2061, col: 1, offset: 64129},
+			pos:  position{line: 2057, col: 1, offset: 64052},
 			expr: &actionExpr{
-				pos: position{line: 2062, col: 5, offset: 64146},
+				pos: position{line: 2058, col: 5, offset: 64069},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2062, col: 5, offset: 64146},
+					pos: position{line: 2058, col: 5, offset: 64069},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2062, col: 5, offset: 64146},
+							pos: position{line: 2058, col: 5, offset: 64069},
 							expr: &seqExpr{
-								pos: position{line: 2062, col: 6, offset: 64147},
+								pos: position{line: 2058, col: 6, offset: 64070},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2062, col: 6, offset: 64147},
+										pos:  position{line: 2058, col: 6, offset: 64070},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2062, col: 9, offset: 64150},
+										pos:  position{line: 2058, col: 9, offset: 64073},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2062, col: 13, offset: 64154},
+							pos: position{line: 2058, col: 13, offset: 64077},
 							expr: &choiceExpr{
-								pos: position{line: 2062, col: 15, offset: 64156},
+								pos: position{line: 2058, col: 15, offset: 64079},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2062, col: 15, offset: 64156},
+										pos:  position{line: 2058, col: 15, offset: 64079},
 										name: "SQLGuard",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2062, col: 26, offset: 64167},
+										pos:  position{line: 2058, col: 26, offset: 64090},
 										name: "DeprecatedFroms",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2062, col: 43, offset: 64184},
+							pos:   position{line: 2058, col: 43, offset: 64107},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2062, col: 48, offset: 64189},
+								pos:  position{line: 2058, col: 48, offset: 64112},
 								name: "IdentifierName",
 							},
 						},
@@ -14826,51 +14822,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2066, col: 1, offset: 64322},
+			pos:  position{line: 2062, col: 1, offset: 64245},
 			expr: &actionExpr{
-				pos: position{line: 2067, col: 5, offset: 64336},
+				pos: position{line: 2063, col: 5, offset: 64259},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2067, col: 5, offset: 64336},
+					pos: position{line: 2063, col: 5, offset: 64259},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2067, col: 5, offset: 64336},
+							pos:   position{line: 2063, col: 5, offset: 64259},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2067, col: 11, offset: 64342},
+								pos:  position{line: 2063, col: 11, offset: 64265},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2067, col: 22, offset: 64353},
+							pos:   position{line: 2063, col: 22, offset: 64276},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2067, col: 27, offset: 64358},
+								pos: position{line: 2063, col: 27, offset: 64281},
 								expr: &actionExpr{
-									pos: position{line: 2067, col: 29, offset: 64360},
+									pos: position{line: 2063, col: 29, offset: 64283},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2067, col: 29, offset: 64360},
+										pos: position{line: 2063, col: 29, offset: 64283},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2067, col: 29, offset: 64360},
+												pos:  position{line: 2063, col: 29, offset: 64283},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2067, col: 32, offset: 64363},
+												pos:        position{line: 2063, col: 32, offset: 64286},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2067, col: 36, offset: 64367},
+												pos:  position{line: 2063, col: 36, offset: 64290},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2067, col: 39, offset: 64370},
+												pos:   position{line: 2063, col: 39, offset: 64293},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2067, col: 41, offset: 64372},
+													pos:  position{line: 2063, col: 41, offset: 64295},
 													name: "SelectElem",
 												},
 											},
@@ -14887,29 +14883,29 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2076, col: 1, offset: 64598},
+			pos:  position{line: 2072, col: 1, offset: 64521},
 			expr: &choiceExpr{
-				pos: position{line: 2077, col: 5, offset: 64614},
+				pos: position{line: 2073, col: 5, offset: 64537},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2077, col: 5, offset: 64614},
+						pos: position{line: 2073, col: 5, offset: 64537},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2077, col: 5, offset: 64614},
+							pos: position{line: 2073, col: 5, offset: 64537},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2077, col: 5, offset: 64614},
+									pos:   position{line: 2073, col: 5, offset: 64537},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2077, col: 7, offset: 64616},
+										pos:  position{line: 2073, col: 7, offset: 64539},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2077, col: 12, offset: 64621},
+									pos:   position{line: 2073, col: 12, offset: 64544},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2077, col: 15, offset: 64624},
+										pos:  position{line: 2073, col: 15, offset: 64547},
 										name: "OptAsClause",
 									},
 								},
@@ -14917,10 +14913,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2088, col: 5, offset: 64840},
+						pos: position{line: 2084, col: 5, offset: 64763},
 						run: (*parser).callonSelectElem8,
 						expr: &litMatcher{
-							pos:        position{line: 2088, col: 5, offset: 64840},
+							pos:        position{line: 2084, col: 5, offset: 64763},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -14933,33 +14929,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2093, col: 1, offset: 64942},
+			pos:  position{line: 2089, col: 1, offset: 64865},
 			expr: &choiceExpr{
-				pos: position{line: 2094, col: 5, offset: 64959},
+				pos: position{line: 2090, col: 5, offset: 64882},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2094, col: 5, offset: 64959},
+						pos: position{line: 2090, col: 5, offset: 64882},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2094, col: 5, offset: 64959},
+							pos: position{line: 2090, col: 5, offset: 64882},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 5, offset: 64959},
+									pos:  position{line: 2090, col: 5, offset: 64882},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 7, offset: 64961},
+									pos:  position{line: 2090, col: 7, offset: 64884},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 10, offset: 64964},
+									pos:  position{line: 2090, col: 10, offset: 64887},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2094, col: 12, offset: 64966},
+									pos:   position{line: 2090, col: 12, offset: 64889},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2094, col: 15, offset: 64969},
+										pos:  position{line: 2090, col: 15, offset: 64892},
 										name: "Identifier",
 									},
 								},
@@ -14967,10 +14963,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2095, col: 5, offset: 65003},
+						pos: position{line: 2091, col: 5, offset: 64926},
 						run: (*parser).callonOptAsClause9,
 						expr: &litMatcher{
-							pos:        position{line: 2095, col: 5, offset: 65003},
+							pos:        position{line: 2091, col: 5, offset: 64926},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14983,41 +14979,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2097, col: 1, offset: 65028},
+			pos:  position{line: 2093, col: 1, offset: 64951},
 			expr: &choiceExpr{
-				pos: position{line: 2098, col: 5, offset: 65050},
+				pos: position{line: 2094, col: 5, offset: 64973},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2098, col: 5, offset: 65050},
+						pos: position{line: 2094, col: 5, offset: 64973},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2098, col: 5, offset: 65050},
+							pos: position{line: 2094, col: 5, offset: 64973},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 5, offset: 65050},
+									pos:  position{line: 2094, col: 5, offset: 64973},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 7, offset: 65052},
+									pos:  position{line: 2094, col: 7, offset: 64975},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 13, offset: 65058},
+									pos:  position{line: 2094, col: 13, offset: 64981},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 15, offset: 65060},
+									pos:  position{line: 2094, col: 15, offset: 64983},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 18, offset: 65063},
+									pos:  position{line: 2094, col: 18, offset: 64986},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2098, col: 20, offset: 65065},
+									pos:   position{line: 2094, col: 20, offset: 64988},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2098, col: 25, offset: 65070},
+										pos:  position{line: 2094, col: 25, offset: 64993},
 										name: "OrderByList",
 									},
 								},
@@ -15025,10 +15021,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2105, col: 5, offset: 65229},
+						pos: position{line: 2101, col: 5, offset: 65152},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2105, col: 5, offset: 65229},
+							pos:        position{line: 2101, col: 5, offset: 65152},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15041,51 +15037,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2107, col: 1, offset: 65262},
+			pos:  position{line: 2103, col: 1, offset: 65185},
 			expr: &actionExpr{
-				pos: position{line: 2108, col: 5, offset: 65279},
+				pos: position{line: 2104, col: 5, offset: 65202},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2108, col: 5, offset: 65279},
+					pos: position{line: 2104, col: 5, offset: 65202},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2108, col: 5, offset: 65279},
+							pos:   position{line: 2104, col: 5, offset: 65202},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2108, col: 11, offset: 65285},
+								pos:  position{line: 2104, col: 11, offset: 65208},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2108, col: 23, offset: 65297},
+							pos:   position{line: 2104, col: 23, offset: 65220},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2108, col: 28, offset: 65302},
+								pos: position{line: 2104, col: 28, offset: 65225},
 								expr: &actionExpr{
-									pos: position{line: 2108, col: 30, offset: 65304},
+									pos: position{line: 2104, col: 30, offset: 65227},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2108, col: 30, offset: 65304},
+										pos: position{line: 2104, col: 30, offset: 65227},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2108, col: 30, offset: 65304},
+												pos:  position{line: 2104, col: 30, offset: 65227},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2108, col: 33, offset: 65307},
+												pos:        position{line: 2104, col: 33, offset: 65230},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2108, col: 37, offset: 65311},
+												pos:  position{line: 2104, col: 37, offset: 65234},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2108, col: 40, offset: 65314},
+												pos:   position{line: 2104, col: 40, offset: 65237},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2108, col: 42, offset: 65316},
+													pos:  position{line: 2104, col: 42, offset: 65239},
 													name: "OrderByItem",
 												},
 											},
@@ -15102,34 +15098,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2112, col: 1, offset: 65417},
+			pos:  position{line: 2108, col: 1, offset: 65340},
 			expr: &actionExpr{
-				pos: position{line: 2113, col: 5, offset: 65433},
+				pos: position{line: 2109, col: 5, offset: 65356},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2113, col: 5, offset: 65433},
+					pos: position{line: 2109, col: 5, offset: 65356},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2113, col: 5, offset: 65433},
+							pos:   position{line: 2109, col: 5, offset: 65356},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2113, col: 7, offset: 65435},
+								pos:  position{line: 2109, col: 7, offset: 65358},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2113, col: 12, offset: 65440},
+							pos:   position{line: 2109, col: 12, offset: 65363},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2113, col: 18, offset: 65446},
+								pos:  position{line: 2109, col: 18, offset: 65369},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2113, col: 29, offset: 65457},
+							pos:   position{line: 2109, col: 29, offset: 65380},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2113, col: 35, offset: 65463},
+								pos:  position{line: 2109, col: 35, offset: 65386},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15141,49 +15137,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2124, col: 1, offset: 65713},
+			pos:  position{line: 2120, col: 1, offset: 65636},
 			expr: &choiceExpr{
-				pos: position{line: 2125, col: 5, offset: 65728},
+				pos: position{line: 2121, col: 5, offset: 65651},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2125, col: 5, offset: 65728},
+						pos: position{line: 2121, col: 5, offset: 65651},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2125, col: 5, offset: 65728},
+							pos: position{line: 2121, col: 5, offset: 65651},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2125, col: 5, offset: 65728},
+									pos:  position{line: 2121, col: 5, offset: 65651},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2125, col: 7, offset: 65730},
+									pos:  position{line: 2121, col: 7, offset: 65653},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2126, col: 5, offset: 65802},
+						pos: position{line: 2122, col: 5, offset: 65725},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2126, col: 5, offset: 65802},
+							pos: position{line: 2122, col: 5, offset: 65725},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2126, col: 5, offset: 65802},
+									pos:  position{line: 2122, col: 5, offset: 65725},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2126, col: 7, offset: 65804},
+									pos:  position{line: 2122, col: 7, offset: 65727},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2127, col: 5, offset: 65876},
+						pos: position{line: 2123, col: 5, offset: 65799},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2127, col: 5, offset: 65876},
+							pos:        position{line: 2123, col: 5, offset: 65799},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15196,65 +15192,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2129, col: 1, offset: 65908},
+			pos:  position{line: 2125, col: 1, offset: 65831},
 			expr: &choiceExpr{
-				pos: position{line: 2130, col: 5, offset: 65926},
+				pos: position{line: 2126, col: 5, offset: 65849},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2130, col: 5, offset: 65926},
+						pos: position{line: 2126, col: 5, offset: 65849},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2130, col: 5, offset: 65926},
+							pos: position{line: 2126, col: 5, offset: 65849},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 5, offset: 65926},
+									pos:  position{line: 2126, col: 5, offset: 65849},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 7, offset: 65928},
+									pos:  position{line: 2126, col: 7, offset: 65851},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 13, offset: 65934},
+									pos:  position{line: 2126, col: 13, offset: 65857},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 15, offset: 65936},
+									pos:  position{line: 2126, col: 15, offset: 65859},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2131, col: 5, offset: 66012},
+						pos: position{line: 2127, col: 5, offset: 65935},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2131, col: 5, offset: 66012},
+							pos: position{line: 2127, col: 5, offset: 65935},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2131, col: 5, offset: 66012},
+									pos:  position{line: 2127, col: 5, offset: 65935},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2131, col: 7, offset: 66014},
+									pos:  position{line: 2127, col: 7, offset: 65937},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2131, col: 13, offset: 66020},
+									pos:  position{line: 2127, col: 13, offset: 65943},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2131, col: 15, offset: 66022},
+									pos:  position{line: 2127, col: 15, offset: 65945},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2132, col: 5, offset: 66097},
+						pos: position{line: 2128, col: 5, offset: 66020},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2132, col: 5, offset: 66097},
+							pos:        position{line: 2128, col: 5, offset: 66020},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15267,29 +15263,29 @@ var g = &grammar{
 		},
 		{
 			name: "SelectLimit",
-			pos:  position{line: 2134, col: 1, offset: 66142},
+			pos:  position{line: 2130, col: 1, offset: 66065},
 			expr: &choiceExpr{
-				pos: position{line: 2135, col: 5, offset: 66158},
+				pos: position{line: 2131, col: 5, offset: 66081},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2135, col: 5, offset: 66158},
+						pos: position{line: 2131, col: 5, offset: 66081},
 						run: (*parser).callonSelectLimit2,
 						expr: &seqExpr{
-							pos: position{line: 2135, col: 5, offset: 66158},
+							pos: position{line: 2131, col: 5, offset: 66081},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2135, col: 5, offset: 66158},
+									pos:   position{line: 2131, col: 5, offset: 66081},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2135, col: 7, offset: 66160},
+										pos:  position{line: 2131, col: 7, offset: 66083},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2135, col: 19, offset: 66172},
+									pos:   position{line: 2131, col: 19, offset: 66095},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2135, col: 21, offset: 66174},
+										pos:  position{line: 2131, col: 21, offset: 66097},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15297,24 +15293,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2142, col: 5, offset: 66320},
+						pos: position{line: 2138, col: 5, offset: 66243},
 						run: (*parser).callonSelectLimit8,
 						expr: &seqExpr{
-							pos: position{line: 2142, col: 5, offset: 66320},
+							pos: position{line: 2138, col: 5, offset: 66243},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2142, col: 5, offset: 66320},
+									pos:   position{line: 2138, col: 5, offset: 66243},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2142, col: 7, offset: 66322},
+										pos:  position{line: 2138, col: 7, offset: 66245},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2142, col: 20, offset: 66335},
+									pos:   position{line: 2138, col: 20, offset: 66258},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2142, col: 22, offset: 66337},
+										pos:  position{line: 2138, col: 22, offset: 66260},
 										name: "OptLimitClause",
 									},
 								},
@@ -15328,25 +15324,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2155, col: 1, offset: 66609},
+			pos:  position{line: 2151, col: 1, offset: 66532},
 			expr: &choiceExpr{
-				pos: position{line: 2156, col: 5, offset: 66629},
+				pos: position{line: 2152, col: 5, offset: 66552},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2156, col: 5, offset: 66629},
+						pos: position{line: 2152, col: 5, offset: 66552},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2156, col: 5, offset: 66629},
+							pos: position{line: 2152, col: 5, offset: 66552},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2156, col: 5, offset: 66629},
+									pos:  position{line: 2152, col: 5, offset: 66552},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2156, col: 7, offset: 66631},
+									pos:   position{line: 2152, col: 7, offset: 66554},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2156, col: 9, offset: 66633},
+										pos:  position{line: 2152, col: 9, offset: 66556},
 										name: "LimitClause",
 									},
 								},
@@ -15354,10 +15350,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2157, col: 5, offset: 66667},
+						pos: position{line: 2153, col: 5, offset: 66590},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2157, col: 5, offset: 66667},
+							pos:        position{line: 2153, col: 5, offset: 66590},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15370,50 +15366,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2159, col: 1, offset: 66704},
+			pos:  position{line: 2155, col: 1, offset: 66627},
 			expr: &choiceExpr{
-				pos: position{line: 2160, col: 5, offset: 66721},
+				pos: position{line: 2156, col: 5, offset: 66644},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2160, col: 5, offset: 66721},
+						pos: position{line: 2156, col: 5, offset: 66644},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2160, col: 5, offset: 66721},
+							pos: position{line: 2156, col: 5, offset: 66644},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2160, col: 5, offset: 66721},
+									pos:  position{line: 2156, col: 5, offset: 66644},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2160, col: 11, offset: 66727},
+									pos:  position{line: 2156, col: 11, offset: 66650},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2160, col: 13, offset: 66729},
+									pos:  position{line: 2156, col: 13, offset: 66652},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2161, col: 5, offset: 66791},
+						pos: position{line: 2157, col: 5, offset: 66714},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2161, col: 5, offset: 66791},
+							pos: position{line: 2157, col: 5, offset: 66714},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2161, col: 5, offset: 66791},
+									pos:  position{line: 2157, col: 5, offset: 66714},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2161, col: 11, offset: 66797},
+									pos:  position{line: 2157, col: 11, offset: 66720},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2161, col: 13, offset: 66799},
+									pos:   position{line: 2157, col: 13, offset: 66722},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2161, col: 15, offset: 66801},
+										pos:  position{line: 2157, col: 15, offset: 66724},
 										name: "Expr",
 									},
 								},
@@ -15427,25 +15423,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2169, col: 1, offset: 66926},
+			pos:  position{line: 2165, col: 1, offset: 66849},
 			expr: &choiceExpr{
-				pos: position{line: 2170, col: 5, offset: 66947},
+				pos: position{line: 2166, col: 5, offset: 66870},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2170, col: 5, offset: 66947},
+						pos: position{line: 2166, col: 5, offset: 66870},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2170, col: 5, offset: 66947},
+							pos: position{line: 2166, col: 5, offset: 66870},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2170, col: 5, offset: 66947},
+									pos:  position{line: 2166, col: 5, offset: 66870},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2170, col: 7, offset: 66949},
+									pos:   position{line: 2166, col: 7, offset: 66872},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2170, col: 9, offset: 66951},
+										pos:  position{line: 2166, col: 9, offset: 66874},
 										name: "OffsetClause",
 									},
 								},
@@ -15453,10 +15449,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2171, col: 5, offset: 66987},
+						pos: position{line: 2167, col: 5, offset: 66910},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2171, col: 5, offset: 66987},
+							pos:        position{line: 2167, col: 5, offset: 66910},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15469,26 +15465,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2173, col: 1, offset: 67012},
+			pos:  position{line: 2169, col: 1, offset: 66935},
 			expr: &actionExpr{
-				pos: position{line: 2174, col: 5, offset: 67030},
+				pos: position{line: 2170, col: 5, offset: 66953},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2174, col: 5, offset: 67030},
+					pos: position{line: 2170, col: 5, offset: 66953},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2174, col: 5, offset: 67030},
+							pos:  position{line: 2170, col: 5, offset: 66953},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2174, col: 12, offset: 67037},
+							pos:  position{line: 2170, col: 12, offset: 66960},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2174, col: 14, offset: 67039},
+							pos:   position{line: 2170, col: 14, offset: 66962},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2174, col: 16, offset: 67041},
+								pos:  position{line: 2170, col: 16, offset: 66964},
 								name: "Expr",
 							},
 						},
@@ -15500,38 +15496,38 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2176, col: 1, offset: 67066},
+			pos:  position{line: 2172, col: 1, offset: 66989},
 			expr: &actionExpr{
-				pos: position{line: 2177, col: 5, offset: 67083},
+				pos: position{line: 2173, col: 5, offset: 67006},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2177, col: 5, offset: 67083},
+					pos: position{line: 2173, col: 5, offset: 67006},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2177, col: 5, offset: 67083},
+							pos:   position{line: 2173, col: 5, offset: 67006},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2177, col: 10, offset: 67088},
+								pos:  position{line: 2173, col: 10, offset: 67011},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2177, col: 21, offset: 67099},
+							pos:   position{line: 2173, col: 21, offset: 67022},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2177, col: 30, offset: 67108},
+								pos:  position{line: 2173, col: 30, offset: 67031},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2177, col: 36, offset: 67114},
+							pos:  position{line: 2173, col: 36, offset: 67037},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2177, col: 38, offset: 67116},
+							pos:   position{line: 2173, col: 38, offset: 67039},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2177, col: 44, offset: 67122},
+								pos:  position{line: 2173, col: 44, offset: 67045},
 								name: "SelectExpr",
 							},
 						},
@@ -15543,65 +15539,65 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2187, col: 1, offset: 67343},
+			pos:  position{line: 2183, col: 1, offset: 67266},
 			expr: &choiceExpr{
-				pos: position{line: 2188, col: 5, offset: 67354},
+				pos: position{line: 2184, col: 5, offset: 67277},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2188, col: 5, offset: 67354},
+						pos: position{line: 2184, col: 5, offset: 67277},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2188, col: 5, offset: 67354},
+							pos: position{line: 2184, col: 5, offset: 67277},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2188, col: 5, offset: 67354},
+									pos:  position{line: 2184, col: 5, offset: 67277},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2188, col: 7, offset: 67356},
+									pos:  position{line: 2184, col: 7, offset: 67279},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2188, col: 13, offset: 67362},
+									pos:  position{line: 2184, col: 13, offset: 67285},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2188, col: 15, offset: 67364},
+									pos:  position{line: 2184, col: 15, offset: 67287},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2189, col: 5, offset: 67400},
+						pos: position{line: 2185, col: 5, offset: 67323},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2189, col: 5, offset: 67400},
+							pos: position{line: 2185, col: 5, offset: 67323},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 5, offset: 67400},
+									pos:  position{line: 2185, col: 5, offset: 67323},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 7, offset: 67402},
+									pos:  position{line: 2185, col: 7, offset: 67325},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 13, offset: 67408},
+									pos:  position{line: 2185, col: 13, offset: 67331},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 15, offset: 67410},
+									pos:  position{line: 2185, col: 15, offset: 67333},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2190, col: 5, offset: 67445},
+						pos: position{line: 2186, col: 5, offset: 67368},
 						run: (*parser).callonSetOp14,
 						expr: &litMatcher{
-							pos:        position{line: 2190, col: 5, offset: 67445},
+							pos:        position{line: 2186, col: 5, offset: 67368},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15614,80 +15610,80 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2193, col: 1, offset: 67508},
+			pos:  position{line: 2189, col: 1, offset: 67431},
 			expr: &choiceExpr{
-				pos: position{line: 2194, col: 5, offset: 67523},
+				pos: position{line: 2190, col: 5, offset: 67446},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2194, col: 5, offset: 67523},
+						pos:  position{line: 2190, col: 5, offset: 67446},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2194, col: 12, offset: 67530},
+						pos:  position{line: 2190, col: 12, offset: 67453},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2194, col: 20, offset: 67538},
+						pos:  position{line: 2190, col: 20, offset: 67461},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2194, col: 29, offset: 67547},
+						pos:  position{line: 2190, col: 29, offset: 67470},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2194, col: 38, offset: 67556},
+						pos:  position{line: 2190, col: 38, offset: 67479},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2195, col: 5, offset: 67570},
+						pos:  position{line: 2191, col: 5, offset: 67493},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2195, col: 13, offset: 67578},
+						pos:  position{line: 2191, col: 13, offset: 67501},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2195, col: 20, offset: 67585},
+						pos:  position{line: 2191, col: 20, offset: 67508},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2195, col: 28, offset: 67593},
+						pos:  position{line: 2191, col: 28, offset: 67516},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2195, col: 36, offset: 67601},
+						pos:  position{line: 2191, col: 36, offset: 67524},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2195, col: 44, offset: 67609},
+						pos:  position{line: 2191, col: 44, offset: 67532},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2196, col: 5, offset: 67618},
+						pos:  position{line: 2192, col: 5, offset: 67541},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2197, col: 5, offset: 67628},
+						pos:  position{line: 2193, col: 5, offset: 67551},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2198, col: 5, offset: 67638},
+						pos:  position{line: 2194, col: 5, offset: 67561},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2199, col: 5, offset: 67648},
+						pos:  position{line: 2195, col: 5, offset: 67571},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2200, col: 5, offset: 67659},
+						pos:  position{line: 2196, col: 5, offset: 67582},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2201, col: 5, offset: 67668},
+						pos:  position{line: 2197, col: 5, offset: 67591},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2202, col: 5, offset: 67678},
+						pos:  position{line: 2198, col: 5, offset: 67601},
 						name: "ON",
 					},
 				},
@@ -15697,20 +15693,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2204, col: 1, offset: 67682},
+			pos:  position{line: 2200, col: 1, offset: 67605},
 			expr: &seqExpr{
-				pos: position{line: 2204, col: 14, offset: 67695},
+				pos: position{line: 2200, col: 14, offset: 67618},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2204, col: 14, offset: 67695},
+						pos:        position{line: 2200, col: 14, offset: 67618},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2204, col: 33, offset: 67714},
+						pos: position{line: 2200, col: 33, offset: 67637},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2204, col: 34, offset: 67715},
+							pos:  position{line: 2200, col: 34, offset: 67638},
 							name: "IdentifierRest",
 						},
 					},
@@ -15721,20 +15717,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2205, col: 1, offset: 67730},
+			pos:  position{line: 2201, col: 1, offset: 67653},
 			expr: &seqExpr{
-				pos: position{line: 2205, col: 14, offset: 67743},
+				pos: position{line: 2201, col: 14, offset: 67666},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2205, col: 14, offset: 67743},
+						pos:        position{line: 2201, col: 14, offset: 67666},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2205, col: 33, offset: 67762},
+						pos: position{line: 2201, col: 33, offset: 67685},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2205, col: 34, offset: 67763},
+							pos:  position{line: 2201, col: 34, offset: 67686},
 							name: "IdentifierRest",
 						},
 					},
@@ -15745,23 +15741,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2206, col: 1, offset: 67778},
+			pos:  position{line: 2202, col: 1, offset: 67701},
 			expr: &actionExpr{
-				pos: position{line: 2206, col: 14, offset: 67791},
+				pos: position{line: 2202, col: 14, offset: 67714},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2206, col: 14, offset: 67791},
+					pos: position{line: 2202, col: 14, offset: 67714},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2206, col: 14, offset: 67791},
+							pos:        position{line: 2202, col: 14, offset: 67714},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2206, col: 33, offset: 67810},
+							pos: position{line: 2202, col: 33, offset: 67733},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2206, col: 34, offset: 67811},
+								pos:  position{line: 2202, col: 34, offset: 67734},
 								name: "IdentifierRest",
 							},
 						},
@@ -15773,20 +15769,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2207, col: 1, offset: 67848},
+			pos:  position{line: 2203, col: 1, offset: 67771},
 			expr: &seqExpr{
-				pos: position{line: 2207, col: 14, offset: 67861},
+				pos: position{line: 2203, col: 14, offset: 67784},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2207, col: 14, offset: 67861},
+						pos:        position{line: 2203, col: 14, offset: 67784},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2207, col: 33, offset: 67880},
+						pos: position{line: 2203, col: 33, offset: 67803},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2207, col: 34, offset: 67881},
+							pos:  position{line: 2203, col: 34, offset: 67804},
 							name: "IdentifierRest",
 						},
 					},
@@ -15797,20 +15793,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2208, col: 1, offset: 67896},
+			pos:  position{line: 2204, col: 1, offset: 67819},
 			expr: &seqExpr{
-				pos: position{line: 2208, col: 14, offset: 67909},
+				pos: position{line: 2204, col: 14, offset: 67832},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2208, col: 14, offset: 67909},
+						pos:        position{line: 2204, col: 14, offset: 67832},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2208, col: 33, offset: 67928},
+						pos: position{line: 2204, col: 33, offset: 67851},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2208, col: 34, offset: 67929},
+							pos:  position{line: 2204, col: 34, offset: 67852},
 							name: "IdentifierRest",
 						},
 					},
@@ -15821,23 +15817,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2209, col: 1, offset: 67944},
+			pos:  position{line: 2205, col: 1, offset: 67867},
 			expr: &actionExpr{
-				pos: position{line: 2209, col: 14, offset: 67957},
+				pos: position{line: 2205, col: 14, offset: 67880},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2209, col: 14, offset: 67957},
+					pos: position{line: 2205, col: 14, offset: 67880},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2209, col: 14, offset: 67957},
+							pos:        position{line: 2205, col: 14, offset: 67880},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2209, col: 33, offset: 67976},
+							pos: position{line: 2205, col: 33, offset: 67899},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2209, col: 34, offset: 67977},
+								pos:  position{line: 2205, col: 34, offset: 67900},
 								name: "IdentifierRest",
 							},
 						},
@@ -15849,20 +15845,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2210, col: 1, offset: 68014},
+			pos:  position{line: 2206, col: 1, offset: 67937},
 			expr: &seqExpr{
-				pos: position{line: 2210, col: 14, offset: 68027},
+				pos: position{line: 2206, col: 14, offset: 67950},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2210, col: 14, offset: 68027},
+						pos:        position{line: 2206, col: 14, offset: 67950},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2210, col: 33, offset: 68046},
+						pos: position{line: 2206, col: 33, offset: 67969},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2210, col: 34, offset: 68047},
+							pos:  position{line: 2206, col: 34, offset: 67970},
 							name: "IdentifierRest",
 						},
 					},
@@ -15873,20 +15869,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2211, col: 1, offset: 68062},
+			pos:  position{line: 2207, col: 1, offset: 67985},
 			expr: &seqExpr{
-				pos: position{line: 2211, col: 14, offset: 68075},
+				pos: position{line: 2207, col: 14, offset: 67998},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2211, col: 14, offset: 68075},
+						pos:        position{line: 2207, col: 14, offset: 67998},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2211, col: 33, offset: 68094},
+						pos: position{line: 2207, col: 33, offset: 68017},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2211, col: 34, offset: 68095},
+							pos:  position{line: 2207, col: 34, offset: 68018},
 							name: "IdentifierRest",
 						},
 					},
@@ -15897,20 +15893,20 @@ var g = &grammar{
 		},
 		{
 			name: "AUTHOR",
-			pos:  position{line: 2212, col: 1, offset: 68110},
+			pos:  position{line: 2208, col: 1, offset: 68033},
 			expr: &seqExpr{
-				pos: position{line: 2212, col: 14, offset: 68123},
+				pos: position{line: 2208, col: 14, offset: 68046},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2212, col: 14, offset: 68123},
+						pos:        position{line: 2208, col: 14, offset: 68046},
 						val:        "author",
 						ignoreCase: true,
 						want:       "\"AUTHOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2212, col: 33, offset: 68142},
+						pos: position{line: 2208, col: 33, offset: 68065},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2212, col: 34, offset: 68143},
+							pos:  position{line: 2208, col: 34, offset: 68066},
 							name: "IdentifierRest",
 						},
 					},
@@ -15921,20 +15917,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2213, col: 1, offset: 68158},
+			pos:  position{line: 2209, col: 1, offset: 68081},
 			expr: &seqExpr{
-				pos: position{line: 2213, col: 14, offset: 68171},
+				pos: position{line: 2209, col: 14, offset: 68094},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2213, col: 14, offset: 68171},
+						pos:        position{line: 2209, col: 14, offset: 68094},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2213, col: 33, offset: 68190},
+						pos: position{line: 2209, col: 33, offset: 68113},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2213, col: 34, offset: 68191},
+							pos:  position{line: 2209, col: 34, offset: 68114},
 							name: "IdentifierRest",
 						},
 					},
@@ -15945,20 +15941,20 @@ var g = &grammar{
 		},
 		{
 			name: "BODY",
-			pos:  position{line: 2214, col: 1, offset: 68206},
+			pos:  position{line: 2210, col: 1, offset: 68129},
 			expr: &seqExpr{
-				pos: position{line: 2214, col: 14, offset: 68219},
+				pos: position{line: 2210, col: 14, offset: 68142},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2214, col: 14, offset: 68219},
+						pos:        position{line: 2210, col: 14, offset: 68142},
 						val:        "body",
 						ignoreCase: true,
 						want:       "\"BODY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2214, col: 33, offset: 68238},
+						pos: position{line: 2210, col: 33, offset: 68161},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2214, col: 34, offset: 68239},
+							pos:  position{line: 2210, col: 34, offset: 68162},
 							name: "IdentifierRest",
 						},
 					},
@@ -15969,20 +15965,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2215, col: 1, offset: 68254},
+			pos:  position{line: 2211, col: 1, offset: 68177},
 			expr: &seqExpr{
-				pos: position{line: 2215, col: 14, offset: 68267},
+				pos: position{line: 2211, col: 14, offset: 68190},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2215, col: 14, offset: 68267},
+						pos:        position{line: 2211, col: 14, offset: 68190},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2215, col: 33, offset: 68286},
+						pos: position{line: 2211, col: 33, offset: 68209},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2215, col: 34, offset: 68287},
+							pos:  position{line: 2211, col: 34, offset: 68210},
 							name: "IdentifierRest",
 						},
 					},
@@ -15993,20 +15989,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2216, col: 1, offset: 68302},
+			pos:  position{line: 2212, col: 1, offset: 68225},
 			expr: &seqExpr{
-				pos: position{line: 2216, col: 14, offset: 68315},
+				pos: position{line: 2212, col: 14, offset: 68238},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2216, col: 14, offset: 68315},
+						pos:        position{line: 2212, col: 14, offset: 68238},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2216, col: 33, offset: 68334},
+						pos: position{line: 2212, col: 33, offset: 68257},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2216, col: 34, offset: 68335},
+							pos:  position{line: 2212, col: 34, offset: 68258},
 							name: "IdentifierRest",
 						},
 					},
@@ -16017,20 +16013,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2217, col: 1, offset: 68350},
+			pos:  position{line: 2213, col: 1, offset: 68273},
 			expr: &seqExpr{
-				pos: position{line: 2217, col: 14, offset: 68363},
+				pos: position{line: 2213, col: 14, offset: 68286},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2217, col: 14, offset: 68363},
+						pos:        position{line: 2213, col: 14, offset: 68286},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2217, col: 33, offset: 68382},
+						pos: position{line: 2213, col: 33, offset: 68305},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2217, col: 34, offset: 68383},
+							pos:  position{line: 2213, col: 34, offset: 68306},
 							name: "IdentifierRest",
 						},
 					},
@@ -16041,20 +16037,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2218, col: 1, offset: 68398},
+			pos:  position{line: 2214, col: 1, offset: 68321},
 			expr: &seqExpr{
-				pos: position{line: 2218, col: 14, offset: 68411},
+				pos: position{line: 2214, col: 14, offset: 68334},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2218, col: 14, offset: 68411},
+						pos:        position{line: 2214, col: 14, offset: 68334},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2218, col: 33, offset: 68430},
+						pos: position{line: 2214, col: 33, offset: 68353},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2218, col: 34, offset: 68431},
+							pos:  position{line: 2214, col: 34, offset: 68354},
 							name: "IdentifierRest",
 						},
 					},
@@ -16065,20 +16061,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2219, col: 1, offset: 68446},
+			pos:  position{line: 2215, col: 1, offset: 68369},
 			expr: &seqExpr{
-				pos: position{line: 2219, col: 14, offset: 68459},
+				pos: position{line: 2215, col: 14, offset: 68382},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2219, col: 14, offset: 68459},
+						pos:        position{line: 2215, col: 14, offset: 68382},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2219, col: 33, offset: 68478},
+						pos: position{line: 2215, col: 33, offset: 68401},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2219, col: 34, offset: 68479},
+							pos:  position{line: 2215, col: 34, offset: 68402},
 							name: "IdentifierRest",
 						},
 					},
@@ -16089,20 +16085,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2220, col: 1, offset: 68494},
+			pos:  position{line: 2216, col: 1, offset: 68417},
 			expr: &seqExpr{
-				pos: position{line: 2220, col: 14, offset: 68507},
+				pos: position{line: 2216, col: 14, offset: 68430},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2220, col: 14, offset: 68507},
+						pos:        position{line: 2216, col: 14, offset: 68430},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2220, col: 33, offset: 68526},
+						pos: position{line: 2216, col: 33, offset: 68449},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2220, col: 34, offset: 68527},
+							pos:  position{line: 2216, col: 34, offset: 68450},
 							name: "IdentifierRest",
 						},
 					},
@@ -16113,20 +16109,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2221, col: 1, offset: 68542},
+			pos:  position{line: 2217, col: 1, offset: 68465},
 			expr: &seqExpr{
-				pos: position{line: 2221, col: 14, offset: 68555},
+				pos: position{line: 2217, col: 14, offset: 68478},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2221, col: 14, offset: 68555},
+						pos:        position{line: 2217, col: 14, offset: 68478},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2221, col: 33, offset: 68574},
+						pos: position{line: 2217, col: 33, offset: 68497},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2221, col: 34, offset: 68575},
+							pos:  position{line: 2217, col: 34, offset: 68498},
 							name: "IdentifierRest",
 						},
 					},
@@ -16137,23 +16133,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2222, col: 1, offset: 68590},
+			pos:  position{line: 2218, col: 1, offset: 68513},
 			expr: &actionExpr{
-				pos: position{line: 2222, col: 14, offset: 68603},
+				pos: position{line: 2218, col: 14, offset: 68526},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2222, col: 14, offset: 68603},
+					pos: position{line: 2218, col: 14, offset: 68526},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2222, col: 14, offset: 68603},
+							pos:        position{line: 2218, col: 14, offset: 68526},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2222, col: 33, offset: 68622},
+							pos: position{line: 2218, col: 33, offset: 68545},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2222, col: 34, offset: 68623},
+								pos:  position{line: 2218, col: 34, offset: 68546},
 								name: "IdentifierRest",
 							},
 						},
@@ -16165,20 +16161,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2223, col: 1, offset: 68661},
+			pos:  position{line: 2219, col: 1, offset: 68584},
 			expr: &seqExpr{
-				pos: position{line: 2223, col: 14, offset: 68674},
+				pos: position{line: 2219, col: 14, offset: 68597},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2223, col: 14, offset: 68674},
+						pos:        position{line: 2219, col: 14, offset: 68597},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2223, col: 33, offset: 68693},
+						pos: position{line: 2219, col: 33, offset: 68616},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2223, col: 34, offset: 68694},
+							pos:  position{line: 2219, col: 34, offset: 68617},
 							name: "IdentifierRest",
 						},
 					},
@@ -16189,20 +16185,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2224, col: 1, offset: 68709},
+			pos:  position{line: 2220, col: 1, offset: 68632},
 			expr: &seqExpr{
-				pos: position{line: 2224, col: 14, offset: 68722},
+				pos: position{line: 2220, col: 14, offset: 68645},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2224, col: 14, offset: 68722},
+						pos:        position{line: 2220, col: 14, offset: 68645},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2224, col: 33, offset: 68741},
+						pos: position{line: 2220, col: 33, offset: 68664},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2224, col: 34, offset: 68742},
+							pos:  position{line: 2220, col: 34, offset: 68665},
 							name: "IdentifierRest",
 						},
 					},
@@ -16213,20 +16209,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2225, col: 1, offset: 68758},
+			pos:  position{line: 2221, col: 1, offset: 68681},
 			expr: &seqExpr{
-				pos: position{line: 2225, col: 14, offset: 68771},
+				pos: position{line: 2221, col: 14, offset: 68694},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2225, col: 14, offset: 68771},
+						pos:        position{line: 2221, col: 14, offset: 68694},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2225, col: 33, offset: 68790},
+						pos: position{line: 2221, col: 33, offset: 68713},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2225, col: 34, offset: 68791},
+							pos:  position{line: 2221, col: 34, offset: 68714},
 							name: "IdentifierRest",
 						},
 					},
@@ -16237,20 +16233,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2226, col: 1, offset: 68806},
+			pos:  position{line: 2222, col: 1, offset: 68729},
 			expr: &seqExpr{
-				pos: position{line: 2226, col: 14, offset: 68819},
+				pos: position{line: 2222, col: 14, offset: 68742},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2226, col: 14, offset: 68819},
+						pos:        position{line: 2222, col: 14, offset: 68742},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2226, col: 33, offset: 68838},
+						pos: position{line: 2222, col: 33, offset: 68761},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2226, col: 34, offset: 68839},
+							pos:  position{line: 2222, col: 34, offset: 68762},
 							name: "IdentifierRest",
 						},
 					},
@@ -16261,20 +16257,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2227, col: 1, offset: 68854},
+			pos:  position{line: 2223, col: 1, offset: 68777},
 			expr: &seqExpr{
-				pos: position{line: 2227, col: 14, offset: 68867},
+				pos: position{line: 2223, col: 14, offset: 68790},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2227, col: 14, offset: 68867},
+						pos:        position{line: 2223, col: 14, offset: 68790},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2227, col: 33, offset: 68886},
+						pos: position{line: 2223, col: 33, offset: 68809},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2227, col: 34, offset: 68887},
+							pos:  position{line: 2223, col: 34, offset: 68810},
 							name: "IdentifierRest",
 						},
 					},
@@ -16285,20 +16281,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2228, col: 1, offset: 68902},
+			pos:  position{line: 2224, col: 1, offset: 68825},
 			expr: &seqExpr{
-				pos: position{line: 2228, col: 14, offset: 68915},
+				pos: position{line: 2224, col: 14, offset: 68838},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2228, col: 14, offset: 68915},
+						pos:        position{line: 2224, col: 14, offset: 68838},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2228, col: 33, offset: 68934},
+						pos: position{line: 2224, col: 33, offset: 68857},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2228, col: 34, offset: 68935},
+							pos:  position{line: 2224, col: 34, offset: 68858},
 							name: "IdentifierRest",
 						},
 					},
@@ -16309,20 +16305,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2229, col: 1, offset: 68950},
+			pos:  position{line: 2225, col: 1, offset: 68873},
 			expr: &seqExpr{
-				pos: position{line: 2229, col: 14, offset: 68963},
+				pos: position{line: 2225, col: 14, offset: 68886},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2229, col: 14, offset: 68963},
+						pos:        position{line: 2225, col: 14, offset: 68886},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2229, col: 33, offset: 68982},
+						pos: position{line: 2225, col: 33, offset: 68905},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2229, col: 34, offset: 68983},
+							pos:  position{line: 2225, col: 34, offset: 68906},
 							name: "IdentifierRest",
 						},
 					},
@@ -16333,20 +16329,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2230, col: 1, offset: 68998},
+			pos:  position{line: 2226, col: 1, offset: 68921},
 			expr: &seqExpr{
-				pos: position{line: 2230, col: 14, offset: 69011},
+				pos: position{line: 2226, col: 14, offset: 68934},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2230, col: 14, offset: 69011},
+						pos:        position{line: 2226, col: 14, offset: 68934},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2230, col: 33, offset: 69030},
+						pos: position{line: 2226, col: 33, offset: 68953},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2230, col: 34, offset: 69031},
+							pos:  position{line: 2226, col: 34, offset: 68954},
 							name: "IdentifierRest",
 						},
 					},
@@ -16357,20 +16353,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2231, col: 1, offset: 69046},
+			pos:  position{line: 2227, col: 1, offset: 68969},
 			expr: &seqExpr{
-				pos: position{line: 2231, col: 14, offset: 69059},
+				pos: position{line: 2227, col: 14, offset: 68982},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2231, col: 14, offset: 69059},
+						pos:        position{line: 2227, col: 14, offset: 68982},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2231, col: 33, offset: 69078},
+						pos: position{line: 2227, col: 33, offset: 69001},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2231, col: 34, offset: 69079},
+							pos:  position{line: 2227, col: 34, offset: 69002},
 							name: "IdentifierRest",
 						},
 					},
@@ -16381,20 +16377,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORMAT",
-			pos:  position{line: 2232, col: 1, offset: 69094},
+			pos:  position{line: 2228, col: 1, offset: 69017},
 			expr: &seqExpr{
-				pos: position{line: 2232, col: 14, offset: 69107},
+				pos: position{line: 2228, col: 14, offset: 69030},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2232, col: 14, offset: 69107},
+						pos:        position{line: 2228, col: 14, offset: 69030},
 						val:        "format",
 						ignoreCase: true,
 						want:       "\"FORMAT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2232, col: 33, offset: 69126},
+						pos: position{line: 2228, col: 33, offset: 69049},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2232, col: 34, offset: 69127},
+							pos:  position{line: 2228, col: 34, offset: 69050},
 							name: "IdentifierRest",
 						},
 					},
@@ -16405,20 +16401,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2233, col: 1, offset: 69142},
+			pos:  position{line: 2229, col: 1, offset: 69065},
 			expr: &seqExpr{
-				pos: position{line: 2233, col: 14, offset: 69155},
+				pos: position{line: 2229, col: 14, offset: 69078},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2233, col: 14, offset: 69155},
+						pos:        position{line: 2229, col: 14, offset: 69078},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2233, col: 33, offset: 69174},
+						pos: position{line: 2229, col: 33, offset: 69097},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2233, col: 34, offset: 69175},
+							pos:  position{line: 2229, col: 34, offset: 69098},
 							name: "IdentifierRest",
 						},
 					},
@@ -16429,20 +16425,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2234, col: 1, offset: 69190},
+			pos:  position{line: 2230, col: 1, offset: 69113},
 			expr: &seqExpr{
-				pos: position{line: 2234, col: 14, offset: 69203},
+				pos: position{line: 2230, col: 14, offset: 69126},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2234, col: 14, offset: 69203},
+						pos:        position{line: 2230, col: 14, offset: 69126},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2234, col: 33, offset: 69222},
+						pos: position{line: 2230, col: 33, offset: 69145},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2234, col: 34, offset: 69223},
+							pos:  position{line: 2230, col: 34, offset: 69146},
 							name: "IdentifierRest",
 						},
 					},
@@ -16453,20 +16449,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2235, col: 1, offset: 69238},
+			pos:  position{line: 2231, col: 1, offset: 69161},
 			expr: &seqExpr{
-				pos: position{line: 2235, col: 14, offset: 69251},
+				pos: position{line: 2231, col: 14, offset: 69174},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2235, col: 14, offset: 69251},
+						pos:        position{line: 2231, col: 14, offset: 69174},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2235, col: 33, offset: 69270},
+						pos: position{line: 2231, col: 33, offset: 69193},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2235, col: 34, offset: 69271},
+							pos:  position{line: 2231, col: 34, offset: 69194},
 							name: "IdentifierRest",
 						},
 					},
@@ -16477,20 +16473,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2236, col: 1, offset: 69286},
+			pos:  position{line: 2232, col: 1, offset: 69209},
 			expr: &seqExpr{
-				pos: position{line: 2236, col: 14, offset: 69299},
+				pos: position{line: 2232, col: 14, offset: 69222},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2236, col: 14, offset: 69299},
+						pos:        position{line: 2232, col: 14, offset: 69222},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2236, col: 33, offset: 69318},
+						pos: position{line: 2232, col: 33, offset: 69241},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2236, col: 34, offset: 69319},
+							pos:  position{line: 2232, col: 34, offset: 69242},
 							name: "IdentifierRest",
 						},
 					},
@@ -16501,20 +16497,20 @@ var g = &grammar{
 		},
 		{
 			name: "GREP",
-			pos:  position{line: 2237, col: 1, offset: 69334},
+			pos:  position{line: 2233, col: 1, offset: 69257},
 			expr: &seqExpr{
-				pos: position{line: 2237, col: 14, offset: 69347},
+				pos: position{line: 2233, col: 14, offset: 69270},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2237, col: 14, offset: 69347},
+						pos:        position{line: 2233, col: 14, offset: 69270},
 						val:        "grep",
 						ignoreCase: true,
 						want:       "\"GREP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2237, col: 33, offset: 69366},
+						pos: position{line: 2233, col: 33, offset: 69289},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2237, col: 34, offset: 69367},
+							pos:  position{line: 2233, col: 34, offset: 69290},
 							name: "IdentifierRest",
 						},
 					},
@@ -16525,20 +16521,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2238, col: 1, offset: 69382},
+			pos:  position{line: 2234, col: 1, offset: 69305},
 			expr: &seqExpr{
-				pos: position{line: 2238, col: 14, offset: 69395},
+				pos: position{line: 2234, col: 14, offset: 69318},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2238, col: 14, offset: 69395},
+						pos:        position{line: 2234, col: 14, offset: 69318},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2238, col: 33, offset: 69414},
+						pos: position{line: 2234, col: 33, offset: 69337},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2238, col: 34, offset: 69415},
+							pos:  position{line: 2234, col: 34, offset: 69338},
 							name: "IdentifierRest",
 						},
 					},
@@ -16549,20 +16545,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2239, col: 1, offset: 69430},
+			pos:  position{line: 2235, col: 1, offset: 69353},
 			expr: &seqExpr{
-				pos: position{line: 2239, col: 14, offset: 69443},
+				pos: position{line: 2235, col: 14, offset: 69366},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2239, col: 14, offset: 69443},
+						pos:        position{line: 2235, col: 14, offset: 69366},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2239, col: 33, offset: 69462},
+						pos: position{line: 2235, col: 33, offset: 69385},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2239, col: 34, offset: 69463},
+							pos:  position{line: 2235, col: 34, offset: 69386},
 							name: "IdentifierRest",
 						},
 					},
@@ -16573,20 +16569,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2240, col: 1, offset: 69478},
+			pos:  position{line: 2236, col: 1, offset: 69401},
 			expr: &seqExpr{
-				pos: position{line: 2240, col: 14, offset: 69491},
+				pos: position{line: 2236, col: 14, offset: 69414},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2240, col: 14, offset: 69491},
+						pos:        position{line: 2236, col: 14, offset: 69414},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2240, col: 33, offset: 69510},
+						pos: position{line: 2236, col: 33, offset: 69433},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2240, col: 34, offset: 69511},
+							pos:  position{line: 2236, col: 34, offset: 69434},
 							name: "IdentifierRest",
 						},
 					},
@@ -16597,20 +16593,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEADERS",
-			pos:  position{line: 2241, col: 1, offset: 69527},
+			pos:  position{line: 2237, col: 1, offset: 69450},
 			expr: &seqExpr{
-				pos: position{line: 2241, col: 14, offset: 69540},
+				pos: position{line: 2237, col: 14, offset: 69463},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2241, col: 14, offset: 69540},
+						pos:        position{line: 2237, col: 14, offset: 69463},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"HEADERS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2241, col: 33, offset: 69559},
+						pos: position{line: 2237, col: 33, offset: 69482},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2241, col: 34, offset: 69560},
+							pos:  position{line: 2237, col: 34, offset: 69483},
 							name: "IdentifierRest",
 						},
 					},
@@ -16621,20 +16617,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2242, col: 1, offset: 69575},
+			pos:  position{line: 2238, col: 1, offset: 69498},
 			expr: &seqExpr{
-				pos: position{line: 2242, col: 14, offset: 69588},
+				pos: position{line: 2238, col: 14, offset: 69511},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2242, col: 14, offset: 69588},
+						pos:        position{line: 2238, col: 14, offset: 69511},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2242, col: 33, offset: 69607},
+						pos: position{line: 2238, col: 33, offset: 69530},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2242, col: 34, offset: 69608},
+							pos:  position{line: 2238, col: 34, offset: 69531},
 							name: "IdentifierRest",
 						},
 					},
@@ -16645,20 +16641,44 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2243, col: 1, offset: 69623},
+			pos:  position{line: 2239, col: 1, offset: 69546},
 			expr: &seqExpr{
-				pos: position{line: 2243, col: 14, offset: 69636},
+				pos: position{line: 2239, col: 14, offset: 69559},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2243, col: 14, offset: 69636},
+						pos:        position{line: 2239, col: 14, offset: 69559},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2243, col: 33, offset: 69655},
+						pos: position{line: 2239, col: 33, offset: 69578},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2243, col: 34, offset: 69656},
+							pos:  position{line: 2239, col: 34, offset: 69579},
+							name: "IdentifierRest",
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "IS",
+			pos:  position{line: 2240, col: 1, offset: 69594},
+			expr: &seqExpr{
+				pos: position{line: 2240, col: 14, offset: 69607},
+				exprs: []any{
+					&litMatcher{
+						pos:        position{line: 2240, col: 14, offset: 69607},
+						val:        "is",
+						ignoreCase: true,
+						want:       "\"IS\"i",
+					},
+					&notExpr{
+						pos: position{line: 2240, col: 33, offset: 69626},
+						expr: &ruleRefExpr{
+							pos:  position{line: 2240, col: 34, offset: 69627},
 							name: "IdentifierRest",
 						},
 					},
@@ -16669,20 +16689,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2244, col: 1, offset: 69671},
+			pos:  position{line: 2241, col: 1, offset: 69642},
 			expr: &seqExpr{
-				pos: position{line: 2244, col: 14, offset: 69684},
+				pos: position{line: 2241, col: 14, offset: 69655},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2244, col: 14, offset: 69684},
+						pos:        position{line: 2241, col: 14, offset: 69655},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2244, col: 33, offset: 69703},
+						pos: position{line: 2241, col: 33, offset: 69674},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2244, col: 34, offset: 69704},
+							pos:  position{line: 2241, col: 34, offset: 69675},
 							name: "IdentifierRest",
 						},
 					},
@@ -16693,20 +16713,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2245, col: 1, offset: 69719},
+			pos:  position{line: 2242, col: 1, offset: 69690},
 			expr: &seqExpr{
-				pos: position{line: 2245, col: 14, offset: 69732},
+				pos: position{line: 2242, col: 14, offset: 69703},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2245, col: 14, offset: 69732},
+						pos:        position{line: 2242, col: 14, offset: 69703},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2245, col: 33, offset: 69751},
+						pos: position{line: 2242, col: 33, offset: 69722},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2245, col: 34, offset: 69752},
+							pos:  position{line: 2242, col: 34, offset: 69723},
 							name: "IdentifierRest",
 						},
 					},
@@ -16717,20 +16737,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2246, col: 1, offset: 69767},
+			pos:  position{line: 2243, col: 1, offset: 69738},
 			expr: &seqExpr{
-				pos: position{line: 2246, col: 14, offset: 69780},
+				pos: position{line: 2243, col: 14, offset: 69751},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2246, col: 14, offset: 69780},
+						pos:        position{line: 2243, col: 14, offset: 69751},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2246, col: 33, offset: 69799},
+						pos: position{line: 2243, col: 33, offset: 69770},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2246, col: 34, offset: 69800},
+							pos:  position{line: 2243, col: 34, offset: 69771},
 							name: "IdentifierRest",
 						},
 					},
@@ -16741,20 +16761,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2247, col: 1, offset: 69815},
+			pos:  position{line: 2244, col: 1, offset: 69786},
 			expr: &seqExpr{
-				pos: position{line: 2247, col: 14, offset: 69828},
+				pos: position{line: 2244, col: 14, offset: 69799},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2247, col: 14, offset: 69828},
+						pos:        position{line: 2244, col: 14, offset: 69799},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2247, col: 32, offset: 69846},
+						pos: position{line: 2244, col: 32, offset: 69817},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2247, col: 33, offset: 69847},
+							pos:  position{line: 2244, col: 33, offset: 69818},
 							name: "IdentifierRest",
 						},
 					},
@@ -16765,20 +16785,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2248, col: 1, offset: 69862},
+			pos:  position{line: 2245, col: 1, offset: 69833},
 			expr: &seqExpr{
-				pos: position{line: 2248, col: 14, offset: 69875},
+				pos: position{line: 2245, col: 14, offset: 69846},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2248, col: 14, offset: 69875},
+						pos:        position{line: 2245, col: 14, offset: 69846},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2248, col: 33, offset: 69894},
+						pos: position{line: 2245, col: 33, offset: 69865},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2248, col: 34, offset: 69895},
+							pos:  position{line: 2245, col: 34, offset: 69866},
 							name: "IdentifierRest",
 						},
 					},
@@ -16789,20 +16809,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2249, col: 1, offset: 69910},
+			pos:  position{line: 2246, col: 1, offset: 69881},
 			expr: &seqExpr{
-				pos: position{line: 2249, col: 14, offset: 69923},
+				pos: position{line: 2246, col: 14, offset: 69894},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2249, col: 14, offset: 69923},
+						pos:        position{line: 2246, col: 14, offset: 69894},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2249, col: 33, offset: 69942},
+						pos: position{line: 2246, col: 33, offset: 69913},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2249, col: 34, offset: 69943},
+							pos:  position{line: 2246, col: 34, offset: 69914},
 							name: "IdentifierRest",
 						},
 					},
@@ -16813,20 +16833,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2250, col: 1, offset: 69958},
+			pos:  position{line: 2247, col: 1, offset: 69929},
 			expr: &seqExpr{
-				pos: position{line: 2250, col: 16, offset: 69973},
+				pos: position{line: 2247, col: 16, offset: 69944},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2250, col: 16, offset: 69973},
+						pos:        position{line: 2247, col: 16, offset: 69944},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2250, col: 33, offset: 69990},
+						pos: position{line: 2247, col: 33, offset: 69961},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2250, col: 34, offset: 69991},
+							pos:  position{line: 2247, col: 34, offset: 69962},
 							name: "IdentifierRest",
 						},
 					},
@@ -16837,20 +16857,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2251, col: 1, offset: 70006},
+			pos:  position{line: 2248, col: 1, offset: 69977},
 			expr: &seqExpr{
-				pos: position{line: 2251, col: 14, offset: 70019},
+				pos: position{line: 2248, col: 14, offset: 69990},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2251, col: 14, offset: 70019},
+						pos:        position{line: 2248, col: 14, offset: 69990},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2251, col: 33, offset: 70038},
+						pos: position{line: 2248, col: 33, offset: 70009},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2251, col: 34, offset: 70039},
+							pos:  position{line: 2248, col: 34, offset: 70010},
 							name: "IdentifierRest",
 						},
 					},
@@ -16861,20 +16881,20 @@ var g = &grammar{
 		},
 		{
 			name: "MESSAGE",
-			pos:  position{line: 2252, col: 1, offset: 70054},
+			pos:  position{line: 2249, col: 1, offset: 70025},
 			expr: &seqExpr{
-				pos: position{line: 2252, col: 14, offset: 70067},
+				pos: position{line: 2249, col: 14, offset: 70038},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2252, col: 14, offset: 70067},
+						pos:        position{line: 2249, col: 14, offset: 70038},
 						val:        "message",
 						ignoreCase: true,
 						want:       "\"MESSAGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2252, col: 33, offset: 70086},
+						pos: position{line: 2249, col: 33, offset: 70057},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2252, col: 34, offset: 70087},
+							pos:  position{line: 2249, col: 34, offset: 70058},
 							name: "IdentifierRest",
 						},
 					},
@@ -16885,20 +16905,20 @@ var g = &grammar{
 		},
 		{
 			name: "META",
-			pos:  position{line: 2253, col: 1, offset: 70102},
+			pos:  position{line: 2250, col: 1, offset: 70073},
 			expr: &seqExpr{
-				pos: position{line: 2253, col: 14, offset: 70115},
+				pos: position{line: 2250, col: 14, offset: 70086},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2253, col: 14, offset: 70115},
+						pos:        position{line: 2250, col: 14, offset: 70086},
 						val:        "meta",
 						ignoreCase: true,
 						want:       "\"META\"i",
 					},
 					&notExpr{
-						pos: position{line: 2253, col: 33, offset: 70134},
+						pos: position{line: 2250, col: 33, offset: 70105},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2253, col: 34, offset: 70135},
+							pos:  position{line: 2250, col: 34, offset: 70106},
 							name: "IdentifierRest",
 						},
 					},
@@ -16909,20 +16929,20 @@ var g = &grammar{
 		},
 		{
 			name: "METHOD",
-			pos:  position{line: 2254, col: 1, offset: 70150},
+			pos:  position{line: 2251, col: 1, offset: 70121},
 			expr: &seqExpr{
-				pos: position{line: 2254, col: 14, offset: 70163},
+				pos: position{line: 2251, col: 14, offset: 70134},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2254, col: 14, offset: 70163},
+						pos:        position{line: 2251, col: 14, offset: 70134},
 						val:        "method",
 						ignoreCase: true,
 						want:       "\"METHOD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2254, col: 33, offset: 70182},
+						pos: position{line: 2251, col: 33, offset: 70153},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2254, col: 34, offset: 70183},
+							pos:  position{line: 2251, col: 34, offset: 70154},
 							name: "IdentifierRest",
 						},
 					},
@@ -16933,20 +16953,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2255, col: 1, offset: 70198},
+			pos:  position{line: 2252, col: 1, offset: 70169},
 			expr: &seqExpr{
-				pos: position{line: 2255, col: 14, offset: 70211},
+				pos: position{line: 2252, col: 14, offset: 70182},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2255, col: 14, offset: 70211},
+						pos:        position{line: 2252, col: 14, offset: 70182},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2255, col: 33, offset: 70230},
+						pos: position{line: 2252, col: 33, offset: 70201},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2255, col: 34, offset: 70231},
+							pos:  position{line: 2252, col: 34, offset: 70202},
 							name: "IdentifierRest",
 						},
 					},
@@ -16957,20 +16977,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2256, col: 1, offset: 70246},
+			pos:  position{line: 2253, col: 1, offset: 70217},
 			expr: &seqExpr{
-				pos: position{line: 2256, col: 14, offset: 70259},
+				pos: position{line: 2253, col: 14, offset: 70230},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2256, col: 14, offset: 70259},
+						pos:        position{line: 2253, col: 14, offset: 70230},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2256, col: 33, offset: 70278},
+						pos: position{line: 2253, col: 33, offset: 70249},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2256, col: 34, offset: 70279},
+							pos:  position{line: 2253, col: 34, offset: 70250},
 							name: "IdentifierRest",
 						},
 					},
@@ -16981,20 +17001,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2257, col: 1, offset: 70294},
+			pos:  position{line: 2254, col: 1, offset: 70265},
 			expr: &seqExpr{
-				pos: position{line: 2257, col: 14, offset: 70307},
+				pos: position{line: 2254, col: 14, offset: 70278},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2257, col: 14, offset: 70307},
+						pos:        position{line: 2254, col: 14, offset: 70278},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2257, col: 33, offset: 70326},
+						pos: position{line: 2254, col: 33, offset: 70297},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2257, col: 34, offset: 70327},
+							pos:  position{line: 2254, col: 34, offset: 70298},
 							name: "IdentifierRest",
 						},
 					},
@@ -17005,20 +17025,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2258, col: 1, offset: 70342},
+			pos:  position{line: 2255, col: 1, offset: 70313},
 			expr: &seqExpr{
-				pos: position{line: 2258, col: 14, offset: 70355},
+				pos: position{line: 2255, col: 14, offset: 70326},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2258, col: 14, offset: 70355},
+						pos:        position{line: 2255, col: 14, offset: 70326},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2258, col: 33, offset: 70374},
+						pos: position{line: 2255, col: 33, offset: 70345},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2258, col: 34, offset: 70375},
+							pos:  position{line: 2255, col: 34, offset: 70346},
 							name: "IdentifierRest",
 						},
 					},
@@ -17029,20 +17049,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2259, col: 1, offset: 70390},
+			pos:  position{line: 2256, col: 1, offset: 70361},
 			expr: &seqExpr{
-				pos: position{line: 2259, col: 14, offset: 70403},
+				pos: position{line: 2256, col: 14, offset: 70374},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2259, col: 14, offset: 70403},
+						pos:        position{line: 2256, col: 14, offset: 70374},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2259, col: 33, offset: 70422},
+						pos: position{line: 2256, col: 33, offset: 70393},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2259, col: 34, offset: 70423},
+							pos:  position{line: 2256, col: 34, offset: 70394},
 							name: "IdentifierRest",
 						},
 					},
@@ -17053,20 +17073,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2260, col: 1, offset: 70438},
+			pos:  position{line: 2257, col: 1, offset: 70409},
 			expr: &seqExpr{
-				pos: position{line: 2260, col: 14, offset: 70451},
+				pos: position{line: 2257, col: 14, offset: 70422},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2260, col: 14, offset: 70451},
+						pos:        position{line: 2257, col: 14, offset: 70422},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2260, col: 33, offset: 70470},
+						pos: position{line: 2257, col: 33, offset: 70441},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2260, col: 34, offset: 70471},
+							pos:  position{line: 2257, col: 34, offset: 70442},
 							name: "IdentifierRest",
 						},
 					},
@@ -17077,23 +17097,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2261, col: 1, offset: 70486},
+			pos:  position{line: 2258, col: 1, offset: 70457},
 			expr: &actionExpr{
-				pos: position{line: 2261, col: 14, offset: 70499},
+				pos: position{line: 2258, col: 14, offset: 70470},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2261, col: 14, offset: 70499},
+					pos: position{line: 2258, col: 14, offset: 70470},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2261, col: 14, offset: 70499},
+							pos:        position{line: 2258, col: 14, offset: 70470},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2261, col: 33, offset: 70518},
+							pos: position{line: 2258, col: 33, offset: 70489},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2261, col: 34, offset: 70519},
+								pos:  position{line: 2258, col: 34, offset: 70490},
 								name: "IdentifierRest",
 							},
 						},
@@ -17105,20 +17125,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2262, col: 1, offset: 70555},
+			pos:  position{line: 2259, col: 1, offset: 70526},
 			expr: &seqExpr{
-				pos: position{line: 2262, col: 14, offset: 70568},
+				pos: position{line: 2259, col: 14, offset: 70539},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2262, col: 14, offset: 70568},
+						pos:        position{line: 2259, col: 14, offset: 70539},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2262, col: 33, offset: 70587},
+						pos: position{line: 2259, col: 33, offset: 70558},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2262, col: 34, offset: 70588},
+							pos:  position{line: 2259, col: 34, offset: 70559},
 							name: "IdentifierRest",
 						},
 					},
@@ -17129,20 +17149,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2263, col: 1, offset: 70603},
+			pos:  position{line: 2260, col: 1, offset: 70574},
 			expr: &seqExpr{
-				pos: position{line: 2263, col: 14, offset: 70616},
+				pos: position{line: 2260, col: 14, offset: 70587},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2263, col: 14, offset: 70616},
+						pos:        position{line: 2260, col: 14, offset: 70587},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2263, col: 33, offset: 70635},
+						pos: position{line: 2260, col: 33, offset: 70606},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2263, col: 34, offset: 70636},
+							pos:  position{line: 2260, col: 34, offset: 70607},
 							name: "IdentifierRest",
 						},
 					},
@@ -17153,20 +17173,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2264, col: 1, offset: 70651},
+			pos:  position{line: 2261, col: 1, offset: 70622},
 			expr: &seqExpr{
-				pos: position{line: 2264, col: 14, offset: 70664},
+				pos: position{line: 2261, col: 14, offset: 70635},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2264, col: 14, offset: 70664},
+						pos:        position{line: 2261, col: 14, offset: 70635},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2264, col: 33, offset: 70683},
+						pos: position{line: 2261, col: 33, offset: 70654},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2264, col: 34, offset: 70684},
+							pos:  position{line: 2261, col: 34, offset: 70655},
 							name: "IdentifierRest",
 						},
 					},
@@ -17177,20 +17197,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2265, col: 1, offset: 70699},
+			pos:  position{line: 2262, col: 1, offset: 70670},
 			expr: &seqExpr{
-				pos: position{line: 2265, col: 14, offset: 70712},
+				pos: position{line: 2262, col: 14, offset: 70683},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2265, col: 14, offset: 70712},
+						pos:        position{line: 2262, col: 14, offset: 70683},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2265, col: 33, offset: 70731},
+						pos: position{line: 2262, col: 33, offset: 70702},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2265, col: 34, offset: 70732},
+							pos:  position{line: 2262, col: 34, offset: 70703},
 							name: "IdentifierRest",
 						},
 					},
@@ -17201,20 +17221,20 @@ var g = &grammar{
 		},
 		{
 			name: "OVER",
-			pos:  position{line: 2266, col: 1, offset: 70747},
+			pos:  position{line: 2263, col: 1, offset: 70718},
 			expr: &seqExpr{
-				pos: position{line: 2266, col: 14, offset: 70760},
+				pos: position{line: 2263, col: 14, offset: 70731},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2266, col: 14, offset: 70760},
+						pos:        position{line: 2263, col: 14, offset: 70731},
 						val:        "over",
 						ignoreCase: true,
 						want:       "\"OVER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2266, col: 33, offset: 70779},
+						pos: position{line: 2263, col: 33, offset: 70750},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2266, col: 34, offset: 70780},
+							pos:  position{line: 2263, col: 34, offset: 70751},
 							name: "IdentifierRest",
 						},
 					},
@@ -17225,20 +17245,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2267, col: 1, offset: 70795},
+			pos:  position{line: 2264, col: 1, offset: 70766},
 			expr: &seqExpr{
-				pos: position{line: 2267, col: 14, offset: 70808},
+				pos: position{line: 2264, col: 14, offset: 70779},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2267, col: 14, offset: 70808},
+						pos:        position{line: 2264, col: 14, offset: 70779},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2267, col: 33, offset: 70827},
+						pos: position{line: 2264, col: 33, offset: 70798},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2267, col: 34, offset: 70828},
+							pos:  position{line: 2264, col: 34, offset: 70799},
 							name: "IdentifierRest",
 						},
 					},
@@ -17249,20 +17269,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2268, col: 1, offset: 70843},
+			pos:  position{line: 2265, col: 1, offset: 70814},
 			expr: &seqExpr{
-				pos: position{line: 2268, col: 14, offset: 70856},
+				pos: position{line: 2265, col: 14, offset: 70827},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2268, col: 14, offset: 70856},
+						pos:        position{line: 2265, col: 14, offset: 70827},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2268, col: 33, offset: 70875},
+						pos: position{line: 2265, col: 33, offset: 70846},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2268, col: 34, offset: 70876},
+							pos:  position{line: 2265, col: 34, offset: 70847},
 							name: "IdentifierRest",
 						},
 					},
@@ -17273,20 +17293,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2269, col: 1, offset: 70891},
+			pos:  position{line: 2266, col: 1, offset: 70862},
 			expr: &seqExpr{
-				pos: position{line: 2269, col: 14, offset: 70904},
+				pos: position{line: 2266, col: 14, offset: 70875},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2269, col: 14, offset: 70904},
+						pos:        position{line: 2266, col: 14, offset: 70875},
 						val:        "RECURSIVE",
 						ignoreCase: false,
 						want:       "\"RECURSIVE\"",
 					},
 					&notExpr{
-						pos: position{line: 2269, col: 33, offset: 70923},
+						pos: position{line: 2266, col: 33, offset: 70894},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2269, col: 34, offset: 70924},
+							pos:  position{line: 2266, col: 34, offset: 70895},
 							name: "IdentifierRest",
 						},
 					},
@@ -17297,20 +17317,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP",
-			pos:  position{line: 2270, col: 1, offset: 70939},
+			pos:  position{line: 2267, col: 1, offset: 70910},
 			expr: &seqExpr{
-				pos: position{line: 2270, col: 14, offset: 70952},
+				pos: position{line: 2267, col: 14, offset: 70923},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2270, col: 14, offset: 70952},
+						pos:        position{line: 2267, col: 14, offset: 70923},
 						val:        "regexp",
 						ignoreCase: true,
 						want:       "\"REGEXP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2270, col: 33, offset: 70971},
+						pos: position{line: 2267, col: 33, offset: 70942},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2270, col: 34, offset: 70972},
+							pos:  position{line: 2267, col: 34, offset: 70943},
 							name: "IdentifierRest",
 						},
 					},
@@ -17321,20 +17341,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP_REPLACE",
-			pos:  position{line: 2271, col: 1, offset: 70987},
+			pos:  position{line: 2268, col: 1, offset: 70958},
 			expr: &seqExpr{
-				pos: position{line: 2271, col: 18, offset: 71004},
+				pos: position{line: 2268, col: 18, offset: 70975},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2271, col: 18, offset: 71004},
+						pos:        position{line: 2268, col: 18, offset: 70975},
 						val:        "regexp_replace",
 						ignoreCase: true,
 						want:       "\"REGEXP_REPLACE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2271, col: 36, offset: 71022},
+						pos: position{line: 2268, col: 36, offset: 70993},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2271, col: 37, offset: 71023},
+							pos:  position{line: 2268, col: 37, offset: 70994},
 							name: "IdentifierRest",
 						},
 					},
@@ -17345,20 +17365,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2272, col: 1, offset: 71038},
+			pos:  position{line: 2269, col: 1, offset: 71009},
 			expr: &seqExpr{
-				pos: position{line: 2272, col: 14, offset: 71051},
+				pos: position{line: 2269, col: 14, offset: 71022},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2272, col: 14, offset: 71051},
+						pos:        position{line: 2269, col: 14, offset: 71022},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2272, col: 33, offset: 71070},
+						pos: position{line: 2269, col: 33, offset: 71041},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2272, col: 34, offset: 71071},
+							pos:  position{line: 2269, col: 34, offset: 71042},
 							name: "IdentifierRest",
 						},
 					},
@@ -17369,20 +17389,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2273, col: 1, offset: 71086},
+			pos:  position{line: 2270, col: 1, offset: 71057},
 			expr: &seqExpr{
-				pos: position{line: 2273, col: 14, offset: 71099},
+				pos: position{line: 2270, col: 14, offset: 71070},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2273, col: 14, offset: 71099},
+						pos:        position{line: 2270, col: 14, offset: 71070},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2273, col: 33, offset: 71118},
+						pos: position{line: 2270, col: 33, offset: 71089},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2273, col: 34, offset: 71119},
+							pos:  position{line: 2270, col: 34, offset: 71090},
 							name: "IdentifierRest",
 						},
 					},
@@ -17393,20 +17413,20 @@ var g = &grammar{
 		},
 		{
 			name: "SAMPLE",
-			pos:  position{line: 2274, col: 1, offset: 71134},
+			pos:  position{line: 2271, col: 1, offset: 71105},
 			expr: &seqExpr{
-				pos: position{line: 2274, col: 14, offset: 71147},
+				pos: position{line: 2271, col: 14, offset: 71118},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2274, col: 14, offset: 71147},
+						pos:        position{line: 2271, col: 14, offset: 71118},
 						val:        "sample",
 						ignoreCase: true,
 						want:       "\"SAMPLE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2274, col: 33, offset: 71166},
+						pos: position{line: 2271, col: 33, offset: 71137},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2274, col: 34, offset: 71167},
+							pos:  position{line: 2271, col: 34, offset: 71138},
 							name: "IdentifierRest",
 						},
 					},
@@ -17417,20 +17437,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2275, col: 1, offset: 71182},
+			pos:  position{line: 2272, col: 1, offset: 71153},
 			expr: &seqExpr{
-				pos: position{line: 2275, col: 14, offset: 71195},
+				pos: position{line: 2272, col: 14, offset: 71166},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2275, col: 14, offset: 71195},
+						pos:        position{line: 2272, col: 14, offset: 71166},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2275, col: 33, offset: 71214},
+						pos: position{line: 2272, col: 33, offset: 71185},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2275, col: 34, offset: 71215},
+							pos:  position{line: 2272, col: 34, offset: 71186},
 							name: "IdentifierRest",
 						},
 					},
@@ -17441,20 +17461,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2276, col: 1, offset: 71230},
+			pos:  position{line: 2273, col: 1, offset: 71201},
 			expr: &seqExpr{
-				pos: position{line: 2276, col: 14, offset: 71243},
+				pos: position{line: 2273, col: 14, offset: 71214},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2276, col: 14, offset: 71243},
+						pos:        position{line: 2273, col: 14, offset: 71214},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2276, col: 33, offset: 71262},
+						pos: position{line: 2273, col: 33, offset: 71233},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2276, col: 34, offset: 71263},
+							pos:  position{line: 2273, col: 34, offset: 71234},
 							name: "IdentifierRest",
 						},
 					},
@@ -17465,20 +17485,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2277, col: 1, offset: 71278},
+			pos:  position{line: 2274, col: 1, offset: 71249},
 			expr: &seqExpr{
-				pos: position{line: 2277, col: 14, offset: 71291},
+				pos: position{line: 2274, col: 14, offset: 71262},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2277, col: 14, offset: 71291},
+						pos:        position{line: 2274, col: 14, offset: 71262},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2277, col: 33, offset: 71310},
+						pos: position{line: 2274, col: 33, offset: 71281},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2277, col: 34, offset: 71311},
+							pos:  position{line: 2274, col: 34, offset: 71282},
 							name: "IdentifierRest",
 						},
 					},
@@ -17489,20 +17509,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2278, col: 1, offset: 71326},
+			pos:  position{line: 2275, col: 1, offset: 71297},
 			expr: &seqExpr{
-				pos: position{line: 2278, col: 14, offset: 71339},
+				pos: position{line: 2275, col: 14, offset: 71310},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2278, col: 14, offset: 71339},
+						pos:        position{line: 2275, col: 14, offset: 71310},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2278, col: 33, offset: 71358},
+						pos: position{line: 2275, col: 33, offset: 71329},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2278, col: 34, offset: 71359},
+							pos:  position{line: 2275, col: 34, offset: 71330},
 							name: "IdentifierRest",
 						},
 					},
@@ -17513,20 +17533,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2279, col: 1, offset: 71374},
+			pos:  position{line: 2276, col: 1, offset: 71345},
 			expr: &seqExpr{
-				pos: position{line: 2279, col: 14, offset: 71387},
+				pos: position{line: 2276, col: 14, offset: 71358},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2279, col: 14, offset: 71387},
+						pos:        position{line: 2276, col: 14, offset: 71358},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2279, col: 33, offset: 71406},
+						pos: position{line: 2276, col: 33, offset: 71377},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2279, col: 34, offset: 71407},
+							pos:  position{line: 2276, col: 34, offset: 71378},
 							name: "IdentifierRest",
 						},
 					},
@@ -17537,20 +17557,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2280, col: 1, offset: 71422},
+			pos:  position{line: 2277, col: 1, offset: 71393},
 			expr: &seqExpr{
-				pos: position{line: 2280, col: 14, offset: 71435},
+				pos: position{line: 2277, col: 14, offset: 71406},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2280, col: 14, offset: 71435},
+						pos:        position{line: 2277, col: 14, offset: 71406},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2280, col: 33, offset: 71454},
+						pos: position{line: 2277, col: 33, offset: 71425},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2280, col: 34, offset: 71455},
+							pos:  position{line: 2277, col: 34, offset: 71426},
 							name: "IdentifierRest",
 						},
 					},
@@ -17561,20 +17581,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2281, col: 1, offset: 71470},
+			pos:  position{line: 2278, col: 1, offset: 71441},
 			expr: &seqExpr{
-				pos: position{line: 2281, col: 14, offset: 71483},
+				pos: position{line: 2278, col: 14, offset: 71454},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2281, col: 14, offset: 71483},
+						pos:        position{line: 2278, col: 14, offset: 71454},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2281, col: 33, offset: 71502},
+						pos: position{line: 2278, col: 33, offset: 71473},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2281, col: 34, offset: 71503},
+							pos:  position{line: 2278, col: 34, offset: 71474},
 							name: "IdentifierRest",
 						},
 					},
@@ -17585,20 +17605,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAP",
-			pos:  position{line: 2282, col: 1, offset: 71519},
+			pos:  position{line: 2279, col: 1, offset: 71490},
 			expr: &seqExpr{
-				pos: position{line: 2282, col: 14, offset: 71532},
+				pos: position{line: 2279, col: 14, offset: 71503},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2282, col: 14, offset: 71532},
+						pos:        position{line: 2279, col: 14, offset: 71503},
 						val:        "tap",
 						ignoreCase: true,
 						want:       "\"TAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2282, col: 33, offset: 71551},
+						pos: position{line: 2279, col: 33, offset: 71522},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2282, col: 34, offset: 71552},
+							pos:  position{line: 2279, col: 34, offset: 71523},
 							name: "IdentifierRest",
 						},
 					},
@@ -17609,20 +17629,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2283, col: 1, offset: 71567},
+			pos:  position{line: 2280, col: 1, offset: 71538},
 			expr: &seqExpr{
-				pos: position{line: 2283, col: 14, offset: 71580},
+				pos: position{line: 2280, col: 14, offset: 71551},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2283, col: 14, offset: 71580},
+						pos:        position{line: 2280, col: 14, offset: 71551},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2283, col: 33, offset: 71599},
+						pos: position{line: 2280, col: 33, offset: 71570},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2283, col: 34, offset: 71600},
+							pos:  position{line: 2280, col: 34, offset: 71571},
 							name: "IdentifierRest",
 						},
 					},
@@ -17633,20 +17653,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2284, col: 1, offset: 71615},
+			pos:  position{line: 2281, col: 1, offset: 71586},
 			expr: &seqExpr{
-				pos: position{line: 2284, col: 14, offset: 71628},
+				pos: position{line: 2281, col: 14, offset: 71599},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2284, col: 14, offset: 71628},
+						pos:        position{line: 2281, col: 14, offset: 71599},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2284, col: 33, offset: 71647},
+						pos: position{line: 2281, col: 33, offset: 71618},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2284, col: 34, offset: 71648},
+							pos:  position{line: 2281, col: 34, offset: 71619},
 							name: "IdentifierRest",
 						},
 					},
@@ -17657,20 +17677,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2285, col: 1, offset: 71663},
+			pos:  position{line: 2282, col: 1, offset: 71634},
 			expr: &seqExpr{
-				pos: position{line: 2285, col: 14, offset: 71676},
+				pos: position{line: 2282, col: 14, offset: 71647},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2285, col: 14, offset: 71676},
+						pos:        position{line: 2282, col: 14, offset: 71647},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2285, col: 33, offset: 71695},
+						pos: position{line: 2282, col: 33, offset: 71666},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2285, col: 34, offset: 71696},
+							pos:  position{line: 2282, col: 34, offset: 71667},
 							name: "IdentifierRest",
 						},
 					},
@@ -17681,20 +17701,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2286, col: 1, offset: 71711},
+			pos:  position{line: 2283, col: 1, offset: 71682},
 			expr: &seqExpr{
-				pos: position{line: 2286, col: 14, offset: 71724},
+				pos: position{line: 2283, col: 14, offset: 71695},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2286, col: 14, offset: 71724},
+						pos:        position{line: 2283, col: 14, offset: 71695},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2286, col: 33, offset: 71743},
+						pos: position{line: 2283, col: 33, offset: 71714},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2286, col: 34, offset: 71744},
+							pos:  position{line: 2283, col: 34, offset: 71715},
 							name: "IdentifierRest",
 						},
 					},
@@ -17705,20 +17725,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2287, col: 1, offset: 71759},
+			pos:  position{line: 2284, col: 1, offset: 71730},
 			expr: &seqExpr{
-				pos: position{line: 2287, col: 14, offset: 71772},
+				pos: position{line: 2284, col: 14, offset: 71743},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2287, col: 14, offset: 71772},
+						pos:        position{line: 2284, col: 14, offset: 71743},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2287, col: 33, offset: 71791},
+						pos: position{line: 2284, col: 33, offset: 71762},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2287, col: 34, offset: 71792},
+							pos:  position{line: 2284, col: 34, offset: 71763},
 							name: "IdentifierRest",
 						},
 					},
@@ -17729,20 +17749,44 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2288, col: 1, offset: 71807},
+			pos:  position{line: 2285, col: 1, offset: 71778},
 			expr: &seqExpr{
-				pos: position{line: 2288, col: 14, offset: 71820},
+				pos: position{line: 2285, col: 14, offset: 71791},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2288, col: 14, offset: 71820},
+						pos:        position{line: 2285, col: 14, offset: 71791},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2288, col: 33, offset: 71839},
+						pos: position{line: 2285, col: 33, offset: 71810},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2288, col: 34, offset: 71840},
+							pos:  position{line: 2285, col: 34, offset: 71811},
+							name: "IdentifierRest",
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "UNNEST",
+			pos:  position{line: 2286, col: 1, offset: 71827},
+			expr: &seqExpr{
+				pos: position{line: 2286, col: 14, offset: 71840},
+				exprs: []any{
+					&litMatcher{
+						pos:        position{line: 2286, col: 14, offset: 71840},
+						val:        "unnest",
+						ignoreCase: true,
+						want:       "\"UNNEST\"i",
+					},
+					&notExpr{
+						pos: position{line: 2286, col: 33, offset: 71859},
+						expr: &ruleRefExpr{
+							pos:  position{line: 2286, col: 34, offset: 71860},
 							name: "IdentifierRest",
 						},
 					},
@@ -17753,20 +17797,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2289, col: 1, offset: 71856},
+			pos:  position{line: 2287, col: 1, offset: 71875},
 			expr: &seqExpr{
-				pos: position{line: 2289, col: 14, offset: 71869},
+				pos: position{line: 2287, col: 14, offset: 71888},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2289, col: 14, offset: 71869},
+						pos:        position{line: 2287, col: 14, offset: 71888},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2289, col: 33, offset: 71888},
+						pos: position{line: 2287, col: 33, offset: 71907},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2289, col: 34, offset: 71889},
+							pos:  position{line: 2287, col: 34, offset: 71908},
 							name: "IdentifierRest",
 						},
 					},
@@ -17777,20 +17821,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2290, col: 1, offset: 71904},
+			pos:  position{line: 2288, col: 1, offset: 71923},
 			expr: &seqExpr{
-				pos: position{line: 2290, col: 14, offset: 71917},
+				pos: position{line: 2288, col: 14, offset: 71936},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2290, col: 14, offset: 71917},
+						pos:        position{line: 2288, col: 14, offset: 71936},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2290, col: 33, offset: 71936},
+						pos: position{line: 2288, col: 33, offset: 71955},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2290, col: 34, offset: 71937},
+							pos:  position{line: 2288, col: 34, offset: 71956},
 							name: "IdentifierRest",
 						},
 					},
@@ -17801,20 +17845,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2291, col: 1, offset: 71952},
+			pos:  position{line: 2289, col: 1, offset: 71971},
 			expr: &seqExpr{
-				pos: position{line: 2291, col: 14, offset: 71965},
+				pos: position{line: 2289, col: 14, offset: 71984},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2291, col: 14, offset: 71965},
+						pos:        position{line: 2289, col: 14, offset: 71984},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2291, col: 33, offset: 71984},
+						pos: position{line: 2289, col: 33, offset: 72003},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2291, col: 34, offset: 71985},
+							pos:  position{line: 2289, col: 34, offset: 72004},
 							name: "IdentifierRest",
 						},
 					},
@@ -17825,20 +17869,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2292, col: 1, offset: 72000},
+			pos:  position{line: 2290, col: 1, offset: 72019},
 			expr: &seqExpr{
-				pos: position{line: 2292, col: 14, offset: 72013},
+				pos: position{line: 2290, col: 14, offset: 72032},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2292, col: 14, offset: 72013},
+						pos:        position{line: 2290, col: 14, offset: 72032},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2292, col: 33, offset: 72032},
+						pos: position{line: 2290, col: 33, offset: 72051},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2292, col: 34, offset: 72033},
+							pos:  position{line: 2290, col: 34, offset: 72052},
 							name: "IdentifierRest",
 						},
 					},
@@ -17849,20 +17893,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2293, col: 1, offset: 72048},
+			pos:  position{line: 2291, col: 1, offset: 72067},
 			expr: &seqExpr{
-				pos: position{line: 2293, col: 14, offset: 72061},
+				pos: position{line: 2291, col: 14, offset: 72080},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2293, col: 14, offset: 72061},
+						pos:        position{line: 2291, col: 14, offset: 72080},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2293, col: 33, offset: 72080},
+						pos: position{line: 2291, col: 33, offset: 72099},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2293, col: 34, offset: 72081},
+							pos:  position{line: 2291, col: 34, offset: 72100},
 							name: "IdentifierRest",
 						},
 					},
@@ -17873,20 +17917,20 @@ var g = &grammar{
 		},
 		{
 			name: "YIELD",
-			pos:  position{line: 2294, col: 1, offset: 72096},
+			pos:  position{line: 2292, col: 1, offset: 72115},
 			expr: &seqExpr{
-				pos: position{line: 2294, col: 14, offset: 72109},
+				pos: position{line: 2292, col: 14, offset: 72128},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2294, col: 14, offset: 72109},
+						pos:        position{line: 2292, col: 14, offset: 72128},
 						val:        "yield",
 						ignoreCase: true,
 						want:       "\"YIELD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2294, col: 33, offset: 72128},
+						pos: position{line: 2292, col: 33, offset: 72147},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2294, col: 34, offset: 72129},
+							pos:  position{line: 2292, col: 34, offset: 72148},
 							name: "IdentifierRest",
 						},
 					},
@@ -18620,21 +18664,23 @@ func (p *parser) callonAssertOp1() (any, error) {
 	return p.cur.onAssertOp1(stack["expr"])
 }
 
-func (c *current) onSortOp10(e any) (any, error) {
+func (c *current) onSortOp15(e any) (any, error) {
 	return e, nil
 }
 
-func (p *parser) callonSortOp10() (any, error) {
+func (p *parser) callonSortOp15() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSortOp10(stack["e"])
+	return p.cur.onSortOp15(stack["e"])
 }
 
 func (c *current) onSortOp1(args, exprs any) (any, error) {
 	o := &ast.Sort{
 		Kind: "Sort",
-		Args: sliceOf[ast.SortExpr](exprs),
 		Loc:  loc(c),
+	}
+	if exprs != nil {
+		o.Args = exprs.([]ast.SortExpr)
 	}
 	argm := args.(map[string]any)
 	if _, ok := argm["r"]; ok {
@@ -18793,7 +18839,7 @@ func (p *parser) callonHeadOp2() (any, error) {
 	return p.cur.onHeadOp2(stack["count"])
 }
 
-func (c *current) onHeadOp10() (any, error) {
+func (c *current) onHeadOp12() (any, error) {
 	return &ast.Head{
 		Kind: "Head",
 		Loc:  loc(c),
@@ -18801,10 +18847,10 @@ func (c *current) onHeadOp10() (any, error) {
 
 }
 
-func (p *parser) callonHeadOp10() (any, error) {
+func (p *parser) callonHeadOp12() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onHeadOp10()
+	return p.cur.onHeadOp12()
 }
 
 func (c *current) onTailOp2(count any) (any, error) {
@@ -19500,63 +19546,6 @@ func (p *parser) callonPoolMeta1() (any, error) {
 	return p.cur.onPoolMeta1(stack["n"])
 }
 
-func (c *current) onSortExprs7(s any) (any, error) {
-	return s, nil
-}
-
-func (p *parser) callonSortExprs7() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSortExprs7(stack["s"])
-}
-
-func (c *current) onSortExprs1(first, rest any) (any, error) {
-	return prepend(first, rest), nil
-
-}
-
-func (p *parser) callonSortExprs1() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSortExprs1(stack["first"], stack["rest"])
-}
-
-func (c *current) onSortExpr7(o any) (any, error) {
-	return o, nil
-}
-
-func (p *parser) callonSortExpr7() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSortExpr7(stack["o"])
-}
-
-func (c *current) onSortExpr1(e, order any) (any, error) {
-	s := ast.SortExpr{Kind: "SortExpr", Expr: e.(ast.Expr), Loc: loc(c)}
-	if order != nil {
-		s.Order = order.(*ast.ID)
-	}
-	return s, nil
-
-}
-
-func (p *parser) callonSortExpr1() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSortExpr1(stack["e"], stack["order"])
-}
-
-func (c *current) onOrderSpec1(o any) (any, error) {
-	return &ast.ID{Kind: "ID", Name: o.(string), Loc: loc(c)}, nil
-
-}
-
-func (p *parser) callonOrderSpec1() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOrderSpec1(stack["o"])
-}
-
 func (c *current) onTapArg2() (any, error) {
 	return true, nil
 }
@@ -19893,17 +19882,34 @@ func (p *parser) callonBetweenExpr2() (any, error) {
 	return p.cur.onBetweenExpr2(stack["expr"], stack["lower"], stack["upper"])
 }
 
-func (c *current) onComparisonExpr15() (any, error) {
+func (c *current) onComparisonExpr2(lhs, op any) (any, error) {
+	return &ast.BinaryExpr{
+		Kind: "BinaryExpr",
+		Op:   op.(string),
+		LHS:  lhs.(ast.Expr),
+		RHS:  newPrimitive(c, "null", ""),
+		Loc:  loc(c),
+	}, nil
+
+}
+
+func (p *parser) callonComparisonExpr2() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onComparisonExpr2(stack["lhs"], stack["op"])
+}
+
+func (c *current) onComparisonExpr23() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonComparisonExpr15() (any, error) {
+func (p *parser) callonComparisonExpr23() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onComparisonExpr15()
+	return p.cur.onComparisonExpr23()
 }
 
-func (c *current) onComparisonExpr1(lhs, opAndRHS any) (any, error) {
+func (c *current) onComparisonExpr9(lhs, opAndRHS any) (any, error) {
 	if opAndRHS == nil {
 		return lhs, nil
 	}
@@ -19917,10 +19923,30 @@ func (c *current) onComparisonExpr1(lhs, opAndRHS any) (any, error) {
 
 }
 
-func (p *parser) callonComparisonExpr1() (any, error) {
+func (p *parser) callonComparisonExpr9() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onComparisonExpr1(stack["lhs"], stack["opAndRHS"])
+	return p.cur.onComparisonExpr9(stack["lhs"], stack["opAndRHS"])
+}
+
+func (c *current) onIsNull2() (any, error) {
+	return "==", nil
+}
+
+func (p *parser) callonIsNull2() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIsNull2()
+}
+
+func (c *current) onIsNull7() (any, error) {
+	return "!=", nil
+}
+
+func (p *parser) callonIsNull7() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIsNull7()
 }
 
 func (c *current) onAdditiveExpr7(op, expr any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -384,11 +384,13 @@ AssertOp
     }
 
 SortOp
-  = SORT &EOKW args:SortArgs exprs:(__ e:SortExprs { return e, nil })? {
+  = (SORT / ORDER _ BY) &EOKW args:SortArgs exprs:(__ e:OrderByList { return e, nil })? {
       o := &ast.Sort{
         Kind: "Sort",
-        Args: sliceOf[ast.SortExpr](exprs),
         Loc: loc(c),
+      }
+      if exprs != nil {
+        o.Args = exprs.([]ast.SortExpr)
       }
       argm := args.(map[string]any)
       if _, ok := argm["r"]; ok {
@@ -445,7 +447,7 @@ DropOp
     }
 
 HeadOp
-  = HEAD _ !EndOfOp count:Expr {
+  = (HEAD / LIMIT) _ !EndOfOp count:Expr {
       return &ast.Head{
         Kind: "Head",
         Count: count.(ast.Expr),
@@ -764,25 +766,6 @@ PoolCommit
 PoolMeta
   = ":" n:Name { return n, nil }
 
-SortExprs
-  = first:SortExpr rest:(__ "," __ s:SortExpr { return s, nil })* {
-      return prepend(first, rest), nil
-    }
-
-SortExpr
-  = e:Expr order:(_ o:OrderSpec { return o, nil })? {
-      s := ast.SortExpr{Kind: "SortExpr", Expr: e.(ast.Expr), Loc:loc(c)}
-      if order != nil {
-        s.Order = order.(*ast.ID)
-      }
-      return s, nil
-    }
-
-OrderSpec
-  = o:(ASC / DESC) {
-      return &ast.ID{Kind: "ID", Name: o.(string), Loc: loc(c)}, nil
-    }
-
 TapArg
   = _ TAP { return true, nil }
   / "" { return false, nil }
@@ -818,7 +801,7 @@ MergeOp
     }
 
 OverOp
-  = OVER _ exprs:Exprs locals:Locals? body:Lateral? {
+  = (OVER / UNNEST) _ exprs:Exprs locals:Locals? body:Lateral? {
       o := &ast.Over{
         Kind: "Over",
         Exprs: sliceOf[ast.Expr](exprs),
@@ -950,7 +933,16 @@ BetweenExpr
   / ComparisonExpr
 
 ComparisonExpr
-  = lhs:AdditiveExpr opAndRHS:(__ Comparator __ AdditiveExpr / __ ("~" { return string(c.text), nil }) __ Regexp)? {
+  = lhs:AdditiveExpr _ op:IsNull {
+      return &ast.BinaryExpr{
+        Kind: "BinaryExpr",
+        Op: op.(string),
+        LHS: lhs.(ast.Expr),
+        RHS: newPrimitive(c, "null", ""),
+        Loc: loc(c),
+      }, nil
+    }   
+  / lhs:AdditiveExpr opAndRHS:(__ Comparator __ AdditiveExpr / __ ("~" { return string(c.text), nil }) __ Regexp)? {
       if opAndRHS == nil {
         return lhs, nil
       }
@@ -962,6 +954,10 @@ ComparisonExpr
         Loc: loc(c),
       }, nil
     }
+ 
+ IsNull
+  = IS _ NULL { return "==", nil }
+  / IS _ NOT _ NULL { return "!=", nil }
 
 AdditiveExpr
   = first:MultiplicativeExpr
@@ -2241,6 +2237,7 @@ HEAD       = "HEAD"i            !IdentifierRest
 HEADERS    = "HEADERS"i         !IdentifierRest
 IN         = "IN"i              !IdentifierRest
 INNER      = "INNER"i           !IdentifierRest
+IS         = "IS"i              !IdentifierRest
 JOIN       = "JOIN"i            !IdentifierRest
 LAST       = "LAST"i            !IdentifierRest
 LEFT       = "LEFT"i            !IdentifierRest
@@ -2286,6 +2283,7 @@ TRUE       = "TRUE"i            !IdentifierRest
 TYPE       = "TYPE"i            !IdentifierRest
 UNION      = "UNION"i           !IdentifierRest
 UNIQ       = "UNIQ"i            !IdentifierRest 
+UNNEST     = "UNNEST"i          !IdentifierRest
 USING      = "USING"i           !IdentifierRest
 VALUE      = "VALUE"i           !IdentifierRest
 WHEN       = "WHEN"i            !IdentifierRest

--- a/compiler/ztests/sql/assignees.yaml
+++ b/compiler/ztests/sql/assignees.yaml
@@ -1,4 +1,3 @@
-
 script: |
   super -z -I query.sql
 

--- a/compiler/ztests/sql/assignees.yaml
+++ b/compiler/ztests/sql/assignees.yaml
@@ -1,0 +1,26 @@
+
+script: |
+  super -z -I query.sql
+
+inputs:
+  - name: query.sql
+    data: |
+      FROM in.jsup
+      | UNNEST [...assignees,assignee]
+      | WHERE this IS NOT NULL
+      | AGGREGATE count() BY assignee:=login
+      | ORDER BY count DESC, assignee DESC 
+      | LIMIT 5
+  - name: in.jsup
+    data: |
+      {assignees:[{login:"joe"},{login:"fred"}]}
+      {assignee:{login:"sue"}}
+      {assignee:{login:"joe"}}
+      {assignees:[{login:"sue"}]}
+
+outputs:
+  - name: stdout
+    data: |
+      {assignee:"sue",count:2(uint64)}
+      {assignee:"joe",count:2(uint64)}
+      {assignee:"fred",count:1(uint64)}


### PR DESCRIPTION
This commit adds some syntactic sugar so that UNNEST can be used in place of OVER, ORDER BY in place of SORT, and LIMIT in place of HEAD.  We also unified the PEG grammar for the sort operaetor with the existing rules for SQL ORDER BY, and we added syntactic sugar for IS NULL and IS NOT NULL.