### PR TITLE
vam: Summarize use vector.Builder to materialize

### DIFF
--- a/runtime/vam/expr/agg/avg.go
+++ b/runtime/vam/expr/agg/avg.go
@@ -43,13 +43,15 @@ func (a *avg) ConsumeAsPartial(partial vector.Any) {
 	if !ok1 || !ok2 {
 		panic("avg: invalid partial")
 	}
-	sumVal, ok1 := rec.Fields[si].(*vector.Const)
-	countVal, ok2 := rec.Fields[ci].(*vector.Const)
-	if !ok1 || !ok2 || sumVal.Type() != super.TypeFloat64 || countVal.Type() != super.TypeUint64 {
+	sumVal := rec.Fields[si]
+	countVal := rec.Fields[ci]
+	if sumVal.Type() != super.TypeFloat64 || countVal.Type() != super.TypeUint64 {
 		panic("avg: invalid partial")
 	}
-	a.sum += sumVal.Value().Float()
-	a.count += countVal.Value().Uint()
+	sum, _ := vector.FloatValue(sumVal, 0)
+	count, _ := vector.UintValue(countVal, 0)
+	a.sum += sum
+	a.count += count
 }
 
 func (a *avg) ResultAsPartial(zctx *super.Context) super.Value {

--- a/runtime/vam/expr/agg/count.go
+++ b/runtime/vam/expr/agg/count.go
@@ -18,11 +18,11 @@ func (a *count) Result(*super.Context) super.Value {
 }
 
 func (a *count) ConsumeAsPartial(partial vector.Any) {
-	c, ok := partial.(*vector.Const)
-	if !ok || c.Len() != 1 || partial.Type() != super.TypeUint64 {
+	if partial.Len() != 1 || partial.Type() != super.TypeUint64 {
 		panic("count: bad partial")
 	}
-	a.count += c.Value().Uint()
+	count, _ := vector.UintValue(partial, 0)
+	a.count += count
 }
 
 func (a *count) ResultAsPartial(*super.Context) super.Value {

--- a/runtime/vam/op/summarize/summarize.go
+++ b/runtime/vam/op/summarize/summarize.go
@@ -111,7 +111,7 @@ func (s *Summarize) newAggTable(keyTypes []super.Type) aggTable {
 		builder:     s.builder,
 		partialsIn:  s.partialsIn,
 		partialsOut: s.partialsOut,
-		table:       make(map[string]aggRow),
+		table:       make(map[string]int),
 		zctx:        s.zctx,
 	}
 }

--- a/vector/builder.go
+++ b/vector/builder.go
@@ -14,6 +14,41 @@ type Builder interface {
 	Build() Any
 }
 
+type DynamicBuilder struct {
+	tags   []uint32
+	values []Builder
+	which  map[super.Type]int
+}
+
+func NewDynamicBuilder() *DynamicBuilder {
+	return &DynamicBuilder{
+		which: make(map[super.Type]int),
+	}
+}
+
+func (d *DynamicBuilder) Write(val super.Value) {
+	typ := val.Type()
+	tag, ok := d.which[typ]
+	if !ok {
+		tag = len(d.values)
+		d.values = append(d.values, NewBuilder(typ))
+		d.which[typ] = tag
+	}
+	d.tags = append(d.tags, uint32(tag))
+	d.values[tag].Write(val.Bytes())
+}
+
+func (d *DynamicBuilder) Build() Any {
+	var vecs []Any
+	for _, b := range d.values {
+		vecs = append(vecs, b.Build())
+	}
+	if len(vecs) == 1 {
+		return vecs[0]
+	}
+	return NewDynamic(d.tags, vecs)
+}
+
 func NewBuilder(typ super.Type) Builder {
 	var b Builder
 	switch typ := typ.(type) {


### PR DESCRIPTION
The commit changes slow path aggregations to use vector.Builder when materializing the aggregation table. The previous approaching of creating a dynamic of consts was causing the system to run out of memory when querying larger datasets.