### PR TITLE
Move dag.Assignment to compiler/dag/op.go

### DIFF
--- a/compiler/dag/expr.go
+++ b/compiler/dag/expr.go
@@ -27,11 +27,6 @@ type (
 		Kind  string       `json:"kind" unpack:""`
 		Elems []VectorElem `json:"elems"`
 	}
-	Assignment struct {
-		Kind string `json:"kind" unpack:""`
-		LHS  Expr   `json:"lhs"`
-		RHS  Expr   `json:"rhs"`
-	}
 	// A BadExpr node is a placeholder for an expression containing semantic
 	// errors.
 	BadExpr struct {

--- a/compiler/dag/op.go
+++ b/compiler/dag/op.go
@@ -294,6 +294,11 @@ func (*Deleter) OpNode() {}
 // Various Op fields
 
 type (
+	Assignment struct {
+		Kind string `json:"kind" unpack:""`
+		LHS  Expr   `json:"lhs"`
+		RHS  Expr   `json:"rhs"`
+	}
 	Case struct {
 		Expr Expr `json:"expr"`
 		Path Seq  `json:"seq"`


### PR DESCRIPTION
It doesn't implement dag.Expr and grouping it with types that do is misleading.