### PR TITLE
support COUNT(*)

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -1922,98 +1922,115 @@ var g = &grammar{
 		{
 			name: "Agg",
 			pos:  position{line: 227, col: 1, offset: 5985},
-			expr: &actionExpr{
+			expr: &choiceExpr{
 				pos: position{line: 228, col: 5, offset: 5993},
-				run: (*parser).callonAgg1,
-				expr: &seqExpr{
-					pos: position{line: 228, col: 5, offset: 5993},
-					exprs: []any{
-						&notExpr{
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 228, col: 5, offset: 5993},
+						run: (*parser).callonAgg2,
+						expr: &seqExpr{
 							pos: position{line: 228, col: 5, offset: 5993},
-							expr: &ruleRefExpr{
-								pos:  position{line: 228, col: 6, offset: 5994},
-								name: "FuncGuard",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 228, col: 16, offset: 6004},
-							label: "op",
-							expr: &ruleRefExpr{
-								pos:  position{line: 228, col: 19, offset: 6007},
-								name: "AggName",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 228, col: 27, offset: 6015},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 228, col: 30, offset: 6018},
-							val:        "(",
-							ignoreCase: false,
-							want:       "\"(\"",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 228, col: 34, offset: 6022},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 228, col: 37, offset: 6025},
-							label: "expr",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 228, col: 42, offset: 6030},
-								expr: &choiceExpr{
-									pos: position{line: 228, col: 43, offset: 6031},
-									alternatives: []any{
-										&ruleRefExpr{
-											pos:  position{line: 228, col: 43, offset: 6031},
-											name: "OverExpr",
+							exprs: []any{
+								&notExpr{
+									pos: position{line: 228, col: 5, offset: 5993},
+									expr: &ruleRefExpr{
+										pos:  position{line: 228, col: 6, offset: 5994},
+										name: "FuncGuard",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 228, col: 16, offset: 6004},
+									label: "op",
+									expr: &ruleRefExpr{
+										pos:  position{line: 228, col: 19, offset: 6007},
+										name: "AggName",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 228, col: 27, offset: 6015},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 228, col: 30, offset: 6018},
+									val:        "(",
+									ignoreCase: false,
+									want:       "\"(\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 228, col: 34, offset: 6022},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 228, col: 37, offset: 6025},
+									label: "expr",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 228, col: 42, offset: 6030},
+										expr: &choiceExpr{
+											pos: position{line: 228, col: 43, offset: 6031},
+											alternatives: []any{
+												&ruleRefExpr{
+													pos:  position{line: 228, col: 43, offset: 6031},
+													name: "OverExpr",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 228, col: 54, offset: 6042},
+													name: "Expr",
+												},
+											},
 										},
-										&ruleRefExpr{
-											pos:  position{line: 228, col: 54, offset: 6042},
-											name: "Expr",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 228, col: 61, offset: 6049},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 228, col: 64, offset: 6052},
+									val:        ")",
+									ignoreCase: false,
+									want:       "\")\"",
+								},
+								&notExpr{
+									pos: position{line: 228, col: 68, offset: 6056},
+									expr: &seqExpr{
+										pos: position{line: 228, col: 70, offset: 6058},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 228, col: 70, offset: 6058},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 228, col: 73, offset: 6061},
+												val:        ".",
+												ignoreCase: false,
+												want:       "\".\"",
+											},
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 228, col: 78, offset: 6066},
+									label: "where",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 228, col: 84, offset: 6072},
+										expr: &ruleRefExpr{
+											pos:  position{line: 228, col: 84, offset: 6072},
+											name: "WhereClause",
 										},
 									},
 								},
 							},
 						},
-						&ruleRefExpr{
-							pos:  position{line: 228, col: 61, offset: 6049},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 228, col: 64, offset: 6052},
-							val:        ")",
-							ignoreCase: false,
-							want:       "\")\"",
-						},
-						&notExpr{
-							pos: position{line: 228, col: 68, offset: 6056},
-							expr: &seqExpr{
-								pos: position{line: 228, col: 70, offset: 6058},
-								exprs: []any{
-									&ruleRefExpr{
-										pos:  position{line: 228, col: 70, offset: 6058},
-										name: "__",
-									},
-									&litMatcher{
-										pos:        position{line: 228, col: 73, offset: 6061},
-										val:        ".",
-										ignoreCase: false,
-										want:       "\".\"",
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 228, col: 78, offset: 6066},
-							label: "where",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 228, col: 84, offset: 6072},
-								expr: &ruleRefExpr{
-									pos:  position{line: 228, col: 84, offset: 6072},
-									name: "WhereClause",
-								},
+					},
+					&actionExpr{
+						pos: position{line: 242, col: 5, offset: 6360},
+						run: (*parser).callonAgg25,
+						expr: &labeledExpr{
+							pos:   position{line: 242, col: 5, offset: 6360},
+							label: "cs",
+							expr: &ruleRefExpr{
+								pos:  position{line: 242, col: 8, offset: 6363},
+								name: "CountStar",
 							},
 						},
 					},
@@ -2024,20 +2041,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 243, col: 1, offset: 6357},
+			pos:  position{line: 250, col: 1, offset: 6501},
 			expr: &choiceExpr{
-				pos: position{line: 244, col: 5, offset: 6369},
+				pos: position{line: 251, col: 5, offset: 6513},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 244, col: 5, offset: 6369},
+						pos:  position{line: 251, col: 5, offset: 6513},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 5, offset: 6388},
+						pos:  position{line: 252, col: 5, offset: 6532},
 						name: "AND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 246, col: 5, offset: 6396},
+						pos:  position{line: 253, col: 5, offset: 6540},
 						name: "OR",
 					},
 				},
@@ -2047,30 +2064,30 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 248, col: 1, offset: 6400},
+			pos:  position{line: 255, col: 1, offset: 6544},
 			expr: &actionExpr{
-				pos: position{line: 248, col: 15, offset: 6414},
+				pos: position{line: 255, col: 15, offset: 6558},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 248, col: 15, offset: 6414},
+					pos: position{line: 255, col: 15, offset: 6558},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 248, col: 15, offset: 6414},
+							pos:  position{line: 255, col: 15, offset: 6558},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 248, col: 17, offset: 6416},
+							pos:  position{line: 255, col: 17, offset: 6560},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 248, col: 23, offset: 6422},
+							pos:  position{line: 255, col: 23, offset: 6566},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 248, col: 25, offset: 6424},
+							pos:   position{line: 255, col: 25, offset: 6568},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 248, col: 30, offset: 6429},
+								pos:  position{line: 255, col: 30, offset: 6573},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -2082,45 +2099,45 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 250, col: 1, offset: 6465},
+			pos:  position{line: 257, col: 1, offset: 6609},
 			expr: &actionExpr{
-				pos: position{line: 251, col: 5, offset: 6484},
+				pos: position{line: 258, col: 5, offset: 6628},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 251, col: 5, offset: 6484},
+					pos: position{line: 258, col: 5, offset: 6628},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 251, col: 5, offset: 6484},
+							pos:   position{line: 258, col: 5, offset: 6628},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 251, col: 11, offset: 6490},
+								pos:  position{line: 258, col: 11, offset: 6634},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 251, col: 25, offset: 6504},
+							pos:   position{line: 258, col: 25, offset: 6648},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 251, col: 30, offset: 6509},
+								pos: position{line: 258, col: 30, offset: 6653},
 								expr: &seqExpr{
-									pos: position{line: 251, col: 31, offset: 6510},
+									pos: position{line: 258, col: 31, offset: 6654},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 251, col: 31, offset: 6510},
+											pos:  position{line: 258, col: 31, offset: 6654},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 251, col: 34, offset: 6513},
+											pos:        position{line: 258, col: 34, offset: 6657},
 											val:        ",",
 											ignoreCase: false,
 											want:       "\",\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 251, col: 38, offset: 6517},
+											pos:  position{line: 258, col: 38, offset: 6661},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 251, col: 41, offset: 6520},
+											pos:  position{line: 258, col: 41, offset: 6664},
 											name: "AggAssignment",
 										},
 									},
@@ -2134,29 +2151,78 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
+			name: "CountStar",
+			pos:  position{line: 266, col: 1, offset: 6838},
+			expr: &actionExpr{
+				pos: position{line: 266, col: 13, offset: 6850},
+				run: (*parser).callonCountStar1,
+				expr: &seqExpr{
+					pos: position{line: 266, col: 13, offset: 6850},
+					exprs: []any{
+						&ruleRefExpr{
+							pos:  position{line: 266, col: 13, offset: 6850},
+							name: "COUNT",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 266, col: 19, offset: 6856},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 266, col: 22, offset: 6859},
+							val:        "(",
+							ignoreCase: false,
+							want:       "\"(\"",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 266, col: 26, offset: 6863},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 266, col: 29, offset: 6866},
+							val:        "*",
+							ignoreCase: false,
+							want:       "\"*\"",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 266, col: 33, offset: 6870},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 266, col: 36, offset: 6873},
+							val:        ")",
+							ignoreCase: false,
+							want:       "\")\"",
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
 			name: "Operator",
-			pos:  position{line: 261, col: 1, offset: 6717},
+			pos:  position{line: 276, col: 1, offset: 7067},
 			expr: &choiceExpr{
-				pos: position{line: 262, col: 5, offset: 6730},
+				pos: position{line: 277, col: 5, offset: 7080},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 262, col: 5, offset: 6730},
+						pos: position{line: 277, col: 5, offset: 7080},
 						run: (*parser).callonOperator2,
 						expr: &seqExpr{
-							pos: position{line: 262, col: 5, offset: 6730},
+							pos: position{line: 277, col: 5, offset: 7080},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 262, col: 5, offset: 6730},
+									pos:   position{line: 277, col: 5, offset: 7080},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 262, col: 8, offset: 6733},
+										pos:  position{line: 277, col: 8, offset: 7083},
 										name: "SelectOp",
 									},
 								},
 								&andExpr{
-									pos: position{line: 262, col: 17, offset: 6742},
+									pos: position{line: 277, col: 17, offset: 7092},
 									expr: &ruleRefExpr{
-										pos:  position{line: 262, col: 18, offset: 6743},
+										pos:  position{line: 277, col: 18, offset: 7093},
 										name: "EndOfOp",
 									},
 								},
@@ -2164,115 +2230,115 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 263, col: 5, offset: 6774},
+						pos:  position{line: 278, col: 5, offset: 7124},
 						name: "ForkOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 264, col: 5, offset: 6785},
+						pos:  position{line: 279, col: 5, offset: 7135},
 						name: "SwitchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 265, col: 5, offset: 6799},
+						pos:  position{line: 280, col: 5, offset: 7149},
 						name: "FromForkOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 266, col: 5, offset: 6814},
+						pos:  position{line: 281, col: 5, offset: 7164},
 						name: "SearchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 267, col: 5, offset: 6827},
+						pos:  position{line: 282, col: 5, offset: 7177},
 						name: "AssertOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 268, col: 5, offset: 6840},
+						pos:  position{line: 283, col: 5, offset: 7190},
 						name: "SortOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 269, col: 5, offset: 6851},
+						pos:  position{line: 284, col: 5, offset: 7201},
 						name: "TopOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 270, col: 5, offset: 6861},
+						pos:  position{line: 285, col: 5, offset: 7211},
 						name: "CutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 271, col: 5, offset: 6871},
+						pos:  position{line: 286, col: 5, offset: 7221},
 						name: "DropOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 272, col: 5, offset: 6882},
+						pos:  position{line: 287, col: 5, offset: 7232},
 						name: "HeadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 273, col: 5, offset: 6893},
+						pos:  position{line: 288, col: 5, offset: 7243},
 						name: "TailOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 274, col: 5, offset: 6904},
+						pos:  position{line: 289, col: 5, offset: 7254},
 						name: "WhereOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 275, col: 5, offset: 6916},
+						pos:  position{line: 290, col: 5, offset: 7266},
 						name: "UniqOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 276, col: 5, offset: 6927},
+						pos:  position{line: 291, col: 5, offset: 7277},
 						name: "PutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 277, col: 5, offset: 6937},
+						pos:  position{line: 292, col: 5, offset: 7287},
 						name: "RenameOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 278, col: 5, offset: 6950},
+						pos:  position{line: 293, col: 5, offset: 7300},
 						name: "FuseOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 279, col: 5, offset: 6961},
+						pos:  position{line: 294, col: 5, offset: 7311},
 						name: "ShapeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 280, col: 5, offset: 6973},
+						pos:  position{line: 295, col: 5, offset: 7323},
 						name: "JoinOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 281, col: 5, offset: 6984},
+						pos:  position{line: 296, col: 5, offset: 7334},
 						name: "SampleOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 282, col: 5, offset: 6997},
+						pos:  position{line: 297, col: 5, offset: 7347},
 						name: "FromOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 283, col: 5, offset: 7008},
+						pos:  position{line: 298, col: 5, offset: 7358},
 						name: "PassOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 284, col: 5, offset: 7019},
+						pos:  position{line: 299, col: 5, offset: 7369},
 						name: "ExplodeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 285, col: 5, offset: 7033},
+						pos:  position{line: 300, col: 5, offset: 7383},
 						name: "MergeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 286, col: 5, offset: 7045},
+						pos:  position{line: 301, col: 5, offset: 7395},
 						name: "OverOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 5, offset: 7056},
+						pos:  position{line: 302, col: 5, offset: 7406},
 						name: "YieldOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 288, col: 5, offset: 7068},
+						pos:  position{line: 303, col: 5, offset: 7418},
 						name: "LoadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 289, col: 5, offset: 7079},
+						pos:  position{line: 304, col: 5, offset: 7429},
 						name: "OutputOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 290, col: 5, offset: 7092},
+						pos:  position{line: 305, col: 5, offset: 7442},
 						name: "DebugOp",
 					},
 				},
@@ -2282,128 +2348,128 @@ var g = &grammar{
 		},
 		{
 			name: "PipeKeyword",
-			pos:  position{line: 292, col: 1, offset: 7101},
+			pos:  position{line: 307, col: 1, offset: 7451},
 			expr: &choiceExpr{
-				pos: position{line: 293, col: 5, offset: 7117},
+				pos: position{line: 308, col: 5, offset: 7467},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 5, offset: 7117},
+						pos:  position{line: 308, col: 5, offset: 7467},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 14, offset: 7126},
+						pos:  position{line: 308, col: 14, offset: 7476},
 						name: "FORK",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 21, offset: 7133},
+						pos:  position{line: 308, col: 21, offset: 7483},
 						name: "SWITCH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 30, offset: 7142},
+						pos:  position{line: 308, col: 30, offset: 7492},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 37, offset: 7149},
+						pos:  position{line: 308, col: 37, offset: 7499},
 						name: "SEARCH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 46, offset: 7158},
+						pos:  position{line: 308, col: 46, offset: 7508},
 						name: "ASSERT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 55, offset: 7167},
+						pos:  position{line: 308, col: 55, offset: 7517},
 						name: "SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 62, offset: 7174},
+						pos:  position{line: 308, col: 62, offset: 7524},
 						name: "TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 67, offset: 7179},
+						pos:  position{line: 308, col: 67, offset: 7529},
 						name: "CUT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 73, offset: 7185},
+						pos:  position{line: 308, col: 73, offset: 7535},
 						name: "DROP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 5, offset: 7194},
+						pos:  position{line: 309, col: 5, offset: 7544},
 						name: "HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 12, offset: 7201},
+						pos:  position{line: 309, col: 12, offset: 7551},
 						name: "TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 19, offset: 7208},
+						pos:  position{line: 309, col: 19, offset: 7558},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 27, offset: 7216},
+						pos:  position{line: 309, col: 27, offset: 7566},
 						name: "UNIQ",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 34, offset: 7223},
+						pos:  position{line: 309, col: 34, offset: 7573},
 						name: "PUT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 40, offset: 7229},
+						pos:  position{line: 309, col: 40, offset: 7579},
 						name: "RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 49, offset: 7238},
+						pos:  position{line: 309, col: 49, offset: 7588},
 						name: "FUSE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 56, offset: 7245},
+						pos:  position{line: 309, col: 56, offset: 7595},
 						name: "SHAPE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 64, offset: 7253},
+						pos:  position{line: 309, col: 64, offset: 7603},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 71, offset: 7260},
+						pos:  position{line: 309, col: 71, offset: 7610},
 						name: "SAMPLE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 5, offset: 7271},
+						pos:  position{line: 310, col: 5, offset: 7621},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 12, offset: 7278},
+						pos:  position{line: 310, col: 12, offset: 7628},
 						name: "PASS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 19, offset: 7285},
+						pos:  position{line: 310, col: 19, offset: 7635},
 						name: "EXPLODE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 29, offset: 7295},
+						pos:  position{line: 310, col: 29, offset: 7645},
 						name: "MERGE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 37, offset: 7303},
+						pos:  position{line: 310, col: 37, offset: 7653},
 						name: "OVER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 44, offset: 7310},
+						pos:  position{line: 310, col: 44, offset: 7660},
 						name: "YIELD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 52, offset: 7318},
+						pos:  position{line: 310, col: 52, offset: 7668},
 						name: "LOAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 59, offset: 7325},
+						pos:  position{line: 310, col: 59, offset: 7675},
 						name: "OUTPUT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 68, offset: 7334},
+						pos:  position{line: 310, col: 68, offset: 7684},
 						name: "DEBUG",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 296, col: 5, offset: 7344},
+						pos:  position{line: 311, col: 5, offset: 7694},
 						name: "SUMMARIZE",
 					},
 				},
@@ -2413,44 +2479,44 @@ var g = &grammar{
 		},
 		{
 			name: "ForkOp",
-			pos:  position{line: 298, col: 2, offset: 7356},
+			pos:  position{line: 313, col: 2, offset: 7706},
 			expr: &actionExpr{
-				pos: position{line: 299, col: 4, offset: 7368},
+				pos: position{line: 314, col: 4, offset: 7718},
 				run: (*parser).callonForkOp1,
 				expr: &seqExpr{
-					pos: position{line: 299, col: 4, offset: 7368},
+					pos: position{line: 314, col: 4, offset: 7718},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 299, col: 4, offset: 7368},
+							pos:  position{line: 314, col: 4, offset: 7718},
 							name: "FORK",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 299, col: 9, offset: 7373},
+							pos:  position{line: 314, col: 9, offset: 7723},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 299, col: 12, offset: 7376},
+							pos:        position{line: 314, col: 12, offset: 7726},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 299, col: 16, offset: 7380},
+							pos:   position{line: 314, col: 16, offset: 7730},
 							label: "paths",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 299, col: 22, offset: 7386},
+								pos: position{line: 314, col: 22, offset: 7736},
 								expr: &ruleRefExpr{
-									pos:  position{line: 299, col: 22, offset: 7386},
+									pos:  position{line: 314, col: 22, offset: 7736},
 									name: "Path",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 299, col: 28, offset: 7392},
+							pos:  position{line: 314, col: 28, offset: 7742},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 299, col: 31, offset: 7395},
+							pos:        position{line: 314, col: 31, offset: 7745},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2463,32 +2529,32 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 311, col: 1, offset: 7644},
+			pos:  position{line: 326, col: 1, offset: 7994},
 			expr: &actionExpr{
-				pos: position{line: 311, col: 8, offset: 7651},
+				pos: position{line: 326, col: 8, offset: 8001},
 				run: (*parser).callonPath1,
 				expr: &seqExpr{
-					pos: position{line: 311, col: 8, offset: 7651},
+					pos: position{line: 326, col: 8, offset: 8001},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 311, col: 8, offset: 7651},
+							pos:  position{line: 326, col: 8, offset: 8001},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 311, col: 11, offset: 7654},
+							pos:        position{line: 326, col: 11, offset: 8004},
 							val:        "=>",
 							ignoreCase: false,
 							want:       "\"=>\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 311, col: 16, offset: 7659},
+							pos:  position{line: 326, col: 16, offset: 8009},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 311, col: 19, offset: 7662},
+							pos:   position{line: 326, col: 19, offset: 8012},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 311, col: 23, offset: 7666},
+								pos:  position{line: 326, col: 23, offset: 8016},
 								name: "Seq",
 							},
 						},
@@ -2500,59 +2566,59 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchOp",
-			pos:  position{line: 313, col: 1, offset: 7691},
+			pos:  position{line: 328, col: 1, offset: 8041},
 			expr: &choiceExpr{
-				pos: position{line: 314, col: 5, offset: 7704},
+				pos: position{line: 329, col: 5, offset: 8054},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 314, col: 5, offset: 7704},
+						pos: position{line: 329, col: 5, offset: 8054},
 						run: (*parser).callonSwitchOp2,
 						expr: &seqExpr{
-							pos: position{line: 314, col: 5, offset: 7704},
+							pos: position{line: 329, col: 5, offset: 8054},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 314, col: 5, offset: 7704},
+									pos:  position{line: 329, col: 5, offset: 8054},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 314, col: 12, offset: 7711},
+									pos:  position{line: 329, col: 12, offset: 8061},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 314, col: 14, offset: 7713},
+									pos:   position{line: 329, col: 14, offset: 8063},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 314, col: 19, offset: 7718},
+										pos:  position{line: 329, col: 19, offset: 8068},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 314, col: 24, offset: 7723},
+									pos:  position{line: 329, col: 24, offset: 8073},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 314, col: 26, offset: 7725},
+									pos:        position{line: 329, col: 26, offset: 8075},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 314, col: 30, offset: 7729},
+									pos:   position{line: 329, col: 30, offset: 8079},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 314, col: 36, offset: 7735},
+										pos: position{line: 329, col: 36, offset: 8085},
 										expr: &ruleRefExpr{
-											pos:  position{line: 314, col: 36, offset: 7735},
+											pos:  position{line: 329, col: 36, offset: 8085},
 											name: "SwitchPath",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 314, col: 48, offset: 7747},
+									pos:  position{line: 329, col: 48, offset: 8097},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 314, col: 51, offset: 7750},
+									pos:        position{line: 329, col: 51, offset: 8100},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -2561,42 +2627,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 322, col: 5, offset: 7930},
+						pos: position{line: 337, col: 5, offset: 8280},
 						run: (*parser).callonSwitchOp15,
 						expr: &seqExpr{
-							pos: position{line: 322, col: 5, offset: 7930},
+							pos: position{line: 337, col: 5, offset: 8280},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 322, col: 5, offset: 7930},
+									pos:  position{line: 337, col: 5, offset: 8280},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 322, col: 12, offset: 7937},
+									pos:  position{line: 337, col: 12, offset: 8287},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 322, col: 15, offset: 7940},
+									pos:        position{line: 337, col: 15, offset: 8290},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 322, col: 19, offset: 7944},
+									pos:   position{line: 337, col: 19, offset: 8294},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 322, col: 25, offset: 7950},
+										pos: position{line: 337, col: 25, offset: 8300},
 										expr: &ruleRefExpr{
-											pos:  position{line: 322, col: 25, offset: 7950},
+											pos:  position{line: 337, col: 25, offset: 8300},
 											name: "SwitchPath",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 322, col: 37, offset: 7962},
+									pos:  position{line: 337, col: 37, offset: 8312},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 322, col: 40, offset: 7965},
+									pos:        position{line: 337, col: 40, offset: 8315},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -2611,30 +2677,30 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchPath",
-			pos:  position{line: 330, col: 1, offset: 8109},
+			pos:  position{line: 345, col: 1, offset: 8459},
 			expr: &actionExpr{
-				pos: position{line: 331, col: 5, offset: 8124},
+				pos: position{line: 346, col: 5, offset: 8474},
 				run: (*parser).callonSwitchPath1,
 				expr: &seqExpr{
-					pos: position{line: 331, col: 5, offset: 8124},
+					pos: position{line: 346, col: 5, offset: 8474},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 331, col: 5, offset: 8124},
+							pos:  position{line: 346, col: 5, offset: 8474},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 331, col: 8, offset: 8127},
+							pos:   position{line: 346, col: 8, offset: 8477},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 331, col: 13, offset: 8132},
+								pos:  position{line: 346, col: 13, offset: 8482},
 								name: "Case",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 331, col: 18, offset: 8137},
+							pos:   position{line: 346, col: 18, offset: 8487},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 331, col: 23, offset: 8142},
+								pos:  position{line: 346, col: 23, offset: 8492},
 								name: "Path",
 							},
 						},
@@ -2646,29 +2712,29 @@ var g = &grammar{
 		},
 		{
 			name: "Case",
-			pos:  position{line: 339, col: 1, offset: 8289},
+			pos:  position{line: 354, col: 1, offset: 8639},
 			expr: &choiceExpr{
-				pos: position{line: 340, col: 5, offset: 8298},
+				pos: position{line: 355, col: 5, offset: 8648},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 340, col: 5, offset: 8298},
+						pos: position{line: 355, col: 5, offset: 8648},
 						run: (*parser).callonCase2,
 						expr: &seqExpr{
-							pos: position{line: 340, col: 5, offset: 8298},
+							pos: position{line: 355, col: 5, offset: 8648},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 340, col: 5, offset: 8298},
+									pos:  position{line: 355, col: 5, offset: 8648},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 340, col: 10, offset: 8303},
+									pos:  position{line: 355, col: 10, offset: 8653},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 340, col: 12, offset: 8305},
+									pos:   position{line: 355, col: 12, offset: 8655},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 340, col: 17, offset: 8310},
+										pos:  position{line: 355, col: 17, offset: 8660},
 										name: "Expr",
 									},
 								},
@@ -2676,10 +2742,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 341, col: 5, offset: 8340},
+						pos: position{line: 356, col: 5, offset: 8690},
 						run: (*parser).callonCase8,
 						expr: &ruleRefExpr{
-							pos:  position{line: 341, col: 5, offset: 8340},
+							pos:  position{line: 356, col: 5, offset: 8690},
 							name: "DEFAULT",
 						},
 					},
@@ -2690,44 +2756,44 @@ var g = &grammar{
 		},
 		{
 			name: "FromForkOp",
-			pos:  position{line: 343, col: 1, offset: 8369},
+			pos:  position{line: 358, col: 1, offset: 8719},
 			expr: &actionExpr{
-				pos: position{line: 344, col: 5, offset: 8384},
+				pos: position{line: 359, col: 5, offset: 8734},
 				run: (*parser).callonFromForkOp1,
 				expr: &seqExpr{
-					pos: position{line: 344, col: 5, offset: 8384},
+					pos: position{line: 359, col: 5, offset: 8734},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 344, col: 5, offset: 8384},
+							pos:  position{line: 359, col: 5, offset: 8734},
 							name: "FROM",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 344, col: 10, offset: 8389},
+							pos:  position{line: 359, col: 10, offset: 8739},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 344, col: 13, offset: 8392},
+							pos:        position{line: 359, col: 13, offset: 8742},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 344, col: 17, offset: 8396},
+							pos:   position{line: 359, col: 17, offset: 8746},
 							label: "trunks",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 344, col: 24, offset: 8403},
+								pos: position{line: 359, col: 24, offset: 8753},
 								expr: &ruleRefExpr{
-									pos:  position{line: 344, col: 24, offset: 8403},
+									pos:  position{line: 359, col: 24, offset: 8753},
 									name: "FromPath",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 344, col: 34, offset: 8413},
+							pos:  position{line: 359, col: 34, offset: 8763},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 344, col: 37, offset: 8416},
+							pos:        position{line: 359, col: 37, offset: 8766},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2740,55 +2806,55 @@ var g = &grammar{
 		},
 		{
 			name: "FromPath",
-			pos:  position{line: 352, col: 1, offset: 8564},
+			pos:  position{line: 367, col: 1, offset: 8914},
 			expr: &actionExpr{
-				pos: position{line: 353, col: 5, offset: 8577},
+				pos: position{line: 368, col: 5, offset: 8927},
 				run: (*parser).callonFromPath1,
 				expr: &seqExpr{
-					pos: position{line: 353, col: 5, offset: 8577},
+					pos: position{line: 368, col: 5, offset: 8927},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 353, col: 5, offset: 8577},
+							pos:  position{line: 368, col: 5, offset: 8927},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 8, offset: 8580},
+							pos:   position{line: 368, col: 8, offset: 8930},
 							label: "source",
 							expr: &ruleRefExpr{
-								pos:  position{line: 353, col: 15, offset: 8587},
+								pos:  position{line: 368, col: 15, offset: 8937},
 								name: "FromSource",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 26, offset: 8598},
+							pos:   position{line: 368, col: 26, offset: 8948},
 							label: "seq",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 353, col: 30, offset: 8602},
+								pos: position{line: 368, col: 30, offset: 8952},
 								expr: &actionExpr{
-									pos: position{line: 353, col: 31, offset: 8603},
+									pos: position{line: 368, col: 31, offset: 8953},
 									run: (*parser).callonFromPath8,
 									expr: &seqExpr{
-										pos: position{line: 353, col: 31, offset: 8603},
+										pos: position{line: 368, col: 31, offset: 8953},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 31, offset: 8603},
+												pos:  position{line: 368, col: 31, offset: 8953},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 353, col: 34, offset: 8606},
+												pos:        position{line: 368, col: 34, offset: 8956},
 												val:        "=>",
 												ignoreCase: false,
 												want:       "\"=>\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 39, offset: 8611},
+												pos:  position{line: 368, col: 39, offset: 8961},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 353, col: 42, offset: 8614},
+												pos:   position{line: 368, col: 42, offset: 8964},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 353, col: 44, offset: 8616},
+													pos:  position{line: 368, col: 44, offset: 8966},
 													name: "Seq",
 												},
 											},
@@ -2805,29 +2871,29 @@ var g = &grammar{
 		},
 		{
 			name: "FromSource",
-			pos:  position{line: 361, col: 1, offset: 8796},
+			pos:  position{line: 376, col: 1, offset: 9146},
 			expr: &choiceExpr{
-				pos: position{line: 362, col: 5, offset: 8811},
+				pos: position{line: 377, col: 5, offset: 9161},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 362, col: 5, offset: 8811},
+						pos: position{line: 377, col: 5, offset: 9161},
 						run: (*parser).callonFromSource2,
 						expr: &seqExpr{
-							pos: position{line: 362, col: 5, offset: 8811},
+							pos: position{line: 377, col: 5, offset: 9161},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 362, col: 5, offset: 8811},
+									pos:  position{line: 377, col: 5, offset: 9161},
 									name: "FromKeyWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 362, col: 17, offset: 8823},
+									pos:  position{line: 377, col: 17, offset: 9173},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 362, col: 19, offset: 8825},
+									pos:   position{line: 377, col: 19, offset: 9175},
 									label: "elem",
 									expr: &ruleRefExpr{
-										pos:  position{line: 362, col: 24, offset: 8830},
+										pos:  position{line: 377, col: 24, offset: 9180},
 										name: "FromElem",
 									},
 								},
@@ -2835,7 +2901,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 369, col: 5, offset: 9001},
+						pos:  position{line: 384, col: 5, offset: 9351},
 						name: "PassOp",
 					},
 				},
@@ -2845,40 +2911,40 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOp",
-			pos:  position{line: 371, col: 1, offset: 9009},
+			pos:  position{line: 386, col: 1, offset: 9359},
 			expr: &actionExpr{
-				pos: position{line: 372, col: 5, offset: 9022},
+				pos: position{line: 387, col: 5, offset: 9372},
 				run: (*parser).callonSearchOp1,
 				expr: &seqExpr{
-					pos: position{line: 372, col: 5, offset: 9022},
+					pos: position{line: 387, col: 5, offset: 9372},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 372, col: 6, offset: 9023},
+							pos: position{line: 387, col: 6, offset: 9373},
 							alternatives: []any{
 								&seqExpr{
-									pos: position{line: 372, col: 6, offset: 9023},
+									pos: position{line: 387, col: 6, offset: 9373},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 372, col: 6, offset: 9023},
+											pos:  position{line: 387, col: 6, offset: 9373},
 											name: "SEARCH",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 372, col: 13, offset: 9030},
+											pos:  position{line: 387, col: 13, offset: 9380},
 											name: "_",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 372, col: 17, offset: 9034},
+									pos: position{line: 387, col: 17, offset: 9384},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 372, col: 17, offset: 9034},
+											pos:        position{line: 387, col: 17, offset: 9384},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 372, col: 21, offset: 9038},
+											pos:  position{line: 387, col: 21, offset: 9388},
 											name: "__",
 										},
 									},
@@ -2886,10 +2952,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 372, col: 25, offset: 9042},
+							pos:   position{line: 387, col: 25, offset: 9392},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 372, col: 30, offset: 9047},
+								pos:  position{line: 387, col: 30, offset: 9397},
 								name: "SearchBoolean",
 							},
 						},
@@ -2901,32 +2967,32 @@ var g = &grammar{
 		},
 		{
 			name: "AssertOp",
-			pos:  position{line: 376, col: 1, offset: 9147},
+			pos:  position{line: 391, col: 1, offset: 9497},
 			expr: &actionExpr{
-				pos: position{line: 377, col: 5, offset: 9160},
+				pos: position{line: 392, col: 5, offset: 9510},
 				run: (*parser).callonAssertOp1,
 				expr: &seqExpr{
-					pos: position{line: 377, col: 5, offset: 9160},
+					pos: position{line: 392, col: 5, offset: 9510},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 377, col: 5, offset: 9160},
+							pos:  position{line: 392, col: 5, offset: 9510},
 							name: "ASSERT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 377, col: 12, offset: 9167},
+							pos:  position{line: 392, col: 12, offset: 9517},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 377, col: 14, offset: 9169},
+							pos:   position{line: 392, col: 14, offset: 9519},
 							label: "expr",
 							expr: &actionExpr{
-								pos: position{line: 377, col: 20, offset: 9175},
+								pos: position{line: 392, col: 20, offset: 9525},
 								run: (*parser).callonAssertOp6,
 								expr: &labeledExpr{
-									pos:   position{line: 377, col: 20, offset: 9175},
+									pos:   position{line: 392, col: 20, offset: 9525},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 377, col: 22, offset: 9177},
+										pos:  position{line: 392, col: 22, offset: 9527},
 										name: "Expr",
 									},
 								},
@@ -2940,33 +3006,33 @@ var g = &grammar{
 		},
 		{
 			name: "SortOp",
-			pos:  position{line: 386, col: 1, offset: 9407},
+			pos:  position{line: 401, col: 1, offset: 9757},
 			expr: &actionExpr{
-				pos: position{line: 387, col: 5, offset: 9418},
+				pos: position{line: 402, col: 5, offset: 9768},
 				run: (*parser).callonSortOp1,
 				expr: &seqExpr{
-					pos: position{line: 387, col: 5, offset: 9418},
+					pos: position{line: 402, col: 5, offset: 9768},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 387, col: 6, offset: 9419},
+							pos: position{line: 402, col: 6, offset: 9769},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 387, col: 6, offset: 9419},
+									pos:  position{line: 402, col: 6, offset: 9769},
 									name: "SORT",
 								},
 								&seqExpr{
-									pos: position{line: 387, col: 13, offset: 9426},
+									pos: position{line: 402, col: 13, offset: 9776},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 387, col: 13, offset: 9426},
+											pos:  position{line: 402, col: 13, offset: 9776},
 											name: "ORDER",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 387, col: 19, offset: 9432},
+											pos:  position{line: 402, col: 19, offset: 9782},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 387, col: 21, offset: 9434},
+											pos:  position{line: 402, col: 21, offset: 9784},
 											name: "BY",
 										},
 									},
@@ -2974,40 +3040,40 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 387, col: 25, offset: 9438},
+							pos: position{line: 402, col: 25, offset: 9788},
 							expr: &ruleRefExpr{
-								pos:  position{line: 387, col: 26, offset: 9439},
+								pos:  position{line: 402, col: 26, offset: 9789},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 387, col: 31, offset: 9444},
+							pos:   position{line: 402, col: 31, offset: 9794},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 387, col: 36, offset: 9449},
+								pos:  position{line: 402, col: 36, offset: 9799},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 387, col: 45, offset: 9458},
+							pos:   position{line: 402, col: 45, offset: 9808},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 387, col: 51, offset: 9464},
+								pos: position{line: 402, col: 51, offset: 9814},
 								expr: &actionExpr{
-									pos: position{line: 387, col: 52, offset: 9465},
+									pos: position{line: 402, col: 52, offset: 9815},
 									run: (*parser).callonSortOp15,
 									expr: &seqExpr{
-										pos: position{line: 387, col: 52, offset: 9465},
+										pos: position{line: 402, col: 52, offset: 9815},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 387, col: 52, offset: 9465},
+												pos:  position{line: 402, col: 52, offset: 9815},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 387, col: 55, offset: 9468},
+												pos:   position{line: 402, col: 55, offset: 9818},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 387, col: 57, offset: 9470},
+													pos:  position{line: 402, col: 57, offset: 9820},
 													name: "OrderByList",
 												},
 											},
@@ -3024,30 +3090,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 405, col: 1, offset: 9869},
+			pos:  position{line: 420, col: 1, offset: 10219},
 			expr: &actionExpr{
-				pos: position{line: 405, col: 12, offset: 9880},
+				pos: position{line: 420, col: 12, offset: 10230},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 405, col: 12, offset: 9880},
+					pos:   position{line: 420, col: 12, offset: 10230},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 405, col: 17, offset: 9885},
+						pos: position{line: 420, col: 17, offset: 10235},
 						expr: &actionExpr{
-							pos: position{line: 405, col: 18, offset: 9886},
+							pos: position{line: 420, col: 18, offset: 10236},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 405, col: 18, offset: 9886},
+								pos: position{line: 420, col: 18, offset: 10236},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 405, col: 18, offset: 9886},
+										pos:  position{line: 420, col: 18, offset: 10236},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 405, col: 20, offset: 9888},
+										pos:   position{line: 420, col: 20, offset: 10238},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 405, col: 22, offset: 9890},
+											pos:  position{line: 420, col: 22, offset: 10240},
 											name: "SortArg",
 										},
 									},
@@ -3062,53 +3128,53 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 407, col: 1, offset: 9947},
+			pos:  position{line: 422, col: 1, offset: 10297},
 			expr: &choiceExpr{
-				pos: position{line: 408, col: 5, offset: 9959},
+				pos: position{line: 423, col: 5, offset: 10309},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 408, col: 5, offset: 9959},
+						pos: position{line: 423, col: 5, offset: 10309},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 408, col: 5, offset: 9959},
+							pos:        position{line: 423, col: 5, offset: 10309},
 							val:        "-r",
 							ignoreCase: false,
 							want:       "\"-r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 409, col: 5, offset: 10026},
+						pos: position{line: 424, col: 5, offset: 10376},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 409, col: 5, offset: 10026},
+							pos: position{line: 424, col: 5, offset: 10376},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 409, col: 5, offset: 10026},
+									pos:        position{line: 424, col: 5, offset: 10376},
 									val:        "-nulls",
 									ignoreCase: false,
 									want:       "\"-nulls\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 409, col: 14, offset: 10035},
+									pos:  position{line: 424, col: 14, offset: 10385},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 409, col: 16, offset: 10037},
+									pos:   position{line: 424, col: 16, offset: 10387},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 409, col: 23, offset: 10044},
+										pos: position{line: 424, col: 23, offset: 10394},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 409, col: 24, offset: 10045},
+											pos: position{line: 424, col: 24, offset: 10395},
 											alternatives: []any{
 												&litMatcher{
-													pos:        position{line: 409, col: 24, offset: 10045},
+													pos:        position{line: 424, col: 24, offset: 10395},
 													val:        "first",
 													ignoreCase: false,
 													want:       "\"first\"",
 												},
 												&litMatcher{
-													pos:        position{line: 409, col: 34, offset: 10055},
+													pos:        position{line: 424, col: 34, offset: 10405},
 													val:        "last",
 													ignoreCase: false,
 													want:       "\"last\"",
@@ -3127,44 +3193,44 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 413, col: 1, offset: 10174},
+			pos:  position{line: 428, col: 1, offset: 10524},
 			expr: &actionExpr{
-				pos: position{line: 414, col: 5, offset: 10184},
+				pos: position{line: 429, col: 5, offset: 10534},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 414, col: 5, offset: 10184},
+					pos: position{line: 429, col: 5, offset: 10534},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 414, col: 5, offset: 10184},
+							pos:  position{line: 429, col: 5, offset: 10534},
 							name: "TOP",
 						},
 						&andExpr{
-							pos: position{line: 414, col: 9, offset: 10188},
+							pos: position{line: 429, col: 9, offset: 10538},
 							expr: &ruleRefExpr{
-								pos:  position{line: 414, col: 10, offset: 10189},
+								pos:  position{line: 429, col: 10, offset: 10539},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 414, col: 15, offset: 10194},
+							pos:   position{line: 429, col: 15, offset: 10544},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 414, col: 21, offset: 10200},
+								pos: position{line: 429, col: 21, offset: 10550},
 								expr: &actionExpr{
-									pos: position{line: 414, col: 22, offset: 10201},
+									pos: position{line: 429, col: 22, offset: 10551},
 									run: (*parser).callonTopOp8,
 									expr: &seqExpr{
-										pos: position{line: 414, col: 22, offset: 10201},
+										pos: position{line: 429, col: 22, offset: 10551},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 414, col: 22, offset: 10201},
+												pos:  position{line: 429, col: 22, offset: 10551},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 414, col: 24, offset: 10203},
+												pos:   position{line: 429, col: 24, offset: 10553},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 414, col: 26, offset: 10205},
+													pos:  position{line: 429, col: 26, offset: 10555},
 													name: "Expr",
 												},
 											},
@@ -3174,19 +3240,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 414, col: 51, offset: 10230},
+							pos:   position{line: 429, col: 51, offset: 10580},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 414, col: 57, offset: 10236},
+								pos: position{line: 429, col: 57, offset: 10586},
 								expr: &seqExpr{
-									pos: position{line: 414, col: 58, offset: 10237},
+									pos: position{line: 429, col: 58, offset: 10587},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 414, col: 58, offset: 10237},
+											pos:  position{line: 429, col: 58, offset: 10587},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 414, col: 60, offset: 10239},
+											pos:        position{line: 429, col: 60, offset: 10589},
 											val:        "-flush",
 											ignoreCase: false,
 											want:       "\"-flush\"",
@@ -3196,25 +3262,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 414, col: 71, offset: 10250},
+							pos:   position{line: 429, col: 71, offset: 10600},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 414, col: 78, offset: 10257},
+								pos: position{line: 429, col: 78, offset: 10607},
 								expr: &actionExpr{
-									pos: position{line: 414, col: 79, offset: 10258},
+									pos: position{line: 429, col: 79, offset: 10608},
 									run: (*parser).callonTopOp20,
 									expr: &seqExpr{
-										pos: position{line: 414, col: 79, offset: 10258},
+										pos: position{line: 429, col: 79, offset: 10608},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 414, col: 79, offset: 10258},
+												pos:  position{line: 429, col: 79, offset: 10608},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 414, col: 81, offset: 10260},
+												pos:   position{line: 429, col: 81, offset: 10610},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 414, col: 83, offset: 10262},
+													pos:  position{line: 429, col: 83, offset: 10612},
 													name: "Lvals",
 												},
 											},
@@ -3231,26 +3297,26 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 431, col: 1, offset: 10591},
+			pos:  position{line: 446, col: 1, offset: 10941},
 			expr: &actionExpr{
-				pos: position{line: 432, col: 5, offset: 10601},
+				pos: position{line: 447, col: 5, offset: 10951},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 432, col: 5, offset: 10601},
+					pos: position{line: 447, col: 5, offset: 10951},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 432, col: 5, offset: 10601},
+							pos:  position{line: 447, col: 5, offset: 10951},
 							name: "CUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 432, col: 9, offset: 10605},
+							pos:  position{line: 447, col: 9, offset: 10955},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 432, col: 11, offset: 10607},
+							pos:   position{line: 447, col: 11, offset: 10957},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 432, col: 16, offset: 10612},
+								pos:  position{line: 447, col: 16, offset: 10962},
 								name: "FlexAssignments",
 							},
 						},
@@ -3262,26 +3328,26 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 440, col: 1, offset: 10760},
+			pos:  position{line: 455, col: 1, offset: 11110},
 			expr: &actionExpr{
-				pos: position{line: 441, col: 5, offset: 10771},
+				pos: position{line: 456, col: 5, offset: 11121},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 441, col: 5, offset: 10771},
+					pos: position{line: 456, col: 5, offset: 11121},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 441, col: 5, offset: 10771},
+							pos:  position{line: 456, col: 5, offset: 11121},
 							name: "DROP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 441, col: 10, offset: 10776},
+							pos:  position{line: 456, col: 10, offset: 11126},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 441, col: 12, offset: 10778},
+							pos:   position{line: 456, col: 12, offset: 11128},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 441, col: 17, offset: 10783},
+								pos:  position{line: 456, col: 17, offset: 11133},
 								name: "Lvals",
 							},
 						},
@@ -3293,45 +3359,45 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 449, col: 1, offset: 10923},
+			pos:  position{line: 464, col: 1, offset: 11273},
 			expr: &choiceExpr{
-				pos: position{line: 450, col: 5, offset: 10934},
+				pos: position{line: 465, col: 5, offset: 11284},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 450, col: 5, offset: 10934},
+						pos: position{line: 465, col: 5, offset: 11284},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 450, col: 5, offset: 10934},
+							pos: position{line: 465, col: 5, offset: 11284},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 450, col: 6, offset: 10935},
+									pos: position{line: 465, col: 6, offset: 11285},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 450, col: 6, offset: 10935},
+											pos:  position{line: 465, col: 6, offset: 11285},
 											name: "HEAD",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 450, col: 13, offset: 10942},
+											pos:  position{line: 465, col: 13, offset: 11292},
 											name: "LIMIT",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 450, col: 20, offset: 10949},
+									pos:  position{line: 465, col: 20, offset: 11299},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 450, col: 22, offset: 10951},
+									pos: position{line: 465, col: 22, offset: 11301},
 									expr: &ruleRefExpr{
-										pos:  position{line: 450, col: 23, offset: 10952},
+										pos:  position{line: 465, col: 23, offset: 11302},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 450, col: 31, offset: 10960},
+									pos:   position{line: 465, col: 31, offset: 11310},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 450, col: 37, offset: 10966},
+										pos:  position{line: 465, col: 37, offset: 11316},
 										name: "Expr",
 									},
 								},
@@ -3339,26 +3405,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 457, col: 5, offset: 11096},
+						pos: position{line: 472, col: 5, offset: 11446},
 						run: (*parser).callonHeadOp12,
 						expr: &seqExpr{
-							pos: position{line: 457, col: 5, offset: 11096},
+							pos: position{line: 472, col: 5, offset: 11446},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 457, col: 5, offset: 11096},
+									pos:  position{line: 472, col: 5, offset: 11446},
 									name: "HEAD",
 								},
 								&notExpr{
-									pos: position{line: 457, col: 10, offset: 11101},
+									pos: position{line: 472, col: 10, offset: 11451},
 									expr: &seqExpr{
-										pos: position{line: 457, col: 12, offset: 11103},
+										pos: position{line: 472, col: 12, offset: 11453},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 457, col: 12, offset: 11103},
+												pos:  position{line: 472, col: 12, offset: 11453},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 457, col: 15, offset: 11106},
+												pos:        position{line: 472, col: 15, offset: 11456},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3367,9 +3433,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 457, col: 20, offset: 11111},
+									pos: position{line: 472, col: 20, offset: 11461},
 									expr: &ruleRefExpr{
-										pos:  position{line: 457, col: 21, offset: 11112},
+										pos:  position{line: 472, col: 21, offset: 11462},
 										name: "EOKW",
 									},
 								},
@@ -3383,36 +3449,36 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 464, col: 1, offset: 11206},
+			pos:  position{line: 479, col: 1, offset: 11556},
 			expr: &choiceExpr{
-				pos: position{line: 465, col: 5, offset: 11217},
+				pos: position{line: 480, col: 5, offset: 11567},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 465, col: 5, offset: 11217},
+						pos: position{line: 480, col: 5, offset: 11567},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 465, col: 5, offset: 11217},
+							pos: position{line: 480, col: 5, offset: 11567},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 465, col: 5, offset: 11217},
+									pos:  position{line: 480, col: 5, offset: 11567},
 									name: "TAIL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 465, col: 10, offset: 11222},
+									pos:  position{line: 480, col: 10, offset: 11572},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 465, col: 12, offset: 11224},
+									pos: position{line: 480, col: 12, offset: 11574},
 									expr: &ruleRefExpr{
-										pos:  position{line: 465, col: 13, offset: 11225},
+										pos:  position{line: 480, col: 13, offset: 11575},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 465, col: 21, offset: 11233},
+									pos:   position{line: 480, col: 21, offset: 11583},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 465, col: 27, offset: 11239},
+										pos:  position{line: 480, col: 27, offset: 11589},
 										name: "Expr",
 									},
 								},
@@ -3420,26 +3486,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 472, col: 5, offset: 11369},
+						pos: position{line: 487, col: 5, offset: 11719},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 472, col: 5, offset: 11369},
+							pos: position{line: 487, col: 5, offset: 11719},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 472, col: 5, offset: 11369},
+									pos:  position{line: 487, col: 5, offset: 11719},
 									name: "TAIL",
 								},
 								&notExpr{
-									pos: position{line: 472, col: 10, offset: 11374},
+									pos: position{line: 487, col: 10, offset: 11724},
 									expr: &seqExpr{
-										pos: position{line: 472, col: 12, offset: 11376},
+										pos: position{line: 487, col: 12, offset: 11726},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 472, col: 12, offset: 11376},
+												pos:  position{line: 487, col: 12, offset: 11726},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 472, col: 15, offset: 11379},
+												pos:        position{line: 487, col: 15, offset: 11729},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3448,9 +3514,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 472, col: 20, offset: 11384},
+									pos: position{line: 487, col: 20, offset: 11734},
 									expr: &ruleRefExpr{
-										pos:  position{line: 472, col: 21, offset: 11385},
+										pos:  position{line: 487, col: 21, offset: 11735},
 										name: "EOKW",
 									},
 								},
@@ -3464,26 +3530,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 479, col: 1, offset: 11479},
+			pos:  position{line: 494, col: 1, offset: 11829},
 			expr: &actionExpr{
-				pos: position{line: 480, col: 5, offset: 11491},
+				pos: position{line: 495, col: 5, offset: 11841},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 480, col: 5, offset: 11491},
+					pos: position{line: 495, col: 5, offset: 11841},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 480, col: 5, offset: 11491},
+							pos:  position{line: 495, col: 5, offset: 11841},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 480, col: 11, offset: 11497},
+							pos:  position{line: 495, col: 11, offset: 11847},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 480, col: 13, offset: 11499},
+							pos:   position{line: 495, col: 13, offset: 11849},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 480, col: 18, offset: 11504},
+								pos:  position{line: 495, col: 18, offset: 11854},
 								name: "Expr",
 							},
 						},
@@ -3495,26 +3561,26 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 488, col: 1, offset: 11631},
+			pos:  position{line: 503, col: 1, offset: 11981},
 			expr: &choiceExpr{
-				pos: position{line: 489, col: 5, offset: 11642},
+				pos: position{line: 504, col: 5, offset: 11992},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 489, col: 5, offset: 11642},
+						pos: position{line: 504, col: 5, offset: 11992},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 489, col: 5, offset: 11642},
+							pos: position{line: 504, col: 5, offset: 11992},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 489, col: 5, offset: 11642},
+									pos:  position{line: 504, col: 5, offset: 11992},
 									name: "UNIQ",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 489, col: 10, offset: 11647},
+									pos:  position{line: 504, col: 10, offset: 11997},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 489, col: 12, offset: 11649},
+									pos:        position{line: 504, col: 12, offset: 11999},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3523,26 +3589,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 492, col: 5, offset: 11734},
+						pos: position{line: 507, col: 5, offset: 12084},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 492, col: 5, offset: 11734},
+							pos: position{line: 507, col: 5, offset: 12084},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 492, col: 5, offset: 11734},
+									pos:  position{line: 507, col: 5, offset: 12084},
 									name: "UNIQ",
 								},
 								&notExpr{
-									pos: position{line: 492, col: 10, offset: 11739},
+									pos: position{line: 507, col: 10, offset: 12089},
 									expr: &seqExpr{
-										pos: position{line: 492, col: 12, offset: 11741},
+										pos: position{line: 507, col: 12, offset: 12091},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 492, col: 12, offset: 11741},
+												pos:  position{line: 507, col: 12, offset: 12091},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 492, col: 15, offset: 11744},
+												pos:        position{line: 507, col: 15, offset: 12094},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3551,9 +3617,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 492, col: 20, offset: 11749},
+									pos: position{line: 507, col: 20, offset: 12099},
 									expr: &ruleRefExpr{
-										pos:  position{line: 492, col: 21, offset: 11750},
+										pos:  position{line: 507, col: 21, offset: 12100},
 										name: "EOKW",
 									},
 								},
@@ -3567,26 +3633,26 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 496, col: 1, offset: 11819},
+			pos:  position{line: 511, col: 1, offset: 12169},
 			expr: &actionExpr{
-				pos: position{line: 497, col: 5, offset: 11829},
+				pos: position{line: 512, col: 5, offset: 12179},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 497, col: 5, offset: 11829},
+					pos: position{line: 512, col: 5, offset: 12179},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 497, col: 5, offset: 11829},
+							pos:  position{line: 512, col: 5, offset: 12179},
 							name: "PUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 497, col: 9, offset: 11833},
+							pos:  position{line: 512, col: 9, offset: 12183},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 497, col: 11, offset: 11835},
+							pos:   position{line: 512, col: 11, offset: 12185},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 497, col: 16, offset: 11840},
+								pos:  position{line: 512, col: 16, offset: 12190},
 								name: "Assignments",
 							},
 						},
@@ -3598,59 +3664,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 505, col: 1, offset: 11990},
+			pos:  position{line: 520, col: 1, offset: 12340},
 			expr: &actionExpr{
-				pos: position{line: 506, col: 5, offset: 12003},
+				pos: position{line: 521, col: 5, offset: 12353},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 506, col: 5, offset: 12003},
+					pos: position{line: 521, col: 5, offset: 12353},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 5, offset: 12003},
+							pos:  position{line: 521, col: 5, offset: 12353},
 							name: "RENAME",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 506, col: 12, offset: 12010},
+							pos:  position{line: 521, col: 12, offset: 12360},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 506, col: 14, offset: 12012},
+							pos:   position{line: 521, col: 14, offset: 12362},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 506, col: 20, offset: 12018},
+								pos:  position{line: 521, col: 20, offset: 12368},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 506, col: 31, offset: 12029},
+							pos:   position{line: 521, col: 31, offset: 12379},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 506, col: 36, offset: 12034},
+								pos: position{line: 521, col: 36, offset: 12384},
 								expr: &actionExpr{
-									pos: position{line: 506, col: 37, offset: 12035},
+									pos: position{line: 521, col: 37, offset: 12385},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 506, col: 37, offset: 12035},
+										pos: position{line: 521, col: 37, offset: 12385},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 506, col: 37, offset: 12035},
+												pos:  position{line: 521, col: 37, offset: 12385},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 506, col: 40, offset: 12038},
+												pos:        position{line: 521, col: 40, offset: 12388},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 506, col: 44, offset: 12042},
+												pos:  position{line: 521, col: 44, offset: 12392},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 506, col: 47, offset: 12045},
+												pos:   position{line: 521, col: 47, offset: 12395},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 506, col: 50, offset: 12048},
+													pos:  position{line: 521, col: 50, offset: 12398},
 													name: "Assignment",
 												},
 											},
@@ -3667,28 +3733,28 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 519, col: 1, offset: 12513},
+			pos:  position{line: 534, col: 1, offset: 12863},
 			expr: &actionExpr{
-				pos: position{line: 520, col: 5, offset: 12524},
+				pos: position{line: 535, col: 5, offset: 12874},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 520, col: 5, offset: 12524},
+					pos: position{line: 535, col: 5, offset: 12874},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 520, col: 5, offset: 12524},
+							pos:  position{line: 535, col: 5, offset: 12874},
 							name: "FUSE",
 						},
 						&notExpr{
-							pos: position{line: 520, col: 10, offset: 12529},
+							pos: position{line: 535, col: 10, offset: 12879},
 							expr: &seqExpr{
-								pos: position{line: 520, col: 12, offset: 12531},
+								pos: position{line: 535, col: 12, offset: 12881},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 520, col: 12, offset: 12531},
+										pos:  position{line: 535, col: 12, offset: 12881},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 520, col: 15, offset: 12534},
+										pos:        position{line: 535, col: 15, offset: 12884},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3697,9 +3763,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 520, col: 20, offset: 12539},
+							pos: position{line: 535, col: 20, offset: 12889},
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 21, offset: 12540},
+								pos:  position{line: 535, col: 21, offset: 12890},
 								name: "EOKW",
 							},
 						},
@@ -3711,28 +3777,28 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 524, col: 1, offset: 12609},
+			pos:  position{line: 539, col: 1, offset: 12959},
 			expr: &actionExpr{
-				pos: position{line: 525, col: 5, offset: 12621},
+				pos: position{line: 540, col: 5, offset: 12971},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 525, col: 5, offset: 12621},
+					pos: position{line: 540, col: 5, offset: 12971},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 525, col: 5, offset: 12621},
+							pos:  position{line: 540, col: 5, offset: 12971},
 							name: "SHAPE",
 						},
 						&notExpr{
-							pos: position{line: 525, col: 11, offset: 12627},
+							pos: position{line: 540, col: 11, offset: 12977},
 							expr: &seqExpr{
-								pos: position{line: 525, col: 13, offset: 12629},
+								pos: position{line: 540, col: 13, offset: 12979},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 525, col: 13, offset: 12629},
+										pos:  position{line: 540, col: 13, offset: 12979},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 525, col: 16, offset: 12632},
+										pos:        position{line: 540, col: 16, offset: 12982},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3741,9 +3807,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 525, col: 21, offset: 12637},
+							pos: position{line: 540, col: 21, offset: 12987},
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 22, offset: 12638},
+								pos:  position{line: 540, col: 22, offset: 12988},
 								name: "EOKW",
 							},
 						},
@@ -3755,55 +3821,55 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 529, col: 1, offset: 12709},
+			pos:  position{line: 544, col: 1, offset: 13059},
 			expr: &actionExpr{
-				pos: position{line: 530, col: 5, offset: 12720},
+				pos: position{line: 545, col: 5, offset: 13070},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 530, col: 5, offset: 12720},
+					pos: position{line: 545, col: 5, offset: 13070},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 530, col: 5, offset: 12720},
+							pos:   position{line: 545, col: 5, offset: 13070},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 11, offset: 12726},
+								pos:  position{line: 545, col: 11, offset: 13076},
 								name: "JoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 530, col: 21, offset: 12736},
+							pos:  position{line: 545, col: 21, offset: 13086},
 							name: "JOIN",
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 26, offset: 12741},
+							pos:   position{line: 545, col: 26, offset: 13091},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 37, offset: 12752},
+								pos:  position{line: 545, col: 37, offset: 13102},
 								name: "JoinRightInput",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 52, offset: 12767},
+							pos:   position{line: 545, col: 52, offset: 13117},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 54, offset: 12769},
+								pos:  position{line: 545, col: 54, offset: 13119},
 								name: "JoinExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 63, offset: 12778},
+							pos:   position{line: 545, col: 63, offset: 13128},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 530, col: 71, offset: 12786},
+								pos: position{line: 545, col: 71, offset: 13136},
 								expr: &seqExpr{
-									pos: position{line: 530, col: 72, offset: 12787},
+									pos: position{line: 545, col: 72, offset: 13137},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 530, col: 72, offset: 12787},
+											pos:  position{line: 545, col: 72, offset: 13137},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 530, col: 74, offset: 12789},
+											pos:  position{line: 545, col: 74, offset: 13139},
 											name: "FlexAssignments",
 										},
 									},
@@ -3818,83 +3884,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 546, col: 1, offset: 13155},
+			pos:  position{line: 561, col: 1, offset: 13505},
 			expr: &choiceExpr{
-				pos: position{line: 547, col: 5, offset: 13169},
+				pos: position{line: 562, col: 5, offset: 13519},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 13169},
+						pos: position{line: 562, col: 5, offset: 13519},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 5, offset: 13169},
+							pos: position{line: 562, col: 5, offset: 13519},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 5, offset: 13169},
+									pos:  position{line: 562, col: 5, offset: 13519},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 10, offset: 13174},
+									pos:  position{line: 562, col: 10, offset: 13524},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 13204},
+						pos: position{line: 563, col: 5, offset: 13554},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 548, col: 5, offset: 13204},
+							pos: position{line: 563, col: 5, offset: 13554},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 5, offset: 13204},
+									pos:  position{line: 563, col: 5, offset: 13554},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 11, offset: 13210},
+									pos:  position{line: 563, col: 11, offset: 13560},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 549, col: 5, offset: 13240},
+						pos: position{line: 564, col: 5, offset: 13590},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 549, col: 5, offset: 13240},
+							pos: position{line: 564, col: 5, offset: 13590},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 549, col: 5, offset: 13240},
+									pos:  position{line: 564, col: 5, offset: 13590},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 549, col: 11, offset: 13246},
+									pos:  position{line: 564, col: 11, offset: 13596},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 550, col: 5, offset: 13275},
+						pos: position{line: 565, col: 5, offset: 13625},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 550, col: 5, offset: 13275},
+							pos: position{line: 565, col: 5, offset: 13625},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 5, offset: 13275},
+									pos:  position{line: 565, col: 5, offset: 13625},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 11, offset: 13281},
+									pos:  position{line: 565, col: 11, offset: 13631},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 551, col: 5, offset: 13311},
+						pos: position{line: 566, col: 5, offset: 13661},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 551, col: 5, offset: 13311},
+							pos:        position{line: 566, col: 5, offset: 13661},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3907,44 +3973,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 553, col: 1, offset: 13346},
+			pos:  position{line: 568, col: 1, offset: 13696},
 			expr: &choiceExpr{
-				pos: position{line: 554, col: 5, offset: 13365},
+				pos: position{line: 569, col: 5, offset: 13715},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 13365},
+						pos: position{line: 569, col: 5, offset: 13715},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 554, col: 5, offset: 13365},
+							pos: position{line: 569, col: 5, offset: 13715},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 554, col: 5, offset: 13365},
+									pos:  position{line: 569, col: 5, offset: 13715},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 554, col: 8, offset: 13368},
+									pos:        position{line: 569, col: 8, offset: 13718},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 554, col: 12, offset: 13372},
+									pos:  position{line: 569, col: 12, offset: 13722},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 554, col: 15, offset: 13375},
+									pos:   position{line: 569, col: 15, offset: 13725},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 554, col: 17, offset: 13377},
+										pos:  position{line: 569, col: 17, offset: 13727},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 554, col: 21, offset: 13381},
+									pos:  position{line: 569, col: 21, offset: 13731},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 554, col: 24, offset: 13384},
+									pos:        position{line: 569, col: 24, offset: 13734},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3953,10 +4019,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 555, col: 5, offset: 13410},
+						pos: position{line: 570, col: 5, offset: 13760},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 555, col: 5, offset: 13410},
+							pos:        position{line: 570, col: 5, offset: 13760},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3969,36 +4035,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 557, col: 1, offset: 13434},
+			pos:  position{line: 572, col: 1, offset: 13784},
 			expr: &choiceExpr{
-				pos: position{line: 558, col: 5, offset: 13446},
+				pos: position{line: 573, col: 5, offset: 13796},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 558, col: 5, offset: 13446},
+						pos:  position{line: 573, col: 5, offset: 13796},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 559, col: 5, offset: 13455},
+						pos: position{line: 574, col: 5, offset: 13805},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 559, col: 5, offset: 13455},
+							pos: position{line: 574, col: 5, offset: 13805},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 559, col: 5, offset: 13455},
+									pos:        position{line: 574, col: 5, offset: 13805},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 559, col: 9, offset: 13459},
+									pos:   position{line: 574, col: 9, offset: 13809},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 14, offset: 13464},
+										pos:  position{line: 574, col: 14, offset: 13814},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 559, col: 19, offset: 13469},
+									pos:        position{line: 574, col: 19, offset: 13819},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4013,44 +4079,44 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 561, col: 1, offset: 13495},
+			pos:  position{line: 576, col: 1, offset: 13845},
 			expr: &actionExpr{
-				pos: position{line: 562, col: 5, offset: 13508},
+				pos: position{line: 577, col: 5, offset: 13858},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 562, col: 5, offset: 13508},
+					pos: position{line: 577, col: 5, offset: 13858},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 5, offset: 13508},
+							pos:  position{line: 577, col: 5, offset: 13858},
 							name: "SAMPLE",
 						},
 						&andExpr{
-							pos: position{line: 562, col: 12, offset: 13515},
+							pos: position{line: 577, col: 12, offset: 13865},
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 13, offset: 13516},
+								pos:  position{line: 577, col: 13, offset: 13866},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 562, col: 18, offset: 13521},
+							pos:   position{line: 577, col: 18, offset: 13871},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 562, col: 23, offset: 13526},
+								pos: position{line: 577, col: 23, offset: 13876},
 								expr: &actionExpr{
-									pos: position{line: 562, col: 24, offset: 13527},
+									pos: position{line: 577, col: 24, offset: 13877},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 562, col: 24, offset: 13527},
+										pos: position{line: 577, col: 24, offset: 13877},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 562, col: 24, offset: 13527},
+												pos:  position{line: 577, col: 24, offset: 13877},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 562, col: 26, offset: 13529},
+												pos:   position{line: 577, col: 26, offset: 13879},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 562, col: 28, offset: 13531},
+													pos:  position{line: 577, col: 28, offset: 13881},
 													name: "Lval",
 												},
 											},
@@ -4067,15 +4133,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 575, col: 1, offset: 13969},
+			pos:  position{line: 590, col: 1, offset: 14319},
 			expr: &actionExpr{
-				pos: position{line: 576, col: 5, offset: 13986},
+				pos: position{line: 591, col: 5, offset: 14336},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 576, col: 5, offset: 13986},
+					pos:   position{line: 591, col: 5, offset: 14336},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 576, col: 7, offset: 13988},
+						pos:  position{line: 591, col: 7, offset: 14338},
 						name: "Assignments",
 					},
 				},
@@ -4085,69 +4151,69 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 584, col: 1, offset: 14160},
+			pos:  position{line: 599, col: 1, offset: 14510},
 			expr: &actionExpr{
-				pos: position{line: 585, col: 5, offset: 14171},
+				pos: position{line: 600, col: 5, offset: 14521},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 585, col: 5, offset: 14171},
+					pos: position{line: 600, col: 5, offset: 14521},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 585, col: 5, offset: 14171},
+							pos:  position{line: 600, col: 5, offset: 14521},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 585, col: 10, offset: 14176},
+							pos:  position{line: 600, col: 10, offset: 14526},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 585, col: 12, offset: 14178},
+							pos:   position{line: 600, col: 12, offset: 14528},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 585, col: 17, offset: 14183},
+								pos:  position{line: 600, col: 17, offset: 14533},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 585, col: 22, offset: 14188},
+							pos:   position{line: 600, col: 22, offset: 14538},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 585, col: 29, offset: 14195},
+								pos: position{line: 600, col: 29, offset: 14545},
 								expr: &ruleRefExpr{
-									pos:  position{line: 585, col: 29, offset: 14195},
+									pos:  position{line: 600, col: 29, offset: 14545},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 585, col: 41, offset: 14207},
+							pos:   position{line: 600, col: 41, offset: 14557},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 585, col: 48, offset: 14214},
+								pos: position{line: 600, col: 48, offset: 14564},
 								expr: &ruleRefExpr{
-									pos:  position{line: 585, col: 48, offset: 14214},
+									pos:  position{line: 600, col: 48, offset: 14564},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 585, col: 59, offset: 14225},
+							pos:   position{line: 600, col: 59, offset: 14575},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 585, col: 67, offset: 14233},
+								pos: position{line: 600, col: 67, offset: 14583},
 								expr: &ruleRefExpr{
-									pos:  position{line: 585, col: 67, offset: 14233},
+									pos:  position{line: 600, col: 67, offset: 14583},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 585, col: 79, offset: 14245},
+							pos:   position{line: 600, col: 79, offset: 14595},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 585, col: 84, offset: 14250},
+								pos: position{line: 600, col: 84, offset: 14600},
 								expr: &ruleRefExpr{
-									pos:  position{line: 585, col: 84, offset: 14250},
+									pos:  position{line: 600, col: 84, offset: 14600},
 									name: "MetaArg",
 								},
 							},
@@ -4160,30 +4226,30 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 597, col: 1, offset: 14532},
+			pos:  position{line: 612, col: 1, offset: 14882},
 			expr: &actionExpr{
-				pos: position{line: 598, col: 5, offset: 14546},
+				pos: position{line: 613, col: 5, offset: 14896},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 598, col: 5, offset: 14546},
+					pos: position{line: 613, col: 5, offset: 14896},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 598, col: 5, offset: 14546},
+							pos:  position{line: 613, col: 5, offset: 14896},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 598, col: 7, offset: 14548},
+							pos:  position{line: 613, col: 7, offset: 14898},
 							name: "AUTHOR",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 598, col: 14, offset: 14555},
+							pos:  position{line: 613, col: 14, offset: 14905},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 598, col: 16, offset: 14557},
+							pos:   position{line: 613, col: 16, offset: 14907},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 598, col: 18, offset: 14559},
+								pos:  position{line: 613, col: 18, offset: 14909},
 								name: "Name",
 							},
 						},
@@ -4195,30 +4261,30 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 600, col: 1, offset: 14583},
+			pos:  position{line: 615, col: 1, offset: 14933},
 			expr: &actionExpr{
-				pos: position{line: 601, col: 5, offset: 14598},
+				pos: position{line: 616, col: 5, offset: 14948},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 601, col: 5, offset: 14598},
+					pos: position{line: 616, col: 5, offset: 14948},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 601, col: 5, offset: 14598},
+							pos:  position{line: 616, col: 5, offset: 14948},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 601, col: 7, offset: 14600},
+							pos:  position{line: 616, col: 7, offset: 14950},
 							name: "MESSAGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 601, col: 15, offset: 14608},
+							pos:  position{line: 616, col: 15, offset: 14958},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 601, col: 17, offset: 14610},
+							pos:   position{line: 616, col: 17, offset: 14960},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 601, col: 19, offset: 14612},
+								pos:  position{line: 616, col: 19, offset: 14962},
 								name: "Name",
 							},
 						},
@@ -4230,30 +4296,30 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 603, col: 1, offset: 14636},
+			pos:  position{line: 618, col: 1, offset: 14986},
 			expr: &actionExpr{
-				pos: position{line: 604, col: 5, offset: 14648},
+				pos: position{line: 619, col: 5, offset: 14998},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 604, col: 5, offset: 14648},
+					pos: position{line: 619, col: 5, offset: 14998},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 604, col: 5, offset: 14648},
+							pos:  position{line: 619, col: 5, offset: 14998},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 604, col: 7, offset: 14650},
+							pos:  position{line: 619, col: 7, offset: 15000},
 							name: "META",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 604, col: 12, offset: 14655},
+							pos:  position{line: 619, col: 12, offset: 15005},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 604, col: 14, offset: 14657},
+							pos:   position{line: 619, col: 14, offset: 15007},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 604, col: 16, offset: 14659},
+								pos:  position{line: 619, col: 16, offset: 15009},
 								name: "Name",
 							},
 						},
@@ -4265,24 +4331,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 606, col: 1, offset: 14683},
+			pos:  position{line: 621, col: 1, offset: 15033},
 			expr: &actionExpr{
-				pos: position{line: 607, col: 5, offset: 14698},
+				pos: position{line: 622, col: 5, offset: 15048},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 607, col: 5, offset: 14698},
+					pos: position{line: 622, col: 5, offset: 15048},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 607, col: 5, offset: 14698},
+							pos:        position{line: 622, col: 5, offset: 15048},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 607, col: 9, offset: 14702},
+							pos:   position{line: 622, col: 9, offset: 15052},
 							label: "branch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 607, col: 16, offset: 14709},
+								pos:  position{line: 622, col: 16, offset: 15059},
 								name: "Name",
 							},
 						},
@@ -4294,26 +4360,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 609, col: 1, offset: 14738},
+			pos:  position{line: 624, col: 1, offset: 15088},
 			expr: &actionExpr{
-				pos: position{line: 610, col: 5, offset: 14751},
+				pos: position{line: 625, col: 5, offset: 15101},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 610, col: 5, offset: 14751},
+					pos: position{line: 625, col: 5, offset: 15101},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 610, col: 5, offset: 14751},
+							pos:  position{line: 625, col: 5, offset: 15101},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 610, col: 12, offset: 14758},
+							pos:  position{line: 625, col: 12, offset: 15108},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 14, offset: 14760},
+							pos:   position{line: 625, col: 14, offset: 15110},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 610, col: 19, offset: 14765},
+								pos:  position{line: 625, col: 19, offset: 15115},
 								name: "Identifier",
 							},
 						},
@@ -4325,44 +4391,44 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 618, col: 1, offset: 14899},
+			pos:  position{line: 633, col: 1, offset: 15249},
 			expr: &actionExpr{
-				pos: position{line: 619, col: 5, offset: 14911},
+				pos: position{line: 634, col: 5, offset: 15261},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 619, col: 5, offset: 14911},
+					pos: position{line: 634, col: 5, offset: 15261},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 619, col: 5, offset: 14911},
+							pos:  position{line: 634, col: 5, offset: 15261},
 							name: "DEBUG",
 						},
 						&andExpr{
-							pos: position{line: 619, col: 11, offset: 14917},
+							pos: position{line: 634, col: 11, offset: 15267},
 							expr: &ruleRefExpr{
-								pos:  position{line: 619, col: 12, offset: 14918},
+								pos:  position{line: 634, col: 12, offset: 15268},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 619, col: 17, offset: 14923},
+							pos:   position{line: 634, col: 17, offset: 15273},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 619, col: 22, offset: 14928},
+								pos: position{line: 634, col: 22, offset: 15278},
 								expr: &actionExpr{
-									pos: position{line: 619, col: 23, offset: 14929},
+									pos: position{line: 634, col: 23, offset: 15279},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 619, col: 23, offset: 14929},
+										pos: position{line: 634, col: 23, offset: 15279},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 619, col: 23, offset: 14929},
+												pos:  position{line: 634, col: 23, offset: 15279},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 619, col: 25, offset: 14931},
+												pos:   position{line: 634, col: 25, offset: 15281},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 619, col: 27, offset: 14933},
+													pos:  position{line: 634, col: 27, offset: 15283},
 													name: "Expr",
 												},
 											},
@@ -4379,26 +4445,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 630, col: 1, offset: 15126},
+			pos:  position{line: 645, col: 1, offset: 15476},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 15137},
+				pos: position{line: 646, col: 5, offset: 15487},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 5, offset: 15137},
+					pos: position{line: 646, col: 5, offset: 15487},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 631, col: 5, offset: 15137},
+							pos:  position{line: 646, col: 5, offset: 15487},
 							name: "FromKeyWord",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 631, col: 17, offset: 15149},
+							pos:  position{line: 646, col: 17, offset: 15499},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 631, col: 19, offset: 15151},
+							pos:   position{line: 646, col: 19, offset: 15501},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 25, offset: 15157},
+								pos:  position{line: 646, col: 25, offset: 15507},
 								name: "FromElems",
 							},
 						},
@@ -4410,16 +4476,16 @@ var g = &grammar{
 		},
 		{
 			name: "FromKeyWord",
-			pos:  position{line: 639, col: 1, offset: 15300},
+			pos:  position{line: 654, col: 1, offset: 15650},
 			expr: &choiceExpr{
-				pos: position{line: 640, col: 5, offset: 15316},
+				pos: position{line: 655, col: 5, offset: 15666},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 640, col: 5, offset: 15316},
+						pos:  position{line: 655, col: 5, offset: 15666},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 641, col: 5, offset: 15325},
+						pos:  position{line: 656, col: 5, offset: 15675},
 						name: "DeprecatedFroms",
 					},
 				},
@@ -4429,24 +4495,24 @@ var g = &grammar{
 		},
 		{
 			name: "DeprecatedFroms",
-			pos:  position{line: 643, col: 1, offset: 15342},
+			pos:  position{line: 658, col: 1, offset: 15692},
 			expr: &choiceExpr{
-				pos: position{line: 643, col: 19, offset: 15360},
+				pos: position{line: 658, col: 19, offset: 15710},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 643, col: 19, offset: 15360},
+						pos:        position{line: 658, col: 19, offset: 15710},
 						val:        "get",
 						ignoreCase: false,
 						want:       "\"get\"",
 					},
 					&litMatcher{
-						pos:        position{line: 643, col: 27, offset: 15368},
+						pos:        position{line: 658, col: 27, offset: 15718},
 						val:        "file",
 						ignoreCase: false,
 						want:       "\"file\"",
 					},
 					&litMatcher{
-						pos:        position{line: 643, col: 36, offset: 15377},
+						pos:        position{line: 658, col: 36, offset: 15727},
 						val:        "pool",
 						ignoreCase: false,
 						want:       "\"pool\"",
@@ -4458,51 +4524,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 645, col: 1, offset: 15385},
+			pos:  position{line: 660, col: 1, offset: 15735},
 			expr: &actionExpr{
-				pos: position{line: 646, col: 5, offset: 15399},
+				pos: position{line: 661, col: 5, offset: 15749},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 646, col: 5, offset: 15399},
+					pos: position{line: 661, col: 5, offset: 15749},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 646, col: 5, offset: 15399},
+							pos:   position{line: 661, col: 5, offset: 15749},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 646, col: 11, offset: 15405},
+								pos:  position{line: 661, col: 11, offset: 15755},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 646, col: 20, offset: 15414},
+							pos:   position{line: 661, col: 20, offset: 15764},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 646, col: 25, offset: 15419},
+								pos: position{line: 661, col: 25, offset: 15769},
 								expr: &actionExpr{
-									pos: position{line: 646, col: 27, offset: 15421},
+									pos: position{line: 661, col: 27, offset: 15771},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 646, col: 27, offset: 15421},
+										pos: position{line: 661, col: 27, offset: 15771},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 646, col: 27, offset: 15421},
+												pos:  position{line: 661, col: 27, offset: 15771},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 646, col: 30, offset: 15424},
+												pos:        position{line: 661, col: 30, offset: 15774},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 646, col: 34, offset: 15428},
+												pos:  position{line: 661, col: 34, offset: 15778},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 646, col: 37, offset: 15431},
+												pos:   position{line: 661, col: 37, offset: 15781},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 646, col: 42, offset: 15436},
+													pos:  position{line: 661, col: 42, offset: 15786},
 													name: "FromElem",
 												},
 											},
@@ -4519,42 +4585,42 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 650, col: 1, offset: 15520},
+			pos:  position{line: 665, col: 1, offset: 15870},
 			expr: &actionExpr{
-				pos: position{line: 651, col: 5, offset: 15533},
+				pos: position{line: 666, col: 5, offset: 15883},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 651, col: 5, offset: 15533},
+					pos: position{line: 666, col: 5, offset: 15883},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 651, col: 5, offset: 15533},
+							pos:   position{line: 666, col: 5, offset: 15883},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 12, offset: 15540},
+								pos:  position{line: 666, col: 12, offset: 15890},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 651, col: 23, offset: 15551},
+							pos:   position{line: 666, col: 23, offset: 15901},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 28, offset: 15556},
+								pos:  position{line: 666, col: 28, offset: 15906},
 								name: "FromArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 651, col: 37, offset: 15565},
+							pos:   position{line: 666, col: 37, offset: 15915},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 39, offset: 15567},
+								pos:  position{line: 666, col: 39, offset: 15917},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 651, col: 53, offset: 15581},
+							pos:   position{line: 666, col: 53, offset: 15931},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 59, offset: 15587},
+								pos:  position{line: 666, col: 59, offset: 15937},
 								name: "OptAlias",
 							},
 						},
@@ -4566,46 +4632,46 @@ var g = &grammar{
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 669, col: 1, offset: 15975},
+			pos:  position{line: 684, col: 1, offset: 16325},
 			expr: &choiceExpr{
-				pos: position{line: 670, col: 5, offset: 15990},
+				pos: position{line: 685, col: 5, offset: 16340},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 670, col: 5, offset: 15990},
+						pos: position{line: 685, col: 5, offset: 16340},
 						run: (*parser).callonFromEntity2,
 						expr: &labeledExpr{
-							pos:   position{line: 670, col: 5, offset: 15990},
+							pos:   position{line: 685, col: 5, offset: 16340},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 670, col: 9, offset: 15994},
+								pos:  position{line: 685, col: 9, offset: 16344},
 								name: "UnquotedURL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 5, offset: 16126},
+						pos:  position{line: 692, col: 5, offset: 16476},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 678, col: 5, offset: 16137},
+						pos:  position{line: 693, col: 5, offset: 16487},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 679, col: 5, offset: 16146},
+						pos: position{line: 694, col: 5, offset: 16496},
 						run: (*parser).callonFromEntity7,
 						expr: &seqExpr{
-							pos: position{line: 679, col: 5, offset: 16146},
+							pos: position{line: 694, col: 5, offset: 16496},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 679, col: 5, offset: 16146},
+									pos:        position{line: 694, col: 5, offset: 16496},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 679, col: 9, offset: 16150},
+									pos: position{line: 694, col: 9, offset: 16500},
 									expr: &ruleRefExpr{
-										pos:  position{line: 679, col: 10, offset: 16151},
+										pos:  position{line: 694, col: 10, offset: 16501},
 										name: "ExprGuard",
 									},
 								},
@@ -4613,43 +4679,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 680, col: 5, offset: 16232},
+						pos: position{line: 695, col: 5, offset: 16582},
 						run: (*parser).callonFromEntity12,
 						expr: &seqExpr{
-							pos: position{line: 680, col: 5, offset: 16232},
+							pos: position{line: 695, col: 5, offset: 16582},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 680, col: 5, offset: 16232},
+									pos:  position{line: 695, col: 5, offset: 16582},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 680, col: 10, offset: 16237},
+									pos:  position{line: 695, col: 10, offset: 16587},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 680, col: 13, offset: 16240},
+									pos:        position{line: 695, col: 13, offset: 16590},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 680, col: 17, offset: 16244},
+									pos:  position{line: 695, col: 17, offset: 16594},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 680, col: 20, offset: 16247},
+									pos:   position{line: 695, col: 20, offset: 16597},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 680, col: 22, offset: 16249},
+										pos:  position{line: 695, col: 22, offset: 16599},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 680, col: 27, offset: 16254},
+									pos:  position{line: 695, col: 27, offset: 16604},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 680, col: 30, offset: 16257},
+									pos:        position{line: 695, col: 30, offset: 16607},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4658,35 +4724,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 687, col: 5, offset: 16393},
+						pos: position{line: 702, col: 5, offset: 16743},
 						run: (*parser).callonFromEntity22,
 						expr: &labeledExpr{
-							pos:   position{line: 687, col: 5, offset: 16393},
+							pos:   position{line: 702, col: 5, offset: 16743},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 10, offset: 16398},
+								pos:  position{line: 702, col: 10, offset: 16748},
 								name: "PoolMeta",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 694, col: 5, offset: 16541},
+						pos: position{line: 709, col: 5, offset: 16891},
 						run: (*parser).callonFromEntity25,
 						expr: &seqExpr{
-							pos: position{line: 694, col: 5, offset: 16541},
+							pos: position{line: 709, col: 5, offset: 16891},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 694, col: 5, offset: 16541},
+									pos:   position{line: 709, col: 5, offset: 16891},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 10, offset: 16546},
+										pos:  position{line: 709, col: 10, offset: 16896},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 694, col: 24, offset: 16560},
+									pos: position{line: 709, col: 24, offset: 16910},
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 25, offset: 16561},
+										pos:  position{line: 709, col: 25, offset: 16911},
 										name: "AliasClause",
 									},
 								},
@@ -4694,35 +4760,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 16596},
+						pos: position{line: 710, col: 5, offset: 16946},
 						run: (*parser).callonFromEntity31,
 						expr: &seqExpr{
-							pos: position{line: 695, col: 5, offset: 16596},
+							pos: position{line: 710, col: 5, offset: 16946},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 695, col: 5, offset: 16596},
+									pos:        position{line: 710, col: 5, offset: 16946},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 695, col: 9, offset: 16600},
+									pos:  position{line: 710, col: 9, offset: 16950},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 695, col: 12, offset: 16603},
+									pos:   position{line: 710, col: 12, offset: 16953},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 695, col: 17, offset: 16608},
+										pos:  position{line: 710, col: 17, offset: 16958},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 695, col: 31, offset: 16622},
+									pos:  position{line: 710, col: 31, offset: 16972},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 695, col: 34, offset: 16625},
+									pos:        position{line: 710, col: 34, offset: 16975},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4731,35 +4797,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 696, col: 5, offset: 16654},
+						pos: position{line: 711, col: 5, offset: 17004},
 						run: (*parser).callonFromEntity39,
 						expr: &seqExpr{
-							pos: position{line: 696, col: 5, offset: 16654},
+							pos: position{line: 711, col: 5, offset: 17004},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 696, col: 5, offset: 16654},
+									pos:        position{line: 711, col: 5, offset: 17004},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 696, col: 9, offset: 16658},
+									pos:  position{line: 711, col: 9, offset: 17008},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 696, col: 12, offset: 16661},
+									pos:   position{line: 711, col: 12, offset: 17011},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 696, col: 14, offset: 16663},
+										pos:  position{line: 711, col: 14, offset: 17013},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 696, col: 22, offset: 16671},
+									pos:  position{line: 711, col: 22, offset: 17021},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 696, col: 25, offset: 16674},
+									pos:        position{line: 711, col: 25, offset: 17024},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4768,58 +4834,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 699, col: 6, offset: 16711},
+						pos: position{line: 714, col: 6, offset: 17061},
 						run: (*parser).callonFromEntity47,
 						expr: &labeledExpr{
-							pos:   position{line: 699, col: 6, offset: 16711},
+							pos:   position{line: 714, col: 6, offset: 17061},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 699, col: 11, offset: 16716},
+								pos:  position{line: 714, col: 11, offset: 17066},
 								name: "Name",
 							},
 						},
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "FromArgs",
-			pos:  position{line: 702, col: 1, offset: 16814},
+			pos:  position{line: 717, col: 1, offset: 17164},
 			expr: &choiceExpr{
-				pos: position{line: 703, col: 5, offset: 16827},
+				pos: position{line: 718, col: 5, offset: 17177},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 703, col: 5, offset: 16827},
+						pos: position{line: 718, col: 5, offset: 17177},
 						run: (*parser).callonFromArgs2,
 						expr: &seqExpr{
-							pos: position{line: 703, col: 5, offset: 16827},
+							pos: position{line: 718, col: 5, offset: 17177},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 703, col: 5, offset: 16827},
+									pos:   position{line: 718, col: 5, offset: 17177},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 703, col: 12, offset: 16834},
+										pos:  position{line: 718, col: 12, offset: 17184},
 										name: "PoolCommit",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 703, col: 23, offset: 16845},
+									pos:   position{line: 718, col: 23, offset: 17195},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 703, col: 28, offset: 16850},
+										pos: position{line: 718, col: 28, offset: 17200},
 										expr: &ruleRefExpr{
-											pos:  position{line: 703, col: 28, offset: 16850},
+											pos:  position{line: 718, col: 28, offset: 17200},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 703, col: 38, offset: 16860},
+									pos:   position{line: 718, col: 38, offset: 17210},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 703, col: 42, offset: 16864},
+										pos:  position{line: 718, col: 42, offset: 17214},
 										name: "TapArg",
 									},
 								},
@@ -4827,24 +4893,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 17068},
+						pos: position{line: 727, col: 5, offset: 17418},
 						run: (*parser).callonFromArgs11,
 						expr: &seqExpr{
-							pos: position{line: 712, col: 5, offset: 17068},
+							pos: position{line: 727, col: 5, offset: 17418},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 712, col: 5, offset: 17068},
+									pos:   position{line: 727, col: 5, offset: 17418},
 									label: "meta",
 									expr: &ruleRefExpr{
-										pos:  position{line: 712, col: 10, offset: 17073},
+										pos:  position{line: 727, col: 10, offset: 17423},
 										name: "PoolMeta",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 712, col: 19, offset: 17082},
+									pos:   position{line: 727, col: 19, offset: 17432},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 712, col: 23, offset: 17086},
+										pos:  position{line: 727, col: 23, offset: 17436},
 										name: "TapArg",
 									},
 								},
@@ -4852,41 +4918,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 720, col: 5, offset: 17252},
+						pos: position{line: 735, col: 5, offset: 17602},
 						run: (*parser).callonFromArgs17,
 						expr: &seqExpr{
-							pos: position{line: 720, col: 5, offset: 17252},
+							pos: position{line: 735, col: 5, offset: 17602},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 720, col: 5, offset: 17252},
+									pos:   position{line: 735, col: 5, offset: 17602},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 720, col: 12, offset: 17259},
+										pos:  position{line: 735, col: 12, offset: 17609},
 										name: "FormatArg",
 									},
 								},
 								&notExpr{
-									pos: position{line: 720, col: 22, offset: 17269},
+									pos: position{line: 735, col: 22, offset: 17619},
 									expr: &seqExpr{
-										pos: position{line: 720, col: 24, offset: 17271},
+										pos: position{line: 735, col: 24, offset: 17621},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 720, col: 24, offset: 17271},
+												pos:  position{line: 735, col: 24, offset: 17621},
 												name: "_",
 											},
 											&choiceExpr{
-												pos: position{line: 720, col: 27, offset: 17274},
+												pos: position{line: 735, col: 27, offset: 17624},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 720, col: 27, offset: 17274},
+														pos:  position{line: 735, col: 27, offset: 17624},
 														name: "METHOD",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 720, col: 36, offset: 17283},
+														pos:  position{line: 735, col: 36, offset: 17633},
 														name: "HEADERS",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 720, col: 46, offset: 17293},
+														pos:  position{line: 735, col: 46, offset: 17643},
 														name: "BODY",
 													},
 												},
@@ -4898,51 +4964,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 727, col: 5, offset: 17438},
+						pos: position{line: 742, col: 5, offset: 17788},
 						run: (*parser).callonFromArgs28,
 						expr: &seqExpr{
-							pos: position{line: 727, col: 5, offset: 17438},
+							pos: position{line: 742, col: 5, offset: 17788},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 727, col: 5, offset: 17438},
+									pos:   position{line: 742, col: 5, offset: 17788},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 727, col: 12, offset: 17445},
+										pos: position{line: 742, col: 12, offset: 17795},
 										expr: &ruleRefExpr{
-											pos:  position{line: 727, col: 12, offset: 17445},
+											pos:  position{line: 742, col: 12, offset: 17795},
 											name: "FormatArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 727, col: 23, offset: 17456},
+									pos:   position{line: 742, col: 23, offset: 17806},
 									label: "method",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 727, col: 30, offset: 17463},
+										pos: position{line: 742, col: 30, offset: 17813},
 										expr: &ruleRefExpr{
-											pos:  position{line: 727, col: 30, offset: 17463},
+											pos:  position{line: 742, col: 30, offset: 17813},
 											name: "MethodArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 727, col: 41, offset: 17474},
+									pos:   position{line: 742, col: 41, offset: 17824},
 									label: "headers",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 727, col: 49, offset: 17482},
+										pos: position{line: 742, col: 49, offset: 17832},
 										expr: &ruleRefExpr{
-											pos:  position{line: 727, col: 49, offset: 17482},
+											pos:  position{line: 742, col: 49, offset: 17832},
 											name: "HeadersArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 727, col: 61, offset: 17494},
+									pos:   position{line: 742, col: 61, offset: 17844},
 									label: "body",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 727, col: 66, offset: 17499},
+										pos: position{line: 742, col: 66, offset: 17849},
 										expr: &ruleRefExpr{
-											pos:  position{line: 727, col: 66, offset: 17499},
+											pos:  position{line: 742, col: 66, offset: 17849},
 											name: "BodyArg",
 										},
 									},
@@ -4957,30 +5023,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 744, col: 1, offset: 17915},
+			pos:  position{line: 759, col: 1, offset: 18265},
 			expr: &actionExpr{
-				pos: position{line: 744, col: 13, offset: 17927},
+				pos: position{line: 759, col: 13, offset: 18277},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 744, col: 13, offset: 17927},
+					pos: position{line: 759, col: 13, offset: 18277},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 13, offset: 17927},
+							pos:  position{line: 759, col: 13, offset: 18277},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 15, offset: 17929},
+							pos:  position{line: 759, col: 15, offset: 18279},
 							name: "FORMAT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 22, offset: 17936},
+							pos:  position{line: 759, col: 22, offset: 18286},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 744, col: 24, offset: 17938},
+							pos:   position{line: 759, col: 24, offset: 18288},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 744, col: 26, offset: 17940},
+								pos:  position{line: 759, col: 26, offset: 18290},
 								name: "Name",
 							},
 						},
@@ -4992,30 +5058,30 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 746, col: 1, offset: 17964},
+			pos:  position{line: 761, col: 1, offset: 18314},
 			expr: &actionExpr{
-				pos: position{line: 746, col: 13, offset: 17976},
+				pos: position{line: 761, col: 13, offset: 18326},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 746, col: 13, offset: 17976},
+					pos: position{line: 761, col: 13, offset: 18326},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 13, offset: 17976},
+							pos:  position{line: 761, col: 13, offset: 18326},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 15, offset: 17978},
+							pos:  position{line: 761, col: 15, offset: 18328},
 							name: "METHOD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 22, offset: 17985},
+							pos:  position{line: 761, col: 22, offset: 18335},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 746, col: 24, offset: 17987},
+							pos:   position{line: 761, col: 24, offset: 18337},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 746, col: 26, offset: 17989},
+								pos:  position{line: 761, col: 26, offset: 18339},
 								name: "Name",
 							},
 						},
@@ -5027,30 +5093,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 748, col: 1, offset: 18013},
+			pos:  position{line: 763, col: 1, offset: 18363},
 			expr: &actionExpr{
-				pos: position{line: 748, col: 14, offset: 18026},
+				pos: position{line: 763, col: 14, offset: 18376},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 748, col: 14, offset: 18026},
+					pos: position{line: 763, col: 14, offset: 18376},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 14, offset: 18026},
+							pos:  position{line: 763, col: 14, offset: 18376},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 16, offset: 18028},
+							pos:  position{line: 763, col: 16, offset: 18378},
 							name: "HEADERS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 24, offset: 18036},
+							pos:  position{line: 763, col: 24, offset: 18386},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 748, col: 26, offset: 18038},
+							pos:   position{line: 763, col: 26, offset: 18388},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 748, col: 28, offset: 18040},
+								pos:  position{line: 763, col: 28, offset: 18390},
 								name: "Record",
 							},
 						},
@@ -5062,30 +5128,30 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 750, col: 1, offset: 18066},
+			pos:  position{line: 765, col: 1, offset: 18416},
 			expr: &actionExpr{
-				pos: position{line: 750, col: 11, offset: 18076},
+				pos: position{line: 765, col: 11, offset: 18426},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 750, col: 11, offset: 18076},
+					pos: position{line: 765, col: 11, offset: 18426},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 750, col: 11, offset: 18076},
+							pos:  position{line: 765, col: 11, offset: 18426},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 750, col: 13, offset: 18078},
+							pos:  position{line: 765, col: 13, offset: 18428},
 							name: "BODY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 750, col: 18, offset: 18083},
+							pos:  position{line: 765, col: 18, offset: 18433},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 750, col: 20, offset: 18085},
+							pos:   position{line: 765, col: 20, offset: 18435},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 750, col: 22, offset: 18087},
+								pos:  position{line: 765, col: 22, offset: 18437},
 								name: "Name",
 							},
 						},
@@ -5097,24 +5163,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 752, col: 1, offset: 18111},
+			pos:  position{line: 767, col: 1, offset: 18461},
 			expr: &actionExpr{
-				pos: position{line: 752, col: 15, offset: 18125},
+				pos: position{line: 767, col: 15, offset: 18475},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 752, col: 15, offset: 18125},
+					pos: position{line: 767, col: 15, offset: 18475},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 752, col: 16, offset: 18126},
+							pos: position{line: 767, col: 16, offset: 18476},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 752, col: 16, offset: 18126},
+									pos:        position{line: 767, col: 16, offset: 18476},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 752, col: 28, offset: 18138},
+									pos:        position{line: 767, col: 28, offset: 18488},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
@@ -5122,9 +5188,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 752, col: 40, offset: 18150},
+							pos: position{line: 767, col: 40, offset: 18500},
 							expr: &ruleRefExpr{
-								pos:  position{line: 752, col: 40, offset: 18150},
+								pos:  position{line: 767, col: 40, offset: 18500},
 								name: "URLChar",
 							},
 						},
@@ -5136,9 +5202,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 754, col: 1, offset: 18191},
+			pos:  position{line: 769, col: 1, offset: 18541},
 			expr: &charClassMatcher{
-				pos:        position{line: 754, col: 11, offset: 18201},
+				pos:        position{line: 769, col: 11, offset: 18551},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -5150,30 +5216,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 757, col: 1, offset: 18265},
+			pos:  position{line: 772, col: 1, offset: 18615},
 			expr: &actionExpr{
-				pos: position{line: 758, col: 5, offset: 18276},
+				pos: position{line: 773, col: 5, offset: 18626},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 758, col: 5, offset: 18276},
+					pos: position{line: 773, col: 5, offset: 18626},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 758, col: 5, offset: 18276},
+							pos:  position{line: 773, col: 5, offset: 18626},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 758, col: 7, offset: 18278},
+							pos:  position{line: 773, col: 7, offset: 18628},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 758, col: 10, offset: 18281},
+							pos:  position{line: 773, col: 10, offset: 18631},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 758, col: 12, offset: 18283},
+							pos:   position{line: 773, col: 12, offset: 18633},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 758, col: 15, offset: 18286},
+								pos:  position{line: 773, col: 15, offset: 18636},
 								name: "KSUID",
 							},
 						},
@@ -5185,14 +5251,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 761, col: 1, offset: 18352},
+			pos:  position{line: 776, col: 1, offset: 18702},
 			expr: &actionExpr{
-				pos: position{line: 761, col: 9, offset: 18360},
+				pos: position{line: 776, col: 9, offset: 18710},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 761, col: 9, offset: 18360},
+					pos: position{line: 776, col: 9, offset: 18710},
 					expr: &charClassMatcher{
-						pos:        position{line: 761, col: 10, offset: 18361},
+						pos:        position{line: 776, col: 10, offset: 18711},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -5205,24 +5271,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 763, col: 1, offset: 18407},
+			pos:  position{line: 778, col: 1, offset: 18757},
 			expr: &actionExpr{
-				pos: position{line: 764, col: 5, offset: 18422},
+				pos: position{line: 779, col: 5, offset: 18772},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 764, col: 5, offset: 18422},
+					pos: position{line: 779, col: 5, offset: 18772},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 764, col: 5, offset: 18422},
+							pos:        position{line: 779, col: 5, offset: 18772},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 764, col: 9, offset: 18426},
+							pos:   position{line: 779, col: 9, offset: 18776},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 764, col: 11, offset: 18428},
+								pos:  position{line: 779, col: 11, offset: 18778},
 								name: "Name",
 							},
 						},
@@ -5234,24 +5300,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 766, col: 1, offset: 18452},
+			pos:  position{line: 781, col: 1, offset: 18802},
 			expr: &actionExpr{
-				pos: position{line: 767, col: 5, offset: 18465},
+				pos: position{line: 782, col: 5, offset: 18815},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 767, col: 5, offset: 18465},
+					pos: position{line: 782, col: 5, offset: 18815},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 767, col: 5, offset: 18465},
+							pos:        position{line: 782, col: 5, offset: 18815},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 767, col: 9, offset: 18469},
+							pos:   position{line: 782, col: 9, offset: 18819},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 767, col: 11, offset: 18471},
+								pos:  position{line: 782, col: 11, offset: 18821},
 								name: "Name",
 							},
 						},
@@ -5263,32 +5329,32 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 769, col: 1, offset: 18495},
+			pos:  position{line: 784, col: 1, offset: 18845},
 			expr: &choiceExpr{
-				pos: position{line: 770, col: 5, offset: 18506},
+				pos: position{line: 785, col: 5, offset: 18856},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 770, col: 5, offset: 18506},
+						pos: position{line: 785, col: 5, offset: 18856},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 770, col: 5, offset: 18506},
+							pos: position{line: 785, col: 5, offset: 18856},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 770, col: 5, offset: 18506},
+									pos:  position{line: 785, col: 5, offset: 18856},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 770, col: 7, offset: 18508},
+									pos:  position{line: 785, col: 7, offset: 18858},
 									name: "TAP",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 771, col: 5, offset: 18537},
+						pos: position{line: 786, col: 5, offset: 18887},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 771, col: 5, offset: 18537},
+							pos:        position{line: 786, col: 5, offset: 18887},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -5301,28 +5367,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 773, col: 1, offset: 18563},
+			pos:  position{line: 788, col: 1, offset: 18913},
 			expr: &actionExpr{
-				pos: position{line: 774, col: 5, offset: 18574},
+				pos: position{line: 789, col: 5, offset: 18924},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 774, col: 5, offset: 18574},
+					pos: position{line: 789, col: 5, offset: 18924},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 774, col: 5, offset: 18574},
+							pos:  position{line: 789, col: 5, offset: 18924},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 774, col: 10, offset: 18579},
+							pos: position{line: 789, col: 10, offset: 18929},
 							expr: &seqExpr{
-								pos: position{line: 774, col: 12, offset: 18581},
+								pos: position{line: 789, col: 12, offset: 18931},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 774, col: 12, offset: 18581},
+										pos:  position{line: 789, col: 12, offset: 18931},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 774, col: 15, offset: 18584},
+										pos:        position{line: 789, col: 15, offset: 18934},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5331,9 +5397,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 774, col: 20, offset: 18589},
+							pos: position{line: 789, col: 20, offset: 18939},
 							expr: &ruleRefExpr{
-								pos:  position{line: 774, col: 21, offset: 18590},
+								pos:  position{line: 789, col: 21, offset: 18940},
 								name: "EOKW",
 							},
 						},
@@ -5345,44 +5411,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 780, col: 1, offset: 18781},
+			pos:  position{line: 795, col: 1, offset: 19131},
 			expr: &actionExpr{
-				pos: position{line: 781, col: 5, offset: 18795},
+				pos: position{line: 796, col: 5, offset: 19145},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 781, col: 5, offset: 18795},
+					pos: position{line: 796, col: 5, offset: 19145},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 781, col: 5, offset: 18795},
+							pos:  position{line: 796, col: 5, offset: 19145},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 781, col: 13, offset: 18803},
+							pos:  position{line: 796, col: 13, offset: 19153},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 781, col: 15, offset: 18805},
+							pos:   position{line: 796, col: 15, offset: 19155},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 781, col: 20, offset: 18810},
+								pos:  position{line: 796, col: 20, offset: 19160},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 781, col: 26, offset: 18816},
+							pos:   position{line: 796, col: 26, offset: 19166},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 781, col: 30, offset: 18820},
+								pos:  position{line: 796, col: 30, offset: 19170},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 781, col: 38, offset: 18828},
+							pos:   position{line: 796, col: 38, offset: 19178},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 781, col: 41, offset: 18831},
+								pos: position{line: 796, col: 41, offset: 19181},
 								expr: &ruleRefExpr{
-									pos:  position{line: 781, col: 41, offset: 18831},
+									pos:  position{line: 796, col: 41, offset: 19181},
 									name: "AsArg",
 								},
 							},
@@ -5395,26 +5461,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 794, col: 1, offset: 19073},
+			pos:  position{line: 809, col: 1, offset: 19423},
 			expr: &actionExpr{
-				pos: position{line: 795, col: 5, offset: 19085},
+				pos: position{line: 810, col: 5, offset: 19435},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 795, col: 5, offset: 19085},
+					pos: position{line: 810, col: 5, offset: 19435},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 5, offset: 19085},
+							pos:  position{line: 810, col: 5, offset: 19435},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 11, offset: 19091},
+							pos:  position{line: 810, col: 11, offset: 19441},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 13, offset: 19093},
+							pos:   position{line: 810, col: 13, offset: 19443},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 18, offset: 19098},
+								pos:  position{line: 810, col: 18, offset: 19448},
 								name: "Expr",
 							},
 						},
@@ -5426,56 +5492,56 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 803, col: 1, offset: 19225},
+			pos:  position{line: 818, col: 1, offset: 19575},
 			expr: &actionExpr{
-				pos: position{line: 804, col: 5, offset: 19236},
+				pos: position{line: 819, col: 5, offset: 19586},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 804, col: 5, offset: 19236},
+					pos: position{line: 819, col: 5, offset: 19586},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 804, col: 6, offset: 19237},
+							pos: position{line: 819, col: 6, offset: 19587},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 804, col: 6, offset: 19237},
+									pos:  position{line: 819, col: 6, offset: 19587},
 									name: "OVER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 804, col: 13, offset: 19244},
+									pos:  position{line: 819, col: 13, offset: 19594},
 									name: "UNNEST",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 804, col: 21, offset: 19252},
+							pos:  position{line: 819, col: 21, offset: 19602},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 804, col: 23, offset: 19254},
+							pos:   position{line: 819, col: 23, offset: 19604},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 804, col: 29, offset: 19260},
+								pos:  position{line: 819, col: 29, offset: 19610},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 804, col: 35, offset: 19266},
+							pos:   position{line: 819, col: 35, offset: 19616},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 804, col: 42, offset: 19273},
+								pos: position{line: 819, col: 42, offset: 19623},
 								expr: &ruleRefExpr{
-									pos:  position{line: 804, col: 42, offset: 19273},
+									pos:  position{line: 819, col: 42, offset: 19623},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 804, col: 50, offset: 19281},
+							pos:   position{line: 819, col: 50, offset: 19631},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 804, col: 55, offset: 19286},
+								pos: position{line: 819, col: 55, offset: 19636},
 								expr: &ruleRefExpr{
-									pos:  position{line: 804, col: 55, offset: 19286},
+									pos:  position{line: 819, col: 55, offset: 19636},
 									name: "Lateral",
 								},
 							},
@@ -5488,54 +5554,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 819, col: 1, offset: 19611},
+			pos:  position{line: 834, col: 1, offset: 19961},
 			expr: &choiceExpr{
-				pos: position{line: 820, col: 5, offset: 19623},
+				pos: position{line: 835, col: 5, offset: 19973},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 820, col: 5, offset: 19623},
+						pos: position{line: 835, col: 5, offset: 19973},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 820, col: 5, offset: 19623},
+							pos: position{line: 835, col: 5, offset: 19973},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 5, offset: 19623},
+									pos:  position{line: 835, col: 5, offset: 19973},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 820, col: 8, offset: 19626},
+									pos:        position{line: 835, col: 8, offset: 19976},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 13, offset: 19631},
+									pos:  position{line: 835, col: 13, offset: 19981},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 820, col: 16, offset: 19634},
+									pos:        position{line: 835, col: 16, offset: 19984},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 20, offset: 19638},
+									pos:  position{line: 835, col: 20, offset: 19988},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 820, col: 23, offset: 19641},
+									pos:   position{line: 835, col: 23, offset: 19991},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 820, col: 29, offset: 19647},
+										pos:  position{line: 835, col: 29, offset: 19997},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 35, offset: 19653},
+									pos:  position{line: 835, col: 35, offset: 20003},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 820, col: 38, offset: 19656},
+									pos:        position{line: 835, col: 38, offset: 20006},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5544,49 +5610,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 823, col: 5, offset: 19737},
+						pos: position{line: 838, col: 5, offset: 20087},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 823, col: 5, offset: 19737},
+							pos: position{line: 838, col: 5, offset: 20087},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 823, col: 5, offset: 19737},
+									pos:  position{line: 838, col: 5, offset: 20087},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 823, col: 8, offset: 19740},
+									pos:        position{line: 838, col: 8, offset: 20090},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 823, col: 13, offset: 19745},
+									pos:  position{line: 838, col: 13, offset: 20095},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 823, col: 16, offset: 19748},
+									pos:        position{line: 838, col: 16, offset: 20098},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 823, col: 20, offset: 19752},
+									pos:  position{line: 838, col: 20, offset: 20102},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 823, col: 23, offset: 19755},
+									pos:   position{line: 838, col: 23, offset: 20105},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 823, col: 27, offset: 19759},
+										pos:  position{line: 838, col: 27, offset: 20109},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 823, col: 31, offset: 19763},
+									pos:  position{line: 838, col: 31, offset: 20113},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 823, col: 34, offset: 19766},
+									pos:        position{line: 838, col: 34, offset: 20116},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5601,63 +5667,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 827, col: 1, offset: 19822},
+			pos:  position{line: 842, col: 1, offset: 20172},
 			expr: &actionExpr{
-				pos: position{line: 828, col: 5, offset: 19833},
+				pos: position{line: 843, col: 5, offset: 20183},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 828, col: 5, offset: 19833},
+					pos: position{line: 843, col: 5, offset: 20183},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 828, col: 5, offset: 19833},
+							pos:  position{line: 843, col: 5, offset: 20183},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 828, col: 7, offset: 19835},
+							pos:  position{line: 843, col: 7, offset: 20185},
 							name: "WITH",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 828, col: 12, offset: 19840},
+							pos:  position{line: 843, col: 12, offset: 20190},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 828, col: 14, offset: 19842},
+							pos:   position{line: 843, col: 14, offset: 20192},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 828, col: 20, offset: 19848},
+								pos:  position{line: 843, col: 20, offset: 20198},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 828, col: 37, offset: 19865},
+							pos:   position{line: 843, col: 37, offset: 20215},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 828, col: 42, offset: 19870},
+								pos: position{line: 843, col: 42, offset: 20220},
 								expr: &actionExpr{
-									pos: position{line: 828, col: 43, offset: 19871},
+									pos: position{line: 843, col: 43, offset: 20221},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 828, col: 43, offset: 19871},
+										pos: position{line: 843, col: 43, offset: 20221},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 828, col: 43, offset: 19871},
+												pos:  position{line: 843, col: 43, offset: 20221},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 828, col: 46, offset: 19874},
+												pos:        position{line: 843, col: 46, offset: 20224},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 828, col: 50, offset: 19878},
+												pos:  position{line: 843, col: 50, offset: 20228},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 828, col: 53, offset: 19881},
+												pos:   position{line: 843, col: 53, offset: 20231},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 828, col: 55, offset: 19883},
+													pos:  position{line: 843, col: 55, offset: 20233},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5674,45 +5740,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 832, col: 1, offset: 19968},
+			pos:  position{line: 847, col: 1, offset: 20318},
 			expr: &actionExpr{
-				pos: position{line: 833, col: 5, offset: 19989},
+				pos: position{line: 848, col: 5, offset: 20339},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 833, col: 5, offset: 19989},
+					pos: position{line: 848, col: 5, offset: 20339},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 833, col: 5, offset: 19989},
+							pos:   position{line: 848, col: 5, offset: 20339},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 833, col: 10, offset: 19994},
+								pos:  position{line: 848, col: 10, offset: 20344},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 833, col: 21, offset: 20005},
+							pos:   position{line: 848, col: 21, offset: 20355},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 833, col: 25, offset: 20009},
+								pos: position{line: 848, col: 25, offset: 20359},
 								expr: &seqExpr{
-									pos: position{line: 833, col: 26, offset: 20010},
+									pos: position{line: 848, col: 26, offset: 20360},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 833, col: 26, offset: 20010},
+											pos:  position{line: 848, col: 26, offset: 20360},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 833, col: 29, offset: 20013},
+											pos:        position{line: 848, col: 29, offset: 20363},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 833, col: 33, offset: 20017},
+											pos:  position{line: 848, col: 33, offset: 20367},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 833, col: 36, offset: 20020},
+											pos:  position{line: 848, col: 36, offset: 20370},
 											name: "Expr",
 										},
 									},
@@ -5727,26 +5793,26 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 845, col: 1, offset: 20244},
+			pos:  position{line: 860, col: 1, offset: 20594},
 			expr: &actionExpr{
-				pos: position{line: 846, col: 5, offset: 20256},
+				pos: position{line: 861, col: 5, offset: 20606},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 846, col: 5, offset: 20256},
+					pos: position{line: 861, col: 5, offset: 20606},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 846, col: 5, offset: 20256},
+							pos:  position{line: 861, col: 5, offset: 20606},
 							name: "YIELD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 846, col: 11, offset: 20262},
+							pos:  position{line: 861, col: 11, offset: 20612},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 846, col: 13, offset: 20264},
+							pos:   position{line: 861, col: 13, offset: 20614},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 846, col: 19, offset: 20270},
+								pos:  position{line: 861, col: 19, offset: 20620},
 								name: "Exprs",
 							},
 						},
@@ -5758,30 +5824,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 854, col: 1, offset: 20414},
+			pos:  position{line: 869, col: 1, offset: 20764},
 			expr: &actionExpr{
-				pos: position{line: 855, col: 5, offset: 20426},
+				pos: position{line: 870, col: 5, offset: 20776},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 855, col: 5, offset: 20426},
+					pos: position{line: 870, col: 5, offset: 20776},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 855, col: 5, offset: 20426},
+							pos:  position{line: 870, col: 5, offset: 20776},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 855, col: 7, offset: 20428},
+							pos:  position{line: 870, col: 7, offset: 20778},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 855, col: 10, offset: 20431},
+							pos:  position{line: 870, col: 10, offset: 20781},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 12, offset: 20433},
+							pos:   position{line: 870, col: 12, offset: 20783},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 16, offset: 20437},
+								pos:  position{line: 870, col: 16, offset: 20787},
 								name: "Type",
 							},
 						},
@@ -5793,30 +5859,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 857, col: 1, offset: 20463},
+			pos:  position{line: 872, col: 1, offset: 20813},
 			expr: &actionExpr{
-				pos: position{line: 858, col: 5, offset: 20473},
+				pos: position{line: 873, col: 5, offset: 20823},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 858, col: 5, offset: 20473},
+					pos: position{line: 873, col: 5, offset: 20823},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 858, col: 5, offset: 20473},
+							pos:  position{line: 873, col: 5, offset: 20823},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 858, col: 7, offset: 20475},
+							pos:  position{line: 873, col: 7, offset: 20825},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 858, col: 10, offset: 20478},
+							pos:  position{line: 873, col: 10, offset: 20828},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 858, col: 12, offset: 20480},
+							pos:   position{line: 873, col: 12, offset: 20830},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 858, col: 16, offset: 20484},
+								pos:  position{line: 873, col: 16, offset: 20834},
 								name: "Lval",
 							},
 						},
@@ -5828,9 +5894,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 862, col: 1, offset: 20535},
+			pos:  position{line: 877, col: 1, offset: 20885},
 			expr: &ruleRefExpr{
-				pos:  position{line: 862, col: 8, offset: 20542},
+				pos:  position{line: 877, col: 8, offset: 20892},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5838,51 +5904,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 864, col: 1, offset: 20553},
+			pos:  position{line: 879, col: 1, offset: 20903},
 			expr: &actionExpr{
-				pos: position{line: 865, col: 5, offset: 20563},
+				pos: position{line: 880, col: 5, offset: 20913},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 865, col: 5, offset: 20563},
+					pos: position{line: 880, col: 5, offset: 20913},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 865, col: 5, offset: 20563},
+							pos:   position{line: 880, col: 5, offset: 20913},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 11, offset: 20569},
+								pos:  position{line: 880, col: 11, offset: 20919},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 865, col: 16, offset: 20574},
+							pos:   position{line: 880, col: 16, offset: 20924},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 865, col: 21, offset: 20579},
+								pos: position{line: 880, col: 21, offset: 20929},
 								expr: &actionExpr{
-									pos: position{line: 865, col: 22, offset: 20580},
+									pos: position{line: 880, col: 22, offset: 20930},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 865, col: 22, offset: 20580},
+										pos: position{line: 880, col: 22, offset: 20930},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 865, col: 22, offset: 20580},
+												pos:  position{line: 880, col: 22, offset: 20930},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 865, col: 25, offset: 20583},
+												pos:        position{line: 880, col: 25, offset: 20933},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 865, col: 29, offset: 20587},
+												pos:  position{line: 880, col: 29, offset: 20937},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 865, col: 32, offset: 20590},
+												pos:   position{line: 880, col: 32, offset: 20940},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 865, col: 37, offset: 20595},
+													pos:  position{line: 880, col: 37, offset: 20945},
 													name: "Lval",
 												},
 											},
@@ -5899,51 +5965,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 869, col: 1, offset: 20671},
+			pos:  position{line: 884, col: 1, offset: 21021},
 			expr: &actionExpr{
-				pos: position{line: 870, col: 5, offset: 20687},
+				pos: position{line: 885, col: 5, offset: 21037},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 870, col: 5, offset: 20687},
+					pos: position{line: 885, col: 5, offset: 21037},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 870, col: 5, offset: 20687},
+							pos:   position{line: 885, col: 5, offset: 21037},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 870, col: 11, offset: 20693},
+								pos:  position{line: 885, col: 11, offset: 21043},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 870, col: 22, offset: 20704},
+							pos:   position{line: 885, col: 22, offset: 21054},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 870, col: 27, offset: 20709},
+								pos: position{line: 885, col: 27, offset: 21059},
 								expr: &actionExpr{
-									pos: position{line: 870, col: 28, offset: 20710},
+									pos: position{line: 885, col: 28, offset: 21060},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 870, col: 28, offset: 20710},
+										pos: position{line: 885, col: 28, offset: 21060},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 870, col: 28, offset: 20710},
+												pos:  position{line: 885, col: 28, offset: 21060},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 870, col: 31, offset: 20713},
+												pos:        position{line: 885, col: 31, offset: 21063},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 870, col: 35, offset: 20717},
+												pos:  position{line: 885, col: 35, offset: 21067},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 870, col: 38, offset: 20720},
+												pos:   position{line: 885, col: 38, offset: 21070},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 870, col: 40, offset: 20722},
+													pos:  position{line: 885, col: 40, offset: 21072},
 													name: "Assignment",
 												},
 											},
@@ -5960,40 +6026,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 874, col: 1, offset: 20797},
+			pos:  position{line: 889, col: 1, offset: 21147},
 			expr: &actionExpr{
-				pos: position{line: 875, col: 5, offset: 20812},
+				pos: position{line: 890, col: 5, offset: 21162},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 875, col: 5, offset: 20812},
+					pos: position{line: 890, col: 5, offset: 21162},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 875, col: 5, offset: 20812},
+							pos:   position{line: 890, col: 5, offset: 21162},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 875, col: 9, offset: 20816},
+								pos:  position{line: 890, col: 9, offset: 21166},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 875, col: 14, offset: 20821},
+							pos:  position{line: 890, col: 14, offset: 21171},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 875, col: 17, offset: 20824},
+							pos:        position{line: 890, col: 17, offset: 21174},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 875, col: 22, offset: 20829},
+							pos:  position{line: 890, col: 22, offset: 21179},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 875, col: 25, offset: 20832},
+							pos:   position{line: 890, col: 25, offset: 21182},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 875, col: 29, offset: 20836},
+								pos:  position{line: 890, col: 29, offset: 21186},
 								name: "Expr",
 							},
 						},
@@ -6005,9 +6071,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 884, col: 1, offset: 21007},
+			pos:  position{line: 899, col: 1, offset: 21357},
 			expr: &ruleRefExpr{
-				pos:  position{line: 884, col: 8, offset: 21014},
+				pos:  position{line: 899, col: 8, offset: 21364},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -6015,63 +6081,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 886, col: 1, offset: 21031},
+			pos:  position{line: 901, col: 1, offset: 21381},
 			expr: &actionExpr{
-				pos: position{line: 887, col: 5, offset: 21051},
+				pos: position{line: 902, col: 5, offset: 21401},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 887, col: 5, offset: 21051},
+					pos: position{line: 902, col: 5, offset: 21401},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 887, col: 5, offset: 21051},
+							pos:   position{line: 902, col: 5, offset: 21401},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 887, col: 10, offset: 21056},
+								pos:  position{line: 902, col: 10, offset: 21406},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 887, col: 24, offset: 21070},
+							pos:   position{line: 902, col: 24, offset: 21420},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 887, col: 28, offset: 21074},
+								pos: position{line: 902, col: 28, offset: 21424},
 								expr: &seqExpr{
-									pos: position{line: 887, col: 29, offset: 21075},
+									pos: position{line: 902, col: 29, offset: 21425},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 887, col: 29, offset: 21075},
+											pos:  position{line: 902, col: 29, offset: 21425},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 887, col: 32, offset: 21078},
+											pos:        position{line: 902, col: 32, offset: 21428},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 887, col: 36, offset: 21082},
+											pos:  position{line: 902, col: 36, offset: 21432},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 887, col: 39, offset: 21085},
+											pos:  position{line: 902, col: 39, offset: 21435},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 887, col: 44, offset: 21090},
+											pos:  position{line: 902, col: 44, offset: 21440},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 887, col: 47, offset: 21093},
+											pos:        position{line: 902, col: 47, offset: 21443},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 887, col: 51, offset: 21097},
+											pos:  position{line: 902, col: 51, offset: 21447},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 887, col: 54, offset: 21100},
+											pos:  position{line: 902, col: 54, offset: 21450},
 											name: "Expr",
 										},
 									},
@@ -6086,53 +6152,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 901, col: 1, offset: 21421},
+			pos:  position{line: 916, col: 1, offset: 21771},
 			expr: &actionExpr{
-				pos: position{line: 902, col: 5, offset: 21439},
+				pos: position{line: 917, col: 5, offset: 21789},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 902, col: 5, offset: 21439},
+					pos: position{line: 917, col: 5, offset: 21789},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 902, col: 5, offset: 21439},
+							pos:   position{line: 917, col: 5, offset: 21789},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 902, col: 11, offset: 21445},
+								pos:  position{line: 917, col: 11, offset: 21795},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 903, col: 5, offset: 21464},
+							pos:   position{line: 918, col: 5, offset: 21814},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 903, col: 10, offset: 21469},
+								pos: position{line: 918, col: 10, offset: 21819},
 								expr: &actionExpr{
-									pos: position{line: 903, col: 11, offset: 21470},
+									pos: position{line: 918, col: 11, offset: 21820},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 903, col: 11, offset: 21470},
+										pos: position{line: 918, col: 11, offset: 21820},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 903, col: 11, offset: 21470},
+												pos:  position{line: 918, col: 11, offset: 21820},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 903, col: 14, offset: 21473},
+												pos:   position{line: 918, col: 14, offset: 21823},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 903, col: 17, offset: 21476},
+													pos:  position{line: 918, col: 17, offset: 21826},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 903, col: 20, offset: 21479},
+												pos:  position{line: 918, col: 20, offset: 21829},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 903, col: 23, offset: 21482},
+												pos:   position{line: 918, col: 23, offset: 21832},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 903, col: 28, offset: 21487},
+													pos:  position{line: 918, col: 28, offset: 21837},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6149,53 +6215,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 907, col: 1, offset: 21601},
+			pos:  position{line: 922, col: 1, offset: 21951},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 5, offset: 21620},
+				pos: position{line: 923, col: 5, offset: 21970},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 908, col: 5, offset: 21620},
+					pos: position{line: 923, col: 5, offset: 21970},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 908, col: 5, offset: 21620},
+							pos:   position{line: 923, col: 5, offset: 21970},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 908, col: 11, offset: 21626},
+								pos:  position{line: 923, col: 11, offset: 21976},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 5, offset: 21638},
+							pos:   position{line: 924, col: 5, offset: 21988},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 909, col: 10, offset: 21643},
+								pos: position{line: 924, col: 10, offset: 21993},
 								expr: &actionExpr{
-									pos: position{line: 909, col: 11, offset: 21644},
+									pos: position{line: 924, col: 11, offset: 21994},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 909, col: 11, offset: 21644},
+										pos: position{line: 924, col: 11, offset: 21994},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 909, col: 11, offset: 21644},
+												pos:  position{line: 924, col: 11, offset: 21994},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 909, col: 14, offset: 21647},
+												pos:   position{line: 924, col: 14, offset: 21997},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 909, col: 17, offset: 21650},
+													pos:  position{line: 924, col: 17, offset: 22000},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 909, col: 21, offset: 21654},
+												pos:  position{line: 924, col: 21, offset: 22004},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 909, col: 24, offset: 21657},
+												pos:   position{line: 924, col: 24, offset: 22007},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 909, col: 29, offset: 21662},
+													pos:  position{line: 924, col: 29, offset: 22012},
 													name: "NotExpr",
 												},
 											},
@@ -6212,43 +6278,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 913, col: 1, offset: 21769},
+			pos:  position{line: 928, col: 1, offset: 22119},
 			expr: &choiceExpr{
-				pos: position{line: 914, col: 5, offset: 21781},
+				pos: position{line: 929, col: 5, offset: 22131},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 914, col: 5, offset: 21781},
+						pos: position{line: 929, col: 5, offset: 22131},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 914, col: 5, offset: 21781},
+							pos: position{line: 929, col: 5, offset: 22131},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 914, col: 6, offset: 21782},
+									pos: position{line: 929, col: 6, offset: 22132},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 914, col: 6, offset: 21782},
+											pos: position{line: 929, col: 6, offset: 22132},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 914, col: 6, offset: 21782},
+													pos:  position{line: 929, col: 6, offset: 22132},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 914, col: 10, offset: 21786},
+													pos:  position{line: 929, col: 10, offset: 22136},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 914, col: 14, offset: 21790},
+											pos: position{line: 929, col: 14, offset: 22140},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 914, col: 14, offset: 21790},
+													pos:        position{line: 929, col: 14, offset: 22140},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 914, col: 18, offset: 21794},
+													pos:  position{line: 929, col: 18, offset: 22144},
 													name: "__",
 												},
 											},
@@ -6256,10 +6322,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 914, col: 22, offset: 21798},
+									pos:   position{line: 929, col: 22, offset: 22148},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 914, col: 24, offset: 21800},
+										pos:  position{line: 929, col: 24, offset: 22150},
 										name: "NotExpr",
 									},
 								},
@@ -6267,7 +6333,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 922, col: 5, offset: 21966},
+						pos:  position{line: 937, col: 5, offset: 22316},
 						name: "BetweenExpr",
 					},
 				},
@@ -6277,61 +6343,61 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 924, col: 1, offset: 21981},
+			pos:  position{line: 939, col: 1, offset: 22331},
 			expr: &choiceExpr{
-				pos: position{line: 925, col: 5, offset: 21997},
+				pos: position{line: 940, col: 5, offset: 22347},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 925, col: 5, offset: 21997},
+						pos: position{line: 940, col: 5, offset: 22347},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 925, col: 5, offset: 21997},
+							pos: position{line: 940, col: 5, offset: 22347},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 925, col: 5, offset: 21997},
+									pos:   position{line: 940, col: 5, offset: 22347},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 925, col: 10, offset: 22002},
+										pos:  position{line: 940, col: 10, offset: 22352},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 25, offset: 22017},
+									pos:  position{line: 940, col: 25, offset: 22367},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 27, offset: 22019},
+									pos:  position{line: 940, col: 27, offset: 22369},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 35, offset: 22027},
+									pos:  position{line: 940, col: 35, offset: 22377},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 925, col: 37, offset: 22029},
+									pos:   position{line: 940, col: 37, offset: 22379},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 925, col: 43, offset: 22035},
+										pos:  position{line: 940, col: 43, offset: 22385},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 55, offset: 22047},
+									pos:  position{line: 940, col: 55, offset: 22397},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 57, offset: 22049},
+									pos:  position{line: 940, col: 57, offset: 22399},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 61, offset: 22053},
+									pos:  position{line: 940, col: 61, offset: 22403},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 925, col: 63, offset: 22055},
+									pos:   position{line: 940, col: 63, offset: 22405},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 925, col: 69, offset: 22061},
+										pos:  position{line: 940, col: 69, offset: 22411},
 										name: "BetweenExpr",
 									},
 								},
@@ -6339,7 +6405,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 933, col: 5, offset: 22247},
+						pos:  position{line: 948, col: 5, offset: 22597},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6349,33 +6415,33 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 935, col: 1, offset: 22263},
+			pos:  position{line: 950, col: 1, offset: 22613},
 			expr: &choiceExpr{
-				pos: position{line: 936, col: 5, offset: 22282},
+				pos: position{line: 951, col: 5, offset: 22632},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 936, col: 5, offset: 22282},
+						pos: position{line: 951, col: 5, offset: 22632},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 936, col: 5, offset: 22282},
+							pos: position{line: 951, col: 5, offset: 22632},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 936, col: 5, offset: 22282},
+									pos:   position{line: 951, col: 5, offset: 22632},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 936, col: 9, offset: 22286},
+										pos:  position{line: 951, col: 9, offset: 22636},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 22, offset: 22299},
+									pos:  position{line: 951, col: 22, offset: 22649},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 936, col: 24, offset: 22301},
+									pos:   position{line: 951, col: 24, offset: 22651},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 936, col: 27, offset: 22304},
+										pos:  position{line: 951, col: 27, offset: 22654},
 										name: "IsNull",
 									},
 								},
@@ -6383,71 +6449,71 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 945, col: 5, offset: 22514},
+						pos: position{line: 960, col: 5, offset: 22864},
 						run: (*parser).callonComparisonExpr9,
 						expr: &seqExpr{
-							pos: position{line: 945, col: 5, offset: 22514},
+							pos: position{line: 960, col: 5, offset: 22864},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 945, col: 5, offset: 22514},
+									pos:   position{line: 960, col: 5, offset: 22864},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 945, col: 9, offset: 22518},
+										pos:  position{line: 960, col: 9, offset: 22868},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 945, col: 22, offset: 22531},
+									pos:   position{line: 960, col: 22, offset: 22881},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 945, col: 31, offset: 22540},
+										pos: position{line: 960, col: 31, offset: 22890},
 										expr: &choiceExpr{
-											pos: position{line: 945, col: 32, offset: 22541},
+											pos: position{line: 960, col: 32, offset: 22891},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 945, col: 32, offset: 22541},
+													pos: position{line: 960, col: 32, offset: 22891},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 945, col: 32, offset: 22541},
+															pos:  position{line: 960, col: 32, offset: 22891},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 945, col: 35, offset: 22544},
+															pos:  position{line: 960, col: 35, offset: 22894},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 945, col: 46, offset: 22555},
+															pos:  position{line: 960, col: 46, offset: 22905},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 945, col: 49, offset: 22558},
+															pos:  position{line: 960, col: 49, offset: 22908},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 945, col: 64, offset: 22573},
+													pos: position{line: 960, col: 64, offset: 22923},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 945, col: 64, offset: 22573},
+															pos:  position{line: 960, col: 64, offset: 22923},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 945, col: 68, offset: 22577},
+															pos: position{line: 960, col: 68, offset: 22927},
 															run: (*parser).callonComparisonExpr23,
 															expr: &litMatcher{
-																pos:        position{line: 945, col: 68, offset: 22577},
+																pos:        position{line: 960, col: 68, offset: 22927},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 945, col: 104, offset: 22613},
+															pos:  position{line: 960, col: 104, offset: 22963},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 945, col: 107, offset: 22616},
+															pos:  position{line: 960, col: 107, offset: 22966},
 															name: "Regexp",
 														},
 													},
@@ -6466,55 +6532,55 @@ var g = &grammar{
 		},
 		{
 			name: "IsNull",
-			pos:  position{line: 958, col: 2, offset: 22903},
+			pos:  position{line: 973, col: 2, offset: 23253},
 			expr: &choiceExpr{
-				pos: position{line: 959, col: 5, offset: 22914},
+				pos: position{line: 974, col: 5, offset: 23264},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 959, col: 5, offset: 22914},
+						pos: position{line: 974, col: 5, offset: 23264},
 						run: (*parser).callonIsNull2,
 						expr: &seqExpr{
-							pos: position{line: 959, col: 5, offset: 22914},
+							pos: position{line: 974, col: 5, offset: 23264},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 959, col: 5, offset: 22914},
+									pos:  position{line: 974, col: 5, offset: 23264},
 									name: "IS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 959, col: 8, offset: 22917},
+									pos:  position{line: 974, col: 8, offset: 23267},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 959, col: 10, offset: 22919},
+									pos:  position{line: 974, col: 10, offset: 23269},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 960, col: 5, offset: 22949},
+						pos: position{line: 975, col: 5, offset: 23299},
 						run: (*parser).callonIsNull7,
 						expr: &seqExpr{
-							pos: position{line: 960, col: 5, offset: 22949},
+							pos: position{line: 975, col: 5, offset: 23299},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 960, col: 5, offset: 22949},
+									pos:  position{line: 975, col: 5, offset: 23299},
 									name: "IS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 960, col: 8, offset: 22952},
+									pos:  position{line: 975, col: 8, offset: 23302},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 960, col: 10, offset: 22954},
+									pos:  position{line: 975, col: 10, offset: 23304},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 960, col: 14, offset: 22958},
+									pos:  position{line: 975, col: 14, offset: 23308},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 960, col: 16, offset: 22960},
+									pos:  position{line: 975, col: 16, offset: 23310},
 									name: "NULL",
 								},
 							},
@@ -6527,53 +6593,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 962, col: 1, offset: 22987},
+			pos:  position{line: 977, col: 1, offset: 23337},
 			expr: &actionExpr{
-				pos: position{line: 963, col: 5, offset: 23004},
+				pos: position{line: 978, col: 5, offset: 23354},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 963, col: 5, offset: 23004},
+					pos: position{line: 978, col: 5, offset: 23354},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 963, col: 5, offset: 23004},
+							pos:   position{line: 978, col: 5, offset: 23354},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 963, col: 11, offset: 23010},
+								pos:  position{line: 978, col: 11, offset: 23360},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 964, col: 5, offset: 23033},
+							pos:   position{line: 979, col: 5, offset: 23383},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 964, col: 10, offset: 23038},
+								pos: position{line: 979, col: 10, offset: 23388},
 								expr: &actionExpr{
-									pos: position{line: 964, col: 11, offset: 23039},
+									pos: position{line: 979, col: 11, offset: 23389},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 964, col: 11, offset: 23039},
+										pos: position{line: 979, col: 11, offset: 23389},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 964, col: 11, offset: 23039},
+												pos:  position{line: 979, col: 11, offset: 23389},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 964, col: 14, offset: 23042},
+												pos:   position{line: 979, col: 14, offset: 23392},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 964, col: 17, offset: 23045},
+													pos:  position{line: 979, col: 17, offset: 23395},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 964, col: 34, offset: 23062},
+												pos:  position{line: 979, col: 34, offset: 23412},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 964, col: 37, offset: 23065},
+												pos:   position{line: 979, col: 37, offset: 23415},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 964, col: 42, offset: 23070},
+													pos:  position{line: 979, col: 42, offset: 23420},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6590,21 +6656,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 968, col: 1, offset: 23188},
+			pos:  position{line: 983, col: 1, offset: 23538},
 			expr: &actionExpr{
-				pos: position{line: 968, col: 20, offset: 23207},
+				pos: position{line: 983, col: 20, offset: 23557},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 968, col: 21, offset: 23208},
+					pos: position{line: 983, col: 21, offset: 23558},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 968, col: 21, offset: 23208},
+							pos:        position{line: 983, col: 21, offset: 23558},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 968, col: 27, offset: 23214},
+							pos:        position{line: 983, col: 27, offset: 23564},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6617,53 +6683,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 970, col: 1, offset: 23251},
+			pos:  position{line: 985, col: 1, offset: 23601},
 			expr: &actionExpr{
-				pos: position{line: 971, col: 5, offset: 23274},
+				pos: position{line: 986, col: 5, offset: 23624},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 971, col: 5, offset: 23274},
+					pos: position{line: 986, col: 5, offset: 23624},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 971, col: 5, offset: 23274},
+							pos:   position{line: 986, col: 5, offset: 23624},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 971, col: 11, offset: 23280},
+								pos:  position{line: 986, col: 11, offset: 23630},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 972, col: 5, offset: 23295},
+							pos:   position{line: 987, col: 5, offset: 23645},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 972, col: 10, offset: 23300},
+								pos: position{line: 987, col: 10, offset: 23650},
 								expr: &actionExpr{
-									pos: position{line: 972, col: 11, offset: 23301},
+									pos: position{line: 987, col: 11, offset: 23651},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 972, col: 11, offset: 23301},
+										pos: position{line: 987, col: 11, offset: 23651},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 972, col: 11, offset: 23301},
+												pos:  position{line: 987, col: 11, offset: 23651},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 972, col: 14, offset: 23304},
+												pos:   position{line: 987, col: 14, offset: 23654},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 972, col: 17, offset: 23307},
+													pos:  position{line: 987, col: 17, offset: 23657},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 972, col: 40, offset: 23330},
+												pos:  position{line: 987, col: 40, offset: 23680},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 972, col: 43, offset: 23333},
+												pos:   position{line: 987, col: 43, offset: 23683},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 972, col: 48, offset: 23338},
+													pos:  position{line: 987, col: 48, offset: 23688},
 													name: "ConcatExpr",
 												},
 											},
@@ -6680,27 +6746,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 976, col: 1, offset: 23448},
+			pos:  position{line: 991, col: 1, offset: 23798},
 			expr: &actionExpr{
-				pos: position{line: 976, col: 26, offset: 23473},
+				pos: position{line: 991, col: 26, offset: 23823},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 976, col: 27, offset: 23474},
+					pos: position{line: 991, col: 27, offset: 23824},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 976, col: 27, offset: 23474},
+							pos:        position{line: 991, col: 27, offset: 23824},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 976, col: 33, offset: 23480},
+							pos:        position{line: 991, col: 33, offset: 23830},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 976, col: 39, offset: 23486},
+							pos:        position{line: 991, col: 39, offset: 23836},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6713,51 +6779,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 978, col: 1, offset: 23523},
+			pos:  position{line: 993, col: 1, offset: 23873},
 			expr: &actionExpr{
-				pos: position{line: 979, col: 5, offset: 23539},
+				pos: position{line: 994, col: 5, offset: 23889},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 979, col: 5, offset: 23539},
+					pos: position{line: 994, col: 5, offset: 23889},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 979, col: 5, offset: 23539},
+							pos:   position{line: 994, col: 5, offset: 23889},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 979, col: 11, offset: 23545},
+								pos:  position{line: 994, col: 11, offset: 23895},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 980, col: 5, offset: 23566},
+							pos:   position{line: 995, col: 5, offset: 23916},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 980, col: 10, offset: 23571},
+								pos: position{line: 995, col: 10, offset: 23921},
 								expr: &actionExpr{
-									pos: position{line: 980, col: 11, offset: 23572},
+									pos: position{line: 995, col: 11, offset: 23922},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 980, col: 11, offset: 23572},
+										pos: position{line: 995, col: 11, offset: 23922},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 980, col: 11, offset: 23572},
+												pos:  position{line: 995, col: 11, offset: 23922},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 980, col: 14, offset: 23575},
+												pos:        position{line: 995, col: 14, offset: 23925},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 980, col: 19, offset: 23580},
+												pos:  position{line: 995, col: 19, offset: 23930},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 980, col: 22, offset: 23583},
+												pos:   position{line: 995, col: 22, offset: 23933},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 980, col: 27, offset: 23588},
+													pos:  position{line: 995, col: 27, offset: 23938},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6774,40 +6840,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 984, col: 1, offset: 23706},
+			pos:  position{line: 999, col: 1, offset: 24056},
 			expr: &choiceExpr{
-				pos: position{line: 985, col: 5, offset: 23727},
+				pos: position{line: 1000, col: 5, offset: 24077},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 985, col: 5, offset: 23727},
+						pos: position{line: 1000, col: 5, offset: 24077},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 985, col: 5, offset: 23727},
+							pos: position{line: 1000, col: 5, offset: 24077},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 985, col: 5, offset: 23727},
+									pos: position{line: 1000, col: 5, offset: 24077},
 									expr: &ruleRefExpr{
-										pos:  position{line: 985, col: 6, offset: 23728},
+										pos:  position{line: 1000, col: 6, offset: 24078},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 985, col: 14, offset: 23736},
+									pos:   position{line: 1000, col: 14, offset: 24086},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 985, col: 17, offset: 23739},
+										pos:  position{line: 1000, col: 17, offset: 24089},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 985, col: 31, offset: 23753},
+									pos:  position{line: 1000, col: 31, offset: 24103},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 985, col: 34, offset: 23756},
+									pos:   position{line: 1000, col: 34, offset: 24106},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 985, col: 36, offset: 23758},
+										pos:  position{line: 1000, col: 36, offset: 24108},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6815,7 +6881,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 994, col: 5, offset: 23942},
+						pos:  position{line: 1009, col: 5, offset: 24292},
 						name: "DerefExpr",
 					},
 				},
@@ -6825,21 +6891,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 996, col: 1, offset: 23953},
+			pos:  position{line: 1011, col: 1, offset: 24303},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 17, offset: 23969},
+				pos: position{line: 1011, col: 17, offset: 24319},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 996, col: 18, offset: 23970},
+					pos: position{line: 1011, col: 18, offset: 24320},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 996, col: 18, offset: 23970},
+							pos:        position{line: 1011, col: 18, offset: 24320},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 996, col: 24, offset: 23976},
+							pos:        position{line: 1011, col: 24, offset: 24326},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6852,73 +6918,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 998, col: 1, offset: 24013},
+			pos:  position{line: 1013, col: 1, offset: 24363},
 			expr: &choiceExpr{
-				pos: position{line: 999, col: 5, offset: 24027},
+				pos: position{line: 1014, col: 5, offset: 24377},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 999, col: 5, offset: 24027},
+						pos: position{line: 1014, col: 5, offset: 24377},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 999, col: 5, offset: 24027},
+							pos: position{line: 1014, col: 5, offset: 24377},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 999, col: 5, offset: 24027},
+									pos:   position{line: 1014, col: 5, offset: 24377},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 999, col: 10, offset: 24032},
+										pos:  position{line: 1014, col: 10, offset: 24382},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 999, col: 20, offset: 24042},
+									pos:        position{line: 1014, col: 20, offset: 24392},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 999, col: 24, offset: 24046},
+									pos:  position{line: 1014, col: 24, offset: 24396},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 999, col: 27, offset: 24049},
+									pos:   position{line: 1014, col: 27, offset: 24399},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 999, col: 32, offset: 24054},
+										pos:  position{line: 1014, col: 32, offset: 24404},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 999, col: 45, offset: 24067},
+									pos:  position{line: 1014, col: 45, offset: 24417},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 999, col: 48, offset: 24070},
+									pos:        position{line: 1014, col: 48, offset: 24420},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 999, col: 52, offset: 24074},
+									pos:  position{line: 1014, col: 52, offset: 24424},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 999, col: 55, offset: 24077},
+									pos:   position{line: 1014, col: 55, offset: 24427},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 999, col: 58, offset: 24080},
+										pos: position{line: 1014, col: 58, offset: 24430},
 										expr: &ruleRefExpr{
-											pos:  position{line: 999, col: 58, offset: 24080},
+											pos:  position{line: 1014, col: 58, offset: 24430},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 999, col: 72, offset: 24094},
+									pos:  position{line: 1014, col: 72, offset: 24444},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 999, col: 75, offset: 24097},
+									pos:        position{line: 1014, col: 75, offset: 24447},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6927,49 +6993,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1011, col: 5, offset: 24336},
+						pos: position{line: 1026, col: 5, offset: 24686},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1011, col: 5, offset: 24336},
+							pos: position{line: 1026, col: 5, offset: 24686},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1011, col: 5, offset: 24336},
+									pos:   position{line: 1026, col: 5, offset: 24686},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1011, col: 10, offset: 24341},
+										pos:  position{line: 1026, col: 10, offset: 24691},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1011, col: 20, offset: 24351},
+									pos:        position{line: 1026, col: 20, offset: 24701},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1011, col: 24, offset: 24355},
+									pos:  position{line: 1026, col: 24, offset: 24705},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1011, col: 27, offset: 24358},
+									pos:        position{line: 1026, col: 27, offset: 24708},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1011, col: 31, offset: 24362},
+									pos:  position{line: 1026, col: 31, offset: 24712},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1011, col: 34, offset: 24365},
+									pos:   position{line: 1026, col: 34, offset: 24715},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1011, col: 37, offset: 24368},
+										pos:  position{line: 1026, col: 37, offset: 24718},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1011, col: 50, offset: 24381},
+									pos:        position{line: 1026, col: 50, offset: 24731},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6978,35 +7044,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 24545},
+						pos: position{line: 1034, col: 5, offset: 24895},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1019, col: 5, offset: 24545},
+							pos: position{line: 1034, col: 5, offset: 24895},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1019, col: 5, offset: 24545},
+									pos:   position{line: 1034, col: 5, offset: 24895},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 10, offset: 24550},
+										pos:  position{line: 1034, col: 10, offset: 24900},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 20, offset: 24560},
+									pos:        position{line: 1034, col: 20, offset: 24910},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1019, col: 24, offset: 24564},
+									pos:   position{line: 1034, col: 24, offset: 24914},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 30, offset: 24570},
+										pos:  position{line: 1034, col: 30, offset: 24920},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 35, offset: 24575},
+									pos:        position{line: 1034, col: 35, offset: 24925},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7015,30 +7081,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1027, col: 5, offset: 24745},
+						pos: position{line: 1042, col: 5, offset: 25095},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1027, col: 5, offset: 24745},
+							pos: position{line: 1042, col: 5, offset: 25095},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1027, col: 5, offset: 24745},
+									pos:   position{line: 1042, col: 5, offset: 25095},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 10, offset: 24750},
+										pos:  position{line: 1042, col: 10, offset: 25100},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 20, offset: 24760},
+									pos:        position{line: 1042, col: 20, offset: 25110},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 24, offset: 24764},
+									pos:   position{line: 1042, col: 24, offset: 25114},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 27, offset: 24767},
+										pos:  position{line: 1042, col: 27, offset: 25117},
 										name: "Identifier",
 									},
 								},
@@ -7046,11 +7112,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1036, col: 5, offset: 24957},
+						pos:  position{line: 1051, col: 5, offset: 25307},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1037, col: 5, offset: 24970},
+						pos:  position{line: 1052, col: 5, offset: 25320},
 						name: "Primary",
 					},
 				},
@@ -7060,16 +7126,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 1039, col: 1, offset: 24979},
+			pos:  position{line: 1054, col: 1, offset: 25329},
 			expr: &choiceExpr{
-				pos: position{line: 1040, col: 5, offset: 24992},
+				pos: position{line: 1055, col: 5, offset: 25342},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1040, col: 5, offset: 24992},
+						pos:  position{line: 1055, col: 5, offset: 25342},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1041, col: 5, offset: 25001},
+						pos:  position{line: 1056, col: 5, offset: 25351},
 						name: "Function",
 					},
 				},
@@ -7079,20 +7145,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1043, col: 1, offset: 25011},
+			pos:  position{line: 1058, col: 1, offset: 25361},
 			expr: &seqExpr{
-				pos: position{line: 1043, col: 13, offset: 25023},
+				pos: position{line: 1058, col: 13, offset: 25373},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1043, col: 13, offset: 25023},
+						pos:  position{line: 1058, col: 13, offset: 25373},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1043, col: 22, offset: 25032},
+						pos:  position{line: 1058, col: 22, offset: 25382},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1043, col: 25, offset: 25035},
+						pos:        position{line: 1058, col: 25, offset: 25385},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -7104,16 +7170,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1045, col: 1, offset: 25040},
+			pos:  position{line: 1060, col: 1, offset: 25390},
 			expr: &choiceExpr{
-				pos: position{line: 1046, col: 5, offset: 25053},
+				pos: position{line: 1061, col: 5, offset: 25403},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1046, col: 5, offset: 25053},
+						pos:  position{line: 1061, col: 5, offset: 25403},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 5, offset: 25061},
+						pos:  position{line: 1062, col: 5, offset: 25411},
 						name: "SELECT",
 					},
 				},
@@ -7123,58 +7189,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1049, col: 1, offset: 25069},
+			pos:  position{line: 1064, col: 1, offset: 25419},
 			expr: &actionExpr{
-				pos: position{line: 1050, col: 5, offset: 25078},
+				pos: position{line: 1065, col: 5, offset: 25428},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1050, col: 5, offset: 25078},
+					pos: position{line: 1065, col: 5, offset: 25428},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1050, col: 5, offset: 25078},
+							pos:   position{line: 1065, col: 5, offset: 25428},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1050, col: 9, offset: 25082},
+								pos:  position{line: 1065, col: 9, offset: 25432},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1050, col: 21, offset: 25094},
+							pos:  position{line: 1065, col: 21, offset: 25444},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1050, col: 24, offset: 25097},
+							pos:        position{line: 1065, col: 24, offset: 25447},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1050, col: 28, offset: 25101},
+							pos:  position{line: 1065, col: 28, offset: 25451},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1050, col: 31, offset: 25104},
+							pos:   position{line: 1065, col: 31, offset: 25454},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1050, col: 37, offset: 25110},
+								pos: position{line: 1065, col: 37, offset: 25460},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1050, col: 37, offset: 25110},
+										pos:  position{line: 1065, col: 37, offset: 25460},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1050, col: 48, offset: 25121},
+										pos:  position{line: 1065, col: 48, offset: 25471},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1050, col: 54, offset: 25127},
+							pos:  position{line: 1065, col: 54, offset: 25477},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1050, col: 57, offset: 25130},
+							pos:        position{line: 1065, col: 57, offset: 25480},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7187,85 +7253,85 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1054, col: 1, offset: 25243},
+			pos:  position{line: 1069, col: 1, offset: 25593},
 			expr: &choiceExpr{
-				pos: position{line: 1055, col: 5, offset: 25256},
+				pos: position{line: 1070, col: 5, offset: 25606},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1055, col: 5, offset: 25256},
+						pos:  position{line: 1070, col: 5, offset: 25606},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 25343},
+						pos: position{line: 1072, col: 5, offset: 25693},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 25343},
+							pos: position{line: 1072, col: 5, offset: 25693},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 5, offset: 25343},
+									pos:  position{line: 1072, col: 5, offset: 25693},
 									name: "REGEXP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 12, offset: 25350},
+									pos:  position{line: 1072, col: 12, offset: 25700},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 15, offset: 25353},
+									pos:        position{line: 1072, col: 15, offset: 25703},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 19, offset: 25357},
+									pos:  position{line: 1072, col: 19, offset: 25707},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 22, offset: 25360},
+									pos:   position{line: 1072, col: 22, offset: 25710},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1057, col: 27, offset: 25365},
+										pos:  position{line: 1072, col: 27, offset: 25715},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 43, offset: 25381},
+									pos:  position{line: 1072, col: 43, offset: 25731},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 46, offset: 25384},
+									pos:        position{line: 1072, col: 46, offset: 25734},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 50, offset: 25388},
+									pos:  position{line: 1072, col: 50, offset: 25738},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 53, offset: 25391},
+									pos:   position{line: 1072, col: 53, offset: 25741},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1057, col: 58, offset: 25396},
+										pos:  position{line: 1072, col: 58, offset: 25746},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 63, offset: 25401},
+									pos:  position{line: 1072, col: 63, offset: 25751},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 66, offset: 25404},
+									pos:        position{line: 1072, col: 66, offset: 25754},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 70, offset: 25408},
+									pos:   position{line: 1072, col: 70, offset: 25758},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1057, col: 76, offset: 25414},
+										pos: position{line: 1072, col: 76, offset: 25764},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1057, col: 76, offset: 25414},
+											pos:  position{line: 1072, col: 76, offset: 25764},
 											name: "WhereClause",
 										},
 									},
@@ -7274,98 +7340,98 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1061, col: 5, offset: 25593},
+						pos: position{line: 1076, col: 5, offset: 25943},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1061, col: 5, offset: 25593},
+							pos: position{line: 1076, col: 5, offset: 25943},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 5, offset: 25593},
+									pos:  position{line: 1076, col: 5, offset: 25943},
 									name: "REGEXP_REPLACE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 20, offset: 25608},
+									pos:  position{line: 1076, col: 20, offset: 25958},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 23, offset: 25611},
+									pos:        position{line: 1076, col: 23, offset: 25961},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 27, offset: 25615},
+									pos:  position{line: 1076, col: 27, offset: 25965},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 30, offset: 25618},
+									pos:   position{line: 1076, col: 30, offset: 25968},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1061, col: 35, offset: 25623},
+										pos:  position{line: 1076, col: 35, offset: 25973},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 40, offset: 25628},
+									pos:  position{line: 1076, col: 40, offset: 25978},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 43, offset: 25631},
+									pos:        position{line: 1076, col: 43, offset: 25981},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 47, offset: 25635},
+									pos:  position{line: 1076, col: 47, offset: 25985},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 50, offset: 25638},
+									pos:   position{line: 1076, col: 50, offset: 25988},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1061, col: 55, offset: 25643},
+										pos:  position{line: 1076, col: 55, offset: 25993},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 71, offset: 25659},
+									pos:  position{line: 1076, col: 71, offset: 26009},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 74, offset: 25662},
+									pos:        position{line: 1076, col: 74, offset: 26012},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 78, offset: 25666},
+									pos:  position{line: 1076, col: 78, offset: 26016},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 81, offset: 25669},
+									pos:   position{line: 1076, col: 81, offset: 26019},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1061, col: 86, offset: 25674},
+										pos:  position{line: 1076, col: 86, offset: 26024},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 91, offset: 25679},
+									pos:  position{line: 1076, col: 91, offset: 26029},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 94, offset: 25682},
+									pos:        position{line: 1076, col: 94, offset: 26032},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 98, offset: 25686},
+									pos:   position{line: 1076, col: 98, offset: 26036},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1061, col: 104, offset: 25692},
+										pos: position{line: 1076, col: 104, offset: 26042},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1061, col: 104, offset: 25692},
+											pos:  position{line: 1076, col: 104, offset: 26042},
 											name: "WhereClause",
 										},
 									},
@@ -7374,71 +7440,75 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 5, offset: 25886},
+						pos: position{line: 1080, col: 5, offset: 26236},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1065, col: 5, offset: 25886},
+							pos: position{line: 1080, col: 5, offset: 26236},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1065, col: 5, offset: 25886},
+									pos: position{line: 1080, col: 5, offset: 26236},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 6, offset: 25887},
+										pos:  position{line: 1080, col: 6, offset: 26237},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 16, offset: 25897},
+									pos:   position{line: 1080, col: 16, offset: 26247},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 19, offset: 25900},
+										pos:  position{line: 1080, col: 19, offset: 26250},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 30, offset: 25911},
+									pos:  position{line: 1080, col: 30, offset: 26261},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1065, col: 33, offset: 25914},
+									pos:        position{line: 1080, col: 33, offset: 26264},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 37, offset: 25918},
+									pos:  position{line: 1080, col: 37, offset: 26268},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 40, offset: 25921},
+									pos:   position{line: 1080, col: 40, offset: 26271},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 45, offset: 25926},
+										pos:  position{line: 1080, col: 45, offset: 26276},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 58, offset: 25939},
+									pos:  position{line: 1080, col: 58, offset: 26289},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1065, col: 61, offset: 25942},
+									pos:        position{line: 1080, col: 61, offset: 26292},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 65, offset: 25946},
+									pos:   position{line: 1080, col: 65, offset: 26296},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1065, col: 71, offset: 25952},
+										pos: position{line: 1080, col: 71, offset: 26302},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1065, col: 71, offset: 25952},
+											pos:  position{line: 1080, col: 71, offset: 26302},
 											name: "WhereClause",
 										},
 									},
 								},
 							},
 						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1083, col: 5, offset: 26373},
+						name: "CountStar",
 					},
 				},
 			},
@@ -7447,15 +7517,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1069, col: 1, offset: 26020},
+			pos:  position{line: 1085, col: 1, offset: 26384},
 			expr: &actionExpr{
-				pos: position{line: 1070, col: 5, offset: 26040},
+				pos: position{line: 1086, col: 5, offset: 26404},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1070, col: 5, offset: 26040},
+					pos:   position{line: 1086, col: 5, offset: 26404},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1070, col: 9, offset: 26044},
+						pos:  position{line: 1086, col: 9, offset: 26408},
 						name: "RegexpPattern",
 					},
 				},
@@ -7465,24 +7535,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1072, col: 1, offset: 26115},
+			pos:  position{line: 1088, col: 1, offset: 26479},
 			expr: &choiceExpr{
-				pos: position{line: 1073, col: 5, offset: 26132},
+				pos: position{line: 1089, col: 5, offset: 26496},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1073, col: 5, offset: 26132},
+						pos: position{line: 1089, col: 5, offset: 26496},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1073, col: 5, offset: 26132},
+							pos:   position{line: 1089, col: 5, offset: 26496},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1073, col: 7, offset: 26134},
+								pos:  position{line: 1089, col: 7, offset: 26498},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1074, col: 5, offset: 26172},
+						pos:  position{line: 1090, col: 5, offset: 26536},
 						name: "OptionalExprs",
 					},
 				},
@@ -7492,96 +7562,96 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1076, col: 1, offset: 26187},
+			pos:  position{line: 1092, col: 1, offset: 26551},
 			expr: &actionExpr{
-				pos: position{line: 1077, col: 5, offset: 26196},
+				pos: position{line: 1093, col: 5, offset: 26560},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1077, col: 5, offset: 26196},
+					pos: position{line: 1093, col: 5, offset: 26560},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1077, col: 5, offset: 26196},
+							pos:  position{line: 1093, col: 5, offset: 26560},
 							name: "GREP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1077, col: 10, offset: 26201},
+							pos:  position{line: 1093, col: 10, offset: 26565},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1077, col: 13, offset: 26204},
+							pos:        position{line: 1093, col: 13, offset: 26568},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1077, col: 17, offset: 26208},
+							pos:  position{line: 1093, col: 17, offset: 26572},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1077, col: 20, offset: 26211},
+							pos:   position{line: 1093, col: 20, offset: 26575},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1077, col: 29, offset: 26220},
+								pos: position{line: 1093, col: 29, offset: 26584},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1077, col: 29, offset: 26220},
+										pos:  position{line: 1093, col: 29, offset: 26584},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1077, col: 38, offset: 26229},
+										pos:  position{line: 1093, col: 38, offset: 26593},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1077, col: 45, offset: 26236},
+										pos:  position{line: 1093, col: 45, offset: 26600},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1077, col: 51, offset: 26242},
+							pos:  position{line: 1093, col: 51, offset: 26606},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1077, col: 54, offset: 26245},
+							pos:   position{line: 1093, col: 54, offset: 26609},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1077, col: 58, offset: 26249},
+								pos: position{line: 1093, col: 58, offset: 26613},
 								expr: &actionExpr{
-									pos: position{line: 1077, col: 59, offset: 26250},
+									pos: position{line: 1093, col: 59, offset: 26614},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1077, col: 59, offset: 26250},
+										pos: position{line: 1093, col: 59, offset: 26614},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1077, col: 59, offset: 26250},
+												pos:        position{line: 1093, col: 59, offset: 26614},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1077, col: 63, offset: 26254},
+												pos:  position{line: 1093, col: 63, offset: 26618},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1077, col: 66, offset: 26257},
+												pos:   position{line: 1093, col: 66, offset: 26621},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1077, col: 69, offset: 26260},
+													pos: position{line: 1093, col: 69, offset: 26624},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1077, col: 69, offset: 26260},
+															pos:  position{line: 1093, col: 69, offset: 26624},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1077, col: 80, offset: 26271},
+															pos:  position{line: 1093, col: 80, offset: 26635},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1077, col: 86, offset: 26277},
+												pos:  position{line: 1093, col: 86, offset: 26641},
 												name: "__",
 											},
 										},
@@ -7590,7 +7660,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1077, col: 109, offset: 26300},
+							pos:        position{line: 1093, col: 109, offset: 26664},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7603,19 +7673,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1089, col: 1, offset: 26513},
+			pos:  position{line: 1105, col: 1, offset: 26877},
 			expr: &choiceExpr{
-				pos: position{line: 1090, col: 5, offset: 26531},
+				pos: position{line: 1106, col: 5, offset: 26895},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1090, col: 5, offset: 26531},
+						pos:  position{line: 1106, col: 5, offset: 26895},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1091, col: 5, offset: 26541},
+						pos: position{line: 1107, col: 5, offset: 26905},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1091, col: 5, offset: 26541},
+							pos:  position{line: 1107, col: 5, offset: 26905},
 							name: "__",
 						},
 					},
@@ -7626,51 +7696,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1093, col: 1, offset: 26569},
+			pos:  position{line: 1109, col: 1, offset: 26933},
 			expr: &actionExpr{
-				pos: position{line: 1094, col: 5, offset: 26579},
+				pos: position{line: 1110, col: 5, offset: 26943},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1094, col: 5, offset: 26579},
+					pos: position{line: 1110, col: 5, offset: 26943},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1094, col: 5, offset: 26579},
+							pos:   position{line: 1110, col: 5, offset: 26943},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1094, col: 11, offset: 26585},
+								pos:  position{line: 1110, col: 11, offset: 26949},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1094, col: 16, offset: 26590},
+							pos:   position{line: 1110, col: 16, offset: 26954},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1094, col: 21, offset: 26595},
+								pos: position{line: 1110, col: 21, offset: 26959},
 								expr: &actionExpr{
-									pos: position{line: 1094, col: 22, offset: 26596},
+									pos: position{line: 1110, col: 22, offset: 26960},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1094, col: 22, offset: 26596},
+										pos: position{line: 1110, col: 22, offset: 26960},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1094, col: 22, offset: 26596},
+												pos:  position{line: 1110, col: 22, offset: 26960},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1094, col: 25, offset: 26599},
+												pos:        position{line: 1110, col: 25, offset: 26963},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1094, col: 29, offset: 26603},
+												pos:  position{line: 1110, col: 29, offset: 26967},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1094, col: 32, offset: 26606},
+												pos:   position{line: 1110, col: 32, offset: 26970},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1094, col: 34, offset: 26608},
+													pos:  position{line: 1110, col: 34, offset: 26972},
 													name: "Expr",
 												},
 											},
@@ -7687,52 +7757,52 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1098, col: 1, offset: 26681},
+			pos:  position{line: 1114, col: 1, offset: 27045},
 			expr: &choiceExpr{
-				pos: position{line: 1099, col: 5, offset: 26693},
+				pos: position{line: 1115, col: 5, offset: 27057},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1099, col: 5, offset: 26693},
+						pos:  position{line: 1115, col: 5, offset: 27057},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 26706},
+						pos:  position{line: 1116, col: 5, offset: 27070},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1101, col: 5, offset: 26717},
+						pos:  position{line: 1117, col: 5, offset: 27081},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1102, col: 5, offset: 26727},
+						pos:  position{line: 1118, col: 5, offset: 27091},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1103, col: 5, offset: 26735},
+						pos:  position{line: 1119, col: 5, offset: 27099},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1104, col: 5, offset: 26743},
+						pos:  position{line: 1120, col: 5, offset: 27107},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1105, col: 5, offset: 26755},
+						pos: position{line: 1121, col: 5, offset: 27119},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1105, col: 5, offset: 26755},
+							pos: position{line: 1121, col: 5, offset: 27119},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1105, col: 5, offset: 26755},
+									pos: position{line: 1121, col: 5, offset: 27119},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 6, offset: 26756},
+										pos:  position{line: 1121, col: 6, offset: 27120},
 										name: "PipeKeyword",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1105, col: 18, offset: 26768},
+									pos:   position{line: 1121, col: 18, offset: 27132},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 21, offset: 26771},
+										pos:  position{line: 1121, col: 21, offset: 27135},
 										name: "Identifier",
 									},
 								},
@@ -7740,39 +7810,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1106, col: 5, offset: 26805},
+						pos:  position{line: 1122, col: 5, offset: 27169},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1107, col: 5, offset: 26815},
+						pos: position{line: 1123, col: 5, offset: 27179},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 1107, col: 5, offset: 26815},
+							pos: position{line: 1123, col: 5, offset: 27179},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1107, col: 5, offset: 26815},
+									pos:        position{line: 1123, col: 5, offset: 27179},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1107, col: 9, offset: 26819},
+									pos:  position{line: 1123, col: 9, offset: 27183},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1107, col: 12, offset: 26822},
+									pos:   position{line: 1123, col: 12, offset: 27186},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1107, col: 17, offset: 26827},
+										pos:  position{line: 1123, col: 17, offset: 27191},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1107, col: 26, offset: 26836},
+									pos:  position{line: 1123, col: 26, offset: 27200},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1107, col: 29, offset: 26839},
+									pos:        position{line: 1123, col: 29, offset: 27203},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7781,35 +7851,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1108, col: 5, offset: 26868},
+						pos: position{line: 1124, col: 5, offset: 27232},
 						run: (*parser).callonPrimary23,
 						expr: &seqExpr{
-							pos: position{line: 1108, col: 5, offset: 26868},
+							pos: position{line: 1124, col: 5, offset: 27232},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1108, col: 5, offset: 26868},
+									pos:        position{line: 1124, col: 5, offset: 27232},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1108, col: 9, offset: 26872},
+									pos:  position{line: 1124, col: 9, offset: 27236},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1108, col: 12, offset: 26875},
+									pos:   position{line: 1124, col: 12, offset: 27239},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1108, col: 17, offset: 26880},
+										pos:  position{line: 1124, col: 17, offset: 27244},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1108, col: 22, offset: 26885},
+									pos:  position{line: 1124, col: 22, offset: 27249},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1108, col: 25, offset: 26888},
+									pos:        position{line: 1124, col: 25, offset: 27252},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7824,53 +7894,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1110, col: 1, offset: 26914},
+			pos:  position{line: 1126, col: 1, offset: 27278},
 			expr: &choiceExpr{
-				pos: position{line: 1111, col: 5, offset: 26927},
+				pos: position{line: 1127, col: 5, offset: 27291},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1111, col: 5, offset: 26927},
+						pos: position{line: 1127, col: 5, offset: 27291},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1111, col: 5, offset: 26927},
+							pos: position{line: 1127, col: 5, offset: 27291},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 5, offset: 26927},
+									pos:  position{line: 1127, col: 5, offset: 27291},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 10, offset: 26932},
+									pos:   position{line: 1127, col: 10, offset: 27296},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1111, col: 16, offset: 26938},
+										pos: position{line: 1127, col: 16, offset: 27302},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1111, col: 16, offset: 26938},
+											pos:  position{line: 1127, col: 16, offset: 27302},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 22, offset: 26944},
+									pos:   position{line: 1127, col: 22, offset: 27308},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1111, col: 28, offset: 26950},
+										pos: position{line: 1127, col: 28, offset: 27314},
 										expr: &seqExpr{
-											pos: position{line: 1111, col: 29, offset: 26951},
+											pos: position{line: 1127, col: 29, offset: 27315},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1111, col: 29, offset: 26951},
+													pos:  position{line: 1127, col: 29, offset: 27315},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1111, col: 31, offset: 26953},
+													pos:  position{line: 1127, col: 31, offset: 27317},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1111, col: 36, offset: 26958},
+													pos:  position{line: 1127, col: 36, offset: 27322},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1111, col: 38, offset: 26960},
+													pos:  position{line: 1127, col: 38, offset: 27324},
 													name: "Expr",
 												},
 											},
@@ -7878,24 +7948,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 45, offset: 26967},
+									pos:  position{line: 1127, col: 45, offset: 27331},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 47, offset: 26969},
+									pos:  position{line: 1127, col: 47, offset: 27333},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1111, col: 51, offset: 26973},
+									pos: position{line: 1127, col: 51, offset: 27337},
 									expr: &seqExpr{
-										pos: position{line: 1111, col: 52, offset: 26974},
+										pos: position{line: 1127, col: 52, offset: 27338},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1111, col: 52, offset: 26974},
+												pos:  position{line: 1127, col: 52, offset: 27338},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1111, col: 54, offset: 26976},
+												pos:  position{line: 1127, col: 54, offset: 27340},
 												name: "CASE",
 											},
 										},
@@ -7905,60 +7975,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1135, col: 5, offset: 27625},
+						pos: position{line: 1151, col: 5, offset: 27989},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1135, col: 5, offset: 27625},
+							pos: position{line: 1151, col: 5, offset: 27989},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1135, col: 5, offset: 27625},
+									pos:  position{line: 1151, col: 5, offset: 27989},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1135, col: 10, offset: 27630},
+									pos:  position{line: 1151, col: 10, offset: 27994},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1135, col: 12, offset: 27632},
+									pos:   position{line: 1151, col: 12, offset: 27996},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1135, col: 17, offset: 27637},
+										pos:  position{line: 1151, col: 17, offset: 28001},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1135, col: 22, offset: 27642},
+									pos:   position{line: 1151, col: 22, offset: 28006},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1135, col: 28, offset: 27648},
+										pos: position{line: 1151, col: 28, offset: 28012},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1135, col: 28, offset: 27648},
+											pos:  position{line: 1151, col: 28, offset: 28012},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1135, col: 34, offset: 27654},
+									pos:   position{line: 1151, col: 34, offset: 28018},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1135, col: 40, offset: 27660},
+										pos: position{line: 1151, col: 40, offset: 28024},
 										expr: &seqExpr{
-											pos: position{line: 1135, col: 41, offset: 27661},
+											pos: position{line: 1151, col: 41, offset: 28025},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1135, col: 41, offset: 27661},
+													pos:  position{line: 1151, col: 41, offset: 28025},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1135, col: 43, offset: 27663},
+													pos:  position{line: 1151, col: 43, offset: 28027},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1135, col: 48, offset: 27668},
+													pos:  position{line: 1151, col: 48, offset: 28032},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1135, col: 50, offset: 27670},
+													pos:  position{line: 1151, col: 50, offset: 28034},
 													name: "Expr",
 												},
 											},
@@ -7966,24 +8036,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1135, col: 57, offset: 27677},
+									pos:  position{line: 1151, col: 57, offset: 28041},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1135, col: 59, offset: 27679},
+									pos:  position{line: 1151, col: 59, offset: 28043},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1135, col: 63, offset: 27683},
+									pos: position{line: 1151, col: 63, offset: 28047},
 									expr: &seqExpr{
-										pos: position{line: 1135, col: 64, offset: 27684},
+										pos: position{line: 1151, col: 64, offset: 28048},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1135, col: 64, offset: 27684},
+												pos:  position{line: 1151, col: 64, offset: 28048},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1135, col: 66, offset: 27686},
+												pos:  position{line: 1151, col: 66, offset: 28050},
 												name: "CASE",
 											},
 										},
@@ -7999,50 +8069,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1148, col: 1, offset: 27992},
+			pos:  position{line: 1164, col: 1, offset: 28356},
 			expr: &actionExpr{
-				pos: position{line: 1149, col: 5, offset: 28001},
+				pos: position{line: 1165, col: 5, offset: 28365},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1149, col: 5, offset: 28001},
+					pos: position{line: 1165, col: 5, offset: 28365},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 5, offset: 28001},
+							pos:  position{line: 1165, col: 5, offset: 28365},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 7, offset: 28003},
+							pos:  position{line: 1165, col: 7, offset: 28367},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 12, offset: 28008},
+							pos:  position{line: 1165, col: 12, offset: 28372},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1149, col: 14, offset: 28010},
+							pos:   position{line: 1165, col: 14, offset: 28374},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1149, col: 19, offset: 28015},
+								pos:  position{line: 1165, col: 19, offset: 28379},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 24, offset: 28020},
+							pos:  position{line: 1165, col: 24, offset: 28384},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 26, offset: 28022},
+							pos:  position{line: 1165, col: 26, offset: 28386},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1149, col: 31, offset: 28027},
+							pos:  position{line: 1165, col: 31, offset: 28391},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1149, col: 33, offset: 28029},
+							pos:   position{line: 1165, col: 33, offset: 28393},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1149, col: 38, offset: 28034},
+								pos:  position{line: 1165, col: 38, offset: 28398},
 								name: "Expr",
 							},
 						},
@@ -8054,57 +8124,57 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1158, col: 1, offset: 28193},
+			pos:  position{line: 1174, col: 1, offset: 28557},
 			expr: &actionExpr{
-				pos: position{line: 1159, col: 5, offset: 28206},
+				pos: position{line: 1175, col: 5, offset: 28570},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1159, col: 5, offset: 28206},
+					pos: position{line: 1175, col: 5, offset: 28570},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 5, offset: 28206},
+							pos:  position{line: 1175, col: 5, offset: 28570},
 							name: "OVER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 10, offset: 28211},
+							pos:  position{line: 1175, col: 10, offset: 28575},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1159, col: 12, offset: 28213},
+							pos:   position{line: 1175, col: 12, offset: 28577},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1159, col: 18, offset: 28219},
+								pos:  position{line: 1175, col: 18, offset: 28583},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1159, col: 24, offset: 28225},
+							pos:   position{line: 1175, col: 24, offset: 28589},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1159, col: 31, offset: 28232},
+								pos: position{line: 1175, col: 31, offset: 28596},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1159, col: 31, offset: 28232},
+									pos:  position{line: 1175, col: 31, offset: 28596},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 39, offset: 28240},
+							pos:  position{line: 1175, col: 39, offset: 28604},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 42, offset: 28243},
+							pos:  position{line: 1175, col: 42, offset: 28607},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 47, offset: 28248},
+							pos:  position{line: 1175, col: 47, offset: 28612},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1159, col: 50, offset: 28251},
+							pos:   position{line: 1175, col: 50, offset: 28615},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1159, col: 55, offset: 28256},
+								pos:  position{line: 1175, col: 55, offset: 28620},
 								name: "Seq",
 							},
 						},
@@ -8116,37 +8186,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1169, col: 1, offset: 28487},
+			pos:  position{line: 1185, col: 1, offset: 28851},
 			expr: &actionExpr{
-				pos: position{line: 1170, col: 5, offset: 28498},
+				pos: position{line: 1186, col: 5, offset: 28862},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1170, col: 5, offset: 28498},
+					pos: position{line: 1186, col: 5, offset: 28862},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1170, col: 5, offset: 28498},
+							pos:        position{line: 1186, col: 5, offset: 28862},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1170, col: 9, offset: 28502},
+							pos:  position{line: 1186, col: 9, offset: 28866},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1170, col: 12, offset: 28505},
+							pos:   position{line: 1186, col: 12, offset: 28869},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1170, col: 18, offset: 28511},
+								pos:  position{line: 1186, col: 18, offset: 28875},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1170, col: 30, offset: 28523},
+							pos:  position{line: 1186, col: 30, offset: 28887},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1170, col: 33, offset: 28526},
+							pos:        position{line: 1186, col: 33, offset: 28890},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8159,31 +8229,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1178, col: 1, offset: 28684},
+			pos:  position{line: 1194, col: 1, offset: 29048},
 			expr: &choiceExpr{
-				pos: position{line: 1179, col: 5, offset: 28700},
+				pos: position{line: 1195, col: 5, offset: 29064},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1179, col: 5, offset: 28700},
+						pos: position{line: 1195, col: 5, offset: 29064},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1179, col: 5, offset: 28700},
+							pos: position{line: 1195, col: 5, offset: 29064},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1179, col: 5, offset: 28700},
+									pos:   position{line: 1195, col: 5, offset: 29064},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1179, col: 11, offset: 28706},
+										pos:  position{line: 1195, col: 11, offset: 29070},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1179, col: 22, offset: 28717},
+									pos:   position{line: 1195, col: 22, offset: 29081},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1179, col: 27, offset: 28722},
+										pos: position{line: 1195, col: 27, offset: 29086},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1179, col: 27, offset: 28722},
+											pos:  position{line: 1195, col: 27, offset: 29086},
 											name: "RecordElemTail",
 										},
 									},
@@ -8192,10 +8262,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1182, col: 5, offset: 28785},
+						pos: position{line: 1198, col: 5, offset: 29149},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1182, col: 5, offset: 28785},
+							pos:  position{line: 1198, col: 5, offset: 29149},
 							name: "__",
 						},
 					},
@@ -8206,32 +8276,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1184, col: 1, offset: 28809},
+			pos:  position{line: 1200, col: 1, offset: 29173},
 			expr: &actionExpr{
-				pos: position{line: 1184, col: 18, offset: 28826},
+				pos: position{line: 1200, col: 18, offset: 29190},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1184, col: 18, offset: 28826},
+					pos: position{line: 1200, col: 18, offset: 29190},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1184, col: 18, offset: 28826},
+							pos:  position{line: 1200, col: 18, offset: 29190},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1184, col: 21, offset: 28829},
+							pos:        position{line: 1200, col: 21, offset: 29193},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1184, col: 25, offset: 28833},
+							pos:  position{line: 1200, col: 25, offset: 29197},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1184, col: 28, offset: 28836},
+							pos:   position{line: 1200, col: 28, offset: 29200},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1184, col: 33, offset: 28841},
+								pos:  position{line: 1200, col: 33, offset: 29205},
 								name: "RecordElem",
 							},
 						},
@@ -8243,20 +8313,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1186, col: 1, offset: 28874},
+			pos:  position{line: 1202, col: 1, offset: 29238},
 			expr: &choiceExpr{
-				pos: position{line: 1187, col: 5, offset: 28889},
+				pos: position{line: 1203, col: 5, offset: 29253},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1187, col: 5, offset: 28889},
+						pos:  position{line: 1203, col: 5, offset: 29253},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1188, col: 5, offset: 28900},
+						pos:  position{line: 1204, col: 5, offset: 29264},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1189, col: 5, offset: 28914},
+						pos:  position{line: 1205, col: 5, offset: 29278},
 						name: "Identifier",
 					},
 				},
@@ -8266,28 +8336,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1191, col: 1, offset: 28926},
+			pos:  position{line: 1207, col: 1, offset: 29290},
 			expr: &actionExpr{
-				pos: position{line: 1192, col: 5, offset: 28937},
+				pos: position{line: 1208, col: 5, offset: 29301},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1192, col: 5, offset: 28937},
+					pos: position{line: 1208, col: 5, offset: 29301},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1192, col: 5, offset: 28937},
+							pos:        position{line: 1208, col: 5, offset: 29301},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1192, col: 11, offset: 28943},
+							pos:  position{line: 1208, col: 11, offset: 29307},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1192, col: 14, offset: 28946},
+							pos:   position{line: 1208, col: 14, offset: 29310},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1192, col: 19, offset: 28951},
+								pos:  position{line: 1208, col: 19, offset: 29315},
 								name: "Expr",
 							},
 						},
@@ -8299,40 +8369,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1196, col: 1, offset: 29047},
+			pos:  position{line: 1212, col: 1, offset: 29411},
 			expr: &actionExpr{
-				pos: position{line: 1197, col: 5, offset: 29061},
+				pos: position{line: 1213, col: 5, offset: 29425},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1197, col: 5, offset: 29061},
+					pos: position{line: 1213, col: 5, offset: 29425},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1197, col: 5, offset: 29061},
+							pos:   position{line: 1213, col: 5, offset: 29425},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1197, col: 10, offset: 29066},
+								pos:  position{line: 1213, col: 10, offset: 29430},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1197, col: 15, offset: 29071},
+							pos:  position{line: 1213, col: 15, offset: 29435},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1197, col: 18, offset: 29074},
+							pos:        position{line: 1213, col: 18, offset: 29438},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1197, col: 22, offset: 29078},
+							pos:  position{line: 1213, col: 22, offset: 29442},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1197, col: 25, offset: 29081},
+							pos:   position{line: 1213, col: 25, offset: 29445},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1197, col: 31, offset: 29087},
+								pos:  position{line: 1213, col: 31, offset: 29451},
 								name: "Expr",
 							},
 						},
@@ -8344,37 +8414,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1206, col: 1, offset: 29256},
+			pos:  position{line: 1222, col: 1, offset: 29620},
 			expr: &actionExpr{
-				pos: position{line: 1207, col: 5, offset: 29266},
+				pos: position{line: 1223, col: 5, offset: 29630},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1207, col: 5, offset: 29266},
+					pos: position{line: 1223, col: 5, offset: 29630},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1207, col: 5, offset: 29266},
+							pos:        position{line: 1223, col: 5, offset: 29630},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1207, col: 9, offset: 29270},
+							pos:  position{line: 1223, col: 9, offset: 29634},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1207, col: 12, offset: 29273},
+							pos:   position{line: 1223, col: 12, offset: 29637},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1207, col: 18, offset: 29279},
+								pos:  position{line: 1223, col: 18, offset: 29643},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1207, col: 30, offset: 29291},
+							pos:  position{line: 1223, col: 30, offset: 29655},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1207, col: 33, offset: 29294},
+							pos:        position{line: 1223, col: 33, offset: 29658},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8387,37 +8457,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1215, col: 1, offset: 29450},
+			pos:  position{line: 1231, col: 1, offset: 29814},
 			expr: &actionExpr{
-				pos: position{line: 1216, col: 5, offset: 29458},
+				pos: position{line: 1232, col: 5, offset: 29822},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1216, col: 5, offset: 29458},
+					pos: position{line: 1232, col: 5, offset: 29822},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1216, col: 5, offset: 29458},
+							pos:        position{line: 1232, col: 5, offset: 29822},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1216, col: 10, offset: 29463},
+							pos:  position{line: 1232, col: 10, offset: 29827},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1216, col: 13, offset: 29466},
+							pos:   position{line: 1232, col: 13, offset: 29830},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1216, col: 19, offset: 29472},
+								pos:  position{line: 1232, col: 19, offset: 29836},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1216, col: 31, offset: 29484},
+							pos:  position{line: 1232, col: 31, offset: 29848},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1216, col: 34, offset: 29487},
+							pos:        position{line: 1232, col: 34, offset: 29851},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8430,54 +8500,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1224, col: 1, offset: 29640},
+			pos:  position{line: 1240, col: 1, offset: 30004},
 			expr: &choiceExpr{
-				pos: position{line: 1225, col: 5, offset: 29656},
+				pos: position{line: 1241, col: 5, offset: 30020},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1225, col: 5, offset: 29656},
+						pos: position{line: 1241, col: 5, offset: 30020},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1225, col: 5, offset: 29656},
+							pos: position{line: 1241, col: 5, offset: 30020},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1225, col: 5, offset: 29656},
+									pos:   position{line: 1241, col: 5, offset: 30020},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1225, col: 11, offset: 29662},
+										pos:  position{line: 1241, col: 11, offset: 30026},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1225, col: 22, offset: 29673},
+									pos:   position{line: 1241, col: 22, offset: 30037},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1225, col: 27, offset: 29678},
+										pos: position{line: 1241, col: 27, offset: 30042},
 										expr: &actionExpr{
-											pos: position{line: 1225, col: 28, offset: 29679},
+											pos: position{line: 1241, col: 28, offset: 30043},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1225, col: 28, offset: 29679},
+												pos: position{line: 1241, col: 28, offset: 30043},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1225, col: 28, offset: 29679},
+														pos:  position{line: 1241, col: 28, offset: 30043},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1225, col: 31, offset: 29682},
+														pos:        position{line: 1241, col: 31, offset: 30046},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1225, col: 35, offset: 29686},
+														pos:  position{line: 1241, col: 35, offset: 30050},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1225, col: 38, offset: 29689},
+														pos:   position{line: 1241, col: 38, offset: 30053},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1225, col: 40, offset: 29691},
+															pos:  position{line: 1241, col: 40, offset: 30055},
 															name: "VectorElem",
 														},
 													},
@@ -8490,10 +8560,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1228, col: 5, offset: 29773},
+						pos: position{line: 1244, col: 5, offset: 30137},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1228, col: 5, offset: 29773},
+							pos:  position{line: 1244, col: 5, offset: 30137},
 							name: "__",
 						},
 					},
@@ -8504,22 +8574,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1230, col: 1, offset: 29797},
+			pos:  position{line: 1246, col: 1, offset: 30161},
 			expr: &choiceExpr{
-				pos: position{line: 1231, col: 5, offset: 29812},
+				pos: position{line: 1247, col: 5, offset: 30176},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 5, offset: 29812},
+						pos:  position{line: 1247, col: 5, offset: 30176},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1232, col: 5, offset: 29823},
+						pos: position{line: 1248, col: 5, offset: 30187},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1232, col: 5, offset: 29823},
+							pos:   position{line: 1248, col: 5, offset: 30187},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1232, col: 7, offset: 29825},
+								pos:  position{line: 1248, col: 7, offset: 30189},
 								name: "Expr",
 							},
 						},
@@ -8531,37 +8601,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1234, col: 1, offset: 29916},
+			pos:  position{line: 1250, col: 1, offset: 30280},
 			expr: &actionExpr{
-				pos: position{line: 1235, col: 5, offset: 29924},
+				pos: position{line: 1251, col: 5, offset: 30288},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1235, col: 5, offset: 29924},
+					pos: position{line: 1251, col: 5, offset: 30288},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1235, col: 5, offset: 29924},
+							pos:        position{line: 1251, col: 5, offset: 30288},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1235, col: 10, offset: 29929},
+							pos:  position{line: 1251, col: 10, offset: 30293},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1235, col: 13, offset: 29932},
+							pos:   position{line: 1251, col: 13, offset: 30296},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1235, col: 19, offset: 29938},
+								pos:  position{line: 1251, col: 19, offset: 30302},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1235, col: 27, offset: 29946},
+							pos:  position{line: 1251, col: 27, offset: 30310},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1235, col: 30, offset: 29949},
+							pos:        position{line: 1251, col: 30, offset: 30313},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8574,31 +8644,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1243, col: 1, offset: 30103},
+			pos:  position{line: 1259, col: 1, offset: 30467},
 			expr: &choiceExpr{
-				pos: position{line: 1244, col: 5, offset: 30115},
+				pos: position{line: 1260, col: 5, offset: 30479},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1244, col: 5, offset: 30115},
+						pos: position{line: 1260, col: 5, offset: 30479},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1244, col: 5, offset: 30115},
+							pos: position{line: 1260, col: 5, offset: 30479},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1244, col: 5, offset: 30115},
+									pos:   position{line: 1260, col: 5, offset: 30479},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1244, col: 11, offset: 30121},
+										pos:  position{line: 1260, col: 11, offset: 30485},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1244, col: 17, offset: 30127},
+									pos:   position{line: 1260, col: 17, offset: 30491},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1244, col: 22, offset: 30132},
+										pos: position{line: 1260, col: 22, offset: 30496},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1244, col: 22, offset: 30132},
+											pos:  position{line: 1260, col: 22, offset: 30496},
 											name: "EntryTail",
 										},
 									},
@@ -8607,10 +8677,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1247, col: 5, offset: 30190},
+						pos: position{line: 1263, col: 5, offset: 30554},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1247, col: 5, offset: 30190},
+							pos:  position{line: 1263, col: 5, offset: 30554},
 							name: "__",
 						},
 					},
@@ -8621,32 +8691,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1250, col: 1, offset: 30215},
+			pos:  position{line: 1266, col: 1, offset: 30579},
 			expr: &actionExpr{
-				pos: position{line: 1250, col: 13, offset: 30227},
+				pos: position{line: 1266, col: 13, offset: 30591},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1250, col: 13, offset: 30227},
+					pos: position{line: 1266, col: 13, offset: 30591},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1250, col: 13, offset: 30227},
+							pos:  position{line: 1266, col: 13, offset: 30591},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1250, col: 16, offset: 30230},
+							pos:        position{line: 1266, col: 16, offset: 30594},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1250, col: 20, offset: 30234},
+							pos:  position{line: 1266, col: 20, offset: 30598},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1250, col: 23, offset: 30237},
+							pos:   position{line: 1266, col: 23, offset: 30601},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1250, col: 25, offset: 30239},
+								pos:  position{line: 1266, col: 25, offset: 30603},
 								name: "Entry",
 							},
 						},
@@ -8658,40 +8728,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1252, col: 1, offset: 30264},
+			pos:  position{line: 1268, col: 1, offset: 30628},
 			expr: &actionExpr{
-				pos: position{line: 1253, col: 5, offset: 30274},
+				pos: position{line: 1269, col: 5, offset: 30638},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1253, col: 5, offset: 30274},
+					pos: position{line: 1269, col: 5, offset: 30638},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1253, col: 5, offset: 30274},
+							pos:   position{line: 1269, col: 5, offset: 30638},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1253, col: 9, offset: 30278},
+								pos:  position{line: 1269, col: 9, offset: 30642},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1253, col: 14, offset: 30283},
+							pos:  position{line: 1269, col: 14, offset: 30647},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1253, col: 17, offset: 30286},
+							pos:        position{line: 1269, col: 17, offset: 30650},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1253, col: 21, offset: 30290},
+							pos:  position{line: 1269, col: 21, offset: 30654},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1253, col: 24, offset: 30293},
+							pos:   position{line: 1269, col: 24, offset: 30657},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1253, col: 30, offset: 30299},
+								pos:  position{line: 1269, col: 30, offset: 30663},
 								name: "Expr",
 							},
 						},
@@ -8703,61 +8773,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1257, col: 1, offset: 30402},
+			pos:  position{line: 1273, col: 1, offset: 30766},
 			expr: &actionExpr{
-				pos: position{line: 1258, col: 5, offset: 30412},
+				pos: position{line: 1274, col: 5, offset: 30776},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1258, col: 5, offset: 30412},
+					pos: position{line: 1274, col: 5, offset: 30776},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1258, col: 5, offset: 30412},
+							pos:        position{line: 1274, col: 5, offset: 30776},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1258, col: 9, offset: 30416},
+							pos:  position{line: 1274, col: 9, offset: 30780},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1258, col: 12, offset: 30419},
+							pos:   position{line: 1274, col: 12, offset: 30783},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1258, col: 18, offset: 30425},
+								pos:  position{line: 1274, col: 18, offset: 30789},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1258, col: 23, offset: 30430},
+							pos:   position{line: 1274, col: 23, offset: 30794},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1258, col: 28, offset: 30435},
+								pos: position{line: 1274, col: 28, offset: 30799},
 								expr: &actionExpr{
-									pos: position{line: 1258, col: 29, offset: 30436},
+									pos: position{line: 1274, col: 29, offset: 30800},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1258, col: 29, offset: 30436},
+										pos: position{line: 1274, col: 29, offset: 30800},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1258, col: 29, offset: 30436},
+												pos:  position{line: 1274, col: 29, offset: 30800},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1258, col: 32, offset: 30439},
+												pos:        position{line: 1274, col: 32, offset: 30803},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1258, col: 36, offset: 30443},
+												pos:  position{line: 1274, col: 36, offset: 30807},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1258, col: 39, offset: 30446},
+												pos:   position{line: 1274, col: 39, offset: 30810},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1258, col: 41, offset: 30448},
+													pos:  position{line: 1274, col: 41, offset: 30812},
 													name: "Expr",
 												},
 											},
@@ -8767,11 +8837,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1258, col: 66, offset: 30473},
+							pos:  position{line: 1274, col: 66, offset: 30837},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1258, col: 69, offset: 30476},
+							pos:        position{line: 1274, col: 69, offset: 30840},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8784,56 +8854,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1268, col: 1, offset: 30657},
+			pos:  position{line: 1284, col: 1, offset: 31021},
 			expr: &choiceExpr{
-				pos: position{line: 1269, col: 5, offset: 30669},
+				pos: position{line: 1285, col: 5, offset: 31033},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1269, col: 5, offset: 30669},
+						pos:  position{line: 1285, col: 5, offset: 31033},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1270, col: 5, offset: 30685},
+						pos:  position{line: 1286, col: 5, offset: 31049},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1271, col: 5, offset: 30703},
+						pos:  position{line: 1287, col: 5, offset: 31067},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1272, col: 5, offset: 30715},
+						pos:  position{line: 1288, col: 5, offset: 31079},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 30733},
+						pos:  position{line: 1289, col: 5, offset: 31097},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1274, col: 5, offset: 30752},
+						pos:  position{line: 1290, col: 5, offset: 31116},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1275, col: 5, offset: 30769},
+						pos:  position{line: 1291, col: 5, offset: 31133},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1276, col: 5, offset: 30782},
+						pos:  position{line: 1292, col: 5, offset: 31146},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1277, col: 5, offset: 30791},
+						pos:  position{line: 1293, col: 5, offset: 31155},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 30808},
+						pos:  position{line: 1294, col: 5, offset: 31172},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 5, offset: 30827},
+						pos:  position{line: 1295, col: 5, offset: 31191},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1280, col: 5, offset: 30846},
+						pos:  position{line: 1296, col: 5, offset: 31210},
 						name: "NullLiteral",
 					},
 				},
@@ -8843,28 +8913,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1282, col: 1, offset: 30859},
+			pos:  position{line: 1298, col: 1, offset: 31223},
 			expr: &choiceExpr{
-				pos: position{line: 1283, col: 5, offset: 30877},
+				pos: position{line: 1299, col: 5, offset: 31241},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1283, col: 5, offset: 30877},
+						pos: position{line: 1299, col: 5, offset: 31241},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1283, col: 5, offset: 30877},
+							pos: position{line: 1299, col: 5, offset: 31241},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1283, col: 5, offset: 30877},
+									pos:   position{line: 1299, col: 5, offset: 31241},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1283, col: 7, offset: 30879},
+										pos:  position{line: 1299, col: 7, offset: 31243},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1283, col: 14, offset: 30886},
+									pos: position{line: 1299, col: 14, offset: 31250},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1283, col: 15, offset: 30887},
+										pos:  position{line: 1299, col: 15, offset: 31251},
 										name: "IdentifierRest",
 									},
 								},
@@ -8872,13 +8942,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1286, col: 5, offset: 30967},
+						pos: position{line: 1302, col: 5, offset: 31331},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1286, col: 5, offset: 30967},
+							pos:   position{line: 1302, col: 5, offset: 31331},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1286, col: 7, offset: 30969},
+								pos:  position{line: 1302, col: 7, offset: 31333},
 								name: "IP4Net",
 							},
 						},
@@ -8890,28 +8960,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1290, col: 1, offset: 31038},
+			pos:  position{line: 1306, col: 1, offset: 31402},
 			expr: &choiceExpr{
-				pos: position{line: 1291, col: 5, offset: 31057},
+				pos: position{line: 1307, col: 5, offset: 31421},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1291, col: 5, offset: 31057},
+						pos: position{line: 1307, col: 5, offset: 31421},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1291, col: 5, offset: 31057},
+							pos: position{line: 1307, col: 5, offset: 31421},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1291, col: 5, offset: 31057},
+									pos:   position{line: 1307, col: 5, offset: 31421},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1291, col: 7, offset: 31059},
+										pos:  position{line: 1307, col: 7, offset: 31423},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1291, col: 11, offset: 31063},
+									pos: position{line: 1307, col: 11, offset: 31427},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1291, col: 12, offset: 31064},
+										pos:  position{line: 1307, col: 12, offset: 31428},
 										name: "IdentifierRest",
 									},
 								},
@@ -8919,13 +8989,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1294, col: 5, offset: 31143},
+						pos: position{line: 1310, col: 5, offset: 31507},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1294, col: 5, offset: 31143},
+							pos:   position{line: 1310, col: 5, offset: 31507},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1294, col: 7, offset: 31145},
+								pos:  position{line: 1310, col: 7, offset: 31509},
 								name: "IP",
 							},
 						},
@@ -8937,15 +9007,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1298, col: 1, offset: 31209},
+			pos:  position{line: 1314, col: 1, offset: 31573},
 			expr: &actionExpr{
-				pos: position{line: 1299, col: 5, offset: 31226},
+				pos: position{line: 1315, col: 5, offset: 31590},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1299, col: 5, offset: 31226},
+					pos:   position{line: 1315, col: 5, offset: 31590},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1299, col: 7, offset: 31228},
+						pos:  position{line: 1315, col: 7, offset: 31592},
 						name: "FloatString",
 					},
 				},
@@ -8955,15 +9025,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1303, col: 1, offset: 31306},
+			pos:  position{line: 1319, col: 1, offset: 31670},
 			expr: &actionExpr{
-				pos: position{line: 1304, col: 5, offset: 31325},
+				pos: position{line: 1320, col: 5, offset: 31689},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1304, col: 5, offset: 31325},
+					pos:   position{line: 1320, col: 5, offset: 31689},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1304, col: 7, offset: 31327},
+						pos:  position{line: 1320, col: 7, offset: 31691},
 						name: "IntString",
 					},
 				},
@@ -8973,23 +9043,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1308, col: 1, offset: 31401},
+			pos:  position{line: 1324, col: 1, offset: 31765},
 			expr: &choiceExpr{
-				pos: position{line: 1309, col: 5, offset: 31420},
+				pos: position{line: 1325, col: 5, offset: 31784},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 31420},
+						pos: position{line: 1325, col: 5, offset: 31784},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1309, col: 5, offset: 31420},
+							pos:  position{line: 1325, col: 5, offset: 31784},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 31478},
+						pos: position{line: 1326, col: 5, offset: 31842},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1310, col: 5, offset: 31478},
+							pos:  position{line: 1326, col: 5, offset: 31842},
 							name: "FALSE",
 						},
 					},
@@ -9000,12 +9070,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1312, col: 1, offset: 31534},
+			pos:  position{line: 1328, col: 1, offset: 31898},
 			expr: &actionExpr{
-				pos: position{line: 1313, col: 5, offset: 31550},
+				pos: position{line: 1329, col: 5, offset: 31914},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1313, col: 5, offset: 31550},
+					pos:  position{line: 1329, col: 5, offset: 31914},
 					name: "NULL",
 				},
 			},
@@ -9014,23 +9084,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1315, col: 1, offset: 31600},
+			pos:  position{line: 1331, col: 1, offset: 31964},
 			expr: &actionExpr{
-				pos: position{line: 1316, col: 5, offset: 31617},
+				pos: position{line: 1332, col: 5, offset: 31981},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1316, col: 5, offset: 31617},
+					pos: position{line: 1332, col: 5, offset: 31981},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1316, col: 5, offset: 31617},
+							pos:        position{line: 1332, col: 5, offset: 31981},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1316, col: 10, offset: 31622},
+							pos: position{line: 1332, col: 10, offset: 31986},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1316, col: 10, offset: 31622},
+								pos:  position{line: 1332, col: 10, offset: 31986},
 								name: "HexDigit",
 							},
 						},
@@ -9042,29 +9112,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1320, col: 1, offset: 31696},
+			pos:  position{line: 1336, col: 1, offset: 32060},
 			expr: &actionExpr{
-				pos: position{line: 1321, col: 5, offset: 31712},
+				pos: position{line: 1337, col: 5, offset: 32076},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1321, col: 5, offset: 31712},
+					pos: position{line: 1337, col: 5, offset: 32076},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1321, col: 5, offset: 31712},
+							pos:        position{line: 1337, col: 5, offset: 32076},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1321, col: 9, offset: 31716},
+							pos:   position{line: 1337, col: 9, offset: 32080},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1321, col: 13, offset: 31720},
+								pos:  position{line: 1337, col: 13, offset: 32084},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1321, col: 18, offset: 31725},
+							pos:        position{line: 1337, col: 18, offset: 32089},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -9077,16 +9147,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1329, col: 1, offset: 31858},
+			pos:  position{line: 1345, col: 1, offset: 32222},
 			expr: &choiceExpr{
-				pos: position{line: 1330, col: 5, offset: 31867},
+				pos: position{line: 1346, col: 5, offset: 32231},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1330, col: 5, offset: 31867},
+						pos:  position{line: 1346, col: 5, offset: 32231},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1331, col: 5, offset: 31885},
+						pos:  position{line: 1347, col: 5, offset: 32249},
 						name: "ComplexType",
 					},
 				},
@@ -9096,28 +9166,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1333, col: 1, offset: 31898},
+			pos:  position{line: 1349, col: 1, offset: 32262},
 			expr: &choiceExpr{
-				pos: position{line: 1334, col: 5, offset: 31916},
+				pos: position{line: 1350, col: 5, offset: 32280},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1334, col: 5, offset: 31916},
+						pos: position{line: 1350, col: 5, offset: 32280},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1334, col: 5, offset: 31916},
+							pos: position{line: 1350, col: 5, offset: 32280},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1334, col: 5, offset: 31916},
+									pos:   position{line: 1350, col: 5, offset: 32280},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1334, col: 10, offset: 31921},
+										pos:  position{line: 1350, col: 10, offset: 32285},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1334, col: 24, offset: 31935},
+									pos: position{line: 1350, col: 24, offset: 32299},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1334, col: 25, offset: 31936},
+										pos:  position{line: 1350, col: 25, offset: 32300},
 										name: "IdentifierRest",
 									},
 								},
@@ -9125,43 +9195,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1335, col: 5, offset: 31976},
+						pos: position{line: 1351, col: 5, offset: 32340},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1335, col: 5, offset: 31976},
+							pos: position{line: 1351, col: 5, offset: 32340},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1335, col: 5, offset: 31976},
+									pos:  position{line: 1351, col: 5, offset: 32340},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1335, col: 11, offset: 31982},
+									pos:  position{line: 1351, col: 11, offset: 32346},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1335, col: 14, offset: 31985},
+									pos:        position{line: 1351, col: 14, offset: 32349},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1335, col: 18, offset: 31989},
+									pos:  position{line: 1351, col: 18, offset: 32353},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1335, col: 21, offset: 31992},
+									pos:   position{line: 1351, col: 21, offset: 32356},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1335, col: 23, offset: 31994},
+										pos:  position{line: 1351, col: 23, offset: 32358},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1335, col: 28, offset: 31999},
+									pos:  position{line: 1351, col: 28, offset: 32363},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1335, col: 31, offset: 32002},
+									pos:        position{line: 1351, col: 31, offset: 32366},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9170,43 +9240,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 32142},
+						pos: position{line: 1358, col: 5, offset: 32506},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1342, col: 5, offset: 32142},
+							pos: position{line: 1358, col: 5, offset: 32506},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1342, col: 5, offset: 32142},
+									pos:   position{line: 1358, col: 5, offset: 32506},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1342, col: 10, offset: 32147},
+										pos:  position{line: 1358, col: 10, offset: 32511},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1342, col: 15, offset: 32152},
+									pos:   position{line: 1358, col: 15, offset: 32516},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1342, col: 19, offset: 32156},
+										pos: position{line: 1358, col: 19, offset: 32520},
 										expr: &seqExpr{
-											pos: position{line: 1342, col: 20, offset: 32157},
+											pos: position{line: 1358, col: 20, offset: 32521},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1342, col: 20, offset: 32157},
+													pos:  position{line: 1358, col: 20, offset: 32521},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1342, col: 23, offset: 32160},
+													pos:        position{line: 1358, col: 23, offset: 32524},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1342, col: 27, offset: 32164},
+													pos:  position{line: 1358, col: 27, offset: 32528},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1342, col: 30, offset: 32167},
+													pos:  position{line: 1358, col: 30, offset: 32531},
 													name: "Type",
 												},
 											},
@@ -9217,31 +9287,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1353, col: 5, offset: 32492},
+						pos: position{line: 1369, col: 5, offset: 32856},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1353, col: 5, offset: 32492},
+							pos: position{line: 1369, col: 5, offset: 32856},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1353, col: 5, offset: 32492},
+									pos:        position{line: 1369, col: 5, offset: 32856},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1353, col: 9, offset: 32496},
+									pos:  position{line: 1369, col: 9, offset: 32860},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1353, col: 12, offset: 32499},
+									pos:   position{line: 1369, col: 12, offset: 32863},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1353, col: 18, offset: 32505},
+										pos:  position{line: 1369, col: 18, offset: 32869},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1353, col: 27, offset: 32514},
+									pos:        position{line: 1369, col: 27, offset: 32878},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9256,28 +9326,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1361, col: 1, offset: 32658},
+			pos:  position{line: 1377, col: 1, offset: 33022},
 			expr: &actionExpr{
-				pos: position{line: 1362, col: 5, offset: 32671},
+				pos: position{line: 1378, col: 5, offset: 33035},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1362, col: 5, offset: 32671},
+					pos: position{line: 1378, col: 5, offset: 33035},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1362, col: 5, offset: 32671},
+							pos:   position{line: 1378, col: 5, offset: 33035},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1362, col: 11, offset: 32677},
+								pos:  position{line: 1378, col: 11, offset: 33041},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1362, col: 16, offset: 32682},
+							pos:   position{line: 1378, col: 16, offset: 33046},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1362, col: 21, offset: 32687},
+								pos: position{line: 1378, col: 21, offset: 33051},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1362, col: 21, offset: 32687},
+									pos:  position{line: 1378, col: 21, offset: 33051},
 									name: "TypeListTail",
 								},
 							},
@@ -9290,32 +9360,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1366, col: 1, offset: 32745},
+			pos:  position{line: 1382, col: 1, offset: 33109},
 			expr: &actionExpr{
-				pos: position{line: 1366, col: 16, offset: 32760},
+				pos: position{line: 1382, col: 16, offset: 33124},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1366, col: 16, offset: 32760},
+					pos: position{line: 1382, col: 16, offset: 33124},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1366, col: 16, offset: 32760},
+							pos:  position{line: 1382, col: 16, offset: 33124},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 19, offset: 32763},
+							pos:        position{line: 1382, col: 19, offset: 33127},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1366, col: 23, offset: 32767},
+							pos:  position{line: 1382, col: 23, offset: 33131},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1366, col: 26, offset: 32770},
+							pos:   position{line: 1382, col: 26, offset: 33134},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1366, col: 30, offset: 32774},
+								pos:  position{line: 1382, col: 30, offset: 33138},
 								name: "Type",
 							},
 						},
@@ -9327,40 +9397,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1368, col: 1, offset: 32800},
+			pos:  position{line: 1384, col: 1, offset: 33164},
 			expr: &choiceExpr{
-				pos: position{line: 1369, col: 5, offset: 32816},
+				pos: position{line: 1385, col: 5, offset: 33180},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 32816},
+						pos: position{line: 1385, col: 5, offset: 33180},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1369, col: 5, offset: 32816},
+							pos: position{line: 1385, col: 5, offset: 33180},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1369, col: 5, offset: 32816},
+									pos:        position{line: 1385, col: 5, offset: 33180},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1369, col: 9, offset: 32820},
+									pos:  position{line: 1385, col: 9, offset: 33184},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1369, col: 12, offset: 32823},
+									pos:   position{line: 1385, col: 12, offset: 33187},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1369, col: 19, offset: 32830},
+										pos:  position{line: 1385, col: 19, offset: 33194},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1369, col: 33, offset: 32844},
+									pos:  position{line: 1385, col: 33, offset: 33208},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1369, col: 36, offset: 32847},
+									pos:        position{line: 1385, col: 36, offset: 33211},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9369,35 +9439,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1376, col: 5, offset: 33009},
+						pos: position{line: 1392, col: 5, offset: 33373},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1376, col: 5, offset: 33009},
+							pos: position{line: 1392, col: 5, offset: 33373},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1376, col: 5, offset: 33009},
+									pos:        position{line: 1392, col: 5, offset: 33373},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1376, col: 9, offset: 33013},
+									pos:  position{line: 1392, col: 9, offset: 33377},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1376, col: 12, offset: 33016},
+									pos:   position{line: 1392, col: 12, offset: 33380},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1376, col: 16, offset: 33020},
+										pos:  position{line: 1392, col: 16, offset: 33384},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1376, col: 21, offset: 33025},
+									pos:  position{line: 1392, col: 21, offset: 33389},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1376, col: 24, offset: 33028},
+									pos:        position{line: 1392, col: 24, offset: 33392},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9406,35 +9476,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1383, col: 5, offset: 33170},
+						pos: position{line: 1399, col: 5, offset: 33534},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1383, col: 5, offset: 33170},
+							pos: position{line: 1399, col: 5, offset: 33534},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1383, col: 5, offset: 33170},
+									pos:        position{line: 1399, col: 5, offset: 33534},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1383, col: 10, offset: 33175},
+									pos:  position{line: 1399, col: 10, offset: 33539},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1383, col: 13, offset: 33178},
+									pos:   position{line: 1399, col: 13, offset: 33542},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1383, col: 17, offset: 33182},
+										pos:  position{line: 1399, col: 17, offset: 33546},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1383, col: 22, offset: 33187},
+									pos:  position{line: 1399, col: 22, offset: 33551},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1383, col: 25, offset: 33190},
+									pos:        position{line: 1399, col: 25, offset: 33554},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9443,57 +9513,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1390, col: 5, offset: 33329},
+						pos: position{line: 1406, col: 5, offset: 33693},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1390, col: 5, offset: 33329},
+							pos: position{line: 1406, col: 5, offset: 33693},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1390, col: 5, offset: 33329},
+									pos:        position{line: 1406, col: 5, offset: 33693},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1390, col: 10, offset: 33334},
+									pos:  position{line: 1406, col: 10, offset: 33698},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1390, col: 13, offset: 33337},
+									pos:   position{line: 1406, col: 13, offset: 33701},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1390, col: 21, offset: 33345},
+										pos:  position{line: 1406, col: 21, offset: 33709},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1390, col: 26, offset: 33350},
+									pos:  position{line: 1406, col: 26, offset: 33714},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1390, col: 29, offset: 33353},
+									pos:        position{line: 1406, col: 29, offset: 33717},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1390, col: 33, offset: 33357},
+									pos:  position{line: 1406, col: 33, offset: 33721},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1390, col: 36, offset: 33360},
+									pos:   position{line: 1406, col: 36, offset: 33724},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1390, col: 44, offset: 33368},
+										pos:  position{line: 1406, col: 44, offset: 33732},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1390, col: 49, offset: 33373},
+									pos:  position{line: 1406, col: 49, offset: 33737},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1390, col: 52, offset: 33376},
+									pos:        position{line: 1406, col: 52, offset: 33740},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9508,35 +9578,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1399, col: 1, offset: 33550},
+			pos:  position{line: 1415, col: 1, offset: 33914},
 			expr: &choiceExpr{
-				pos: position{line: 1400, col: 5, offset: 33568},
+				pos: position{line: 1416, col: 5, offset: 33932},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1400, col: 5, offset: 33568},
+						pos: position{line: 1416, col: 5, offset: 33932},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1400, col: 5, offset: 33568},
+							pos: position{line: 1416, col: 5, offset: 33932},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1400, col: 5, offset: 33568},
+									pos:        position{line: 1416, col: 5, offset: 33932},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1400, col: 9, offset: 33572},
+									pos:   position{line: 1416, col: 9, offset: 33936},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1400, col: 11, offset: 33574},
+										pos: position{line: 1416, col: 11, offset: 33938},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1400, col: 11, offset: 33574},
+											pos:  position{line: 1416, col: 11, offset: 33938},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1400, col: 29, offset: 33592},
+									pos:        position{line: 1416, col: 29, offset: 33956},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9545,30 +9615,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1401, col: 5, offset: 33656},
+						pos: position{line: 1417, col: 5, offset: 34020},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1401, col: 5, offset: 33656},
+							pos: position{line: 1417, col: 5, offset: 34020},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1401, col: 5, offset: 33656},
+									pos:        position{line: 1417, col: 5, offset: 34020},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1401, col: 9, offset: 33660},
+									pos:   position{line: 1417, col: 9, offset: 34024},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1401, col: 11, offset: 33662},
+										pos: position{line: 1417, col: 11, offset: 34026},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1401, col: 11, offset: 33662},
+											pos:  position{line: 1417, col: 11, offset: 34026},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1401, col: 29, offset: 33680},
+									pos:        position{line: 1417, col: 29, offset: 34044},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9583,35 +9653,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1403, col: 1, offset: 33741},
+			pos:  position{line: 1419, col: 1, offset: 34105},
 			expr: &choiceExpr{
-				pos: position{line: 1404, col: 5, offset: 33753},
+				pos: position{line: 1420, col: 5, offset: 34117},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1404, col: 5, offset: 33753},
+						pos: position{line: 1420, col: 5, offset: 34117},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1404, col: 5, offset: 33753},
+							pos: position{line: 1420, col: 5, offset: 34117},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1404, col: 5, offset: 33753},
+									pos:        position{line: 1420, col: 5, offset: 34117},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1404, col: 11, offset: 33759},
+									pos:   position{line: 1420, col: 11, offset: 34123},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1404, col: 13, offset: 33761},
+										pos: position{line: 1420, col: 13, offset: 34125},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1404, col: 13, offset: 33761},
+											pos:  position{line: 1420, col: 13, offset: 34125},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1404, col: 38, offset: 33786},
+									pos:        position{line: 1420, col: 38, offset: 34150},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9620,30 +9690,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1411, col: 5, offset: 33932},
+						pos: position{line: 1427, col: 5, offset: 34296},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1411, col: 5, offset: 33932},
+							pos: position{line: 1427, col: 5, offset: 34296},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1411, col: 5, offset: 33932},
+									pos:        position{line: 1427, col: 5, offset: 34296},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1411, col: 10, offset: 33937},
+									pos:   position{line: 1427, col: 10, offset: 34301},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1411, col: 12, offset: 33939},
+										pos: position{line: 1427, col: 12, offset: 34303},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1411, col: 12, offset: 33939},
+											pos:  position{line: 1427, col: 12, offset: 34303},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1411, col: 37, offset: 33964},
+									pos:        position{line: 1427, col: 37, offset: 34328},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9658,24 +9728,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1419, col: 1, offset: 34107},
+			pos:  position{line: 1435, col: 1, offset: 34471},
 			expr: &choiceExpr{
-				pos: position{line: 1420, col: 5, offset: 34135},
+				pos: position{line: 1436, col: 5, offset: 34499},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1420, col: 5, offset: 34135},
+						pos:  position{line: 1436, col: 5, offset: 34499},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1421, col: 5, offset: 34151},
+						pos: position{line: 1437, col: 5, offset: 34515},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1421, col: 5, offset: 34151},
+							pos:   position{line: 1437, col: 5, offset: 34515},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1421, col: 7, offset: 34153},
+								pos: position{line: 1437, col: 7, offset: 34517},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1421, col: 7, offset: 34153},
+									pos:  position{line: 1437, col: 7, offset: 34517},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9688,27 +9758,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1425, col: 1, offset: 34276},
+			pos:  position{line: 1441, col: 1, offset: 34640},
 			expr: &choiceExpr{
-				pos: position{line: 1426, col: 5, offset: 34304},
+				pos: position{line: 1442, col: 5, offset: 34668},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1426, col: 5, offset: 34304},
+						pos: position{line: 1442, col: 5, offset: 34668},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1426, col: 5, offset: 34304},
+							pos: position{line: 1442, col: 5, offset: 34668},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1426, col: 5, offset: 34304},
+									pos:        position{line: 1442, col: 5, offset: 34668},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1426, col: 10, offset: 34309},
+									pos:   position{line: 1442, col: 10, offset: 34673},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1426, col: 12, offset: 34311},
+										pos:        position{line: 1442, col: 12, offset: 34675},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9718,25 +9788,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1427, col: 5, offset: 34337},
+						pos: position{line: 1443, col: 5, offset: 34701},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1427, col: 5, offset: 34337},
+							pos: position{line: 1443, col: 5, offset: 34701},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1427, col: 5, offset: 34337},
+									pos: position{line: 1443, col: 5, offset: 34701},
 									expr: &litMatcher{
-										pos:        position{line: 1427, col: 7, offset: 34339},
+										pos:        position{line: 1443, col: 7, offset: 34703},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1427, col: 12, offset: 34344},
+									pos:   position{line: 1443, col: 12, offset: 34708},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1427, col: 14, offset: 34346},
+										pos:  position{line: 1443, col: 14, offset: 34710},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9750,24 +9820,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1429, col: 1, offset: 34382},
+			pos:  position{line: 1445, col: 1, offset: 34746},
 			expr: &choiceExpr{
-				pos: position{line: 1430, col: 5, offset: 34410},
+				pos: position{line: 1446, col: 5, offset: 34774},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1430, col: 5, offset: 34410},
+						pos:  position{line: 1446, col: 5, offset: 34774},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1431, col: 5, offset: 34426},
+						pos: position{line: 1447, col: 5, offset: 34790},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1431, col: 5, offset: 34426},
+							pos:   position{line: 1447, col: 5, offset: 34790},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1431, col: 7, offset: 34428},
+								pos: position{line: 1447, col: 7, offset: 34792},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1431, col: 7, offset: 34428},
+									pos:  position{line: 1447, col: 7, offset: 34792},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9780,27 +9850,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1435, col: 1, offset: 34551},
+			pos:  position{line: 1451, col: 1, offset: 34915},
 			expr: &choiceExpr{
-				pos: position{line: 1436, col: 5, offset: 34579},
+				pos: position{line: 1452, col: 5, offset: 34943},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1436, col: 5, offset: 34579},
+						pos: position{line: 1452, col: 5, offset: 34943},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1436, col: 5, offset: 34579},
+							pos: position{line: 1452, col: 5, offset: 34943},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1436, col: 5, offset: 34579},
+									pos:        position{line: 1452, col: 5, offset: 34943},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1436, col: 10, offset: 34584},
+									pos:   position{line: 1452, col: 10, offset: 34948},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1436, col: 12, offset: 34586},
+										pos:        position{line: 1452, col: 12, offset: 34950},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9810,25 +9880,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1437, col: 5, offset: 34612},
+						pos: position{line: 1453, col: 5, offset: 34976},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1437, col: 5, offset: 34612},
+							pos: position{line: 1453, col: 5, offset: 34976},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1437, col: 5, offset: 34612},
+									pos: position{line: 1453, col: 5, offset: 34976},
 									expr: &litMatcher{
-										pos:        position{line: 1437, col: 7, offset: 34614},
+										pos:        position{line: 1453, col: 7, offset: 34978},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1437, col: 12, offset: 34619},
+									pos:   position{line: 1453, col: 12, offset: 34983},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1437, col: 14, offset: 34621},
+										pos:  position{line: 1453, col: 14, offset: 34985},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9842,37 +9912,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1439, col: 1, offset: 34657},
+			pos:  position{line: 1455, col: 1, offset: 35021},
 			expr: &actionExpr{
-				pos: position{line: 1440, col: 5, offset: 34673},
+				pos: position{line: 1456, col: 5, offset: 35037},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1440, col: 5, offset: 34673},
+					pos: position{line: 1456, col: 5, offset: 35037},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1440, col: 5, offset: 34673},
+							pos:        position{line: 1456, col: 5, offset: 35037},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1440, col: 9, offset: 34677},
+							pos:  position{line: 1456, col: 9, offset: 35041},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1440, col: 12, offset: 34680},
+							pos:   position{line: 1456, col: 12, offset: 35044},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1440, col: 14, offset: 34682},
+								pos:  position{line: 1456, col: 14, offset: 35046},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1440, col: 19, offset: 34687},
+							pos:  position{line: 1456, col: 19, offset: 35051},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1440, col: 22, offset: 34690},
+							pos:        position{line: 1456, col: 22, offset: 35054},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9885,129 +9955,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1448, col: 1, offset: 34825},
+			pos:  position{line: 1464, col: 1, offset: 35189},
 			expr: &actionExpr{
-				pos: position{line: 1449, col: 5, offset: 34843},
+				pos: position{line: 1465, col: 5, offset: 35207},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1449, col: 9, offset: 34847},
+					pos: position{line: 1465, col: 9, offset: 35211},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1449, col: 9, offset: 34847},
+							pos:        position{line: 1465, col: 9, offset: 35211},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 19, offset: 34857},
+							pos:        position{line: 1465, col: 19, offset: 35221},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 30, offset: 34868},
+							pos:        position{line: 1465, col: 30, offset: 35232},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 41, offset: 34879},
+							pos:        position{line: 1465, col: 41, offset: 35243},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 9, offset: 34896},
+							pos:        position{line: 1466, col: 9, offset: 35260},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 18, offset: 34905},
+							pos:        position{line: 1466, col: 18, offset: 35269},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 28, offset: 34915},
+							pos:        position{line: 1466, col: 28, offset: 35279},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 38, offset: 34925},
+							pos:        position{line: 1466, col: 38, offset: 35289},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1451, col: 9, offset: 34941},
+							pos:        position{line: 1467, col: 9, offset: 35305},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1451, col: 21, offset: 34953},
+							pos:        position{line: 1467, col: 21, offset: 35317},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1451, col: 33, offset: 34965},
+							pos:        position{line: 1467, col: 33, offset: 35329},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1452, col: 9, offset: 34983},
+							pos:        position{line: 1468, col: 9, offset: 35347},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1452, col: 18, offset: 34992},
+							pos:        position{line: 1468, col: 18, offset: 35356},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1453, col: 9, offset: 35009},
+							pos:        position{line: 1469, col: 9, offset: 35373},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1453, col: 22, offset: 35022},
+							pos:        position{line: 1469, col: 22, offset: 35386},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 9, offset: 35037},
+							pos:        position{line: 1470, col: 9, offset: 35401},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 9, offset: 35053},
+							pos:        position{line: 1471, col: 9, offset: 35417},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 16, offset: 35060},
+							pos:        position{line: 1471, col: 16, offset: 35424},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1456, col: 9, offset: 35074},
+							pos:        position{line: 1472, col: 9, offset: 35438},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1456, col: 18, offset: 35083},
+							pos:        position{line: 1472, col: 18, offset: 35447},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -10020,31 +10090,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1464, col: 1, offset: 35268},
+			pos:  position{line: 1480, col: 1, offset: 35632},
 			expr: &choiceExpr{
-				pos: position{line: 1465, col: 5, offset: 35286},
+				pos: position{line: 1481, col: 5, offset: 35650},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1465, col: 5, offset: 35286},
+						pos: position{line: 1481, col: 5, offset: 35650},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1465, col: 5, offset: 35286},
+							pos: position{line: 1481, col: 5, offset: 35650},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1465, col: 5, offset: 35286},
+									pos:   position{line: 1481, col: 5, offset: 35650},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1465, col: 11, offset: 35292},
+										pos:  position{line: 1481, col: 11, offset: 35656},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1465, col: 21, offset: 35302},
+									pos:   position{line: 1481, col: 21, offset: 35666},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1465, col: 26, offset: 35307},
+										pos: position{line: 1481, col: 26, offset: 35671},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1465, col: 26, offset: 35307},
+											pos:  position{line: 1481, col: 26, offset: 35671},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10053,10 +10123,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1468, col: 5, offset: 35373},
+						pos: position{line: 1484, col: 5, offset: 35737},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1468, col: 5, offset: 35373},
+							pos:        position{line: 1484, col: 5, offset: 35737},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10069,32 +10139,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1470, col: 1, offset: 35397},
+			pos:  position{line: 1486, col: 1, offset: 35761},
 			expr: &actionExpr{
-				pos: position{line: 1470, col: 21, offset: 35417},
+				pos: position{line: 1486, col: 21, offset: 35781},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1470, col: 21, offset: 35417},
+					pos: position{line: 1486, col: 21, offset: 35781},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1470, col: 21, offset: 35417},
+							pos:  position{line: 1486, col: 21, offset: 35781},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1470, col: 24, offset: 35420},
+							pos:        position{line: 1486, col: 24, offset: 35784},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1470, col: 28, offset: 35424},
+							pos:  position{line: 1486, col: 28, offset: 35788},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1470, col: 31, offset: 35427},
+							pos:   position{line: 1486, col: 31, offset: 35791},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1470, col: 35, offset: 35431},
+								pos:  position{line: 1486, col: 35, offset: 35795},
 								name: "TypeField",
 							},
 						},
@@ -10106,40 +10176,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1472, col: 1, offset: 35462},
+			pos:  position{line: 1488, col: 1, offset: 35826},
 			expr: &actionExpr{
-				pos: position{line: 1473, col: 5, offset: 35476},
+				pos: position{line: 1489, col: 5, offset: 35840},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1473, col: 5, offset: 35476},
+					pos: position{line: 1489, col: 5, offset: 35840},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1473, col: 5, offset: 35476},
+							pos:   position{line: 1489, col: 5, offset: 35840},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1473, col: 10, offset: 35481},
+								pos:  position{line: 1489, col: 10, offset: 35845},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1473, col: 15, offset: 35486},
+							pos:  position{line: 1489, col: 15, offset: 35850},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1473, col: 18, offset: 35489},
+							pos:        position{line: 1489, col: 18, offset: 35853},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1473, col: 22, offset: 35493},
+							pos:  position{line: 1489, col: 22, offset: 35857},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1473, col: 25, offset: 35496},
+							pos:   position{line: 1489, col: 25, offset: 35860},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1473, col: 29, offset: 35500},
+								pos:  position{line: 1489, col: 29, offset: 35864},
 								name: "Type",
 							},
 						},
@@ -10151,54 +10221,54 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1481, col: 1, offset: 35649},
+			pos:  position{line: 1497, col: 1, offset: 36013},
 			expr: &choiceExpr{
-				pos: position{line: 1482, col: 5, offset: 35658},
+				pos: position{line: 1498, col: 5, offset: 36022},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1482, col: 5, offset: 35658},
+						pos: position{line: 1498, col: 5, offset: 36022},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1482, col: 5, offset: 35658},
+							pos:   position{line: 1498, col: 5, offset: 36022},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1482, col: 7, offset: 35660},
+								pos:  position{line: 1498, col: 7, offset: 36024},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1483, col: 5, offset: 35749},
+						pos: position{line: 1499, col: 5, offset: 36113},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1483, col: 5, offset: 35749},
+							pos:   position{line: 1499, col: 5, offset: 36113},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1483, col: 7, offset: 35751},
+								pos:  position{line: 1499, col: 7, offset: 36115},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1484, col: 5, offset: 35840},
+						pos: position{line: 1500, col: 5, offset: 36204},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1484, col: 5, offset: 35840},
+							pos:   position{line: 1500, col: 5, offset: 36204},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1484, col: 7, offset: 35842},
+								pos:  position{line: 1500, col: 7, offset: 36206},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1485, col: 5, offset: 35931},
+						pos: position{line: 1501, col: 5, offset: 36295},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1485, col: 5, offset: 35931},
+							pos:   position{line: 1501, col: 5, offset: 36295},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1485, col: 7, offset: 35933},
+								pos:  position{line: 1501, col: 7, offset: 36297},
 								name: "KSUID",
 							},
 						},
@@ -10210,22 +10280,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1487, col: 1, offset: 36019},
+			pos:  position{line: 1503, col: 1, offset: 36383},
 			expr: &actionExpr{
-				pos: position{line: 1488, col: 5, offset: 36033},
+				pos: position{line: 1504, col: 5, offset: 36397},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1488, col: 5, offset: 36033},
+					pos: position{line: 1504, col: 5, offset: 36397},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1488, col: 6, offset: 36034},
+							pos: position{line: 1504, col: 6, offset: 36398},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1488, col: 6, offset: 36034},
+									pos:  position{line: 1504, col: 6, offset: 36398},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1488, col: 24, offset: 36052},
+									pos:        position{line: 1504, col: 24, offset: 36416},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -10233,16 +10303,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1488, col: 29, offset: 36057},
+							pos: position{line: 1504, col: 29, offset: 36421},
 							expr: &choiceExpr{
-								pos: position{line: 1488, col: 30, offset: 36058},
+								pos: position{line: 1504, col: 30, offset: 36422},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1488, col: 30, offset: 36058},
+										pos:  position{line: 1504, col: 30, offset: 36422},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1488, col: 47, offset: 36075},
+										pos:        position{line: 1504, col: 47, offset: 36439},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -10258,15 +10328,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1490, col: 1, offset: 36113},
+			pos:  position{line: 1506, col: 1, offset: 36477},
 			expr: &actionExpr{
-				pos: position{line: 1491, col: 5, offset: 36128},
+				pos: position{line: 1507, col: 5, offset: 36492},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1491, col: 5, offset: 36128},
+					pos:   position{line: 1507, col: 5, offset: 36492},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1491, col: 8, offset: 36131},
+						pos:  position{line: 1507, col: 8, offset: 36495},
 						name: "IdentifierName",
 					},
 				},
@@ -10276,51 +10346,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1499, col: 1, offset: 36264},
+			pos:  position{line: 1515, col: 1, offset: 36628},
 			expr: &actionExpr{
-				pos: position{line: 1500, col: 5, offset: 36280},
+				pos: position{line: 1516, col: 5, offset: 36644},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1500, col: 5, offset: 36280},
+					pos: position{line: 1516, col: 5, offset: 36644},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1500, col: 5, offset: 36280},
+							pos:   position{line: 1516, col: 5, offset: 36644},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1500, col: 11, offset: 36286},
+								pos:  position{line: 1516, col: 11, offset: 36650},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1500, col: 22, offset: 36297},
+							pos:   position{line: 1516, col: 22, offset: 36661},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1500, col: 27, offset: 36302},
+								pos: position{line: 1516, col: 27, offset: 36666},
 								expr: &actionExpr{
-									pos: position{line: 1500, col: 28, offset: 36303},
+									pos: position{line: 1516, col: 28, offset: 36667},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1500, col: 28, offset: 36303},
+										pos: position{line: 1516, col: 28, offset: 36667},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1500, col: 28, offset: 36303},
+												pos:  position{line: 1516, col: 28, offset: 36667},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1500, col: 31, offset: 36306},
+												pos:        position{line: 1516, col: 31, offset: 36670},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1500, col: 35, offset: 36310},
+												pos:  position{line: 1516, col: 35, offset: 36674},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1500, col: 38, offset: 36313},
+												pos:   position{line: 1516, col: 38, offset: 36677},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1500, col: 43, offset: 36318},
+													pos:  position{line: 1516, col: 43, offset: 36682},
 													name: "Identifier",
 												},
 											},
@@ -10337,29 +10407,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1504, col: 1, offset: 36396},
+			pos:  position{line: 1520, col: 1, offset: 36760},
 			expr: &choiceExpr{
-				pos: position{line: 1505, col: 5, offset: 36415},
+				pos: position{line: 1521, col: 5, offset: 36779},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1505, col: 5, offset: 36415},
+						pos: position{line: 1521, col: 5, offset: 36779},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1505, col: 5, offset: 36415},
+							pos: position{line: 1521, col: 5, offset: 36779},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1505, col: 5, offset: 36415},
+									pos: position{line: 1521, col: 5, offset: 36779},
 									expr: &seqExpr{
-										pos: position{line: 1505, col: 7, offset: 36417},
+										pos: position{line: 1521, col: 7, offset: 36781},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1505, col: 7, offset: 36417},
+												pos:  position{line: 1521, col: 7, offset: 36781},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1505, col: 15, offset: 36425},
+												pos: position{line: 1521, col: 15, offset: 36789},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1505, col: 16, offset: 36426},
+													pos:  position{line: 1521, col: 16, offset: 36790},
 													name: "IdentifierRest",
 												},
 											},
@@ -10367,13 +10437,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1505, col: 32, offset: 36442},
+									pos:  position{line: 1521, col: 32, offset: 36806},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1505, col: 48, offset: 36458},
+									pos: position{line: 1521, col: 48, offset: 36822},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1505, col: 48, offset: 36458},
+										pos:  position{line: 1521, col: 48, offset: 36822},
 										name: "IdentifierRest",
 									},
 								},
@@ -10381,32 +10451,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1506, col: 5, offset: 36509},
+						pos: position{line: 1522, col: 5, offset: 36873},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1506, col: 5, offset: 36509},
+							pos:        position{line: 1522, col: 5, offset: 36873},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1507, col: 5, offset: 36548},
+						pos: position{line: 1523, col: 5, offset: 36912},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1507, col: 5, offset: 36548},
+							pos: position{line: 1523, col: 5, offset: 36912},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1507, col: 5, offset: 36548},
+									pos:        position{line: 1523, col: 5, offset: 36912},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1507, col: 10, offset: 36553},
+									pos:   position{line: 1523, col: 10, offset: 36917},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1507, col: 13, offset: 36556},
+										pos:  position{line: 1523, col: 13, offset: 36920},
 										name: "IDGuard",
 									},
 								},
@@ -10414,17 +10484,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1509, col: 5, offset: 36647},
+						pos: position{line: 1525, col: 5, offset: 37011},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1509, col: 5, offset: 36647},
+							pos:        position{line: 1525, col: 5, offset: 37011},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1510, col: 5, offset: 36689},
+						pos:  position{line: 1526, col: 5, offset: 37053},
 						name: "BacktickString",
 					},
 				},
@@ -10434,22 +10504,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1512, col: 1, offset: 36706},
+			pos:  position{line: 1528, col: 1, offset: 37070},
 			expr: &choiceExpr{
-				pos: position{line: 1513, col: 5, offset: 36726},
+				pos: position{line: 1529, col: 5, offset: 37090},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1513, col: 5, offset: 36726},
+						pos:  position{line: 1529, col: 5, offset: 37090},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1514, col: 5, offset: 36744},
+						pos:        position{line: 1530, col: 5, offset: 37108},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1515, col: 5, offset: 36752},
+						pos:        position{line: 1531, col: 5, offset: 37116},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10461,24 +10531,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1517, col: 1, offset: 36757},
+			pos:  position{line: 1533, col: 1, offset: 37121},
 			expr: &choiceExpr{
-				pos: position{line: 1518, col: 5, offset: 36776},
+				pos: position{line: 1534, col: 5, offset: 37140},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1518, col: 5, offset: 36776},
+						pos:  position{line: 1534, col: 5, offset: 37140},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1519, col: 5, offset: 36796},
+						pos:  position{line: 1535, col: 5, offset: 37160},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1520, col: 5, offset: 36821},
+						pos:  position{line: 1536, col: 5, offset: 37185},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1521, col: 5, offset: 36838},
+						pos:  position{line: 1537, col: 5, offset: 37202},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10488,24 +10558,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1523, col: 1, offset: 36867},
+			pos:  position{line: 1539, col: 1, offset: 37231},
 			expr: &choiceExpr{
-				pos: position{line: 1524, col: 5, offset: 36879},
+				pos: position{line: 1540, col: 5, offset: 37243},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1524, col: 5, offset: 36879},
+						pos:  position{line: 1540, col: 5, offset: 37243},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1525, col: 5, offset: 36898},
+						pos:  position{line: 1541, col: 5, offset: 37262},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1526, col: 5, offset: 36914},
+						pos:  position{line: 1542, col: 5, offset: 37278},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1527, col: 5, offset: 36922},
+						pos:  position{line: 1543, col: 5, offset: 37286},
 						name: "Infinity",
 					},
 				},
@@ -10515,25 +10585,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1529, col: 1, offset: 36932},
+			pos:  position{line: 1545, col: 1, offset: 37296},
 			expr: &actionExpr{
-				pos: position{line: 1530, col: 5, offset: 36941},
+				pos: position{line: 1546, col: 5, offset: 37305},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1530, col: 5, offset: 36941},
+					pos: position{line: 1546, col: 5, offset: 37305},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1530, col: 5, offset: 36941},
+							pos:  position{line: 1546, col: 5, offset: 37305},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1530, col: 14, offset: 36950},
+							pos:        position{line: 1546, col: 14, offset: 37314},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1530, col: 18, offset: 36954},
+							pos:  position{line: 1546, col: 18, offset: 37318},
 							name: "FullTime",
 						},
 					},
@@ -10544,32 +10614,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1534, col: 1, offset: 37030},
+			pos:  position{line: 1550, col: 1, offset: 37394},
 			expr: &seqExpr{
-				pos: position{line: 1534, col: 12, offset: 37041},
+				pos: position{line: 1550, col: 12, offset: 37405},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 12, offset: 37041},
+						pos:  position{line: 1550, col: 12, offset: 37405},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1534, col: 15, offset: 37044},
+						pos:        position{line: 1550, col: 15, offset: 37408},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 19, offset: 37048},
+						pos:  position{line: 1550, col: 19, offset: 37412},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1534, col: 22, offset: 37051},
+						pos:        position{line: 1550, col: 22, offset: 37415},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 26, offset: 37055},
+						pos:  position{line: 1550, col: 26, offset: 37419},
 						name: "D2",
 					},
 				},
@@ -10579,33 +10649,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1536, col: 1, offset: 37059},
+			pos:  position{line: 1552, col: 1, offset: 37423},
 			expr: &seqExpr{
-				pos: position{line: 1536, col: 6, offset: 37064},
+				pos: position{line: 1552, col: 6, offset: 37428},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 6, offset: 37064},
+						pos:        position{line: 1552, col: 6, offset: 37428},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 11, offset: 37069},
+						pos:        position{line: 1552, col: 11, offset: 37433},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 16, offset: 37074},
+						pos:        position{line: 1552, col: 16, offset: 37438},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 21, offset: 37079},
+						pos:        position{line: 1552, col: 21, offset: 37443},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10618,19 +10688,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1537, col: 1, offset: 37085},
+			pos:  position{line: 1553, col: 1, offset: 37449},
 			expr: &seqExpr{
-				pos: position{line: 1537, col: 6, offset: 37090},
+				pos: position{line: 1553, col: 6, offset: 37454},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1537, col: 6, offset: 37090},
+						pos:        position{line: 1553, col: 6, offset: 37454},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1537, col: 11, offset: 37095},
+						pos:        position{line: 1553, col: 11, offset: 37459},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10643,16 +10713,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1539, col: 1, offset: 37102},
+			pos:  position{line: 1555, col: 1, offset: 37466},
 			expr: &seqExpr{
-				pos: position{line: 1539, col: 12, offset: 37113},
+				pos: position{line: 1555, col: 12, offset: 37477},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1539, col: 12, offset: 37113},
+						pos:  position{line: 1555, col: 12, offset: 37477},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1539, col: 24, offset: 37125},
+						pos:  position{line: 1555, col: 24, offset: 37489},
 						name: "TimeOffset",
 					},
 				},
@@ -10662,49 +10732,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1541, col: 1, offset: 37137},
+			pos:  position{line: 1557, col: 1, offset: 37501},
 			expr: &seqExpr{
-				pos: position{line: 1541, col: 15, offset: 37151},
+				pos: position{line: 1557, col: 15, offset: 37515},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 15, offset: 37151},
+						pos:  position{line: 1557, col: 15, offset: 37515},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1541, col: 18, offset: 37154},
+						pos:        position{line: 1557, col: 18, offset: 37518},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 22, offset: 37158},
+						pos:  position{line: 1557, col: 22, offset: 37522},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1541, col: 25, offset: 37161},
+						pos:        position{line: 1557, col: 25, offset: 37525},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 29, offset: 37165},
+						pos:  position{line: 1557, col: 29, offset: 37529},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1541, col: 32, offset: 37168},
+						pos: position{line: 1557, col: 32, offset: 37532},
 						expr: &seqExpr{
-							pos: position{line: 1541, col: 33, offset: 37169},
+							pos: position{line: 1557, col: 33, offset: 37533},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1541, col: 33, offset: 37169},
+									pos:        position{line: 1557, col: 33, offset: 37533},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1541, col: 37, offset: 37173},
+									pos: position{line: 1557, col: 37, offset: 37537},
 									expr: &charClassMatcher{
-										pos:        position{line: 1541, col: 37, offset: 37173},
+										pos:        position{line: 1557, col: 37, offset: 37537},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10721,30 +10791,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1543, col: 1, offset: 37183},
+			pos:  position{line: 1559, col: 1, offset: 37547},
 			expr: &choiceExpr{
-				pos: position{line: 1544, col: 5, offset: 37198},
+				pos: position{line: 1560, col: 5, offset: 37562},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1544, col: 5, offset: 37198},
+						pos:        position{line: 1560, col: 5, offset: 37562},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1545, col: 5, offset: 37206},
+						pos: position{line: 1561, col: 5, offset: 37570},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1545, col: 6, offset: 37207},
+								pos: position{line: 1561, col: 6, offset: 37571},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1545, col: 6, offset: 37207},
+										pos:        position{line: 1561, col: 6, offset: 37571},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1545, col: 12, offset: 37213},
+										pos:        position{line: 1561, col: 12, offset: 37577},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10752,34 +10822,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 17, offset: 37218},
+								pos:  position{line: 1561, col: 17, offset: 37582},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1545, col: 20, offset: 37221},
+								pos:        position{line: 1561, col: 20, offset: 37585},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 24, offset: 37225},
+								pos:  position{line: 1561, col: 24, offset: 37589},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1545, col: 27, offset: 37228},
+								pos: position{line: 1561, col: 27, offset: 37592},
 								expr: &seqExpr{
-									pos: position{line: 1545, col: 28, offset: 37229},
+									pos: position{line: 1561, col: 28, offset: 37593},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1545, col: 28, offset: 37229},
+											pos:        position{line: 1561, col: 28, offset: 37593},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1545, col: 32, offset: 37233},
+											pos: position{line: 1561, col: 32, offset: 37597},
 											expr: &charClassMatcher{
-												pos:        position{line: 1545, col: 32, offset: 37233},
+												pos:        position{line: 1561, col: 32, offset: 37597},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10798,33 +10868,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1547, col: 1, offset: 37243},
+			pos:  position{line: 1563, col: 1, offset: 37607},
 			expr: &actionExpr{
-				pos: position{line: 1548, col: 5, offset: 37256},
+				pos: position{line: 1564, col: 5, offset: 37620},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1548, col: 5, offset: 37256},
+					pos: position{line: 1564, col: 5, offset: 37620},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1548, col: 5, offset: 37256},
+							pos: position{line: 1564, col: 5, offset: 37620},
 							expr: &litMatcher{
-								pos:        position{line: 1548, col: 5, offset: 37256},
+								pos:        position{line: 1564, col: 5, offset: 37620},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1548, col: 10, offset: 37261},
+							pos: position{line: 1564, col: 10, offset: 37625},
 							expr: &seqExpr{
-								pos: position{line: 1548, col: 11, offset: 37262},
+								pos: position{line: 1564, col: 11, offset: 37626},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1548, col: 11, offset: 37262},
+										pos:  position{line: 1564, col: 11, offset: 37626},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1548, col: 19, offset: 37270},
+										pos:  position{line: 1564, col: 19, offset: 37634},
 										name: "TimeUnit",
 									},
 								},
@@ -10838,27 +10908,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1552, col: 1, offset: 37352},
+			pos:  position{line: 1568, col: 1, offset: 37716},
 			expr: &seqExpr{
-				pos: position{line: 1552, col: 11, offset: 37362},
+				pos: position{line: 1568, col: 11, offset: 37726},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1552, col: 11, offset: 37362},
+						pos:  position{line: 1568, col: 11, offset: 37726},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1552, col: 16, offset: 37367},
+						pos: position{line: 1568, col: 16, offset: 37731},
 						expr: &seqExpr{
-							pos: position{line: 1552, col: 17, offset: 37368},
+							pos: position{line: 1568, col: 17, offset: 37732},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1552, col: 17, offset: 37368},
+									pos:        position{line: 1568, col: 17, offset: 37732},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1552, col: 21, offset: 37372},
+									pos:  position{line: 1568, col: 21, offset: 37736},
 									name: "UInt",
 								},
 							},
@@ -10871,60 +10941,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1554, col: 1, offset: 37380},
+			pos:  position{line: 1570, col: 1, offset: 37744},
 			expr: &choiceExpr{
-				pos: position{line: 1555, col: 5, offset: 37393},
+				pos: position{line: 1571, col: 5, offset: 37757},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1555, col: 5, offset: 37393},
+						pos:        position{line: 1571, col: 5, offset: 37757},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1556, col: 5, offset: 37402},
+						pos:        position{line: 1572, col: 5, offset: 37766},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1557, col: 5, offset: 37411},
+						pos:        position{line: 1573, col: 5, offset: 37775},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1558, col: 5, offset: 37420},
+						pos:        position{line: 1574, col: 5, offset: 37784},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1559, col: 5, offset: 37428},
+						pos:        position{line: 1575, col: 5, offset: 37792},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1560, col: 5, offset: 37436},
+						pos:        position{line: 1576, col: 5, offset: 37800},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1561, col: 5, offset: 37444},
+						pos:        position{line: 1577, col: 5, offset: 37808},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1562, col: 5, offset: 37452},
+						pos:        position{line: 1578, col: 5, offset: 37816},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1563, col: 5, offset: 37460},
+						pos:        position{line: 1579, col: 5, offset: 37824},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10936,45 +11006,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1565, col: 1, offset: 37465},
+			pos:  position{line: 1581, col: 1, offset: 37829},
 			expr: &actionExpr{
-				pos: position{line: 1566, col: 5, offset: 37472},
+				pos: position{line: 1582, col: 5, offset: 37836},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1566, col: 5, offset: 37472},
+					pos: position{line: 1582, col: 5, offset: 37836},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 5, offset: 37472},
+							pos:  position{line: 1582, col: 5, offset: 37836},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 10, offset: 37477},
+							pos:        position{line: 1582, col: 10, offset: 37841},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 14, offset: 37481},
+							pos:  position{line: 1582, col: 14, offset: 37845},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 19, offset: 37486},
+							pos:        position{line: 1582, col: 19, offset: 37850},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 23, offset: 37490},
+							pos:  position{line: 1582, col: 23, offset: 37854},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 28, offset: 37495},
+							pos:        position{line: 1582, col: 28, offset: 37859},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 32, offset: 37499},
+							pos:  position{line: 1582, col: 32, offset: 37863},
 							name: "UInt",
 						},
 					},
@@ -10985,43 +11055,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1568, col: 1, offset: 37536},
+			pos:  position{line: 1584, col: 1, offset: 37900},
 			expr: &actionExpr{
-				pos: position{line: 1569, col: 5, offset: 37544},
+				pos: position{line: 1585, col: 5, offset: 37908},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1569, col: 5, offset: 37544},
+					pos: position{line: 1585, col: 5, offset: 37908},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1569, col: 5, offset: 37544},
+							pos: position{line: 1585, col: 5, offset: 37908},
 							expr: &seqExpr{
-								pos: position{line: 1569, col: 7, offset: 37546},
+								pos: position{line: 1585, col: 7, offset: 37910},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1569, col: 7, offset: 37546},
+										pos:  position{line: 1585, col: 7, offset: 37910},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1569, col: 11, offset: 37550},
+										pos:        position{line: 1585, col: 11, offset: 37914},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1569, col: 15, offset: 37554},
+										pos:  position{line: 1585, col: 15, offset: 37918},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1569, col: 19, offset: 37558},
+										pos: position{line: 1585, col: 19, offset: 37922},
 										expr: &choiceExpr{
-											pos: position{line: 1569, col: 21, offset: 37560},
+											pos: position{line: 1585, col: 21, offset: 37924},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1569, col: 21, offset: 37560},
+													pos:  position{line: 1585, col: 21, offset: 37924},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1569, col: 32, offset: 37571},
+													pos:        position{line: 1585, col: 32, offset: 37935},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11033,10 +11103,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1569, col: 38, offset: 37577},
+							pos:   position{line: 1585, col: 38, offset: 37941},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1569, col: 40, offset: 37579},
+								pos:  position{line: 1585, col: 40, offset: 37943},
 								name: "IP6Variations",
 							},
 						},
@@ -11048,32 +11118,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1573, col: 1, offset: 37743},
+			pos:  position{line: 1589, col: 1, offset: 38107},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 5, offset: 37761},
+				pos: position{line: 1590, col: 5, offset: 38125},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1574, col: 5, offset: 37761},
+						pos: position{line: 1590, col: 5, offset: 38125},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1574, col: 5, offset: 37761},
+							pos: position{line: 1590, col: 5, offset: 38125},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1574, col: 5, offset: 37761},
+									pos:   position{line: 1590, col: 5, offset: 38125},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1574, col: 7, offset: 37763},
+										pos: position{line: 1590, col: 7, offset: 38127},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1574, col: 7, offset: 37763},
+											pos:  position{line: 1590, col: 7, offset: 38127},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1574, col: 17, offset: 37773},
+									pos:   position{line: 1590, col: 17, offset: 38137},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1574, col: 19, offset: 37775},
+										pos:  position{line: 1590, col: 19, offset: 38139},
 										name: "IP6Tail",
 									},
 								},
@@ -11081,52 +11151,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1577, col: 5, offset: 37839},
+						pos: position{line: 1593, col: 5, offset: 38203},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1577, col: 5, offset: 37839},
+							pos: position{line: 1593, col: 5, offset: 38203},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1577, col: 5, offset: 37839},
+									pos:   position{line: 1593, col: 5, offset: 38203},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1577, col: 7, offset: 37841},
+										pos:  position{line: 1593, col: 7, offset: 38205},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 11, offset: 37845},
+									pos:   position{line: 1593, col: 11, offset: 38209},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1577, col: 13, offset: 37847},
+										pos: position{line: 1593, col: 13, offset: 38211},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1577, col: 13, offset: 37847},
+											pos:  position{line: 1593, col: 13, offset: 38211},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1577, col: 23, offset: 37857},
+									pos:        position{line: 1593, col: 23, offset: 38221},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 28, offset: 37862},
+									pos:   position{line: 1593, col: 28, offset: 38226},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1577, col: 30, offset: 37864},
+										pos: position{line: 1593, col: 30, offset: 38228},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1577, col: 30, offset: 37864},
+											pos:  position{line: 1593, col: 30, offset: 38228},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 40, offset: 37874},
+									pos:   position{line: 1593, col: 40, offset: 38238},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1577, col: 42, offset: 37876},
+										pos:  position{line: 1593, col: 42, offset: 38240},
 										name: "IP6Tail",
 									},
 								},
@@ -11134,33 +11204,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1580, col: 5, offset: 37975},
+						pos: position{line: 1596, col: 5, offset: 38339},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1580, col: 5, offset: 37975},
+							pos: position{line: 1596, col: 5, offset: 38339},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1580, col: 5, offset: 37975},
+									pos:        position{line: 1596, col: 5, offset: 38339},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1580, col: 10, offset: 37980},
+									pos:   position{line: 1596, col: 10, offset: 38344},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1580, col: 12, offset: 37982},
+										pos: position{line: 1596, col: 12, offset: 38346},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1580, col: 12, offset: 37982},
+											pos:  position{line: 1596, col: 12, offset: 38346},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1580, col: 22, offset: 37992},
+									pos:   position{line: 1596, col: 22, offset: 38356},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1580, col: 24, offset: 37994},
+										pos:  position{line: 1596, col: 24, offset: 38358},
 										name: "IP6Tail",
 									},
 								},
@@ -11168,32 +11238,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1583, col: 5, offset: 38065},
+						pos: position{line: 1599, col: 5, offset: 38429},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1583, col: 5, offset: 38065},
+							pos: position{line: 1599, col: 5, offset: 38429},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1583, col: 5, offset: 38065},
+									pos:   position{line: 1599, col: 5, offset: 38429},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1583, col: 7, offset: 38067},
+										pos:  position{line: 1599, col: 7, offset: 38431},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1583, col: 11, offset: 38071},
+									pos:   position{line: 1599, col: 11, offset: 38435},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1583, col: 13, offset: 38073},
+										pos: position{line: 1599, col: 13, offset: 38437},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1583, col: 13, offset: 38073},
+											pos:  position{line: 1599, col: 13, offset: 38437},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1583, col: 23, offset: 38083},
+									pos:        position{line: 1599, col: 23, offset: 38447},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -11202,10 +11272,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1586, col: 5, offset: 38151},
+						pos: position{line: 1602, col: 5, offset: 38515},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1586, col: 5, offset: 38151},
+							pos:        position{line: 1602, col: 5, offset: 38515},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11218,16 +11288,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1590, col: 1, offset: 38188},
+			pos:  position{line: 1606, col: 1, offset: 38552},
 			expr: &choiceExpr{
-				pos: position{line: 1591, col: 5, offset: 38200},
+				pos: position{line: 1607, col: 5, offset: 38564},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1591, col: 5, offset: 38200},
+						pos:  position{line: 1607, col: 5, offset: 38564},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1592, col: 5, offset: 38207},
+						pos:  position{line: 1608, col: 5, offset: 38571},
 						name: "Hex",
 					},
 				},
@@ -11237,24 +11307,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1594, col: 1, offset: 38212},
+			pos:  position{line: 1610, col: 1, offset: 38576},
 			expr: &actionExpr{
-				pos: position{line: 1594, col: 12, offset: 38223},
+				pos: position{line: 1610, col: 12, offset: 38587},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1594, col: 12, offset: 38223},
+					pos: position{line: 1610, col: 12, offset: 38587},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1594, col: 12, offset: 38223},
+							pos:        position{line: 1610, col: 12, offset: 38587},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1594, col: 16, offset: 38227},
+							pos:   position{line: 1610, col: 16, offset: 38591},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1594, col: 18, offset: 38229},
+								pos:  position{line: 1610, col: 18, offset: 38593},
 								name: "Hex",
 							},
 						},
@@ -11266,23 +11336,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1596, col: 1, offset: 38267},
+			pos:  position{line: 1612, col: 1, offset: 38631},
 			expr: &actionExpr{
-				pos: position{line: 1596, col: 12, offset: 38278},
+				pos: position{line: 1612, col: 12, offset: 38642},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1596, col: 12, offset: 38278},
+					pos: position{line: 1612, col: 12, offset: 38642},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1596, col: 12, offset: 38278},
+							pos:   position{line: 1612, col: 12, offset: 38642},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1596, col: 14, offset: 38280},
+								pos:  position{line: 1612, col: 14, offset: 38644},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1596, col: 18, offset: 38284},
+							pos:        position{line: 1612, col: 18, offset: 38648},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11295,32 +11365,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1598, col: 1, offset: 38322},
+			pos:  position{line: 1614, col: 1, offset: 38686},
 			expr: &actionExpr{
-				pos: position{line: 1599, col: 5, offset: 38333},
+				pos: position{line: 1615, col: 5, offset: 38697},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1599, col: 5, offset: 38333},
+					pos: position{line: 1615, col: 5, offset: 38697},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1599, col: 5, offset: 38333},
+							pos:   position{line: 1615, col: 5, offset: 38697},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 7, offset: 38335},
+								pos:  position{line: 1615, col: 7, offset: 38699},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1599, col: 10, offset: 38338},
+							pos:        position{line: 1615, col: 10, offset: 38702},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1599, col: 14, offset: 38342},
+							pos:   position{line: 1615, col: 14, offset: 38706},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 16, offset: 38344},
+								pos:  position{line: 1615, col: 16, offset: 38708},
 								name: "UIntString",
 							},
 						},
@@ -11332,32 +11402,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1603, col: 1, offset: 38412},
+			pos:  position{line: 1619, col: 1, offset: 38776},
 			expr: &actionExpr{
-				pos: position{line: 1604, col: 5, offset: 38423},
+				pos: position{line: 1620, col: 5, offset: 38787},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1604, col: 5, offset: 38423},
+					pos: position{line: 1620, col: 5, offset: 38787},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1604, col: 5, offset: 38423},
+							pos:   position{line: 1620, col: 5, offset: 38787},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1604, col: 7, offset: 38425},
+								pos:  position{line: 1620, col: 7, offset: 38789},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1604, col: 11, offset: 38429},
+							pos:        position{line: 1620, col: 11, offset: 38793},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1604, col: 15, offset: 38433},
+							pos:   position{line: 1620, col: 15, offset: 38797},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1604, col: 17, offset: 38435},
+								pos:  position{line: 1620, col: 17, offset: 38799},
 								name: "UIntString",
 							},
 						},
@@ -11369,15 +11439,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1608, col: 1, offset: 38503},
+			pos:  position{line: 1624, col: 1, offset: 38867},
 			expr: &actionExpr{
-				pos: position{line: 1609, col: 4, offset: 38511},
+				pos: position{line: 1625, col: 4, offset: 38875},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1609, col: 4, offset: 38511},
+					pos:   position{line: 1625, col: 4, offset: 38875},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1609, col: 6, offset: 38513},
+						pos:  position{line: 1625, col: 6, offset: 38877},
 						name: "UIntString",
 					},
 				},
@@ -11387,16 +11457,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1611, col: 1, offset: 38553},
+			pos:  position{line: 1627, col: 1, offset: 38917},
 			expr: &choiceExpr{
-				pos: position{line: 1612, col: 5, offset: 38567},
+				pos: position{line: 1628, col: 5, offset: 38931},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1612, col: 5, offset: 38567},
+						pos:  position{line: 1628, col: 5, offset: 38931},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1613, col: 5, offset: 38582},
+						pos:  position{line: 1629, col: 5, offset: 38946},
 						name: "MinusIntString",
 					},
 				},
@@ -11406,14 +11476,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1615, col: 1, offset: 38598},
+			pos:  position{line: 1631, col: 1, offset: 38962},
 			expr: &actionExpr{
-				pos: position{line: 1615, col: 14, offset: 38611},
+				pos: position{line: 1631, col: 14, offset: 38975},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1615, col: 14, offset: 38611},
+					pos: position{line: 1631, col: 14, offset: 38975},
 					expr: &charClassMatcher{
-						pos:        position{line: 1615, col: 14, offset: 38611},
+						pos:        position{line: 1631, col: 14, offset: 38975},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11426,21 +11496,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1617, col: 1, offset: 38650},
+			pos:  position{line: 1633, col: 1, offset: 39014},
 			expr: &actionExpr{
-				pos: position{line: 1618, col: 5, offset: 38669},
+				pos: position{line: 1634, col: 5, offset: 39033},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1618, col: 5, offset: 38669},
+					pos: position{line: 1634, col: 5, offset: 39033},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1618, col: 5, offset: 38669},
+							pos:        position{line: 1634, col: 5, offset: 39033},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1618, col: 9, offset: 38673},
+							pos:  position{line: 1634, col: 9, offset: 39037},
 							name: "UIntString",
 						},
 					},
@@ -11451,29 +11521,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1620, col: 1, offset: 38716},
+			pos:  position{line: 1636, col: 1, offset: 39080},
 			expr: &choiceExpr{
-				pos: position{line: 1621, col: 5, offset: 38732},
+				pos: position{line: 1637, col: 5, offset: 39096},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1621, col: 5, offset: 38732},
+						pos: position{line: 1637, col: 5, offset: 39096},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1621, col: 5, offset: 38732},
+							pos: position{line: 1637, col: 5, offset: 39096},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1621, col: 5, offset: 38732},
+									pos: position{line: 1637, col: 5, offset: 39096},
 									expr: &litMatcher{
-										pos:        position{line: 1621, col: 5, offset: 38732},
+										pos:        position{line: 1637, col: 5, offset: 39096},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1621, col: 10, offset: 38737},
+									pos: position{line: 1637, col: 10, offset: 39101},
 									expr: &charClassMatcher{
-										pos:        position{line: 1621, col: 10, offset: 38737},
+										pos:        position{line: 1637, col: 10, offset: 39101},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11481,15 +11551,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1621, col: 17, offset: 38744},
+									pos:        position{line: 1637, col: 17, offset: 39108},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1621, col: 21, offset: 38748},
+									pos: position{line: 1637, col: 21, offset: 39112},
 									expr: &charClassMatcher{
-										pos:        position{line: 1621, col: 21, offset: 38748},
+										pos:        position{line: 1637, col: 21, offset: 39112},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11497,9 +11567,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1621, col: 28, offset: 38755},
+									pos: position{line: 1637, col: 28, offset: 39119},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1621, col: 28, offset: 38755},
+										pos:  position{line: 1637, col: 28, offset: 39119},
 										name: "ExponentPart",
 									},
 								},
@@ -11507,30 +11577,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1622, col: 5, offset: 38804},
+						pos: position{line: 1638, col: 5, offset: 39168},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1622, col: 5, offset: 38804},
+							pos: position{line: 1638, col: 5, offset: 39168},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1622, col: 5, offset: 38804},
+									pos: position{line: 1638, col: 5, offset: 39168},
 									expr: &litMatcher{
-										pos:        position{line: 1622, col: 5, offset: 38804},
+										pos:        position{line: 1638, col: 5, offset: 39168},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1622, col: 10, offset: 38809},
+									pos:        position{line: 1638, col: 10, offset: 39173},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1622, col: 14, offset: 38813},
+									pos: position{line: 1638, col: 14, offset: 39177},
 									expr: &charClassMatcher{
-										pos:        position{line: 1622, col: 14, offset: 38813},
+										pos:        position{line: 1638, col: 14, offset: 39177},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11538,9 +11608,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1622, col: 21, offset: 38820},
+									pos: position{line: 1638, col: 21, offset: 39184},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1622, col: 21, offset: 38820},
+										pos:  position{line: 1638, col: 21, offset: 39184},
 										name: "ExponentPart",
 									},
 								},
@@ -11548,17 +11618,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1623, col: 5, offset: 38869},
+						pos: position{line: 1639, col: 5, offset: 39233},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1623, col: 6, offset: 38870},
+							pos: position{line: 1639, col: 6, offset: 39234},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1623, col: 6, offset: 38870},
+									pos:  position{line: 1639, col: 6, offset: 39234},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1623, col: 12, offset: 38876},
+									pos:  position{line: 1639, col: 12, offset: 39240},
 									name: "Infinity",
 								},
 							},
@@ -11571,20 +11641,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1626, col: 1, offset: 38919},
+			pos:  position{line: 1642, col: 1, offset: 39283},
 			expr: &seqExpr{
-				pos: position{line: 1626, col: 16, offset: 38934},
+				pos: position{line: 1642, col: 16, offset: 39298},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1626, col: 16, offset: 38934},
+						pos:        position{line: 1642, col: 16, offset: 39298},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1626, col: 21, offset: 38939},
+						pos: position{line: 1642, col: 21, offset: 39303},
 						expr: &charClassMatcher{
-							pos:        position{line: 1626, col: 21, offset: 38939},
+							pos:        position{line: 1642, col: 21, offset: 39303},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11592,7 +11662,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1626, col: 27, offset: 38945},
+						pos:  position{line: 1642, col: 27, offset: 39309},
 						name: "UIntString",
 					},
 				},
@@ -11602,9 +11672,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1628, col: 1, offset: 38957},
+			pos:  position{line: 1644, col: 1, offset: 39321},
 			expr: &litMatcher{
-				pos:        position{line: 1628, col: 7, offset: 38963},
+				pos:        position{line: 1644, col: 7, offset: 39327},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11614,23 +11684,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1630, col: 1, offset: 38970},
+			pos:  position{line: 1646, col: 1, offset: 39334},
 			expr: &seqExpr{
-				pos: position{line: 1630, col: 12, offset: 38981},
+				pos: position{line: 1646, col: 12, offset: 39345},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1630, col: 12, offset: 38981},
+						pos: position{line: 1646, col: 12, offset: 39345},
 						expr: &choiceExpr{
-							pos: position{line: 1630, col: 13, offset: 38982},
+							pos: position{line: 1646, col: 13, offset: 39346},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1630, col: 13, offset: 38982},
+									pos:        position{line: 1646, col: 13, offset: 39346},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1630, col: 19, offset: 38988},
+									pos:        position{line: 1646, col: 19, offset: 39352},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11639,7 +11709,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1630, col: 25, offset: 38994},
+						pos:        position{line: 1646, col: 25, offset: 39358},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11651,14 +11721,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1632, col: 1, offset: 39001},
+			pos:  position{line: 1648, col: 1, offset: 39365},
 			expr: &actionExpr{
-				pos: position{line: 1632, col: 7, offset: 39007},
+				pos: position{line: 1648, col: 7, offset: 39371},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1632, col: 7, offset: 39007},
+					pos: position{line: 1648, col: 7, offset: 39371},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1632, col: 7, offset: 39007},
+						pos:  position{line: 1648, col: 7, offset: 39371},
 						name: "HexDigit",
 					},
 				},
@@ -11668,9 +11738,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1634, col: 1, offset: 39049},
+			pos:  position{line: 1650, col: 1, offset: 39413},
 			expr: &charClassMatcher{
-				pos:        position{line: 1634, col: 12, offset: 39060},
+				pos:        position{line: 1650, col: 12, offset: 39424},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11681,35 +11751,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1636, col: 1, offset: 39073},
+			pos:  position{line: 1652, col: 1, offset: 39437},
 			expr: &choiceExpr{
-				pos: position{line: 1637, col: 5, offset: 39090},
+				pos: position{line: 1653, col: 5, offset: 39454},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1637, col: 5, offset: 39090},
+						pos: position{line: 1653, col: 5, offset: 39454},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1637, col: 5, offset: 39090},
+							pos: position{line: 1653, col: 5, offset: 39454},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1637, col: 5, offset: 39090},
+									pos:        position{line: 1653, col: 5, offset: 39454},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1637, col: 9, offset: 39094},
+									pos:   position{line: 1653, col: 9, offset: 39458},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1637, col: 11, offset: 39096},
+										pos: position{line: 1653, col: 11, offset: 39460},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1637, col: 11, offset: 39096},
+											pos:  position{line: 1653, col: 11, offset: 39460},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1637, col: 29, offset: 39114},
+									pos:        position{line: 1653, col: 29, offset: 39478},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11718,30 +11788,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1638, col: 5, offset: 39151},
+						pos: position{line: 1654, col: 5, offset: 39515},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1638, col: 5, offset: 39151},
+							pos: position{line: 1654, col: 5, offset: 39515},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1638, col: 5, offset: 39151},
+									pos:        position{line: 1654, col: 5, offset: 39515},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1638, col: 9, offset: 39155},
+									pos:   position{line: 1654, col: 9, offset: 39519},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1638, col: 11, offset: 39157},
+										pos: position{line: 1654, col: 11, offset: 39521},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1638, col: 11, offset: 39157},
+											pos:  position{line: 1654, col: 11, offset: 39521},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1638, col: 29, offset: 39175},
+									pos:        position{line: 1654, col: 29, offset: 39539},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11756,57 +11826,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1640, col: 1, offset: 39209},
+			pos:  position{line: 1656, col: 1, offset: 39573},
 			expr: &choiceExpr{
-				pos: position{line: 1641, col: 5, offset: 39230},
+				pos: position{line: 1657, col: 5, offset: 39594},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1641, col: 5, offset: 39230},
+						pos: position{line: 1657, col: 5, offset: 39594},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1641, col: 5, offset: 39230},
+							pos: position{line: 1657, col: 5, offset: 39594},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1641, col: 5, offset: 39230},
+									pos: position{line: 1657, col: 5, offset: 39594},
 									expr: &choiceExpr{
-										pos: position{line: 1641, col: 7, offset: 39232},
+										pos: position{line: 1657, col: 7, offset: 39596},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1641, col: 7, offset: 39232},
+												pos:        position{line: 1657, col: 7, offset: 39596},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1641, col: 13, offset: 39238},
+												pos:  position{line: 1657, col: 13, offset: 39602},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1641, col: 26, offset: 39251,
+									line: 1657, col: 26, offset: 39615,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1642, col: 5, offset: 39288},
+						pos: position{line: 1658, col: 5, offset: 39652},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1642, col: 5, offset: 39288},
+							pos: position{line: 1658, col: 5, offset: 39652},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1642, col: 5, offset: 39288},
+									pos:        position{line: 1658, col: 5, offset: 39652},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1642, col: 10, offset: 39293},
+									pos:   position{line: 1658, col: 10, offset: 39657},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1642, col: 12, offset: 39295},
+										pos:  position{line: 1658, col: 12, offset: 39659},
 										name: "EscapeSequence",
 									},
 								},
@@ -11820,32 +11890,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1644, col: 1, offset: 39329},
+			pos:  position{line: 1660, col: 1, offset: 39693},
 			expr: &actionExpr{
-				pos: position{line: 1645, col: 5, offset: 39348},
+				pos: position{line: 1661, col: 5, offset: 39712},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1645, col: 5, offset: 39348},
+					pos: position{line: 1661, col: 5, offset: 39712},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1645, col: 5, offset: 39348},
+							pos:        position{line: 1661, col: 5, offset: 39712},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1645, col: 9, offset: 39352},
+							pos:   position{line: 1661, col: 9, offset: 39716},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1645, col: 11, offset: 39354},
+								pos: position{line: 1661, col: 11, offset: 39718},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1645, col: 11, offset: 39354},
+									pos:  position{line: 1661, col: 11, offset: 39718},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1645, col: 25, offset: 39368},
+							pos:        position{line: 1661, col: 25, offset: 39732},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11858,57 +11928,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1647, col: 1, offset: 39402},
+			pos:  position{line: 1663, col: 1, offset: 39766},
 			expr: &choiceExpr{
-				pos: position{line: 1648, col: 5, offset: 39419},
+				pos: position{line: 1664, col: 5, offset: 39783},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1648, col: 5, offset: 39419},
+						pos: position{line: 1664, col: 5, offset: 39783},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1648, col: 5, offset: 39419},
+							pos: position{line: 1664, col: 5, offset: 39783},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1648, col: 5, offset: 39419},
+									pos: position{line: 1664, col: 5, offset: 39783},
 									expr: &choiceExpr{
-										pos: position{line: 1648, col: 7, offset: 39421},
+										pos: position{line: 1664, col: 7, offset: 39785},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1648, col: 7, offset: 39421},
+												pos:        position{line: 1664, col: 7, offset: 39785},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1648, col: 13, offset: 39427},
+												pos:  position{line: 1664, col: 13, offset: 39791},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1648, col: 26, offset: 39440,
+									line: 1664, col: 26, offset: 39804,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1649, col: 5, offset: 39477},
+						pos: position{line: 1665, col: 5, offset: 39841},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1649, col: 5, offset: 39477},
+							pos: position{line: 1665, col: 5, offset: 39841},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1649, col: 5, offset: 39477},
+									pos:        position{line: 1665, col: 5, offset: 39841},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1649, col: 10, offset: 39482},
+									pos:   position{line: 1665, col: 10, offset: 39846},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1649, col: 12, offset: 39484},
+										pos:  position{line: 1665, col: 12, offset: 39848},
 										name: "EscapeSequence",
 									},
 								},
@@ -11922,28 +11992,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1651, col: 1, offset: 39518},
+			pos:  position{line: 1667, col: 1, offset: 39882},
 			expr: &actionExpr{
-				pos: position{line: 1652, col: 5, offset: 39530},
+				pos: position{line: 1668, col: 5, offset: 39894},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1652, col: 5, offset: 39530},
+					pos: position{line: 1668, col: 5, offset: 39894},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1652, col: 5, offset: 39530},
+							pos:   position{line: 1668, col: 5, offset: 39894},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1652, col: 10, offset: 39535},
+								pos:  position{line: 1668, col: 10, offset: 39899},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1652, col: 23, offset: 39548},
+							pos:   position{line: 1668, col: 23, offset: 39912},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1652, col: 28, offset: 39553},
+								pos: position{line: 1668, col: 28, offset: 39917},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1652, col: 28, offset: 39553},
+									pos:  position{line: 1668, col: 28, offset: 39917},
 									name: "KeyWordRest",
 								},
 							},
@@ -11956,16 +12026,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1654, col: 1, offset: 39615},
+			pos:  position{line: 1670, col: 1, offset: 39979},
 			expr: &choiceExpr{
-				pos: position{line: 1655, col: 5, offset: 39632},
+				pos: position{line: 1671, col: 5, offset: 39996},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1655, col: 5, offset: 39632},
+						pos:  position{line: 1671, col: 5, offset: 39996},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1656, col: 5, offset: 39649},
+						pos:  position{line: 1672, col: 5, offset: 40013},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11975,16 +12045,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1658, col: 1, offset: 39661},
+			pos:  position{line: 1674, col: 1, offset: 40025},
 			expr: &choiceExpr{
-				pos: position{line: 1659, col: 5, offset: 39677},
+				pos: position{line: 1675, col: 5, offset: 40041},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1659, col: 5, offset: 39677},
+						pos:  position{line: 1675, col: 5, offset: 40041},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1660, col: 5, offset: 39694},
+						pos:        position{line: 1676, col: 5, offset: 40058},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11997,19 +12067,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1662, col: 1, offset: 39701},
+			pos:  position{line: 1678, col: 1, offset: 40065},
 			expr: &actionExpr{
-				pos: position{line: 1662, col: 16, offset: 39716},
+				pos: position{line: 1678, col: 16, offset: 40080},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1662, col: 17, offset: 39717},
+					pos: position{line: 1678, col: 17, offset: 40081},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1662, col: 17, offset: 39717},
+							pos:  position{line: 1678, col: 17, offset: 40081},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1662, col: 33, offset: 39733},
+							pos:        position{line: 1678, col: 33, offset: 40097},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12023,31 +12093,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1664, col: 1, offset: 39777},
+			pos:  position{line: 1680, col: 1, offset: 40141},
 			expr: &actionExpr{
-				pos: position{line: 1664, col: 14, offset: 39790},
+				pos: position{line: 1680, col: 14, offset: 40154},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1664, col: 14, offset: 39790},
+					pos: position{line: 1680, col: 14, offset: 40154},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1664, col: 14, offset: 39790},
+							pos:        position{line: 1680, col: 14, offset: 40154},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1664, col: 19, offset: 39795},
+							pos:   position{line: 1680, col: 19, offset: 40159},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1664, col: 22, offset: 39798},
+								pos: position{line: 1680, col: 22, offset: 40162},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1664, col: 22, offset: 39798},
+										pos:  position{line: 1680, col: 22, offset: 40162},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1664, col: 38, offset: 39814},
+										pos:  position{line: 1680, col: 38, offset: 40178},
 										name: "EscapeSequence",
 									},
 								},
@@ -12061,42 +12131,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1666, col: 1, offset: 39849},
+			pos:  position{line: 1682, col: 1, offset: 40213},
 			expr: &actionExpr{
-				pos: position{line: 1667, col: 5, offset: 39865},
+				pos: position{line: 1683, col: 5, offset: 40229},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1667, col: 5, offset: 39865},
+					pos: position{line: 1683, col: 5, offset: 40229},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1667, col: 5, offset: 39865},
+							pos: position{line: 1683, col: 5, offset: 40229},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1667, col: 6, offset: 39866},
+								pos:  position{line: 1683, col: 6, offset: 40230},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1667, col: 22, offset: 39882},
+							pos: position{line: 1683, col: 22, offset: 40246},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1667, col: 23, offset: 39883},
+								pos:  position{line: 1683, col: 23, offset: 40247},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1667, col: 35, offset: 39895},
+							pos:   position{line: 1683, col: 35, offset: 40259},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1667, col: 40, offset: 39900},
+								pos:  position{line: 1683, col: 40, offset: 40264},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1667, col: 50, offset: 39910},
+							pos:   position{line: 1683, col: 50, offset: 40274},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1667, col: 55, offset: 39915},
+								pos: position{line: 1683, col: 55, offset: 40279},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1667, col: 55, offset: 39915},
+									pos:  position{line: 1683, col: 55, offset: 40279},
 									name: "GlobRest",
 								},
 							},
@@ -12109,28 +12179,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1671, col: 1, offset: 39984},
+			pos:  position{line: 1687, col: 1, offset: 40348},
 			expr: &choiceExpr{
-				pos: position{line: 1671, col: 19, offset: 40002},
+				pos: position{line: 1687, col: 19, offset: 40366},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1671, col: 19, offset: 40002},
+						pos:  position{line: 1687, col: 19, offset: 40366},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1671, col: 34, offset: 40017},
+						pos: position{line: 1687, col: 34, offset: 40381},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1671, col: 34, offset: 40017},
+								pos: position{line: 1687, col: 34, offset: 40381},
 								expr: &litMatcher{
-									pos:        position{line: 1671, col: 34, offset: 40017},
+									pos:        position{line: 1687, col: 34, offset: 40381},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1671, col: 39, offset: 40022},
+								pos:  position{line: 1687, col: 39, offset: 40386},
 								name: "KeyWordRest",
 							},
 						},
@@ -12142,19 +12212,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1672, col: 1, offset: 40034},
+			pos:  position{line: 1688, col: 1, offset: 40398},
 			expr: &seqExpr{
-				pos: position{line: 1672, col: 15, offset: 40048},
+				pos: position{line: 1688, col: 15, offset: 40412},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1672, col: 15, offset: 40048},
+						pos: position{line: 1688, col: 15, offset: 40412},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1672, col: 15, offset: 40048},
+							pos:  position{line: 1688, col: 15, offset: 40412},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1672, col: 28, offset: 40061},
+						pos:        position{line: 1688, col: 28, offset: 40425},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12166,23 +12236,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1674, col: 1, offset: 40066},
+			pos:  position{line: 1690, col: 1, offset: 40430},
 			expr: &choiceExpr{
-				pos: position{line: 1675, col: 5, offset: 40080},
+				pos: position{line: 1691, col: 5, offset: 40444},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1675, col: 5, offset: 40080},
+						pos:  position{line: 1691, col: 5, offset: 40444},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1676, col: 5, offset: 40097},
+						pos:  position{line: 1692, col: 5, offset: 40461},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1677, col: 5, offset: 40109},
+						pos: position{line: 1693, col: 5, offset: 40473},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1677, col: 5, offset: 40109},
+							pos:        position{line: 1693, col: 5, offset: 40473},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12195,16 +12265,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1679, col: 1, offset: 40134},
+			pos:  position{line: 1695, col: 1, offset: 40498},
 			expr: &choiceExpr{
-				pos: position{line: 1680, col: 5, offset: 40147},
+				pos: position{line: 1696, col: 5, offset: 40511},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1680, col: 5, offset: 40147},
+						pos:  position{line: 1696, col: 5, offset: 40511},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1681, col: 5, offset: 40161},
+						pos:        position{line: 1697, col: 5, offset: 40525},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12217,31 +12287,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1683, col: 1, offset: 40168},
+			pos:  position{line: 1699, col: 1, offset: 40532},
 			expr: &actionExpr{
-				pos: position{line: 1683, col: 11, offset: 40178},
+				pos: position{line: 1699, col: 11, offset: 40542},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1683, col: 11, offset: 40178},
+					pos: position{line: 1699, col: 11, offset: 40542},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1683, col: 11, offset: 40178},
+							pos:        position{line: 1699, col: 11, offset: 40542},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1683, col: 16, offset: 40183},
+							pos:   position{line: 1699, col: 16, offset: 40547},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1683, col: 19, offset: 40186},
+								pos: position{line: 1699, col: 19, offset: 40550},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1683, col: 19, offset: 40186},
+										pos:  position{line: 1699, col: 19, offset: 40550},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1683, col: 32, offset: 40199},
+										pos:  position{line: 1699, col: 32, offset: 40563},
 										name: "EscapeSequence",
 									},
 								},
@@ -12255,32 +12325,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1685, col: 1, offset: 40234},
+			pos:  position{line: 1701, col: 1, offset: 40598},
 			expr: &choiceExpr{
-				pos: position{line: 1686, col: 5, offset: 40249},
+				pos: position{line: 1702, col: 5, offset: 40613},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1686, col: 5, offset: 40249},
+						pos: position{line: 1702, col: 5, offset: 40613},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1686, col: 5, offset: 40249},
+							pos:        position{line: 1702, col: 5, offset: 40613},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1687, col: 5, offset: 40277},
+						pos: position{line: 1703, col: 5, offset: 40641},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1687, col: 5, offset: 40277},
+							pos:        position{line: 1703, col: 5, offset: 40641},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1688, col: 5, offset: 40307},
+						pos:        position{line: 1704, col: 5, offset: 40671},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12293,57 +12363,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1690, col: 1, offset: 40313},
+			pos:  position{line: 1706, col: 1, offset: 40677},
 			expr: &choiceExpr{
-				pos: position{line: 1691, col: 5, offset: 40334},
+				pos: position{line: 1707, col: 5, offset: 40698},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1691, col: 5, offset: 40334},
+						pos: position{line: 1707, col: 5, offset: 40698},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1691, col: 5, offset: 40334},
+							pos: position{line: 1707, col: 5, offset: 40698},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1691, col: 5, offset: 40334},
+									pos: position{line: 1707, col: 5, offset: 40698},
 									expr: &choiceExpr{
-										pos: position{line: 1691, col: 7, offset: 40336},
+										pos: position{line: 1707, col: 7, offset: 40700},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1691, col: 7, offset: 40336},
+												pos:        position{line: 1707, col: 7, offset: 40700},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1691, col: 13, offset: 40342},
+												pos:  position{line: 1707, col: 13, offset: 40706},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1691, col: 26, offset: 40355,
+									line: 1707, col: 26, offset: 40719,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1692, col: 5, offset: 40392},
+						pos: position{line: 1708, col: 5, offset: 40756},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1692, col: 5, offset: 40392},
+							pos: position{line: 1708, col: 5, offset: 40756},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1692, col: 5, offset: 40392},
+									pos:        position{line: 1708, col: 5, offset: 40756},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1692, col: 10, offset: 40397},
+									pos:   position{line: 1708, col: 10, offset: 40761},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1692, col: 12, offset: 40399},
+										pos:  position{line: 1708, col: 12, offset: 40763},
 										name: "EscapeSequence",
 									},
 								},
@@ -12357,16 +12427,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1694, col: 1, offset: 40433},
+			pos:  position{line: 1710, col: 1, offset: 40797},
 			expr: &choiceExpr{
-				pos: position{line: 1695, col: 5, offset: 40452},
+				pos: position{line: 1711, col: 5, offset: 40816},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1695, col: 5, offset: 40452},
+						pos:  position{line: 1711, col: 5, offset: 40816},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1696, col: 5, offset: 40473},
+						pos:  position{line: 1712, col: 5, offset: 40837},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12376,87 +12446,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1698, col: 1, offset: 40488},
+			pos:  position{line: 1714, col: 1, offset: 40852},
 			expr: &choiceExpr{
-				pos: position{line: 1699, col: 5, offset: 40509},
+				pos: position{line: 1715, col: 5, offset: 40873},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1699, col: 5, offset: 40509},
+						pos:        position{line: 1715, col: 5, offset: 40873},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1700, col: 5, offset: 40517},
+						pos: position{line: 1716, col: 5, offset: 40881},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1700, col: 5, offset: 40517},
+							pos:        position{line: 1716, col: 5, offset: 40881},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1701, col: 5, offset: 40557},
+						pos:        position{line: 1717, col: 5, offset: 40921},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1702, col: 5, offset: 40566},
+						pos: position{line: 1718, col: 5, offset: 40930},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1702, col: 5, offset: 40566},
+							pos:        position{line: 1718, col: 5, offset: 40930},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1703, col: 5, offset: 40595},
+						pos: position{line: 1719, col: 5, offset: 40959},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1703, col: 5, offset: 40595},
+							pos:        position{line: 1719, col: 5, offset: 40959},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1704, col: 5, offset: 40624},
+						pos: position{line: 1720, col: 5, offset: 40988},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1704, col: 5, offset: 40624},
+							pos:        position{line: 1720, col: 5, offset: 40988},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1705, col: 5, offset: 40653},
+						pos: position{line: 1721, col: 5, offset: 41017},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1705, col: 5, offset: 40653},
+							pos:        position{line: 1721, col: 5, offset: 41017},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1706, col: 5, offset: 40682},
+						pos: position{line: 1722, col: 5, offset: 41046},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1706, col: 5, offset: 40682},
+							pos:        position{line: 1722, col: 5, offset: 41046},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1707, col: 5, offset: 40711},
+						pos: position{line: 1723, col: 5, offset: 41075},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1707, col: 5, offset: 40711},
+							pos:        position{line: 1723, col: 5, offset: 41075},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12469,32 +12539,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1709, col: 1, offset: 40737},
+			pos:  position{line: 1725, col: 1, offset: 41101},
 			expr: &choiceExpr{
-				pos: position{line: 1710, col: 5, offset: 40755},
+				pos: position{line: 1726, col: 5, offset: 41119},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1710, col: 5, offset: 40755},
+						pos: position{line: 1726, col: 5, offset: 41119},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1710, col: 5, offset: 40755},
+							pos:        position{line: 1726, col: 5, offset: 41119},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1711, col: 5, offset: 40783},
+						pos: position{line: 1727, col: 5, offset: 41147},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1711, col: 5, offset: 40783},
+							pos:        position{line: 1727, col: 5, offset: 41147},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1712, col: 5, offset: 40811},
+						pos:        position{line: 1728, col: 5, offset: 41175},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12507,42 +12577,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1714, col: 1, offset: 40817},
+			pos:  position{line: 1730, col: 1, offset: 41181},
 			expr: &choiceExpr{
-				pos: position{line: 1715, col: 5, offset: 40835},
+				pos: position{line: 1731, col: 5, offset: 41199},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1715, col: 5, offset: 40835},
+						pos: position{line: 1731, col: 5, offset: 41199},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1715, col: 5, offset: 40835},
+							pos: position{line: 1731, col: 5, offset: 41199},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1715, col: 5, offset: 40835},
+									pos:        position{line: 1731, col: 5, offset: 41199},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1715, col: 9, offset: 40839},
+									pos:   position{line: 1731, col: 9, offset: 41203},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1715, col: 16, offset: 40846},
+										pos: position{line: 1731, col: 16, offset: 41210},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1715, col: 16, offset: 40846},
+												pos:  position{line: 1731, col: 16, offset: 41210},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1715, col: 25, offset: 40855},
+												pos:  position{line: 1731, col: 25, offset: 41219},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1715, col: 34, offset: 40864},
+												pos:  position{line: 1731, col: 34, offset: 41228},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1715, col: 43, offset: 40873},
+												pos:  position{line: 1731, col: 43, offset: 41237},
 												name: "HexDigit",
 											},
 										},
@@ -12552,65 +12622,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1718, col: 5, offset: 40936},
+						pos: position{line: 1734, col: 5, offset: 41300},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1718, col: 5, offset: 40936},
+							pos: position{line: 1734, col: 5, offset: 41300},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1718, col: 5, offset: 40936},
+									pos:        position{line: 1734, col: 5, offset: 41300},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1718, col: 9, offset: 40940},
+									pos:        position{line: 1734, col: 9, offset: 41304},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1718, col: 13, offset: 40944},
+									pos:   position{line: 1734, col: 13, offset: 41308},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1718, col: 20, offset: 40951},
+										pos: position{line: 1734, col: 20, offset: 41315},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1718, col: 20, offset: 40951},
+												pos:  position{line: 1734, col: 20, offset: 41315},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1718, col: 29, offset: 40960},
+												pos: position{line: 1734, col: 29, offset: 41324},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1718, col: 29, offset: 40960},
+													pos:  position{line: 1734, col: 29, offset: 41324},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1718, col: 39, offset: 40970},
+												pos: position{line: 1734, col: 39, offset: 41334},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1718, col: 39, offset: 40970},
+													pos:  position{line: 1734, col: 39, offset: 41334},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1718, col: 49, offset: 40980},
+												pos: position{line: 1734, col: 49, offset: 41344},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1718, col: 49, offset: 40980},
+													pos:  position{line: 1734, col: 49, offset: 41344},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1718, col: 59, offset: 40990},
+												pos: position{line: 1734, col: 59, offset: 41354},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1718, col: 59, offset: 40990},
+													pos:  position{line: 1734, col: 59, offset: 41354},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1718, col: 69, offset: 41000},
+												pos: position{line: 1734, col: 69, offset: 41364},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1718, col: 69, offset: 41000},
+													pos:  position{line: 1734, col: 69, offset: 41364},
 													name: "HexDigit",
 												},
 											},
@@ -12618,7 +12688,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1718, col: 80, offset: 41011},
+									pos:        position{line: 1734, col: 80, offset: 41375},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12633,37 +12703,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1722, col: 1, offset: 41065},
+			pos:  position{line: 1738, col: 1, offset: 41429},
 			expr: &actionExpr{
-				pos: position{line: 1723, col: 5, offset: 41083},
+				pos: position{line: 1739, col: 5, offset: 41447},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1723, col: 5, offset: 41083},
+					pos: position{line: 1739, col: 5, offset: 41447},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1723, col: 5, offset: 41083},
+							pos:        position{line: 1739, col: 5, offset: 41447},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1723, col: 9, offset: 41087},
+							pos:   position{line: 1739, col: 9, offset: 41451},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1723, col: 14, offset: 41092},
+								pos:  position{line: 1739, col: 14, offset: 41456},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1723, col: 25, offset: 41103},
+							pos:        position{line: 1739, col: 25, offset: 41467},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1723, col: 29, offset: 41107},
+							pos: position{line: 1739, col: 29, offset: 41471},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1723, col: 30, offset: 41108},
+								pos:  position{line: 1739, col: 30, offset: 41472},
 								name: "KeyWordStart",
 							},
 						},
@@ -12675,33 +12745,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1725, col: 1, offset: 41143},
+			pos:  position{line: 1741, col: 1, offset: 41507},
 			expr: &actionExpr{
-				pos: position{line: 1726, col: 5, offset: 41158},
+				pos: position{line: 1742, col: 5, offset: 41522},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1726, col: 5, offset: 41158},
+					pos: position{line: 1742, col: 5, offset: 41522},
 					expr: &choiceExpr{
-						pos: position{line: 1726, col: 6, offset: 41159},
+						pos: position{line: 1742, col: 6, offset: 41523},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1726, col: 6, offset: 41159},
+								pos:        position{line: 1742, col: 6, offset: 41523},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1726, col: 15, offset: 41168},
+								pos: position{line: 1742, col: 15, offset: 41532},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1726, col: 15, offset: 41168},
+										pos:        position{line: 1742, col: 15, offset: 41532},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1726, col: 20, offset: 41173,
+										line: 1742, col: 20, offset: 41537,
 									},
 								},
 							},
@@ -12714,9 +12784,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1728, col: 1, offset: 41209},
+			pos:  position{line: 1744, col: 1, offset: 41573},
 			expr: &charClassMatcher{
-				pos:        position{line: 1729, col: 5, offset: 41225},
+				pos:        position{line: 1745, col: 5, offset: 41589},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12728,11 +12798,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1731, col: 1, offset: 41240},
+			pos:  position{line: 1747, col: 1, offset: 41604},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1731, col: 5, offset: 41244},
+				pos: position{line: 1747, col: 5, offset: 41608},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1731, col: 5, offset: 41244},
+					pos:  position{line: 1747, col: 5, offset: 41608},
 					name: "AnySpace",
 				},
 			},
@@ -12741,11 +12811,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1733, col: 1, offset: 41255},
+			pos:  position{line: 1749, col: 1, offset: 41619},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1733, col: 6, offset: 41260},
+				pos: position{line: 1749, col: 6, offset: 41624},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1733, col: 6, offset: 41260},
+					pos:  position{line: 1749, col: 6, offset: 41624},
 					name: "AnySpace",
 				},
 			},
@@ -12754,20 +12824,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1735, col: 1, offset: 41271},
+			pos:  position{line: 1751, col: 1, offset: 41635},
 			expr: &choiceExpr{
-				pos: position{line: 1736, col: 5, offset: 41284},
+				pos: position{line: 1752, col: 5, offset: 41648},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1736, col: 5, offset: 41284},
+						pos:  position{line: 1752, col: 5, offset: 41648},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1737, col: 5, offset: 41299},
+						pos:  position{line: 1753, col: 5, offset: 41663},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1738, col: 5, offset: 41318},
+						pos:  position{line: 1754, col: 5, offset: 41682},
 						name: "Comment",
 					},
 				},
@@ -12777,32 +12847,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1740, col: 1, offset: 41327},
+			pos:  position{line: 1756, col: 1, offset: 41691},
 			expr: &choiceExpr{
-				pos: position{line: 1741, col: 5, offset: 41345},
+				pos: position{line: 1757, col: 5, offset: 41709},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1741, col: 5, offset: 41345},
+						pos:  position{line: 1757, col: 5, offset: 41709},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1742, col: 5, offset: 41352},
+						pos:  position{line: 1758, col: 5, offset: 41716},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1743, col: 5, offset: 41359},
+						pos:  position{line: 1759, col: 5, offset: 41723},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 5, offset: 41366},
+						pos:  position{line: 1760, col: 5, offset: 41730},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1745, col: 5, offset: 41373},
+						pos:  position{line: 1761, col: 5, offset: 41737},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1746, col: 5, offset: 41380},
+						pos:  position{line: 1762, col: 5, offset: 41744},
 						name: "Nl",
 					},
 				},
@@ -12812,16 +12882,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1748, col: 1, offset: 41384},
+			pos:  position{line: 1764, col: 1, offset: 41748},
 			expr: &choiceExpr{
-				pos: position{line: 1749, col: 5, offset: 41409},
+				pos: position{line: 1765, col: 5, offset: 41773},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1749, col: 5, offset: 41409},
+						pos:  position{line: 1765, col: 5, offset: 41773},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1750, col: 5, offset: 41416},
+						pos:  position{line: 1766, col: 5, offset: 41780},
 						name: "Mc",
 					},
 				},
@@ -12831,9 +12901,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1752, col: 1, offset: 41420},
+			pos:  position{line: 1768, col: 1, offset: 41784},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1753, col: 5, offset: 41437},
+				pos:  position{line: 1769, col: 5, offset: 41801},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12841,9 +12911,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1755, col: 1, offset: 41441},
+			pos:  position{line: 1771, col: 1, offset: 41805},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1756, col: 5, offset: 41473},
+				pos:  position{line: 1772, col: 5, offset: 41837},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12851,9 +12921,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1762, col: 1, offset: 41654},
+			pos:  position{line: 1778, col: 1, offset: 42018},
 			expr: &charClassMatcher{
-				pos:        position{line: 1762, col: 6, offset: 41659},
+				pos:        position{line: 1778, col: 6, offset: 42023},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12865,9 +12935,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1765, col: 1, offset: 45811},
+			pos:  position{line: 1781, col: 1, offset: 46175},
 			expr: &charClassMatcher{
-				pos:        position{line: 1765, col: 6, offset: 45816},
+				pos:        position{line: 1781, col: 6, offset: 46180},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12879,9 +12949,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1768, col: 1, offset: 46301},
+			pos:  position{line: 1784, col: 1, offset: 46665},
 			expr: &charClassMatcher{
-				pos:        position{line: 1768, col: 6, offset: 46306},
+				pos:        position{line: 1784, col: 6, offset: 46670},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12893,9 +12963,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1771, col: 1, offset: 49753},
+			pos:  position{line: 1787, col: 1, offset: 50117},
 			expr: &charClassMatcher{
-				pos:        position{line: 1771, col: 6, offset: 49758},
+				pos:        position{line: 1787, col: 6, offset: 50122},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12907,9 +12977,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1774, col: 1, offset: 49864},
+			pos:  position{line: 1790, col: 1, offset: 50228},
 			expr: &charClassMatcher{
-				pos:        position{line: 1774, col: 6, offset: 49869},
+				pos:        position{line: 1790, col: 6, offset: 50233},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12921,9 +12991,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1777, col: 1, offset: 53870},
+			pos:  position{line: 1793, col: 1, offset: 54234},
 			expr: &charClassMatcher{
-				pos:        position{line: 1777, col: 6, offset: 53875},
+				pos:        position{line: 1793, col: 6, offset: 54239},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12935,9 +13005,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1780, col: 1, offset: 55063},
+			pos:  position{line: 1796, col: 1, offset: 55427},
 			expr: &charClassMatcher{
-				pos:        position{line: 1780, col: 6, offset: 55068},
+				pos:        position{line: 1796, col: 6, offset: 55432},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12949,9 +13019,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1783, col: 1, offset: 57248},
+			pos:  position{line: 1799, col: 1, offset: 57612},
 			expr: &charClassMatcher{
-				pos:        position{line: 1783, col: 6, offset: 57253},
+				pos:        position{line: 1799, col: 6, offset: 57617},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12962,9 +13032,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1786, col: 1, offset: 57756},
+			pos:  position{line: 1802, col: 1, offset: 58120},
 			expr: &charClassMatcher{
-				pos:        position{line: 1786, col: 6, offset: 57761},
+				pos:        position{line: 1802, col: 6, offset: 58125},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12976,9 +13046,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1789, col: 1, offset: 57875},
+			pos:  position{line: 1805, col: 1, offset: 58239},
 			expr: &charClassMatcher{
-				pos:        position{line: 1789, col: 6, offset: 57880},
+				pos:        position{line: 1805, col: 6, offset: 58244},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12990,9 +13060,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1792, col: 1, offset: 57961},
+			pos:  position{line: 1808, col: 1, offset: 58325},
 			expr: &charClassMatcher{
-				pos:        position{line: 1792, col: 6, offset: 57966},
+				pos:        position{line: 1808, col: 6, offset: 58330},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13004,9 +13074,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1794, col: 1, offset: 58019},
+			pos:  position{line: 1810, col: 1, offset: 58383},
 			expr: &anyMatcher{
-				line: 1795, col: 5, offset: 58039,
+				line: 1811, col: 5, offset: 58403,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13014,48 +13084,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1797, col: 1, offset: 58042},
+			pos:         position{line: 1813, col: 1, offset: 58406},
 			expr: &choiceExpr{
-				pos: position{line: 1798, col: 5, offset: 58070},
+				pos: position{line: 1814, col: 5, offset: 58434},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1798, col: 5, offset: 58070},
+						pos:        position{line: 1814, col: 5, offset: 58434},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1799, col: 5, offset: 58079},
+						pos:        position{line: 1815, col: 5, offset: 58443},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1800, col: 5, offset: 58088},
+						pos:        position{line: 1816, col: 5, offset: 58452},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1801, col: 5, offset: 58097},
+						pos:        position{line: 1817, col: 5, offset: 58461},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1802, col: 5, offset: 58105},
+						pos:        position{line: 1818, col: 5, offset: 58469},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1803, col: 5, offset: 58118},
+						pos:        position{line: 1819, col: 5, offset: 58482},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1804, col: 5, offset: 58131},
+						pos:  position{line: 1820, col: 5, offset: 58495},
 						name: "Zs",
 					},
 				},
@@ -13065,9 +13135,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1806, col: 1, offset: 58135},
+			pos:  position{line: 1822, col: 1, offset: 58499},
 			expr: &charClassMatcher{
-				pos:        position{line: 1807, col: 5, offset: 58154},
+				pos:        position{line: 1823, col: 5, offset: 58518},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13079,9 +13149,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1813, col: 1, offset: 58484},
+			pos:         position{line: 1829, col: 1, offset: 58848},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1816, col: 5, offset: 58555},
+				pos:  position{line: 1832, col: 5, offset: 58919},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -13089,39 +13159,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1818, col: 1, offset: 58574},
+			pos:  position{line: 1834, col: 1, offset: 58938},
 			expr: &seqExpr{
-				pos: position{line: 1819, col: 5, offset: 58595},
+				pos: position{line: 1835, col: 5, offset: 58959},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1819, col: 5, offset: 58595},
+						pos:        position{line: 1835, col: 5, offset: 58959},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1819, col: 10, offset: 58600},
+						pos: position{line: 1835, col: 10, offset: 58964},
 						expr: &seqExpr{
-							pos: position{line: 1819, col: 11, offset: 58601},
+							pos: position{line: 1835, col: 11, offset: 58965},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1819, col: 11, offset: 58601},
+									pos: position{line: 1835, col: 11, offset: 58965},
 									expr: &litMatcher{
-										pos:        position{line: 1819, col: 12, offset: 58602},
+										pos:        position{line: 1835, col: 12, offset: 58966},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1819, col: 17, offset: 58607},
+									pos:  position{line: 1835, col: 17, offset: 58971},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1819, col: 35, offset: 58625},
+						pos:        position{line: 1835, col: 35, offset: 58989},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13133,33 +13203,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1821, col: 1, offset: 58631},
+			pos:  position{line: 1837, col: 1, offset: 58995},
 			expr: &choiceExpr{
-				pos: position{line: 1822, col: 5, offset: 58653},
+				pos: position{line: 1838, col: 5, offset: 59017},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1822, col: 5, offset: 58653},
+						pos: position{line: 1838, col: 5, offset: 59017},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1822, col: 5, offset: 58653},
+								pos:        position{line: 1838, col: 5, offset: 59017},
 								val:        "//",
 								ignoreCase: false,
 								want:       "\"//\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1822, col: 10, offset: 58658},
+								pos: position{line: 1838, col: 10, offset: 59022},
 								expr: &seqExpr{
-									pos: position{line: 1822, col: 11, offset: 58659},
+									pos: position{line: 1838, col: 11, offset: 59023},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1822, col: 11, offset: 58659},
+											pos: position{line: 1838, col: 11, offset: 59023},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1822, col: 12, offset: 58660},
+												pos:  position{line: 1838, col: 12, offset: 59024},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1822, col: 27, offset: 58675},
+											pos:  position{line: 1838, col: 27, offset: 59039},
 											name: "SourceCharacter",
 										},
 									},
@@ -13168,28 +13238,28 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1823, col: 5, offset: 58697},
+						pos: position{line: 1839, col: 5, offset: 59061},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1823, col: 5, offset: 58697},
+								pos:        position{line: 1839, col: 5, offset: 59061},
 								val:        "--",
 								ignoreCase: false,
 								want:       "\"--\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1823, col: 10, offset: 58702},
+								pos: position{line: 1839, col: 10, offset: 59066},
 								expr: &seqExpr{
-									pos: position{line: 1823, col: 11, offset: 58703},
+									pos: position{line: 1839, col: 11, offset: 59067},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1823, col: 11, offset: 58703},
+											pos: position{line: 1839, col: 11, offset: 59067},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1823, col: 12, offset: 58704},
+												pos:  position{line: 1839, col: 12, offset: 59068},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1823, col: 27, offset: 58719},
+											pos:  position{line: 1839, col: 27, offset: 59083},
 											name: "SourceCharacter",
 										},
 									},
@@ -13204,19 +13274,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1825, col: 1, offset: 58738},
+			pos:  position{line: 1841, col: 1, offset: 59102},
 			expr: &seqExpr{
-				pos: position{line: 1825, col: 7, offset: 58744},
+				pos: position{line: 1841, col: 7, offset: 59108},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1825, col: 7, offset: 58744},
+						pos: position{line: 1841, col: 7, offset: 59108},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1825, col: 7, offset: 58744},
+							pos:  position{line: 1841, col: 7, offset: 59108},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1825, col: 19, offset: 58756},
+						pos:  position{line: 1841, col: 19, offset: 59120},
 						name: "LineTerminator",
 					},
 				},
@@ -13226,16 +13296,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1827, col: 1, offset: 58772},
+			pos:  position{line: 1843, col: 1, offset: 59136},
 			expr: &choiceExpr{
-				pos: position{line: 1827, col: 7, offset: 58778},
+				pos: position{line: 1843, col: 7, offset: 59142},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1827, col: 7, offset: 58778},
+						pos:  position{line: 1843, col: 7, offset: 59142},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1827, col: 11, offset: 58782},
+						pos:  position{line: 1843, col: 11, offset: 59146},
 						name: "EOF",
 					},
 				},
@@ -13245,11 +13315,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1829, col: 1, offset: 58787},
+			pos:  position{line: 1845, col: 1, offset: 59151},
 			expr: &notExpr{
-				pos: position{line: 1829, col: 7, offset: 58793},
+				pos: position{line: 1845, col: 7, offset: 59157},
 				expr: &anyMatcher{
-					line: 1829, col: 8, offset: 58794,
+					line: 1845, col: 8, offset: 59158,
 				},
 			},
 			leader:        false,
@@ -13257,11 +13327,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1831, col: 1, offset: 58797},
+			pos:  position{line: 1847, col: 1, offset: 59161},
 			expr: &notExpr{
-				pos: position{line: 1831, col: 8, offset: 58804},
+				pos: position{line: 1847, col: 8, offset: 59168},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1831, col: 9, offset: 58805},
+					pos:  position{line: 1847, col: 9, offset: 59169},
 					name: "KeyWordChars",
 				},
 			},
@@ -13270,15 +13340,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1835, col: 1, offset: 58841},
+			pos:  position{line: 1851, col: 1, offset: 59205},
 			expr: &actionExpr{
-				pos: position{line: 1836, col: 5, offset: 58854},
+				pos: position{line: 1852, col: 5, offset: 59218},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1836, col: 5, offset: 58854},
+					pos:   position{line: 1852, col: 5, offset: 59218},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1836, col: 7, offset: 58856},
+						pos:  position{line: 1852, col: 7, offset: 59220},
 						name: "Seq",
 					},
 				},
@@ -13288,27 +13358,27 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1844, col: 1, offset: 59002},
+			pos:  position{line: 1860, col: 1, offset: 59366},
 			expr: &actionExpr{
-				pos: position{line: 1844, col: 12, offset: 59013},
+				pos: position{line: 1860, col: 12, offset: 59377},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1844, col: 12, offset: 59013},
+					pos: position{line: 1860, col: 12, offset: 59377},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1844, col: 12, offset: 59013},
+							pos: position{line: 1860, col: 12, offset: 59377},
 							expr: &litMatcher{
-								pos:        position{line: 1844, col: 13, offset: 59014},
+								pos:        position{line: 1860, col: 13, offset: 59378},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1844, col: 17, offset: 59018},
+							pos:   position{line: 1860, col: 17, offset: 59382},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1844, col: 20, offset: 59021},
+								pos:  position{line: 1860, col: 20, offset: 59385},
 								name: "SelectExpr",
 							},
 						},
@@ -13320,65 +13390,65 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1846, col: 1, offset: 59051},
+			pos:  position{line: 1862, col: 1, offset: 59415},
 			expr: &actionExpr{
-				pos: position{line: 1847, col: 5, offset: 59067},
+				pos: position{line: 1863, col: 5, offset: 59431},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1847, col: 5, offset: 59067},
+					pos: position{line: 1863, col: 5, offset: 59431},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1847, col: 5, offset: 59067},
+							pos:   position{line: 1863, col: 5, offset: 59431},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1847, col: 10, offset: 59072},
+								pos:  position{line: 1863, col: 10, offset: 59436},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1848, col: 5, offset: 59090},
+							pos:   position{line: 1864, col: 5, offset: 59454},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1849, col: 9, offset: 59105},
+								pos: position{line: 1865, col: 9, offset: 59469},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1849, col: 9, offset: 59105},
+										pos:  position{line: 1865, col: 9, offset: 59469},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1850, col: 9, offset: 59126},
+										pos:  position{line: 1866, col: 9, offset: 59490},
 										name: "Select",
 									},
 									&actionExpr{
-										pos: position{line: 1851, col: 9, offset: 59141},
+										pos: position{line: 1867, col: 9, offset: 59505},
 										run: (*parser).callonSelectExpr9,
 										expr: &seqExpr{
-											pos: position{line: 1851, col: 9, offset: 59141},
+											pos: position{line: 1867, col: 9, offset: 59505},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1851, col: 9, offset: 59141},
+													pos:        position{line: 1867, col: 9, offset: 59505},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1851, col: 13, offset: 59145},
+													pos:  position{line: 1867, col: 13, offset: 59509},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1851, col: 16, offset: 59148},
+													pos:   position{line: 1867, col: 16, offset: 59512},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1851, col: 18, offset: 59150},
+														pos:  position{line: 1867, col: 18, offset: 59514},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1851, col: 26, offset: 59158},
+													pos:  position{line: 1867, col: 26, offset: 59522},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1851, col: 28, offset: 59160},
+													pos:        position{line: 1867, col: 28, offset: 59524},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13390,97 +13460,97 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1853, col: 5, offset: 59197},
+							pos:   position{line: 1869, col: 5, offset: 59561},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1853, col: 13, offset: 59205},
+								pos:  position{line: 1869, col: 13, offset: 59569},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1854, col: 5, offset: 59226},
+							pos:   position{line: 1870, col: 5, offset: 59590},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1854, col: 11, offset: 59232},
+								pos:  position{line: 1870, col: 11, offset: 59596},
 								name: "OptLimitClause",
 							},
 						},
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1874, col: 1, offset: 59618},
+			pos:  position{line: 1890, col: 1, offset: 59982},
 			expr: &actionExpr{
-				pos: position{line: 1875, col: 5, offset: 59630},
+				pos: position{line: 1891, col: 5, offset: 59994},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1875, col: 5, offset: 59630},
+					pos: position{line: 1891, col: 5, offset: 59994},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1875, col: 5, offset: 59630},
+							pos:  position{line: 1891, col: 5, offset: 59994},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1876, col: 5, offset: 59642},
+							pos:   position{line: 1892, col: 5, offset: 60006},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1876, col: 14, offset: 59651},
+								pos:  position{line: 1892, col: 14, offset: 60015},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1877, col: 5, offset: 59667},
+							pos:   position{line: 1893, col: 5, offset: 60031},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1877, col: 11, offset: 59673},
+								pos:  position{line: 1893, col: 11, offset: 60037},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1880, col: 5, offset: 59813},
+							pos:  position{line: 1896, col: 5, offset: 60177},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1880, col: 7, offset: 59815},
+							pos:   position{line: 1896, col: 7, offset: 60179},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1880, col: 17, offset: 59825},
+								pos:  position{line: 1896, col: 17, offset: 60189},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1881, col: 5, offset: 59839},
+							pos:   position{line: 1897, col: 5, offset: 60203},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1881, col: 10, offset: 59844},
+								pos:  position{line: 1897, col: 10, offset: 60208},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1882, col: 5, offset: 59862},
+							pos:   position{line: 1898, col: 5, offset: 60226},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1882, col: 11, offset: 59868},
+								pos:  position{line: 1898, col: 11, offset: 60232},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1883, col: 5, offset: 59887},
+							pos:   position{line: 1899, col: 5, offset: 60251},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1883, col: 11, offset: 59893},
+								pos:  position{line: 1899, col: 11, offset: 60257},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1884, col: 5, offset: 59912},
+							pos:   position{line: 1900, col: 5, offset: 60276},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1884, col: 12, offset: 59919},
+								pos:  position{line: 1900, col: 12, offset: 60283},
 								name: "OptHavingClause",
 							},
 						},
@@ -13492,49 +13562,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 1910, col: 1, offset: 60525},
+			pos:  position{line: 1926, col: 1, offset: 60889},
 			expr: &choiceExpr{
-				pos: position{line: 1911, col: 5, offset: 60541},
+				pos: position{line: 1927, col: 5, offset: 60905},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1911, col: 5, offset: 60541},
+						pos: position{line: 1927, col: 5, offset: 60905},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 1911, col: 5, offset: 60541},
+							pos: position{line: 1927, col: 5, offset: 60905},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1911, col: 5, offset: 60541},
+									pos:  position{line: 1927, col: 5, offset: 60905},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1911, col: 7, offset: 60543},
+									pos:  position{line: 1927, col: 7, offset: 60907},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1912, col: 5, offset: 60580},
+						pos: position{line: 1928, col: 5, offset: 60944},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 1912, col: 5, offset: 60580},
+							pos: position{line: 1928, col: 5, offset: 60944},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1912, col: 5, offset: 60580},
+									pos:  position{line: 1928, col: 5, offset: 60944},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1912, col: 7, offset: 60582},
+									pos:  position{line: 1928, col: 7, offset: 60946},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1913, col: 5, offset: 60618},
+						pos: position{line: 1929, col: 5, offset: 60982},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 1913, col: 5, offset: 60618},
+							pos:        position{line: 1929, col: 5, offset: 60982},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13547,57 +13617,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 1915, col: 1, offset: 60657},
+			pos:  position{line: 1931, col: 1, offset: 61021},
 			expr: &choiceExpr{
-				pos: position{line: 1916, col: 5, offset: 60676},
+				pos: position{line: 1932, col: 5, offset: 61040},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1916, col: 5, offset: 60676},
+						pos: position{line: 1932, col: 5, offset: 61040},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 1916, col: 5, offset: 60676},
+							pos: position{line: 1932, col: 5, offset: 61040},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1916, col: 5, offset: 60676},
+									pos:  position{line: 1932, col: 5, offset: 61040},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1916, col: 7, offset: 60678},
+									pos:  position{line: 1932, col: 7, offset: 61042},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1916, col: 10, offset: 60681},
+									pos:  position{line: 1932, col: 10, offset: 61045},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1916, col: 12, offset: 60683},
+									pos:  position{line: 1932, col: 12, offset: 61047},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1917, col: 5, offset: 60715},
+						pos: position{line: 1933, col: 5, offset: 61079},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 1917, col: 5, offset: 60715},
+							pos: position{line: 1933, col: 5, offset: 61079},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1917, col: 5, offset: 60715},
+									pos:  position{line: 1933, col: 5, offset: 61079},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1917, col: 7, offset: 60717},
+									pos:  position{line: 1933, col: 7, offset: 61081},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1918, col: 5, offset: 60788},
+						pos: position{line: 1934, col: 5, offset: 61152},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 1918, col: 5, offset: 60788},
+							pos:        position{line: 1934, col: 5, offset: 61152},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13610,19 +13680,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 1920, col: 1, offset: 60831},
+			pos:  position{line: 1936, col: 1, offset: 61195},
 			expr: &choiceExpr{
-				pos: position{line: 1921, col: 5, offset: 60850},
+				pos: position{line: 1937, col: 5, offset: 61214},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1921, col: 5, offset: 60850},
+						pos:  position{line: 1937, col: 5, offset: 61214},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 1922, col: 5, offset: 60866},
+						pos: position{line: 1938, col: 5, offset: 61230},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 1922, col: 5, offset: 60866},
+							pos:        position{line: 1938, col: 5, offset: 61230},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13635,38 +13705,38 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 1924, col: 1, offset: 60899},
+			pos:  position{line: 1940, col: 1, offset: 61263},
 			expr: &actionExpr{
-				pos: position{line: 1925, col: 5, offset: 60915},
+				pos: position{line: 1941, col: 5, offset: 61279},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 1925, col: 5, offset: 60915},
+					pos: position{line: 1941, col: 5, offset: 61279},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1925, col: 5, offset: 60915},
+							pos:  position{line: 1941, col: 5, offset: 61279},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1925, col: 7, offset: 60917},
+							pos:  position{line: 1941, col: 7, offset: 61281},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 1925, col: 12, offset: 60922},
+							pos:   position{line: 1941, col: 12, offset: 61286},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1925, col: 14, offset: 60924},
+								pos:  position{line: 1941, col: 14, offset: 61288},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1925, col: 27, offset: 60937},
+							pos:  position{line: 1941, col: 27, offset: 61301},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1925, col: 29, offset: 60939},
+							pos:   position{line: 1941, col: 29, offset: 61303},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1925, col: 34, offset: 60944},
+								pos:  position{line: 1941, col: 34, offset: 61308},
 								name: "CteList",
 							},
 						},
@@ -13678,32 +13748,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 1934, col: 1, offset: 61129},
+			pos:  position{line: 1950, col: 1, offset: 61493},
 			expr: &choiceExpr{
-				pos: position{line: 1935, col: 5, offset: 61147},
+				pos: position{line: 1951, col: 5, offset: 61511},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1935, col: 5, offset: 61147},
+						pos: position{line: 1951, col: 5, offset: 61511},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 1935, col: 5, offset: 61147},
+							pos: position{line: 1951, col: 5, offset: 61511},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1935, col: 5, offset: 61147},
+									pos:  position{line: 1951, col: 5, offset: 61511},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1935, col: 7, offset: 61149},
+									pos:  position{line: 1951, col: 7, offset: 61513},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1936, col: 5, offset: 61185},
+						pos: position{line: 1952, col: 5, offset: 61549},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 1936, col: 5, offset: 61185},
+							pos:        position{line: 1952, col: 5, offset: 61549},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13716,51 +13786,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 1938, col: 1, offset: 61224},
+			pos:  position{line: 1954, col: 1, offset: 61588},
 			expr: &actionExpr{
-				pos: position{line: 1938, col: 11, offset: 61234},
+				pos: position{line: 1954, col: 11, offset: 61598},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 1938, col: 11, offset: 61234},
+					pos: position{line: 1954, col: 11, offset: 61598},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1938, col: 11, offset: 61234},
+							pos:   position{line: 1954, col: 11, offset: 61598},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1938, col: 17, offset: 61240},
+								pos:  position{line: 1954, col: 17, offset: 61604},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1938, col: 21, offset: 61244},
+							pos:   position{line: 1954, col: 21, offset: 61608},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1938, col: 26, offset: 61249},
+								pos: position{line: 1954, col: 26, offset: 61613},
 								expr: &actionExpr{
-									pos: position{line: 1938, col: 28, offset: 61251},
+									pos: position{line: 1954, col: 28, offset: 61615},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 1938, col: 28, offset: 61251},
+										pos: position{line: 1954, col: 28, offset: 61615},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1938, col: 28, offset: 61251},
+												pos:  position{line: 1954, col: 28, offset: 61615},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1938, col: 31, offset: 61254},
+												pos:        position{line: 1954, col: 31, offset: 61618},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1938, col: 35, offset: 61258},
+												pos:  position{line: 1954, col: 35, offset: 61622},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1938, col: 38, offset: 61261},
+												pos:   position{line: 1954, col: 38, offset: 61625},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1938, col: 42, offset: 61265},
+													pos:  position{line: 1954, col: 42, offset: 61629},
 													name: "Cte",
 												},
 											},
@@ -13777,65 +13847,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 1942, col: 1, offset: 61334},
+			pos:  position{line: 1958, col: 1, offset: 61698},
 			expr: &actionExpr{
-				pos: position{line: 1943, col: 5, offset: 61342},
+				pos: position{line: 1959, col: 5, offset: 61706},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 1943, col: 5, offset: 61342},
+					pos: position{line: 1959, col: 5, offset: 61706},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1943, col: 5, offset: 61342},
+							pos:   position{line: 1959, col: 5, offset: 61706},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1943, col: 10, offset: 61347},
+								pos:  position{line: 1959, col: 10, offset: 61711},
 								name: "AliasName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1943, col: 20, offset: 61357},
+							pos:  position{line: 1959, col: 20, offset: 61721},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1943, col: 22, offset: 61359},
+							pos:  position{line: 1959, col: 22, offset: 61723},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 1943, col: 25, offset: 61362},
+							pos:   position{line: 1959, col: 25, offset: 61726},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1943, col: 27, offset: 61364},
+								pos:  position{line: 1959, col: 27, offset: 61728},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1943, col: 43, offset: 61380},
+							pos:  position{line: 1959, col: 43, offset: 61744},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1943, col: 46, offset: 61383},
+							pos:        position{line: 1959, col: 46, offset: 61747},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1943, col: 50, offset: 61387},
+							pos:  position{line: 1959, col: 50, offset: 61751},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1943, col: 53, offset: 61390},
+							pos:   position{line: 1959, col: 53, offset: 61754},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1943, col: 55, offset: 61392},
+								pos:  position{line: 1959, col: 55, offset: 61756},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1943, col: 63, offset: 61400},
+							pos:  position{line: 1959, col: 63, offset: 61764},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1943, col: 66, offset: 61403},
+							pos:        position{line: 1959, col: 66, offset: 61767},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13848,9 +13918,9 @@ var g = &grammar{
 		},
 		{
 			name: "AliasName",
-			pos:  position{line: 1952, col: 1, offset: 61578},
+			pos:  position{line: 1968, col: 1, offset: 61942},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1952, col: 13, offset: 61590},
+				pos:  position{line: 1968, col: 13, offset: 61954},
 				name: "Identifier",
 			},
 			leader:        false,
@@ -13858,65 +13928,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 1954, col: 1, offset: 61602},
+			pos:  position{line: 1970, col: 1, offset: 61966},
 			expr: &choiceExpr{
-				pos: position{line: 1955, col: 5, offset: 61623},
+				pos: position{line: 1971, col: 5, offset: 61987},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1955, col: 5, offset: 61623},
+						pos: position{line: 1971, col: 5, offset: 61987},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 1955, col: 5, offset: 61623},
+							pos: position{line: 1971, col: 5, offset: 61987},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1955, col: 5, offset: 61623},
+									pos:  position{line: 1971, col: 5, offset: 61987},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1955, col: 7, offset: 61625},
+									pos:  position{line: 1971, col: 7, offset: 61989},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1955, col: 20, offset: 61638},
+									pos:  position{line: 1971, col: 20, offset: 62002},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1956, col: 5, offset: 61677},
+						pos: position{line: 1972, col: 5, offset: 62041},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 1956, col: 5, offset: 61677},
+							pos: position{line: 1972, col: 5, offset: 62041},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1956, col: 5, offset: 61677},
+									pos:  position{line: 1972, col: 5, offset: 62041},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1956, col: 7, offset: 61679},
+									pos:  position{line: 1972, col: 7, offset: 62043},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1956, col: 11, offset: 61683},
+									pos:  position{line: 1972, col: 11, offset: 62047},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1956, col: 13, offset: 61685},
+									pos:  position{line: 1972, col: 13, offset: 62049},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1956, col: 26, offset: 61698},
+									pos:  position{line: 1972, col: 26, offset: 62062},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1957, col: 5, offset: 61729},
+						pos: position{line: 1973, col: 5, offset: 62093},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 1957, col: 5, offset: 61729},
+							pos:        position{line: 1973, col: 5, offset: 62093},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13929,25 +13999,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 1959, col: 1, offset: 61784},
+			pos:  position{line: 1975, col: 1, offset: 62148},
 			expr: &choiceExpr{
-				pos: position{line: 1960, col: 5, offset: 61801},
+				pos: position{line: 1976, col: 5, offset: 62165},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1960, col: 5, offset: 61801},
+						pos: position{line: 1976, col: 5, offset: 62165},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1960, col: 5, offset: 61801},
+								pos:  position{line: 1976, col: 5, offset: 62165},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1960, col: 7, offset: 61803},
+								pos:  position{line: 1976, col: 7, offset: 62167},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1961, col: 5, offset: 61812},
+						pos:        position{line: 1977, col: 5, offset: 62176},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -13959,25 +14029,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 1963, col: 1, offset: 61816},
+			pos:  position{line: 1979, col: 1, offset: 62180},
 			expr: &choiceExpr{
-				pos: position{line: 1964, col: 5, offset: 61834},
+				pos: position{line: 1980, col: 5, offset: 62198},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1964, col: 5, offset: 61834},
+						pos: position{line: 1980, col: 5, offset: 62198},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 1964, col: 5, offset: 61834},
+							pos: position{line: 1980, col: 5, offset: 62198},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1964, col: 5, offset: 61834},
+									pos:  position{line: 1980, col: 5, offset: 62198},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1964, col: 7, offset: 61836},
+									pos:   position{line: 1980, col: 7, offset: 62200},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1964, col: 12, offset: 61841},
+										pos:  position{line: 1980, col: 12, offset: 62205},
 										name: "FromOp",
 									},
 								},
@@ -13985,10 +14055,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1967, col: 5, offset: 61883},
+						pos: position{line: 1983, col: 5, offset: 62247},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1967, col: 5, offset: 61883},
+							pos:        position{line: 1983, col: 5, offset: 62247},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14001,27 +14071,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 1969, col: 1, offset: 61924},
+			pos:  position{line: 1985, col: 1, offset: 62288},
 			expr: &choiceExpr{
-				pos: position{line: 1970, col: 5, offset: 61943},
+				pos: position{line: 1986, col: 5, offset: 62307},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1970, col: 5, offset: 61943},
+						pos: position{line: 1986, col: 5, offset: 62307},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 1970, col: 5, offset: 61943},
+							pos:   position{line: 1986, col: 5, offset: 62307},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1970, col: 11, offset: 61949},
+								pos:  position{line: 1986, col: 11, offset: 62313},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1971, col: 5, offset: 61991},
+						pos: position{line: 1987, col: 5, offset: 62355},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 1971, col: 5, offset: 61991},
+							pos:        position{line: 1987, col: 5, offset: 62355},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14034,25 +14104,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 1973, col: 1, offset: 62036},
+			pos:  position{line: 1989, col: 1, offset: 62400},
 			expr: &choiceExpr{
-				pos: position{line: 1974, col: 5, offset: 62055},
+				pos: position{line: 1990, col: 5, offset: 62419},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1974, col: 5, offset: 62055},
+						pos: position{line: 1990, col: 5, offset: 62419},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 1974, col: 5, offset: 62055},
+							pos: position{line: 1990, col: 5, offset: 62419},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1974, col: 5, offset: 62055},
+									pos:  position{line: 1990, col: 5, offset: 62419},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1974, col: 7, offset: 62057},
+									pos:   position{line: 1990, col: 7, offset: 62421},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1974, col: 13, offset: 62063},
+										pos:  position{line: 1990, col: 13, offset: 62427},
 										name: "GroupClause",
 									},
 								},
@@ -14060,10 +14130,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1975, col: 5, offset: 62101},
+						pos: position{line: 1991, col: 5, offset: 62465},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1975, col: 5, offset: 62101},
+							pos:        position{line: 1991, col: 5, offset: 62465},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14076,34 +14146,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 1977, col: 1, offset: 62142},
+			pos:  position{line: 1993, col: 1, offset: 62506},
 			expr: &actionExpr{
-				pos: position{line: 1978, col: 5, offset: 62158},
+				pos: position{line: 1994, col: 5, offset: 62522},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 1978, col: 5, offset: 62158},
+					pos: position{line: 1994, col: 5, offset: 62522},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1978, col: 5, offset: 62158},
+							pos:  position{line: 1994, col: 5, offset: 62522},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1978, col: 11, offset: 62164},
+							pos:  position{line: 1994, col: 11, offset: 62528},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1978, col: 13, offset: 62166},
+							pos:  position{line: 1994, col: 13, offset: 62530},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1978, col: 16, offset: 62169},
+							pos:  position{line: 1994, col: 16, offset: 62533},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1978, col: 18, offset: 62171},
+							pos:   position{line: 1994, col: 18, offset: 62535},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1978, col: 23, offset: 62176},
+								pos:  position{line: 1994, col: 23, offset: 62540},
 								name: "GroupByList",
 							},
 						},
@@ -14115,51 +14185,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 1980, col: 1, offset: 62210},
+			pos:  position{line: 1996, col: 1, offset: 62574},
 			expr: &actionExpr{
-				pos: position{line: 1981, col: 5, offset: 62227},
+				pos: position{line: 1997, col: 5, offset: 62591},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 1981, col: 5, offset: 62227},
+					pos: position{line: 1997, col: 5, offset: 62591},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1981, col: 5, offset: 62227},
+							pos:   position{line: 1997, col: 5, offset: 62591},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1981, col: 11, offset: 62233},
+								pos:  position{line: 1997, col: 11, offset: 62597},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1981, col: 23, offset: 62245},
+							pos:   position{line: 1997, col: 23, offset: 62609},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1981, col: 28, offset: 62250},
+								pos: position{line: 1997, col: 28, offset: 62614},
 								expr: &actionExpr{
-									pos: position{line: 1981, col: 30, offset: 62252},
+									pos: position{line: 1997, col: 30, offset: 62616},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 1981, col: 30, offset: 62252},
+										pos: position{line: 1997, col: 30, offset: 62616},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1981, col: 30, offset: 62252},
+												pos:  position{line: 1997, col: 30, offset: 62616},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1981, col: 33, offset: 62255},
+												pos:        position{line: 1997, col: 33, offset: 62619},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1981, col: 37, offset: 62259},
+												pos:  position{line: 1997, col: 37, offset: 62623},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1981, col: 40, offset: 62262},
+												pos:   position{line: 1997, col: 40, offset: 62626},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1981, col: 42, offset: 62264},
+													pos:  position{line: 1997, col: 42, offset: 62628},
 													name: "GroupByItem",
 												},
 											},
@@ -14176,9 +14246,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 1985, col: 1, offset: 62345},
+			pos:  position{line: 2001, col: 1, offset: 62709},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1985, col: 15, offset: 62359},
+				pos:  position{line: 2001, col: 15, offset: 62723},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14186,25 +14256,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 1987, col: 1, offset: 62365},
+			pos:  position{line: 2003, col: 1, offset: 62729},
 			expr: &choiceExpr{
-				pos: position{line: 1988, col: 5, offset: 62385},
+				pos: position{line: 2004, col: 5, offset: 62749},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1988, col: 5, offset: 62385},
+						pos: position{line: 2004, col: 5, offset: 62749},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 1988, col: 5, offset: 62385},
+							pos: position{line: 2004, col: 5, offset: 62749},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1988, col: 5, offset: 62385},
+									pos:  position{line: 2004, col: 5, offset: 62749},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1988, col: 7, offset: 62387},
+									pos:   position{line: 2004, col: 7, offset: 62751},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1988, col: 9, offset: 62389},
+										pos:  position{line: 2004, col: 9, offset: 62753},
 										name: "HavingClause",
 									},
 								},
@@ -14212,10 +14282,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1989, col: 5, offset: 62424},
+						pos: position{line: 2005, col: 5, offset: 62788},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 1989, col: 5, offset: 62424},
+							pos:        position{line: 2005, col: 5, offset: 62788},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14228,26 +14298,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 1991, col: 1, offset: 62448},
+			pos:  position{line: 2007, col: 1, offset: 62812},
 			expr: &actionExpr{
-				pos: position{line: 1992, col: 5, offset: 62465},
+				pos: position{line: 2008, col: 5, offset: 62829},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 1992, col: 5, offset: 62465},
+					pos: position{line: 2008, col: 5, offset: 62829},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1992, col: 5, offset: 62465},
+							pos:  position{line: 2008, col: 5, offset: 62829},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1992, col: 12, offset: 62472},
+							pos:  position{line: 2008, col: 12, offset: 62836},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1992, col: 14, offset: 62474},
+							pos:   position{line: 2008, col: 14, offset: 62838},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1992, col: 16, offset: 62476},
+								pos:  position{line: 2008, col: 16, offset: 62840},
 								name: "Expr",
 							},
 						},
@@ -14259,49 +14329,49 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 1994, col: 1, offset: 62500},
+			pos:  position{line: 2010, col: 1, offset: 62864},
 			expr: &choiceExpr{
-				pos: position{line: 1995, col: 5, offset: 62518},
+				pos: position{line: 2011, col: 5, offset: 62882},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1995, col: 5, offset: 62518},
+						pos:  position{line: 2011, col: 5, offset: 62882},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1996, col: 5, offset: 62532},
+						pos:  position{line: 2012, col: 5, offset: 62896},
 						name: "ConditionJoin",
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 1998, col: 1, offset: 62547},
+			pos:  position{line: 2014, col: 1, offset: 62911},
 			expr: &actionExpr{
-				pos: position{line: 1999, col: 5, offset: 62561},
+				pos: position{line: 2015, col: 5, offset: 62925},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 1999, col: 5, offset: 62561},
+					pos: position{line: 2015, col: 5, offset: 62925},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1999, col: 5, offset: 62561},
+							pos:   position{line: 2015, col: 5, offset: 62925},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1999, col: 10, offset: 62566},
+								pos:  position{line: 2015, col: 10, offset: 62930},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1999, col: 19, offset: 62575},
+							pos:  position{line: 2015, col: 19, offset: 62939},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 1999, col: 31, offset: 62587},
+							pos:   position{line: 2015, col: 31, offset: 62951},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1999, col: 37, offset: 62593},
+								pos:  position{line: 2015, col: 37, offset: 62957},
 								name: "FromElem",
 							},
 						},
@@ -14313,50 +14383,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2008, col: 1, offset: 62795},
+			pos:  position{line: 2024, col: 1, offset: 63159},
 			expr: &choiceExpr{
-				pos: position{line: 2009, col: 5, offset: 62812},
+				pos: position{line: 2025, col: 5, offset: 63176},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2009, col: 5, offset: 62812},
+						pos: position{line: 2025, col: 5, offset: 63176},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2009, col: 5, offset: 62812},
+								pos:  position{line: 2025, col: 5, offset: 63176},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2009, col: 8, offset: 62815},
+								pos:        position{line: 2025, col: 8, offset: 63179},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2009, col: 12, offset: 62819},
+								pos:  position{line: 2025, col: 12, offset: 63183},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2010, col: 5, offset: 62827},
+						pos: position{line: 2026, col: 5, offset: 63191},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2010, col: 5, offset: 62827},
+								pos:  position{line: 2026, col: 5, offset: 63191},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2010, col: 7, offset: 62829},
+								pos:  position{line: 2026, col: 7, offset: 63193},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2010, col: 13, offset: 62835},
+								pos:  position{line: 2026, col: 13, offset: 63199},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2010, col: 15, offset: 62837},
+								pos:  position{line: 2026, col: 15, offset: 63201},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2010, col: 20, offset: 62842},
+								pos:  position{line: 2026, col: 20, offset: 63206},
 								name: "_",
 							},
 						},
@@ -14368,46 +14438,46 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2012, col: 1, offset: 62846},
+			pos:  position{line: 2028, col: 1, offset: 63210},
 			expr: &actionExpr{
-				pos: position{line: 2013, col: 5, offset: 62864},
+				pos: position{line: 2029, col: 5, offset: 63228},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2013, col: 5, offset: 62864},
+					pos: position{line: 2029, col: 5, offset: 63228},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2013, col: 5, offset: 62864},
+							pos:   position{line: 2029, col: 5, offset: 63228},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2013, col: 10, offset: 62869},
+								pos:  position{line: 2029, col: 10, offset: 63233},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2013, col: 19, offset: 62878},
+							pos:   position{line: 2029, col: 19, offset: 63242},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2013, col: 25, offset: 62884},
+								pos:  position{line: 2029, col: 25, offset: 63248},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2013, col: 38, offset: 62897},
+							pos:  position{line: 2029, col: 38, offset: 63261},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2013, col: 40, offset: 62899},
+							pos:   position{line: 2029, col: 40, offset: 63263},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2013, col: 46, offset: 62905},
+								pos:  position{line: 2029, col: 46, offset: 63269},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2013, col: 55, offset: 62914},
+							pos:   position{line: 2029, col: 55, offset: 63278},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2013, col: 57, offset: 62916},
+								pos:  position{line: 2029, col: 57, offset: 63280},
 								name: "JoinExpr",
 							},
 						},
@@ -14419,161 +14489,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2024, col: 1, offset: 63185},
+			pos:  position{line: 2040, col: 1, offset: 63549},
 			expr: &choiceExpr{
-				pos: position{line: 2025, col: 5, offset: 63203},
+				pos: position{line: 2041, col: 5, offset: 63567},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2025, col: 5, offset: 63203},
+						pos: position{line: 2041, col: 5, offset: 63567},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2025, col: 5, offset: 63203},
+							pos: position{line: 2041, col: 5, offset: 63567},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2025, col: 5, offset: 63203},
+									pos: position{line: 2041, col: 5, offset: 63567},
 									expr: &seqExpr{
-										pos: position{line: 2025, col: 6, offset: 63204},
+										pos: position{line: 2041, col: 6, offset: 63568},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2025, col: 6, offset: 63204},
+												pos:  position{line: 2041, col: 6, offset: 63568},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2025, col: 8, offset: 63206},
+												pos:  position{line: 2041, col: 8, offset: 63570},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2025, col: 16, offset: 63214},
+									pos:  position{line: 2041, col: 16, offset: 63578},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2025, col: 18, offset: 63216},
+									pos:  position{line: 2041, col: 18, offset: 63580},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2026, col: 5, offset: 63261},
+						pos: position{line: 2042, col: 5, offset: 63625},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2026, col: 5, offset: 63261},
+							pos: position{line: 2042, col: 5, offset: 63625},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2026, col: 5, offset: 63261},
+									pos:  position{line: 2042, col: 5, offset: 63625},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2026, col: 7, offset: 63263},
+									pos:  position{line: 2042, col: 7, offset: 63627},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2026, col: 12, offset: 63268},
+									pos: position{line: 2042, col: 12, offset: 63632},
 									expr: &seqExpr{
-										pos: position{line: 2026, col: 13, offset: 63269},
+										pos: position{line: 2042, col: 13, offset: 63633},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2026, col: 13, offset: 63269},
+												pos:  position{line: 2042, col: 13, offset: 63633},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2026, col: 15, offset: 63271},
+												pos:  position{line: 2042, col: 15, offset: 63635},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2026, col: 23, offset: 63279},
+									pos:  position{line: 2042, col: 23, offset: 63643},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2026, col: 25, offset: 63281},
+									pos:  position{line: 2042, col: 25, offset: 63645},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2027, col: 5, offset: 63315},
+						pos: position{line: 2043, col: 5, offset: 63679},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2027, col: 5, offset: 63315},
+							pos: position{line: 2043, col: 5, offset: 63679},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2027, col: 5, offset: 63315},
+									pos:  position{line: 2043, col: 5, offset: 63679},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2027, col: 7, offset: 63317},
+									pos:  position{line: 2043, col: 7, offset: 63681},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2027, col: 12, offset: 63322},
+									pos: position{line: 2043, col: 12, offset: 63686},
 									expr: &seqExpr{
-										pos: position{line: 2027, col: 13, offset: 63323},
+										pos: position{line: 2043, col: 13, offset: 63687},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2027, col: 13, offset: 63323},
+												pos:  position{line: 2043, col: 13, offset: 63687},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2027, col: 15, offset: 63325},
+												pos:  position{line: 2043, col: 15, offset: 63689},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2027, col: 23, offset: 63333},
+									pos:  position{line: 2043, col: 23, offset: 63697},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2027, col: 25, offset: 63335},
+									pos:  position{line: 2043, col: 25, offset: 63699},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2028, col: 5, offset: 63369},
+						pos: position{line: 2044, col: 5, offset: 63733},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2028, col: 5, offset: 63369},
+							pos: position{line: 2044, col: 5, offset: 63733},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2028, col: 5, offset: 63369},
+									pos:  position{line: 2044, col: 5, offset: 63733},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2028, col: 7, offset: 63371},
+									pos:  position{line: 2044, col: 7, offset: 63735},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2028, col: 13, offset: 63377},
+									pos: position{line: 2044, col: 13, offset: 63741},
 									expr: &seqExpr{
-										pos: position{line: 2028, col: 14, offset: 63378},
+										pos: position{line: 2044, col: 14, offset: 63742},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2028, col: 14, offset: 63378},
+												pos:  position{line: 2044, col: 14, offset: 63742},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2028, col: 16, offset: 63380},
+												pos:  position{line: 2044, col: 16, offset: 63744},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2028, col: 24, offset: 63388},
+									pos:  position{line: 2044, col: 24, offset: 63752},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2028, col: 26, offset: 63390},
+									pos:  position{line: 2044, col: 26, offset: 63754},
 									name: "JOIN",
 								},
 							},
@@ -14586,33 +14656,33 @@ var g = &grammar{
 		},
 		{
 			name: "JoinExpr",
-			pos:  position{line: 2030, col: 1, offset: 63422},
+			pos:  position{line: 2046, col: 1, offset: 63786},
 			expr: &choiceExpr{
-				pos: position{line: 2031, col: 5, offset: 63436},
+				pos: position{line: 2047, col: 5, offset: 63800},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2031, col: 5, offset: 63436},
+						pos: position{line: 2047, col: 5, offset: 63800},
 						run: (*parser).callonJoinExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2031, col: 5, offset: 63436},
+							pos: position{line: 2047, col: 5, offset: 63800},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 5, offset: 63436},
+									pos:  position{line: 2047, col: 5, offset: 63800},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 7, offset: 63438},
+									pos:  position{line: 2047, col: 7, offset: 63802},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 10, offset: 63441},
+									pos:  position{line: 2047, col: 10, offset: 63805},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2031, col: 12, offset: 63443},
+									pos:   position{line: 2047, col: 12, offset: 63807},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2031, col: 14, offset: 63445},
+										pos:  position{line: 2047, col: 14, offset: 63809},
 										name: "Expr",
 									},
 								},
@@ -14620,47 +14690,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2037, col: 5, offset: 63575},
+						pos: position{line: 2053, col: 5, offset: 63939},
 						run: (*parser).callonJoinExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2037, col: 5, offset: 63575},
+							pos: position{line: 2053, col: 5, offset: 63939},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2037, col: 5, offset: 63575},
+									pos:  position{line: 2053, col: 5, offset: 63939},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2037, col: 7, offset: 63577},
+									pos:  position{line: 2053, col: 7, offset: 63941},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2037, col: 13, offset: 63583},
+									pos:  position{line: 2053, col: 13, offset: 63947},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2037, col: 16, offset: 63586},
+									pos:        position{line: 2053, col: 16, offset: 63950},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2037, col: 20, offset: 63590},
+									pos:  position{line: 2053, col: 20, offset: 63954},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2037, col: 23, offset: 63593},
+									pos:   position{line: 2053, col: 23, offset: 63957},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2037, col: 30, offset: 63600},
+										pos:  position{line: 2053, col: 30, offset: 63964},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2037, col: 36, offset: 63606},
+									pos:  position{line: 2053, col: 36, offset: 63970},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2037, col: 39, offset: 63609},
+									pos:        position{line: 2053, col: 39, offset: 63973},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14675,40 +14745,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2044, col: 1, offset: 63754},
+			pos:  position{line: 2060, col: 1, offset: 64118},
 			expr: &choiceExpr{
-				pos: position{line: 2045, col: 5, offset: 63773},
+				pos: position{line: 2061, col: 5, offset: 64137},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2045, col: 5, offset: 63773},
+						pos: position{line: 2061, col: 5, offset: 64137},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2045, col: 5, offset: 63773},
+							pos: position{line: 2061, col: 5, offset: 64137},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2045, col: 5, offset: 63773},
+									pos:  position{line: 2061, col: 5, offset: 64137},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2045, col: 7, offset: 63775},
+									pos:  position{line: 2061, col: 7, offset: 64139},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2045, col: 12, offset: 63780},
+									pos:  position{line: 2061, col: 12, offset: 64144},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2045, col: 14, offset: 63782},
+									pos:  position{line: 2061, col: 14, offset: 64146},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2051, col: 5, offset: 63911},
+						pos: position{line: 2067, col: 5, offset: 64275},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2051, col: 5, offset: 63911},
+							pos:        position{line: 2067, col: 5, offset: 64275},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14721,25 +14791,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2053, col: 1, offset: 63960},
+			pos:  position{line: 2069, col: 1, offset: 64324},
 			expr: &choiceExpr{
-				pos: position{line: 2054, col: 5, offset: 63973},
+				pos: position{line: 2070, col: 5, offset: 64337},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2054, col: 5, offset: 63973},
+						pos: position{line: 2070, col: 5, offset: 64337},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2054, col: 5, offset: 63973},
+							pos: position{line: 2070, col: 5, offset: 64337},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2054, col: 5, offset: 63973},
+									pos:  position{line: 2070, col: 5, offset: 64337},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2054, col: 7, offset: 63975},
+									pos:   position{line: 2070, col: 7, offset: 64339},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2054, col: 9, offset: 63977},
+										pos:  position{line: 2070, col: 9, offset: 64341},
 										name: "AliasClause",
 									},
 								},
@@ -14747,10 +14817,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2055, col: 5, offset: 64011},
+						pos: position{line: 2071, col: 5, offset: 64375},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2055, col: 5, offset: 64011},
+							pos:        position{line: 2071, col: 5, offset: 64375},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14763,50 +14833,50 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2057, col: 1, offset: 64048},
+			pos:  position{line: 2073, col: 1, offset: 64412},
 			expr: &actionExpr{
-				pos: position{line: 2058, col: 5, offset: 64065},
+				pos: position{line: 2074, col: 5, offset: 64429},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2058, col: 5, offset: 64065},
+					pos: position{line: 2074, col: 5, offset: 64429},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2058, col: 5, offset: 64065},
+							pos: position{line: 2074, col: 5, offset: 64429},
 							expr: &seqExpr{
-								pos: position{line: 2058, col: 6, offset: 64066},
+								pos: position{line: 2074, col: 6, offset: 64430},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2058, col: 6, offset: 64066},
+										pos:  position{line: 2074, col: 6, offset: 64430},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2058, col: 9, offset: 64069},
+										pos:  position{line: 2074, col: 9, offset: 64433},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2058, col: 13, offset: 64073},
+							pos: position{line: 2074, col: 13, offset: 64437},
 							expr: &choiceExpr{
-								pos: position{line: 2058, col: 15, offset: 64075},
+								pos: position{line: 2074, col: 15, offset: 64439},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2058, col: 15, offset: 64075},
+										pos:  position{line: 2074, col: 15, offset: 64439},
 										name: "SQLGuard",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2058, col: 26, offset: 64086},
+										pos:  position{line: 2074, col: 26, offset: 64450},
 										name: "DeprecatedFroms",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2058, col: 43, offset: 64103},
+							pos:   position{line: 2074, col: 43, offset: 64467},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2058, col: 48, offset: 64108},
+								pos:  position{line: 2074, col: 48, offset: 64472},
 								name: "IdentifierName",
 							},
 						},
@@ -14818,51 +14888,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2062, col: 1, offset: 64241},
+			pos:  position{line: 2078, col: 1, offset: 64605},
 			expr: &actionExpr{
-				pos: position{line: 2063, col: 5, offset: 64255},
+				pos: position{line: 2079, col: 5, offset: 64619},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2063, col: 5, offset: 64255},
+					pos: position{line: 2079, col: 5, offset: 64619},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2063, col: 5, offset: 64255},
+							pos:   position{line: 2079, col: 5, offset: 64619},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2063, col: 11, offset: 64261},
+								pos:  position{line: 2079, col: 11, offset: 64625},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2063, col: 22, offset: 64272},
+							pos:   position{line: 2079, col: 22, offset: 64636},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2063, col: 27, offset: 64277},
+								pos: position{line: 2079, col: 27, offset: 64641},
 								expr: &actionExpr{
-									pos: position{line: 2063, col: 29, offset: 64279},
+									pos: position{line: 2079, col: 29, offset: 64643},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2063, col: 29, offset: 64279},
+										pos: position{line: 2079, col: 29, offset: 64643},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2063, col: 29, offset: 64279},
+												pos:  position{line: 2079, col: 29, offset: 64643},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2063, col: 32, offset: 64282},
+												pos:        position{line: 2079, col: 32, offset: 64646},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2063, col: 36, offset: 64286},
+												pos:  position{line: 2079, col: 36, offset: 64650},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2063, col: 39, offset: 64289},
+												pos:   position{line: 2079, col: 39, offset: 64653},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2063, col: 41, offset: 64291},
+													pos:  position{line: 2079, col: 41, offset: 64655},
 													name: "SelectElem",
 												},
 											},
@@ -14879,29 +14949,29 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2072, col: 1, offset: 64517},
+			pos:  position{line: 2088, col: 1, offset: 64881},
 			expr: &choiceExpr{
-				pos: position{line: 2073, col: 5, offset: 64533},
+				pos: position{line: 2089, col: 5, offset: 64897},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2073, col: 5, offset: 64533},
+						pos: position{line: 2089, col: 5, offset: 64897},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2073, col: 5, offset: 64533},
+							pos: position{line: 2089, col: 5, offset: 64897},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2073, col: 5, offset: 64533},
+									pos:   position{line: 2089, col: 5, offset: 64897},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2073, col: 7, offset: 64535},
+										pos:  position{line: 2089, col: 7, offset: 64899},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2073, col: 12, offset: 64540},
+									pos:   position{line: 2089, col: 12, offset: 64904},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2073, col: 15, offset: 64543},
+										pos:  position{line: 2089, col: 15, offset: 64907},
 										name: "OptAsClause",
 									},
 								},
@@ -14909,10 +14979,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2084, col: 5, offset: 64759},
+						pos: position{line: 2100, col: 5, offset: 65123},
 						run: (*parser).callonSelectElem8,
 						expr: &litMatcher{
-							pos:        position{line: 2084, col: 5, offset: 64759},
+							pos:        position{line: 2100, col: 5, offset: 65123},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -14925,33 +14995,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2089, col: 1, offset: 64861},
+			pos:  position{line: 2105, col: 1, offset: 65225},
 			expr: &choiceExpr{
-				pos: position{line: 2090, col: 5, offset: 64878},
+				pos: position{line: 2106, col: 5, offset: 65242},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2090, col: 5, offset: 64878},
+						pos: position{line: 2106, col: 5, offset: 65242},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2090, col: 5, offset: 64878},
+							pos: position{line: 2106, col: 5, offset: 65242},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 5, offset: 64878},
+									pos:  position{line: 2106, col: 5, offset: 65242},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 7, offset: 64880},
+									pos:  position{line: 2106, col: 7, offset: 65244},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 10, offset: 64883},
+									pos:  position{line: 2106, col: 10, offset: 65247},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2090, col: 12, offset: 64885},
+									pos:   position{line: 2106, col: 12, offset: 65249},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2090, col: 15, offset: 64888},
+										pos:  position{line: 2106, col: 15, offset: 65252},
 										name: "Identifier",
 									},
 								},
@@ -14959,10 +15029,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2091, col: 5, offset: 64922},
+						pos: position{line: 2107, col: 5, offset: 65286},
 						run: (*parser).callonOptAsClause9,
 						expr: &litMatcher{
-							pos:        position{line: 2091, col: 5, offset: 64922},
+							pos:        position{line: 2107, col: 5, offset: 65286},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14975,41 +15045,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2093, col: 1, offset: 64947},
+			pos:  position{line: 2109, col: 1, offset: 65311},
 			expr: &choiceExpr{
-				pos: position{line: 2094, col: 5, offset: 64969},
+				pos: position{line: 2110, col: 5, offset: 65333},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2094, col: 5, offset: 64969},
+						pos: position{line: 2110, col: 5, offset: 65333},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2094, col: 5, offset: 64969},
+							pos: position{line: 2110, col: 5, offset: 65333},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 5, offset: 64969},
+									pos:  position{line: 2110, col: 5, offset: 65333},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 7, offset: 64971},
+									pos:  position{line: 2110, col: 7, offset: 65335},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 13, offset: 64977},
+									pos:  position{line: 2110, col: 13, offset: 65341},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 15, offset: 64979},
+									pos:  position{line: 2110, col: 15, offset: 65343},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 18, offset: 64982},
+									pos:  position{line: 2110, col: 18, offset: 65346},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2094, col: 20, offset: 64984},
+									pos:   position{line: 2110, col: 20, offset: 65348},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2094, col: 25, offset: 64989},
+										pos:  position{line: 2110, col: 25, offset: 65353},
 										name: "OrderByList",
 									},
 								},
@@ -15017,10 +15087,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2101, col: 5, offset: 65148},
+						pos: position{line: 2117, col: 5, offset: 65512},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2101, col: 5, offset: 65148},
+							pos:        position{line: 2117, col: 5, offset: 65512},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15033,51 +15103,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2103, col: 1, offset: 65181},
+			pos:  position{line: 2119, col: 1, offset: 65545},
 			expr: &actionExpr{
-				pos: position{line: 2104, col: 5, offset: 65198},
+				pos: position{line: 2120, col: 5, offset: 65562},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2104, col: 5, offset: 65198},
+					pos: position{line: 2120, col: 5, offset: 65562},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2104, col: 5, offset: 65198},
+							pos:   position{line: 2120, col: 5, offset: 65562},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2104, col: 11, offset: 65204},
+								pos:  position{line: 2120, col: 11, offset: 65568},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2104, col: 23, offset: 65216},
+							pos:   position{line: 2120, col: 23, offset: 65580},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2104, col: 28, offset: 65221},
+								pos: position{line: 2120, col: 28, offset: 65585},
 								expr: &actionExpr{
-									pos: position{line: 2104, col: 30, offset: 65223},
+									pos: position{line: 2120, col: 30, offset: 65587},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2104, col: 30, offset: 65223},
+										pos: position{line: 2120, col: 30, offset: 65587},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2104, col: 30, offset: 65223},
+												pos:  position{line: 2120, col: 30, offset: 65587},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2104, col: 33, offset: 65226},
+												pos:        position{line: 2120, col: 33, offset: 65590},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2104, col: 37, offset: 65230},
+												pos:  position{line: 2120, col: 37, offset: 65594},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2104, col: 40, offset: 65233},
+												pos:   position{line: 2120, col: 40, offset: 65597},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2104, col: 42, offset: 65235},
+													pos:  position{line: 2120, col: 42, offset: 65599},
 													name: "OrderByItem",
 												},
 											},
@@ -15094,34 +15164,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2108, col: 1, offset: 65336},
+			pos:  position{line: 2124, col: 1, offset: 65700},
 			expr: &actionExpr{
-				pos: position{line: 2109, col: 5, offset: 65352},
+				pos: position{line: 2125, col: 5, offset: 65716},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2109, col: 5, offset: 65352},
+					pos: position{line: 2125, col: 5, offset: 65716},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2109, col: 5, offset: 65352},
+							pos:   position{line: 2125, col: 5, offset: 65716},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2109, col: 7, offset: 65354},
+								pos:  position{line: 2125, col: 7, offset: 65718},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2109, col: 12, offset: 65359},
+							pos:   position{line: 2125, col: 12, offset: 65723},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2109, col: 18, offset: 65365},
+								pos:  position{line: 2125, col: 18, offset: 65729},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2109, col: 29, offset: 65376},
+							pos:   position{line: 2125, col: 29, offset: 65740},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2109, col: 35, offset: 65382},
+								pos:  position{line: 2125, col: 35, offset: 65746},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15133,49 +15203,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2120, col: 1, offset: 65632},
+			pos:  position{line: 2136, col: 1, offset: 65996},
 			expr: &choiceExpr{
-				pos: position{line: 2121, col: 5, offset: 65647},
+				pos: position{line: 2137, col: 5, offset: 66011},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2121, col: 5, offset: 65647},
+						pos: position{line: 2137, col: 5, offset: 66011},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2121, col: 5, offset: 65647},
+							pos: position{line: 2137, col: 5, offset: 66011},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2121, col: 5, offset: 65647},
+									pos:  position{line: 2137, col: 5, offset: 66011},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2121, col: 7, offset: 65649},
+									pos:  position{line: 2137, col: 7, offset: 66013},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2122, col: 5, offset: 65721},
+						pos: position{line: 2138, col: 5, offset: 66085},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2122, col: 5, offset: 65721},
+							pos: position{line: 2138, col: 5, offset: 66085},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2122, col: 5, offset: 65721},
+									pos:  position{line: 2138, col: 5, offset: 66085},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2122, col: 7, offset: 65723},
+									pos:  position{line: 2138, col: 7, offset: 66087},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2123, col: 5, offset: 65795},
+						pos: position{line: 2139, col: 5, offset: 66159},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2123, col: 5, offset: 65795},
+							pos:        position{line: 2139, col: 5, offset: 66159},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15188,65 +15258,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2125, col: 1, offset: 65827},
+			pos:  position{line: 2141, col: 1, offset: 66191},
 			expr: &choiceExpr{
-				pos: position{line: 2126, col: 5, offset: 65845},
+				pos: position{line: 2142, col: 5, offset: 66209},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2126, col: 5, offset: 65845},
+						pos: position{line: 2142, col: 5, offset: 66209},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2126, col: 5, offset: 65845},
+							pos: position{line: 2142, col: 5, offset: 66209},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2126, col: 5, offset: 65845},
+									pos:  position{line: 2142, col: 5, offset: 66209},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2126, col: 7, offset: 65847},
+									pos:  position{line: 2142, col: 7, offset: 66211},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2126, col: 13, offset: 65853},
+									pos:  position{line: 2142, col: 13, offset: 66217},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2126, col: 15, offset: 65855},
+									pos:  position{line: 2142, col: 15, offset: 66219},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2127, col: 5, offset: 65931},
+						pos: position{line: 2143, col: 5, offset: 66295},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2127, col: 5, offset: 65931},
+							pos: position{line: 2143, col: 5, offset: 66295},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 5, offset: 65931},
+									pos:  position{line: 2143, col: 5, offset: 66295},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 7, offset: 65933},
+									pos:  position{line: 2143, col: 7, offset: 66297},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 13, offset: 65939},
+									pos:  position{line: 2143, col: 13, offset: 66303},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 15, offset: 65941},
+									pos:  position{line: 2143, col: 15, offset: 66305},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2128, col: 5, offset: 66016},
+						pos: position{line: 2144, col: 5, offset: 66380},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2128, col: 5, offset: 66016},
+							pos:        position{line: 2144, col: 5, offset: 66380},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15259,29 +15329,29 @@ var g = &grammar{
 		},
 		{
 			name: "SelectLimit",
-			pos:  position{line: 2130, col: 1, offset: 66061},
+			pos:  position{line: 2146, col: 1, offset: 66425},
 			expr: &choiceExpr{
-				pos: position{line: 2131, col: 5, offset: 66077},
+				pos: position{line: 2147, col: 5, offset: 66441},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2131, col: 5, offset: 66077},
+						pos: position{line: 2147, col: 5, offset: 66441},
 						run: (*parser).callonSelectLimit2,
 						expr: &seqExpr{
-							pos: position{line: 2131, col: 5, offset: 66077},
+							pos: position{line: 2147, col: 5, offset: 66441},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2131, col: 5, offset: 66077},
+									pos:   position{line: 2147, col: 5, offset: 66441},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2131, col: 7, offset: 66079},
+										pos:  position{line: 2147, col: 7, offset: 66443},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2131, col: 19, offset: 66091},
+									pos:   position{line: 2147, col: 19, offset: 66455},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2131, col: 21, offset: 66093},
+										pos:  position{line: 2147, col: 21, offset: 66457},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15289,24 +15359,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2138, col: 5, offset: 66239},
+						pos: position{line: 2154, col: 5, offset: 66603},
 						run: (*parser).callonSelectLimit8,
 						expr: &seqExpr{
-							pos: position{line: 2138, col: 5, offset: 66239},
+							pos: position{line: 2154, col: 5, offset: 66603},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2138, col: 5, offset: 66239},
+									pos:   position{line: 2154, col: 5, offset: 66603},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2138, col: 7, offset: 66241},
+										pos:  position{line: 2154, col: 7, offset: 66605},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2138, col: 20, offset: 66254},
+									pos:   position{line: 2154, col: 20, offset: 66618},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2138, col: 22, offset: 66256},
+										pos:  position{line: 2154, col: 22, offset: 66620},
 										name: "OptLimitClause",
 									},
 								},
@@ -15320,25 +15390,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2151, col: 1, offset: 66528},
+			pos:  position{line: 2167, col: 1, offset: 66892},
 			expr: &choiceExpr{
-				pos: position{line: 2152, col: 5, offset: 66548},
+				pos: position{line: 2168, col: 5, offset: 66912},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2152, col: 5, offset: 66548},
+						pos: position{line: 2168, col: 5, offset: 66912},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2152, col: 5, offset: 66548},
+							pos: position{line: 2168, col: 5, offset: 66912},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2152, col: 5, offset: 66548},
+									pos:  position{line: 2168, col: 5, offset: 66912},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2152, col: 7, offset: 66550},
+									pos:   position{line: 2168, col: 7, offset: 66914},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2152, col: 9, offset: 66552},
+										pos:  position{line: 2168, col: 9, offset: 66916},
 										name: "LimitClause",
 									},
 								},
@@ -15346,10 +15416,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2153, col: 5, offset: 66586},
+						pos: position{line: 2169, col: 5, offset: 66950},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2153, col: 5, offset: 66586},
+							pos:        position{line: 2169, col: 5, offset: 66950},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15362,50 +15432,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2155, col: 1, offset: 66623},
+			pos:  position{line: 2171, col: 1, offset: 66987},
 			expr: &choiceExpr{
-				pos: position{line: 2156, col: 5, offset: 66640},
+				pos: position{line: 2172, col: 5, offset: 67004},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2156, col: 5, offset: 66640},
+						pos: position{line: 2172, col: 5, offset: 67004},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2156, col: 5, offset: 66640},
+							pos: position{line: 2172, col: 5, offset: 67004},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2156, col: 5, offset: 66640},
+									pos:  position{line: 2172, col: 5, offset: 67004},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2156, col: 11, offset: 66646},
+									pos:  position{line: 2172, col: 11, offset: 67010},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2156, col: 13, offset: 66648},
+									pos:  position{line: 2172, col: 13, offset: 67012},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2157, col: 5, offset: 66710},
+						pos: position{line: 2173, col: 5, offset: 67074},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2157, col: 5, offset: 66710},
+							pos: position{line: 2173, col: 5, offset: 67074},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2157, col: 5, offset: 66710},
+									pos:  position{line: 2173, col: 5, offset: 67074},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2157, col: 11, offset: 66716},
+									pos:  position{line: 2173, col: 11, offset: 67080},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2157, col: 13, offset: 66718},
+									pos:   position{line: 2173, col: 13, offset: 67082},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2157, col: 15, offset: 66720},
+										pos:  position{line: 2173, col: 15, offset: 67084},
 										name: "Expr",
 									},
 								},
@@ -15419,25 +15489,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2165, col: 1, offset: 66845},
+			pos:  position{line: 2181, col: 1, offset: 67209},
 			expr: &choiceExpr{
-				pos: position{line: 2166, col: 5, offset: 66866},
+				pos: position{line: 2182, col: 5, offset: 67230},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2166, col: 5, offset: 66866},
+						pos: position{line: 2182, col: 5, offset: 67230},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2166, col: 5, offset: 66866},
+							pos: position{line: 2182, col: 5, offset: 67230},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2166, col: 5, offset: 66866},
+									pos:  position{line: 2182, col: 5, offset: 67230},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2166, col: 7, offset: 66868},
+									pos:   position{line: 2182, col: 7, offset: 67232},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2166, col: 9, offset: 66870},
+										pos:  position{line: 2182, col: 9, offset: 67234},
 										name: "OffsetClause",
 									},
 								},
@@ -15445,10 +15515,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2167, col: 5, offset: 66906},
+						pos: position{line: 2183, col: 5, offset: 67270},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2167, col: 5, offset: 66906},
+							pos:        position{line: 2183, col: 5, offset: 67270},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15461,26 +15531,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2169, col: 1, offset: 66931},
+			pos:  position{line: 2185, col: 1, offset: 67295},
 			expr: &actionExpr{
-				pos: position{line: 2170, col: 5, offset: 66949},
+				pos: position{line: 2186, col: 5, offset: 67313},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2170, col: 5, offset: 66949},
+					pos: position{line: 2186, col: 5, offset: 67313},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2170, col: 5, offset: 66949},
+							pos:  position{line: 2186, col: 5, offset: 67313},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2170, col: 12, offset: 66956},
+							pos:  position{line: 2186, col: 12, offset: 67320},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2170, col: 14, offset: 66958},
+							pos:   position{line: 2186, col: 14, offset: 67322},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2170, col: 16, offset: 66960},
+								pos:  position{line: 2186, col: 16, offset: 67324},
 								name: "Expr",
 							},
 						},
@@ -15492,108 +15562,108 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2172, col: 1, offset: 66985},
+			pos:  position{line: 2188, col: 1, offset: 67349},
 			expr: &actionExpr{
-				pos: position{line: 2173, col: 5, offset: 67002},
+				pos: position{line: 2189, col: 5, offset: 67366},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2173, col: 5, offset: 67002},
+					pos: position{line: 2189, col: 5, offset: 67366},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2173, col: 5, offset: 67002},
+							pos:   position{line: 2189, col: 5, offset: 67366},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2173, col: 10, offset: 67007},
+								pos:  position{line: 2189, col: 10, offset: 67371},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2173, col: 21, offset: 67018},
+							pos:   position{line: 2189, col: 21, offset: 67382},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2173, col: 30, offset: 67027},
+								pos:  position{line: 2189, col: 30, offset: 67391},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2173, col: 36, offset: 67033},
+							pos:  position{line: 2189, col: 36, offset: 67397},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2173, col: 38, offset: 67035},
+							pos:   position{line: 2189, col: 38, offset: 67399},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2173, col: 44, offset: 67041},
+								pos:  position{line: 2189, col: 44, offset: 67405},
 								name: "SelectExpr",
 							},
 						},
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2183, col: 1, offset: 67262},
+			pos:  position{line: 2199, col: 1, offset: 67626},
 			expr: &choiceExpr{
-				pos: position{line: 2184, col: 5, offset: 67273},
+				pos: position{line: 2200, col: 5, offset: 67637},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2184, col: 5, offset: 67273},
+						pos: position{line: 2200, col: 5, offset: 67637},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2184, col: 5, offset: 67273},
+							pos: position{line: 2200, col: 5, offset: 67637},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2184, col: 5, offset: 67273},
+									pos:  position{line: 2200, col: 5, offset: 67637},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2184, col: 7, offset: 67275},
+									pos:  position{line: 2200, col: 7, offset: 67639},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2184, col: 13, offset: 67281},
+									pos:  position{line: 2200, col: 13, offset: 67645},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2184, col: 15, offset: 67283},
+									pos:  position{line: 2200, col: 15, offset: 67647},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2185, col: 5, offset: 67319},
+						pos: position{line: 2201, col: 5, offset: 67683},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2185, col: 5, offset: 67319},
+							pos: position{line: 2201, col: 5, offset: 67683},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2185, col: 5, offset: 67319},
+									pos:  position{line: 2201, col: 5, offset: 67683},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2185, col: 7, offset: 67321},
+									pos:  position{line: 2201, col: 7, offset: 67685},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2185, col: 13, offset: 67327},
+									pos:  position{line: 2201, col: 13, offset: 67691},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2185, col: 15, offset: 67329},
+									pos:  position{line: 2201, col: 15, offset: 67693},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2186, col: 5, offset: 67364},
+						pos: position{line: 2202, col: 5, offset: 67728},
 						run: (*parser).callonSetOp14,
 						expr: &litMatcher{
-							pos:        position{line: 2186, col: 5, offset: 67364},
+							pos:        position{line: 2202, col: 5, offset: 67728},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15606,80 +15676,80 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2189, col: 1, offset: 67427},
+			pos:  position{line: 2205, col: 1, offset: 67791},
 			expr: &choiceExpr{
-				pos: position{line: 2190, col: 5, offset: 67442},
+				pos: position{line: 2206, col: 5, offset: 67806},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2190, col: 5, offset: 67442},
+						pos:  position{line: 2206, col: 5, offset: 67806},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2190, col: 12, offset: 67449},
+						pos:  position{line: 2206, col: 12, offset: 67813},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2190, col: 20, offset: 67457},
+						pos:  position{line: 2206, col: 20, offset: 67821},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2190, col: 29, offset: 67466},
+						pos:  position{line: 2206, col: 29, offset: 67830},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2190, col: 38, offset: 67475},
+						pos:  position{line: 2206, col: 38, offset: 67839},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2191, col: 5, offset: 67489},
+						pos:  position{line: 2207, col: 5, offset: 67853},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2191, col: 13, offset: 67497},
+						pos:  position{line: 2207, col: 13, offset: 67861},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2191, col: 20, offset: 67504},
+						pos:  position{line: 2207, col: 20, offset: 67868},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2191, col: 28, offset: 67512},
+						pos:  position{line: 2207, col: 28, offset: 67876},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2191, col: 36, offset: 67520},
+						pos:  position{line: 2207, col: 36, offset: 67884},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2191, col: 44, offset: 67528},
+						pos:  position{line: 2207, col: 44, offset: 67892},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2192, col: 5, offset: 67537},
+						pos:  position{line: 2208, col: 5, offset: 67901},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2193, col: 5, offset: 67547},
+						pos:  position{line: 2209, col: 5, offset: 67911},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2194, col: 5, offset: 67557},
+						pos:  position{line: 2210, col: 5, offset: 67921},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2195, col: 5, offset: 67567},
+						pos:  position{line: 2211, col: 5, offset: 67931},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2196, col: 5, offset: 67578},
+						pos:  position{line: 2212, col: 5, offset: 67942},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2197, col: 5, offset: 67587},
+						pos:  position{line: 2213, col: 5, offset: 67951},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2198, col: 5, offset: 67597},
+						pos:  position{line: 2214, col: 5, offset: 67961},
 						name: "ON",
 					},
 				},
@@ -15689,20 +15759,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2200, col: 1, offset: 67601},
+			pos:  position{line: 2216, col: 1, offset: 67965},
 			expr: &seqExpr{
-				pos: position{line: 2200, col: 14, offset: 67614},
+				pos: position{line: 2216, col: 14, offset: 67978},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2200, col: 14, offset: 67614},
+						pos:        position{line: 2216, col: 14, offset: 67978},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2200, col: 33, offset: 67633},
+						pos: position{line: 2216, col: 33, offset: 67997},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2200, col: 34, offset: 67634},
+							pos:  position{line: 2216, col: 34, offset: 67998},
 							name: "IdentifierRest",
 						},
 					},
@@ -15713,20 +15783,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2201, col: 1, offset: 67649},
+			pos:  position{line: 2217, col: 1, offset: 68013},
 			expr: &seqExpr{
-				pos: position{line: 2201, col: 14, offset: 67662},
+				pos: position{line: 2217, col: 14, offset: 68026},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2201, col: 14, offset: 67662},
+						pos:        position{line: 2217, col: 14, offset: 68026},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2201, col: 33, offset: 67681},
+						pos: position{line: 2217, col: 33, offset: 68045},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2201, col: 34, offset: 67682},
+							pos:  position{line: 2217, col: 34, offset: 68046},
 							name: "IdentifierRest",
 						},
 					},
@@ -15737,23 +15807,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2202, col: 1, offset: 67697},
+			pos:  position{line: 2218, col: 1, offset: 68061},
 			expr: &actionExpr{
-				pos: position{line: 2202, col: 14, offset: 67710},
+				pos: position{line: 2218, col: 14, offset: 68074},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2202, col: 14, offset: 67710},
+					pos: position{line: 2218, col: 14, offset: 68074},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2202, col: 14, offset: 67710},
+							pos:        position{line: 2218, col: 14, offset: 68074},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2202, col: 33, offset: 67729},
+							pos: position{line: 2218, col: 33, offset: 68093},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2202, col: 34, offset: 67730},
+								pos:  position{line: 2218, col: 34, offset: 68094},
 								name: "IdentifierRest",
 							},
 						},
@@ -15765,20 +15835,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2203, col: 1, offset: 67767},
+			pos:  position{line: 2219, col: 1, offset: 68131},
 			expr: &seqExpr{
-				pos: position{line: 2203, col: 14, offset: 67780},
+				pos: position{line: 2219, col: 14, offset: 68144},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2203, col: 14, offset: 67780},
+						pos:        position{line: 2219, col: 14, offset: 68144},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2203, col: 33, offset: 67799},
+						pos: position{line: 2219, col: 33, offset: 68163},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2203, col: 34, offset: 67800},
+							pos:  position{line: 2219, col: 34, offset: 68164},
 							name: "IdentifierRest",
 						},
 					},
@@ -15789,20 +15859,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2204, col: 1, offset: 67815},
+			pos:  position{line: 2220, col: 1, offset: 68179},
 			expr: &seqExpr{
-				pos: position{line: 2204, col: 14, offset: 67828},
+				pos: position{line: 2220, col: 14, offset: 68192},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2204, col: 14, offset: 67828},
+						pos:        position{line: 2220, col: 14, offset: 68192},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2204, col: 33, offset: 67847},
+						pos: position{line: 2220, col: 33, offset: 68211},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2204, col: 34, offset: 67848},
+							pos:  position{line: 2220, col: 34, offset: 68212},
 							name: "IdentifierRest",
 						},
 					},
@@ -15813,23 +15883,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2205, col: 1, offset: 67863},
+			pos:  position{line: 2221, col: 1, offset: 68227},
 			expr: &actionExpr{
-				pos: position{line: 2205, col: 14, offset: 67876},
+				pos: position{line: 2221, col: 14, offset: 68240},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2205, col: 14, offset: 67876},
+					pos: position{line: 2221, col: 14, offset: 68240},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2205, col: 14, offset: 67876},
+							pos:        position{line: 2221, col: 14, offset: 68240},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2205, col: 33, offset: 67895},
+							pos: position{line: 2221, col: 33, offset: 68259},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2205, col: 34, offset: 67896},
+								pos:  position{line: 2221, col: 34, offset: 68260},
 								name: "IdentifierRest",
 							},
 						},
@@ -15841,20 +15911,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2206, col: 1, offset: 67933},
+			pos:  position{line: 2222, col: 1, offset: 68297},
 			expr: &seqExpr{
-				pos: position{line: 2206, col: 14, offset: 67946},
+				pos: position{line: 2222, col: 14, offset: 68310},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2206, col: 14, offset: 67946},
+						pos:        position{line: 2222, col: 14, offset: 68310},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2206, col: 33, offset: 67965},
+						pos: position{line: 2222, col: 33, offset: 68329},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2206, col: 34, offset: 67966},
+							pos:  position{line: 2222, col: 34, offset: 68330},
 							name: "IdentifierRest",
 						},
 					},
@@ -15865,20 +15935,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2207, col: 1, offset: 67981},
+			pos:  position{line: 2223, col: 1, offset: 68345},
 			expr: &seqExpr{
-				pos: position{line: 2207, col: 14, offset: 67994},
+				pos: position{line: 2223, col: 14, offset: 68358},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2207, col: 14, offset: 67994},
+						pos:        position{line: 2223, col: 14, offset: 68358},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2207, col: 33, offset: 68013},
+						pos: position{line: 2223, col: 33, offset: 68377},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2207, col: 34, offset: 68014},
+							pos:  position{line: 2223, col: 34, offset: 68378},
 							name: "IdentifierRest",
 						},
 					},
@@ -15889,20 +15959,20 @@ var g = &grammar{
 		},
 		{
 			name: "AUTHOR",
-			pos:  position{line: 2208, col: 1, offset: 68029},
+			pos:  position{line: 2224, col: 1, offset: 68393},
 			expr: &seqExpr{
-				pos: position{line: 2208, col: 14, offset: 68042},
+				pos: position{line: 2224, col: 14, offset: 68406},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2208, col: 14, offset: 68042},
+						pos:        position{line: 2224, col: 14, offset: 68406},
 						val:        "author",
 						ignoreCase: true,
 						want:       "\"AUTHOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2208, col: 33, offset: 68061},
+						pos: position{line: 2224, col: 33, offset: 68425},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2208, col: 34, offset: 68062},
+							pos:  position{line: 2224, col: 34, offset: 68426},
 							name: "IdentifierRest",
 						},
 					},
@@ -15913,20 +15983,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2209, col: 1, offset: 68077},
+			pos:  position{line: 2225, col: 1, offset: 68441},
 			expr: &seqExpr{
-				pos: position{line: 2209, col: 14, offset: 68090},
+				pos: position{line: 2225, col: 14, offset: 68454},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2209, col: 14, offset: 68090},
+						pos:        position{line: 2225, col: 14, offset: 68454},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2209, col: 33, offset: 68109},
+						pos: position{line: 2225, col: 33, offset: 68473},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2209, col: 34, offset: 68110},
+							pos:  position{line: 2225, col: 34, offset: 68474},
 							name: "IdentifierRest",
 						},
 					},
@@ -15937,20 +16007,20 @@ var g = &grammar{
 		},
 		{
 			name: "BODY",
-			pos:  position{line: 2210, col: 1, offset: 68125},
+			pos:  position{line: 2226, col: 1, offset: 68489},
 			expr: &seqExpr{
-				pos: position{line: 2210, col: 14, offset: 68138},
+				pos: position{line: 2226, col: 14, offset: 68502},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2210, col: 14, offset: 68138},
+						pos:        position{line: 2226, col: 14, offset: 68502},
 						val:        "body",
 						ignoreCase: true,
 						want:       "\"BODY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2210, col: 33, offset: 68157},
+						pos: position{line: 2226, col: 33, offset: 68521},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2210, col: 34, offset: 68158},
+							pos:  position{line: 2226, col: 34, offset: 68522},
 							name: "IdentifierRest",
 						},
 					},
@@ -15961,20 +16031,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2211, col: 1, offset: 68173},
+			pos:  position{line: 2227, col: 1, offset: 68537},
 			expr: &seqExpr{
-				pos: position{line: 2211, col: 14, offset: 68186},
+				pos: position{line: 2227, col: 14, offset: 68550},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2211, col: 14, offset: 68186},
+						pos:        position{line: 2227, col: 14, offset: 68550},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2211, col: 33, offset: 68205},
+						pos: position{line: 2227, col: 33, offset: 68569},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2211, col: 34, offset: 68206},
+							pos:  position{line: 2227, col: 34, offset: 68570},
 							name: "IdentifierRest",
 						},
 					},
@@ -15985,20 +16055,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2212, col: 1, offset: 68221},
+			pos:  position{line: 2228, col: 1, offset: 68585},
 			expr: &seqExpr{
-				pos: position{line: 2212, col: 14, offset: 68234},
+				pos: position{line: 2228, col: 14, offset: 68598},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2212, col: 14, offset: 68234},
+						pos:        position{line: 2228, col: 14, offset: 68598},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2212, col: 33, offset: 68253},
+						pos: position{line: 2228, col: 33, offset: 68617},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2212, col: 34, offset: 68254},
+							pos:  position{line: 2228, col: 34, offset: 68618},
 							name: "IdentifierRest",
 						},
 					},
@@ -16009,20 +16079,44 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2213, col: 1, offset: 68269},
+			pos:  position{line: 2229, col: 1, offset: 68633},
 			expr: &seqExpr{
-				pos: position{line: 2213, col: 14, offset: 68282},
+				pos: position{line: 2229, col: 14, offset: 68646},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2213, col: 14, offset: 68282},
+						pos:        position{line: 2229, col: 14, offset: 68646},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2213, col: 33, offset: 68301},
+						pos: position{line: 2229, col: 33, offset: 68665},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2213, col: 34, offset: 68302},
+							pos:  position{line: 2229, col: 34, offset: 68666},
+							name: "IdentifierRest",
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "COUNT",
+			pos:  position{line: 2230, col: 1, offset: 68681},
+			expr: &seqExpr{
+				pos: position{line: 2230, col: 14, offset: 68694},
+				exprs: []any{
+					&litMatcher{
+						pos:        position{line: 2230, col: 14, offset: 68694},
+						val:        "count",
+						ignoreCase: true,
+						want:       "\"COUNT\"i",
+					},
+					&notExpr{
+						pos: position{line: 2230, col: 33, offset: 68713},
+						expr: &ruleRefExpr{
+							pos:  position{line: 2230, col: 34, offset: 68714},
 							name: "IdentifierRest",
 						},
 					},
@@ -16033,20 +16127,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2214, col: 1, offset: 68317},
+			pos:  position{line: 2231, col: 1, offset: 68729},
 			expr: &seqExpr{
-				pos: position{line: 2214, col: 14, offset: 68330},
+				pos: position{line: 2231, col: 14, offset: 68742},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2214, col: 14, offset: 68330},
+						pos:        position{line: 2231, col: 14, offset: 68742},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2214, col: 33, offset: 68349},
+						pos: position{line: 2231, col: 33, offset: 68761},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2214, col: 34, offset: 68350},
+							pos:  position{line: 2231, col: 34, offset: 68762},
 							name: "IdentifierRest",
 						},
 					},
@@ -16057,20 +16151,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2215, col: 1, offset: 68365},
+			pos:  position{line: 2232, col: 1, offset: 68777},
 			expr: &seqExpr{
-				pos: position{line: 2215, col: 14, offset: 68378},
+				pos: position{line: 2232, col: 14, offset: 68790},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2215, col: 14, offset: 68378},
+						pos:        position{line: 2232, col: 14, offset: 68790},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2215, col: 33, offset: 68397},
+						pos: position{line: 2232, col: 33, offset: 68809},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2215, col: 34, offset: 68398},
+							pos:  position{line: 2232, col: 34, offset: 68810},
 							name: "IdentifierRest",
 						},
 					},
@@ -16081,20 +16175,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2216, col: 1, offset: 68413},
+			pos:  position{line: 2233, col: 1, offset: 68825},
 			expr: &seqExpr{
-				pos: position{line: 2216, col: 14, offset: 68426},
+				pos: position{line: 2233, col: 14, offset: 68838},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2216, col: 14, offset: 68426},
+						pos:        position{line: 2233, col: 14, offset: 68838},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2216, col: 33, offset: 68445},
+						pos: position{line: 2233, col: 33, offset: 68857},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2216, col: 34, offset: 68446},
+							pos:  position{line: 2233, col: 34, offset: 68858},
 							name: "IdentifierRest",
 						},
 					},
@@ -16105,20 +16199,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2217, col: 1, offset: 68461},
+			pos:  position{line: 2234, col: 1, offset: 68873},
 			expr: &seqExpr{
-				pos: position{line: 2217, col: 14, offset: 68474},
+				pos: position{line: 2234, col: 14, offset: 68886},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2217, col: 14, offset: 68474},
+						pos:        position{line: 2234, col: 14, offset: 68886},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2217, col: 33, offset: 68493},
+						pos: position{line: 2234, col: 33, offset: 68905},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2217, col: 34, offset: 68494},
+							pos:  position{line: 2234, col: 34, offset: 68906},
 							name: "IdentifierRest",
 						},
 					},
@@ -16129,23 +16223,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2218, col: 1, offset: 68509},
+			pos:  position{line: 2235, col: 1, offset: 68921},
 			expr: &actionExpr{
-				pos: position{line: 2218, col: 14, offset: 68522},
+				pos: position{line: 2235, col: 14, offset: 68934},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2218, col: 14, offset: 68522},
+					pos: position{line: 2235, col: 14, offset: 68934},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2218, col: 14, offset: 68522},
+							pos:        position{line: 2235, col: 14, offset: 68934},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2218, col: 33, offset: 68541},
+							pos: position{line: 2235, col: 33, offset: 68953},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2218, col: 34, offset: 68542},
+								pos:  position{line: 2235, col: 34, offset: 68954},
 								name: "IdentifierRest",
 							},
 						},
@@ -16157,20 +16251,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2219, col: 1, offset: 68580},
+			pos:  position{line: 2236, col: 1, offset: 68992},
 			expr: &seqExpr{
-				pos: position{line: 2219, col: 14, offset: 68593},
+				pos: position{line: 2236, col: 14, offset: 69005},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2219, col: 14, offset: 68593},
+						pos:        position{line: 2236, col: 14, offset: 69005},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2219, col: 33, offset: 68612},
+						pos: position{line: 2236, col: 33, offset: 69024},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2219, col: 34, offset: 68613},
+							pos:  position{line: 2236, col: 34, offset: 69025},
 							name: "IdentifierRest",
 						},
 					},
@@ -16181,20 +16275,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2220, col: 1, offset: 68628},
+			pos:  position{line: 2237, col: 1, offset: 69040},
 			expr: &seqExpr{
-				pos: position{line: 2220, col: 14, offset: 68641},
+				pos: position{line: 2237, col: 14, offset: 69053},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2220, col: 14, offset: 68641},
+						pos:        position{line: 2237, col: 14, offset: 69053},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2220, col: 33, offset: 68660},
+						pos: position{line: 2237, col: 33, offset: 69072},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2220, col: 34, offset: 68661},
+							pos:  position{line: 2237, col: 34, offset: 69073},
 							name: "IdentifierRest",
 						},
 					},
@@ -16205,20 +16299,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2221, col: 1, offset: 68677},
+			pos:  position{line: 2238, col: 1, offset: 69089},
 			expr: &seqExpr{
-				pos: position{line: 2221, col: 14, offset: 68690},
+				pos: position{line: 2238, col: 14, offset: 69102},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2221, col: 14, offset: 68690},
+						pos:        position{line: 2238, col: 14, offset: 69102},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2221, col: 33, offset: 68709},
+						pos: position{line: 2238, col: 33, offset: 69121},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2221, col: 34, offset: 68710},
+							pos:  position{line: 2238, col: 34, offset: 69122},
 							name: "IdentifierRest",
 						},
 					},
@@ -16229,20 +16323,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2222, col: 1, offset: 68725},
+			pos:  position{line: 2239, col: 1, offset: 69137},
 			expr: &seqExpr{
-				pos: position{line: 2222, col: 14, offset: 68738},
+				pos: position{line: 2239, col: 14, offset: 69150},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2222, col: 14, offset: 68738},
+						pos:        position{line: 2239, col: 14, offset: 69150},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2222, col: 33, offset: 68757},
+						pos: position{line: 2239, col: 33, offset: 69169},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2222, col: 34, offset: 68758},
+							pos:  position{line: 2239, col: 34, offset: 69170},
 							name: "IdentifierRest",
 						},
 					},
@@ -16253,20 +16347,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2223, col: 1, offset: 68773},
+			pos:  position{line: 2240, col: 1, offset: 69185},
 			expr: &seqExpr{
-				pos: position{line: 2223, col: 14, offset: 68786},
+				pos: position{line: 2240, col: 14, offset: 69198},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2223, col: 14, offset: 68786},
+						pos:        position{line: 2240, col: 14, offset: 69198},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2223, col: 33, offset: 68805},
+						pos: position{line: 2240, col: 33, offset: 69217},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2223, col: 34, offset: 68806},
+							pos:  position{line: 2240, col: 34, offset: 69218},
 							name: "IdentifierRest",
 						},
 					},
@@ -16277,20 +16371,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2224, col: 1, offset: 68821},
+			pos:  position{line: 2241, col: 1, offset: 69233},
 			expr: &seqExpr{
-				pos: position{line: 2224, col: 14, offset: 68834},
+				pos: position{line: 2241, col: 14, offset: 69246},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2224, col: 14, offset: 68834},
+						pos:        position{line: 2241, col: 14, offset: 69246},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2224, col: 33, offset: 68853},
+						pos: position{line: 2241, col: 33, offset: 69265},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2224, col: 34, offset: 68854},
+							pos:  position{line: 2241, col: 34, offset: 69266},
 							name: "IdentifierRest",
 						},
 					},
@@ -16301,20 +16395,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2225, col: 1, offset: 68869},
+			pos:  position{line: 2242, col: 1, offset: 69281},
 			expr: &seqExpr{
-				pos: position{line: 2225, col: 14, offset: 68882},
+				pos: position{line: 2242, col: 14, offset: 69294},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2225, col: 14, offset: 68882},
+						pos:        position{line: 2242, col: 14, offset: 69294},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2225, col: 33, offset: 68901},
+						pos: position{line: 2242, col: 33, offset: 69313},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2225, col: 34, offset: 68902},
+							pos:  position{line: 2242, col: 34, offset: 69314},
 							name: "IdentifierRest",
 						},
 					},
@@ -16325,20 +16419,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2226, col: 1, offset: 68917},
+			pos:  position{line: 2243, col: 1, offset: 69329},
 			expr: &seqExpr{
-				pos: position{line: 2226, col: 14, offset: 68930},
+				pos: position{line: 2243, col: 14, offset: 69342},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2226, col: 14, offset: 68930},
+						pos:        position{line: 2243, col: 14, offset: 69342},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2226, col: 33, offset: 68949},
+						pos: position{line: 2243, col: 33, offset: 69361},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2226, col: 34, offset: 68950},
+							pos:  position{line: 2243, col: 34, offset: 69362},
 							name: "IdentifierRest",
 						},
 					},
@@ -16349,20 +16443,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2227, col: 1, offset: 68965},
+			pos:  position{line: 2244, col: 1, offset: 69377},
 			expr: &seqExpr{
-				pos: position{line: 2227, col: 14, offset: 68978},
+				pos: position{line: 2244, col: 14, offset: 69390},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2227, col: 14, offset: 68978},
+						pos:        position{line: 2244, col: 14, offset: 69390},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2227, col: 33, offset: 68997},
+						pos: position{line: 2244, col: 33, offset: 69409},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2227, col: 34, offset: 68998},
+							pos:  position{line: 2244, col: 34, offset: 69410},
 							name: "IdentifierRest",
 						},
 					},
@@ -16373,20 +16467,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2228, col: 1, offset: 69013},
+			pos:  position{line: 2245, col: 1, offset: 69425},
 			expr: &seqExpr{
-				pos: position{line: 2228, col: 14, offset: 69026},
+				pos: position{line: 2245, col: 14, offset: 69438},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2228, col: 14, offset: 69026},
+						pos:        position{line: 2245, col: 14, offset: 69438},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2228, col: 33, offset: 69045},
+						pos: position{line: 2245, col: 33, offset: 69457},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2228, col: 34, offset: 69046},
+							pos:  position{line: 2245, col: 34, offset: 69458},
 							name: "IdentifierRest",
 						},
 					},
@@ -16397,20 +16491,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORMAT",
-			pos:  position{line: 2229, col: 1, offset: 69061},
+			pos:  position{line: 2246, col: 1, offset: 69473},
 			expr: &seqExpr{
-				pos: position{line: 2229, col: 14, offset: 69074},
+				pos: position{line: 2246, col: 14, offset: 69486},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2229, col: 14, offset: 69074},
+						pos:        position{line: 2246, col: 14, offset: 69486},
 						val:        "format",
 						ignoreCase: true,
 						want:       "\"FORMAT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2229, col: 33, offset: 69093},
+						pos: position{line: 2246, col: 33, offset: 69505},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2229, col: 34, offset: 69094},
+							pos:  position{line: 2246, col: 34, offset: 69506},
 							name: "IdentifierRest",
 						},
 					},
@@ -16421,20 +16515,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2230, col: 1, offset: 69109},
+			pos:  position{line: 2247, col: 1, offset: 69521},
 			expr: &seqExpr{
-				pos: position{line: 2230, col: 14, offset: 69122},
+				pos: position{line: 2247, col: 14, offset: 69534},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2230, col: 14, offset: 69122},
+						pos:        position{line: 2247, col: 14, offset: 69534},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2230, col: 33, offset: 69141},
+						pos: position{line: 2247, col: 33, offset: 69553},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2230, col: 34, offset: 69142},
+							pos:  position{line: 2247, col: 34, offset: 69554},
 							name: "IdentifierRest",
 						},
 					},
@@ -16445,20 +16539,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2231, col: 1, offset: 69157},
+			pos:  position{line: 2248, col: 1, offset: 69569},
 			expr: &seqExpr{
-				pos: position{line: 2231, col: 14, offset: 69170},
+				pos: position{line: 2248, col: 14, offset: 69582},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2231, col: 14, offset: 69170},
+						pos:        position{line: 2248, col: 14, offset: 69582},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2231, col: 33, offset: 69189},
+						pos: position{line: 2248, col: 33, offset: 69601},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2231, col: 34, offset: 69190},
+							pos:  position{line: 2248, col: 34, offset: 69602},
 							name: "IdentifierRest",
 						},
 					},
@@ -16469,20 +16563,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2232, col: 1, offset: 69205},
+			pos:  position{line: 2249, col: 1, offset: 69617},
 			expr: &seqExpr{
-				pos: position{line: 2232, col: 14, offset: 69218},
+				pos: position{line: 2249, col: 14, offset: 69630},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2232, col: 14, offset: 69218},
+						pos:        position{line: 2249, col: 14, offset: 69630},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2232, col: 33, offset: 69237},
+						pos: position{line: 2249, col: 33, offset: 69649},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2232, col: 34, offset: 69238},
+							pos:  position{line: 2249, col: 34, offset: 69650},
 							name: "IdentifierRest",
 						},
 					},
@@ -16493,20 +16587,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2233, col: 1, offset: 69253},
+			pos:  position{line: 2250, col: 1, offset: 69665},
 			expr: &seqExpr{
-				pos: position{line: 2233, col: 14, offset: 69266},
+				pos: position{line: 2250, col: 14, offset: 69678},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2233, col: 14, offset: 69266},
+						pos:        position{line: 2250, col: 14, offset: 69678},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2233, col: 33, offset: 69285},
+						pos: position{line: 2250, col: 33, offset: 69697},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2233, col: 34, offset: 69286},
+							pos:  position{line: 2250, col: 34, offset: 69698},
 							name: "IdentifierRest",
 						},
 					},
@@ -16517,20 +16611,20 @@ var g = &grammar{
 		},
 		{
 			name: "GREP",
-			pos:  position{line: 2234, col: 1, offset: 69301},
+			pos:  position{line: 2251, col: 1, offset: 69713},
 			expr: &seqExpr{
-				pos: position{line: 2234, col: 14, offset: 69314},
+				pos: position{line: 2251, col: 14, offset: 69726},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2234, col: 14, offset: 69314},
+						pos:        position{line: 2251, col: 14, offset: 69726},
 						val:        "grep",
 						ignoreCase: true,
 						want:       "\"GREP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2234, col: 33, offset: 69333},
+						pos: position{line: 2251, col: 33, offset: 69745},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2234, col: 34, offset: 69334},
+							pos:  position{line: 2251, col: 34, offset: 69746},
 							name: "IdentifierRest",
 						},
 					},
@@ -16541,20 +16635,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2235, col: 1, offset: 69349},
+			pos:  position{line: 2252, col: 1, offset: 69761},
 			expr: &seqExpr{
-				pos: position{line: 2235, col: 14, offset: 69362},
+				pos: position{line: 2252, col: 14, offset: 69774},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2235, col: 14, offset: 69362},
+						pos:        position{line: 2252, col: 14, offset: 69774},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2235, col: 33, offset: 69381},
+						pos: position{line: 2252, col: 33, offset: 69793},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2235, col: 34, offset: 69382},
+							pos:  position{line: 2252, col: 34, offset: 69794},
 							name: "IdentifierRest",
 						},
 					},
@@ -16565,20 +16659,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2236, col: 1, offset: 69397},
+			pos:  position{line: 2253, col: 1, offset: 69809},
 			expr: &seqExpr{
-				pos: position{line: 2236, col: 14, offset: 69410},
+				pos: position{line: 2253, col: 14, offset: 69822},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2236, col: 14, offset: 69410},
+						pos:        position{line: 2253, col: 14, offset: 69822},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2236, col: 33, offset: 69429},
+						pos: position{line: 2253, col: 33, offset: 69841},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2236, col: 34, offset: 69430},
+							pos:  position{line: 2253, col: 34, offset: 69842},
 							name: "IdentifierRest",
 						},
 					},
@@ -16589,20 +16683,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2237, col: 1, offset: 69445},
+			pos:  position{line: 2254, col: 1, offset: 69857},
 			expr: &seqExpr{
-				pos: position{line: 2237, col: 14, offset: 69458},
+				pos: position{line: 2254, col: 14, offset: 69870},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2237, col: 14, offset: 69458},
+						pos:        position{line: 2254, col: 14, offset: 69870},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2237, col: 33, offset: 69477},
+						pos: position{line: 2254, col: 33, offset: 69889},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2237, col: 34, offset: 69478},
+							pos:  position{line: 2254, col: 34, offset: 69890},
 							name: "IdentifierRest",
 						},
 					},
@@ -16613,20 +16707,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEADERS",
-			pos:  position{line: 2238, col: 1, offset: 69494},
+			pos:  position{line: 2255, col: 1, offset: 69906},
 			expr: &seqExpr{
-				pos: position{line: 2238, col: 14, offset: 69507},
+				pos: position{line: 2255, col: 14, offset: 69919},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2238, col: 14, offset: 69507},
+						pos:        position{line: 2255, col: 14, offset: 69919},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"HEADERS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2238, col: 33, offset: 69526},
+						pos: position{line: 2255, col: 33, offset: 69938},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2238, col: 34, offset: 69527},
+							pos:  position{line: 2255, col: 34, offset: 69939},
 							name: "IdentifierRest",
 						},
 					},
@@ -16637,20 +16731,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2239, col: 1, offset: 69542},
+			pos:  position{line: 2256, col: 1, offset: 69954},
 			expr: &seqExpr{
-				pos: position{line: 2239, col: 14, offset: 69555},
+				pos: position{line: 2256, col: 14, offset: 69967},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2239, col: 14, offset: 69555},
+						pos:        position{line: 2256, col: 14, offset: 69967},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2239, col: 33, offset: 69574},
+						pos: position{line: 2256, col: 33, offset: 69986},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2239, col: 34, offset: 69575},
+							pos:  position{line: 2256, col: 34, offset: 69987},
 							name: "IdentifierRest",
 						},
 					},
@@ -16661,20 +16755,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2240, col: 1, offset: 69590},
+			pos:  position{line: 2257, col: 1, offset: 70002},
 			expr: &seqExpr{
-				pos: position{line: 2240, col: 14, offset: 69603},
+				pos: position{line: 2257, col: 14, offset: 70015},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2240, col: 14, offset: 69603},
+						pos:        position{line: 2257, col: 14, offset: 70015},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2240, col: 33, offset: 69622},
+						pos: position{line: 2257, col: 33, offset: 70034},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2240, col: 34, offset: 69623},
+							pos:  position{line: 2257, col: 34, offset: 70035},
 							name: "IdentifierRest",
 						},
 					},
@@ -16685,20 +16779,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2241, col: 1, offset: 69638},
+			pos:  position{line: 2258, col: 1, offset: 70050},
 			expr: &seqExpr{
-				pos: position{line: 2241, col: 14, offset: 69651},
+				pos: position{line: 2258, col: 14, offset: 70063},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2241, col: 14, offset: 69651},
+						pos:        position{line: 2258, col: 14, offset: 70063},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2241, col: 33, offset: 69670},
+						pos: position{line: 2258, col: 33, offset: 70082},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2241, col: 34, offset: 69671},
+							pos:  position{line: 2258, col: 34, offset: 70083},
 							name: "IdentifierRest",
 						},
 					},
@@ -16709,20 +16803,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2242, col: 1, offset: 69686},
+			pos:  position{line: 2259, col: 1, offset: 70098},
 			expr: &seqExpr{
-				pos: position{line: 2242, col: 14, offset: 69699},
+				pos: position{line: 2259, col: 14, offset: 70111},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2242, col: 14, offset: 69699},
+						pos:        position{line: 2259, col: 14, offset: 70111},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2242, col: 33, offset: 69718},
+						pos: position{line: 2259, col: 33, offset: 70130},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2242, col: 34, offset: 69719},
+							pos:  position{line: 2259, col: 34, offset: 70131},
 							name: "IdentifierRest",
 						},
 					},
@@ -16733,20 +16827,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2243, col: 1, offset: 69734},
+			pos:  position{line: 2260, col: 1, offset: 70146},
 			expr: &seqExpr{
-				pos: position{line: 2243, col: 14, offset: 69747},
+				pos: position{line: 2260, col: 14, offset: 70159},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2243, col: 14, offset: 69747},
+						pos:        position{line: 2260, col: 14, offset: 70159},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2243, col: 33, offset: 69766},
+						pos: position{line: 2260, col: 33, offset: 70178},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2243, col: 34, offset: 69767},
+							pos:  position{line: 2260, col: 34, offset: 70179},
 							name: "IdentifierRest",
 						},
 					},
@@ -16757,20 +16851,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2244, col: 1, offset: 69782},
+			pos:  position{line: 2261, col: 1, offset: 70194},
 			expr: &seqExpr{
-				pos: position{line: 2244, col: 14, offset: 69795},
+				pos: position{line: 2261, col: 14, offset: 70207},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2244, col: 14, offset: 69795},
+						pos:        position{line: 2261, col: 14, offset: 70207},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2244, col: 33, offset: 69814},
+						pos: position{line: 2261, col: 33, offset: 70226},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2244, col: 34, offset: 69815},
+							pos:  position{line: 2261, col: 34, offset: 70227},
 							name: "IdentifierRest",
 						},
 					},
@@ -16781,20 +16875,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2245, col: 1, offset: 69830},
+			pos:  position{line: 2262, col: 1, offset: 70242},
 			expr: &seqExpr{
-				pos: position{line: 2245, col: 14, offset: 69843},
+				pos: position{line: 2262, col: 14, offset: 70255},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2245, col: 14, offset: 69843},
+						pos:        position{line: 2262, col: 14, offset: 70255},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2245, col: 32, offset: 69861},
+						pos: position{line: 2262, col: 32, offset: 70273},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2245, col: 33, offset: 69862},
+							pos:  position{line: 2262, col: 33, offset: 70274},
 							name: "IdentifierRest",
 						},
 					},
@@ -16805,20 +16899,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2246, col: 1, offset: 69877},
+			pos:  position{line: 2263, col: 1, offset: 70289},
 			expr: &seqExpr{
-				pos: position{line: 2246, col: 14, offset: 69890},
+				pos: position{line: 2263, col: 14, offset: 70302},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2246, col: 14, offset: 69890},
+						pos:        position{line: 2263, col: 14, offset: 70302},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2246, col: 33, offset: 69909},
+						pos: position{line: 2263, col: 33, offset: 70321},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2246, col: 34, offset: 69910},
+							pos:  position{line: 2263, col: 34, offset: 70322},
 							name: "IdentifierRest",
 						},
 					},
@@ -16829,20 +16923,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2247, col: 1, offset: 69925},
+			pos:  position{line: 2264, col: 1, offset: 70337},
 			expr: &seqExpr{
-				pos: position{line: 2247, col: 14, offset: 69938},
+				pos: position{line: 2264, col: 14, offset: 70350},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2247, col: 14, offset: 69938},
+						pos:        position{line: 2264, col: 14, offset: 70350},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2247, col: 33, offset: 69957},
+						pos: position{line: 2264, col: 33, offset: 70369},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2247, col: 34, offset: 69958},
+							pos:  position{line: 2264, col: 34, offset: 70370},
 							name: "IdentifierRest",
 						},
 					},
@@ -16853,20 +16947,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2248, col: 1, offset: 69973},
+			pos:  position{line: 2265, col: 1, offset: 70385},
 			expr: &seqExpr{
-				pos: position{line: 2248, col: 16, offset: 69988},
+				pos: position{line: 2265, col: 16, offset: 70400},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2248, col: 16, offset: 69988},
+						pos:        position{line: 2265, col: 16, offset: 70400},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2248, col: 33, offset: 70005},
+						pos: position{line: 2265, col: 33, offset: 70417},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2248, col: 34, offset: 70006},
+							pos:  position{line: 2265, col: 34, offset: 70418},
 							name: "IdentifierRest",
 						},
 					},
@@ -16877,20 +16971,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2249, col: 1, offset: 70021},
+			pos:  position{line: 2266, col: 1, offset: 70433},
 			expr: &seqExpr{
-				pos: position{line: 2249, col: 14, offset: 70034},
+				pos: position{line: 2266, col: 14, offset: 70446},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2249, col: 14, offset: 70034},
+						pos:        position{line: 2266, col: 14, offset: 70446},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2249, col: 33, offset: 70053},
+						pos: position{line: 2266, col: 33, offset: 70465},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2249, col: 34, offset: 70054},
+							pos:  position{line: 2266, col: 34, offset: 70466},
 							name: "IdentifierRest",
 						},
 					},
@@ -16901,20 +16995,20 @@ var g = &grammar{
 		},
 		{
 			name: "MESSAGE",
-			pos:  position{line: 2250, col: 1, offset: 70069},
+			pos:  position{line: 2267, col: 1, offset: 70481},
 			expr: &seqExpr{
-				pos: position{line: 2250, col: 14, offset: 70082},
+				pos: position{line: 2267, col: 14, offset: 70494},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2250, col: 14, offset: 70082},
+						pos:        position{line: 2267, col: 14, offset: 70494},
 						val:        "message",
 						ignoreCase: true,
 						want:       "\"MESSAGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2250, col: 33, offset: 70101},
+						pos: position{line: 2267, col: 33, offset: 70513},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2250, col: 34, offset: 70102},
+							pos:  position{line: 2267, col: 34, offset: 70514},
 							name: "IdentifierRest",
 						},
 					},
@@ -16925,20 +17019,20 @@ var g = &grammar{
 		},
 		{
 			name: "META",
-			pos:  position{line: 2251, col: 1, offset: 70117},
+			pos:  position{line: 2268, col: 1, offset: 70529},
 			expr: &seqExpr{
-				pos: position{line: 2251, col: 14, offset: 70130},
+				pos: position{line: 2268, col: 14, offset: 70542},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2251, col: 14, offset: 70130},
+						pos:        position{line: 2268, col: 14, offset: 70542},
 						val:        "meta",
 						ignoreCase: true,
 						want:       "\"META\"i",
 					},
 					&notExpr{
-						pos: position{line: 2251, col: 33, offset: 70149},
+						pos: position{line: 2268, col: 33, offset: 70561},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2251, col: 34, offset: 70150},
+							pos:  position{line: 2268, col: 34, offset: 70562},
 							name: "IdentifierRest",
 						},
 					},
@@ -16949,20 +17043,20 @@ var g = &grammar{
 		},
 		{
 			name: "METHOD",
-			pos:  position{line: 2252, col: 1, offset: 70165},
+			pos:  position{line: 2269, col: 1, offset: 70577},
 			expr: &seqExpr{
-				pos: position{line: 2252, col: 14, offset: 70178},
+				pos: position{line: 2269, col: 14, offset: 70590},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2252, col: 14, offset: 70178},
+						pos:        position{line: 2269, col: 14, offset: 70590},
 						val:        "method",
 						ignoreCase: true,
 						want:       "\"METHOD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2252, col: 33, offset: 70197},
+						pos: position{line: 2269, col: 33, offset: 70609},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2252, col: 34, offset: 70198},
+							pos:  position{line: 2269, col: 34, offset: 70610},
 							name: "IdentifierRest",
 						},
 					},
@@ -16973,20 +17067,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2253, col: 1, offset: 70213},
+			pos:  position{line: 2270, col: 1, offset: 70625},
 			expr: &seqExpr{
-				pos: position{line: 2253, col: 14, offset: 70226},
+				pos: position{line: 2270, col: 14, offset: 70638},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2253, col: 14, offset: 70226},
+						pos:        position{line: 2270, col: 14, offset: 70638},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2253, col: 33, offset: 70245},
+						pos: position{line: 2270, col: 33, offset: 70657},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2253, col: 34, offset: 70246},
+							pos:  position{line: 2270, col: 34, offset: 70658},
 							name: "IdentifierRest",
 						},
 					},
@@ -16997,20 +17091,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2254, col: 1, offset: 70261},
+			pos:  position{line: 2271, col: 1, offset: 70673},
 			expr: &seqExpr{
-				pos: position{line: 2254, col: 14, offset: 70274},
+				pos: position{line: 2271, col: 14, offset: 70686},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2254, col: 14, offset: 70274},
+						pos:        position{line: 2271, col: 14, offset: 70686},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2254, col: 33, offset: 70293},
+						pos: position{line: 2271, col: 33, offset: 70705},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2254, col: 34, offset: 70294},
+							pos:  position{line: 2271, col: 34, offset: 70706},
 							name: "IdentifierRest",
 						},
 					},
@@ -17021,20 +17115,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2255, col: 1, offset: 70309},
+			pos:  position{line: 2272, col: 1, offset: 70721},
 			expr: &seqExpr{
-				pos: position{line: 2255, col: 14, offset: 70322},
+				pos: position{line: 2272, col: 14, offset: 70734},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2255, col: 14, offset: 70322},
+						pos:        position{line: 2272, col: 14, offset: 70734},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2255, col: 33, offset: 70341},
+						pos: position{line: 2272, col: 33, offset: 70753},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2255, col: 34, offset: 70342},
+							pos:  position{line: 2272, col: 34, offset: 70754},
 							name: "IdentifierRest",
 						},
 					},
@@ -17045,20 +17139,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2256, col: 1, offset: 70357},
+			pos:  position{line: 2273, col: 1, offset: 70769},
 			expr: &seqExpr{
-				pos: position{line: 2256, col: 14, offset: 70370},
+				pos: position{line: 2273, col: 14, offset: 70782},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2256, col: 14, offset: 70370},
+						pos:        position{line: 2273, col: 14, offset: 70782},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2256, col: 33, offset: 70389},
+						pos: position{line: 2273, col: 33, offset: 70801},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2256, col: 34, offset: 70390},
+							pos:  position{line: 2273, col: 34, offset: 70802},
 							name: "IdentifierRest",
 						},
 					},
@@ -17069,20 +17163,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2257, col: 1, offset: 70405},
+			pos:  position{line: 2274, col: 1, offset: 70817},
 			expr: &seqExpr{
-				pos: position{line: 2257, col: 14, offset: 70418},
+				pos: position{line: 2274, col: 14, offset: 70830},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2257, col: 14, offset: 70418},
+						pos:        position{line: 2274, col: 14, offset: 70830},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2257, col: 33, offset: 70437},
+						pos: position{line: 2274, col: 33, offset: 70849},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2257, col: 34, offset: 70438},
+							pos:  position{line: 2274, col: 34, offset: 70850},
 							name: "IdentifierRest",
 						},
 					},
@@ -17093,20 +17187,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2258, col: 1, offset: 70453},
+			pos:  position{line: 2275, col: 1, offset: 70865},
 			expr: &seqExpr{
-				pos: position{line: 2258, col: 14, offset: 70466},
+				pos: position{line: 2275, col: 14, offset: 70878},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2258, col: 14, offset: 70466},
+						pos:        position{line: 2275, col: 14, offset: 70878},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2258, col: 33, offset: 70485},
+						pos: position{line: 2275, col: 33, offset: 70897},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2258, col: 34, offset: 70486},
+							pos:  position{line: 2275, col: 34, offset: 70898},
 							name: "IdentifierRest",
 						},
 					},
@@ -17117,23 +17211,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2259, col: 1, offset: 70501},
+			pos:  position{line: 2276, col: 1, offset: 70913},
 			expr: &actionExpr{
-				pos: position{line: 2259, col: 14, offset: 70514},
+				pos: position{line: 2276, col: 14, offset: 70926},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2259, col: 14, offset: 70514},
+					pos: position{line: 2276, col: 14, offset: 70926},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2259, col: 14, offset: 70514},
+							pos:        position{line: 2276, col: 14, offset: 70926},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2259, col: 33, offset: 70533},
+							pos: position{line: 2276, col: 33, offset: 70945},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2259, col: 34, offset: 70534},
+								pos:  position{line: 2276, col: 34, offset: 70946},
 								name: "IdentifierRest",
 							},
 						},
@@ -17145,20 +17239,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2260, col: 1, offset: 70570},
+			pos:  position{line: 2277, col: 1, offset: 70982},
 			expr: &seqExpr{
-				pos: position{line: 2260, col: 14, offset: 70583},
+				pos: position{line: 2277, col: 14, offset: 70995},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2260, col: 14, offset: 70583},
+						pos:        position{line: 2277, col: 14, offset: 70995},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2260, col: 33, offset: 70602},
+						pos: position{line: 2277, col: 33, offset: 71014},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2260, col: 34, offset: 70603},
+							pos:  position{line: 2277, col: 34, offset: 71015},
 							name: "IdentifierRest",
 						},
 					},
@@ -17169,20 +17263,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2261, col: 1, offset: 70618},
+			pos:  position{line: 2278, col: 1, offset: 71030},
 			expr: &seqExpr{
-				pos: position{line: 2261, col: 14, offset: 70631},
+				pos: position{line: 2278, col: 14, offset: 71043},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2261, col: 14, offset: 70631},
+						pos:        position{line: 2278, col: 14, offset: 71043},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2261, col: 33, offset: 70650},
+						pos: position{line: 2278, col: 33, offset: 71062},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2261, col: 34, offset: 70651},
+							pos:  position{line: 2278, col: 34, offset: 71063},
 							name: "IdentifierRest",
 						},
 					},
@@ -17193,20 +17287,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2262, col: 1, offset: 70666},
+			pos:  position{line: 2279, col: 1, offset: 71078},
 			expr: &seqExpr{
-				pos: position{line: 2262, col: 14, offset: 70679},
+				pos: position{line: 2279, col: 14, offset: 71091},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2262, col: 14, offset: 70679},
+						pos:        position{line: 2279, col: 14, offset: 71091},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2262, col: 33, offset: 70698},
+						pos: position{line: 2279, col: 33, offset: 71110},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2262, col: 34, offset: 70699},
+							pos:  position{line: 2279, col: 34, offset: 71111},
 							name: "IdentifierRest",
 						},
 					},
@@ -17217,20 +17311,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2263, col: 1, offset: 70714},
+			pos:  position{line: 2280, col: 1, offset: 71126},
 			expr: &seqExpr{
-				pos: position{line: 2263, col: 14, offset: 70727},
+				pos: position{line: 2280, col: 14, offset: 71139},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2263, col: 14, offset: 70727},
+						pos:        position{line: 2280, col: 14, offset: 71139},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2263, col: 33, offset: 70746},
+						pos: position{line: 2280, col: 33, offset: 71158},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2263, col: 34, offset: 70747},
+							pos:  position{line: 2280, col: 34, offset: 71159},
 							name: "IdentifierRest",
 						},
 					},
@@ -17241,20 +17335,20 @@ var g = &grammar{
 		},
 		{
 			name: "OVER",
-			pos:  position{line: 2264, col: 1, offset: 70762},
+			pos:  position{line: 2281, col: 1, offset: 71174},
 			expr: &seqExpr{
-				pos: position{line: 2264, col: 14, offset: 70775},
+				pos: position{line: 2281, col: 14, offset: 71187},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2264, col: 14, offset: 70775},
+						pos:        position{line: 2281, col: 14, offset: 71187},
 						val:        "over",
 						ignoreCase: true,
 						want:       "\"OVER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2264, col: 33, offset: 70794},
+						pos: position{line: 2281, col: 33, offset: 71206},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2264, col: 34, offset: 70795},
+							pos:  position{line: 2281, col: 34, offset: 71207},
 							name: "IdentifierRest",
 						},
 					},
@@ -17265,20 +17359,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2265, col: 1, offset: 70810},
+			pos:  position{line: 2282, col: 1, offset: 71222},
 			expr: &seqExpr{
-				pos: position{line: 2265, col: 14, offset: 70823},
+				pos: position{line: 2282, col: 14, offset: 71235},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2265, col: 14, offset: 70823},
+						pos:        position{line: 2282, col: 14, offset: 71235},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2265, col: 33, offset: 70842},
+						pos: position{line: 2282, col: 33, offset: 71254},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2265, col: 34, offset: 70843},
+							pos:  position{line: 2282, col: 34, offset: 71255},
 							name: "IdentifierRest",
 						},
 					},
@@ -17289,20 +17383,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2266, col: 1, offset: 70858},
+			pos:  position{line: 2283, col: 1, offset: 71270},
 			expr: &seqExpr{
-				pos: position{line: 2266, col: 14, offset: 70871},
+				pos: position{line: 2283, col: 14, offset: 71283},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2266, col: 14, offset: 70871},
+						pos:        position{line: 2283, col: 14, offset: 71283},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2266, col: 33, offset: 70890},
+						pos: position{line: 2283, col: 33, offset: 71302},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2266, col: 34, offset: 70891},
+							pos:  position{line: 2283, col: 34, offset: 71303},
 							name: "IdentifierRest",
 						},
 					},
@@ -17313,20 +17407,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2267, col: 1, offset: 70906},
+			pos:  position{line: 2284, col: 1, offset: 71318},
 			expr: &seqExpr{
-				pos: position{line: 2267, col: 14, offset: 70919},
+				pos: position{line: 2284, col: 14, offset: 71331},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2267, col: 14, offset: 70919},
+						pos:        position{line: 2284, col: 14, offset: 71331},
 						val:        "RECURSIVE",
 						ignoreCase: false,
 						want:       "\"RECURSIVE\"",
 					},
 					&notExpr{
-						pos: position{line: 2267, col: 33, offset: 70938},
+						pos: position{line: 2284, col: 33, offset: 71350},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2267, col: 34, offset: 70939},
+							pos:  position{line: 2284, col: 34, offset: 71351},
 							name: "IdentifierRest",
 						},
 					},
@@ -17337,20 +17431,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP",
-			pos:  position{line: 2268, col: 1, offset: 70954},
+			pos:  position{line: 2285, col: 1, offset: 71366},
 			expr: &seqExpr{
-				pos: position{line: 2268, col: 14, offset: 70967},
+				pos: position{line: 2285, col: 14, offset: 71379},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2268, col: 14, offset: 70967},
+						pos:        position{line: 2285, col: 14, offset: 71379},
 						val:        "regexp",
 						ignoreCase: true,
 						want:       "\"REGEXP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2268, col: 33, offset: 70986},
+						pos: position{line: 2285, col: 33, offset: 71398},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2268, col: 34, offset: 70987},
+							pos:  position{line: 2285, col: 34, offset: 71399},
 							name: "IdentifierRest",
 						},
 					},
@@ -17361,20 +17455,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP_REPLACE",
-			pos:  position{line: 2269, col: 1, offset: 71002},
+			pos:  position{line: 2286, col: 1, offset: 71414},
 			expr: &seqExpr{
-				pos: position{line: 2269, col: 18, offset: 71019},
+				pos: position{line: 2286, col: 18, offset: 71431},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2269, col: 18, offset: 71019},
+						pos:        position{line: 2286, col: 18, offset: 71431},
 						val:        "regexp_replace",
 						ignoreCase: true,
 						want:       "\"REGEXP_REPLACE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2269, col: 36, offset: 71037},
+						pos: position{line: 2286, col: 36, offset: 71449},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2269, col: 37, offset: 71038},
+							pos:  position{line: 2286, col: 37, offset: 71450},
 							name: "IdentifierRest",
 						},
 					},
@@ -17385,20 +17479,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2270, col: 1, offset: 71053},
+			pos:  position{line: 2287, col: 1, offset: 71465},
 			expr: &seqExpr{
-				pos: position{line: 2270, col: 14, offset: 71066},
+				pos: position{line: 2287, col: 14, offset: 71478},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2270, col: 14, offset: 71066},
+						pos:        position{line: 2287, col: 14, offset: 71478},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2270, col: 33, offset: 71085},
+						pos: position{line: 2287, col: 33, offset: 71497},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2270, col: 34, offset: 71086},
+							pos:  position{line: 2287, col: 34, offset: 71498},
 							name: "IdentifierRest",
 						},
 					},
@@ -17409,20 +17503,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2271, col: 1, offset: 71101},
+			pos:  position{line: 2288, col: 1, offset: 71513},
 			expr: &seqExpr{
-				pos: position{line: 2271, col: 14, offset: 71114},
+				pos: position{line: 2288, col: 14, offset: 71526},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2271, col: 14, offset: 71114},
+						pos:        position{line: 2288, col: 14, offset: 71526},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2271, col: 33, offset: 71133},
+						pos: position{line: 2288, col: 33, offset: 71545},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2271, col: 34, offset: 71134},
+							pos:  position{line: 2288, col: 34, offset: 71546},
 							name: "IdentifierRest",
 						},
 					},
@@ -17433,20 +17527,20 @@ var g = &grammar{
 		},
 		{
 			name: "SAMPLE",
-			pos:  position{line: 2272, col: 1, offset: 71149},
+			pos:  position{line: 2289, col: 1, offset: 71561},
 			expr: &seqExpr{
-				pos: position{line: 2272, col: 14, offset: 71162},
+				pos: position{line: 2289, col: 14, offset: 71574},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2272, col: 14, offset: 71162},
+						pos:        position{line: 2289, col: 14, offset: 71574},
 						val:        "sample",
 						ignoreCase: true,
 						want:       "\"SAMPLE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2272, col: 33, offset: 71181},
+						pos: position{line: 2289, col: 33, offset: 71593},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2272, col: 34, offset: 71182},
+							pos:  position{line: 2289, col: 34, offset: 71594},
 							name: "IdentifierRest",
 						},
 					},
@@ -17457,20 +17551,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2273, col: 1, offset: 71197},
+			pos:  position{line: 2290, col: 1, offset: 71609},
 			expr: &seqExpr{
-				pos: position{line: 2273, col: 14, offset: 71210},
+				pos: position{line: 2290, col: 14, offset: 71622},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2273, col: 14, offset: 71210},
+						pos:        position{line: 2290, col: 14, offset: 71622},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2273, col: 33, offset: 71229},
+						pos: position{line: 2290, col: 33, offset: 71641},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2273, col: 34, offset: 71230},
+							pos:  position{line: 2290, col: 34, offset: 71642},
 							name: "IdentifierRest",
 						},
 					},
@@ -17481,20 +17575,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2274, col: 1, offset: 71245},
+			pos:  position{line: 2291, col: 1, offset: 71657},
 			expr: &seqExpr{
-				pos: position{line: 2274, col: 14, offset: 71258},
+				pos: position{line: 2291, col: 14, offset: 71670},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2274, col: 14, offset: 71258},
+						pos:        position{line: 2291, col: 14, offset: 71670},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2274, col: 33, offset: 71277},
+						pos: position{line: 2291, col: 33, offset: 71689},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2274, col: 34, offset: 71278},
+							pos:  position{line: 2291, col: 34, offset: 71690},
 							name: "IdentifierRest",
 						},
 					},
@@ -17505,20 +17599,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2275, col: 1, offset: 71293},
+			pos:  position{line: 2292, col: 1, offset: 71705},
 			expr: &seqExpr{
-				pos: position{line: 2275, col: 14, offset: 71306},
+				pos: position{line: 2292, col: 14, offset: 71718},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2275, col: 14, offset: 71306},
+						pos:        position{line: 2292, col: 14, offset: 71718},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2275, col: 33, offset: 71325},
+						pos: position{line: 2292, col: 33, offset: 71737},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2275, col: 34, offset: 71326},
+							pos:  position{line: 2292, col: 34, offset: 71738},
 							name: "IdentifierRest",
 						},
 					},
@@ -17529,20 +17623,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2276, col: 1, offset: 71341},
+			pos:  position{line: 2293, col: 1, offset: 71753},
 			expr: &seqExpr{
-				pos: position{line: 2276, col: 14, offset: 71354},
+				pos: position{line: 2293, col: 14, offset: 71766},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2276, col: 14, offset: 71354},
+						pos:        position{line: 2293, col: 14, offset: 71766},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2276, col: 33, offset: 71373},
+						pos: position{line: 2293, col: 33, offset: 71785},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2276, col: 34, offset: 71374},
+							pos:  position{line: 2293, col: 34, offset: 71786},
 							name: "IdentifierRest",
 						},
 					},
@@ -17553,20 +17647,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2277, col: 1, offset: 71389},
+			pos:  position{line: 2294, col: 1, offset: 71801},
 			expr: &seqExpr{
-				pos: position{line: 2277, col: 14, offset: 71402},
+				pos: position{line: 2294, col: 14, offset: 71814},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2277, col: 14, offset: 71402},
+						pos:        position{line: 2294, col: 14, offset: 71814},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2277, col: 33, offset: 71421},
+						pos: position{line: 2294, col: 33, offset: 71833},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2277, col: 34, offset: 71422},
+							pos:  position{line: 2294, col: 34, offset: 71834},
 							name: "IdentifierRest",
 						},
 					},
@@ -17577,20 +17671,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2278, col: 1, offset: 71437},
+			pos:  position{line: 2295, col: 1, offset: 71849},
 			expr: &seqExpr{
-				pos: position{line: 2278, col: 14, offset: 71450},
+				pos: position{line: 2295, col: 14, offset: 71862},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2278, col: 14, offset: 71450},
+						pos:        position{line: 2295, col: 14, offset: 71862},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2278, col: 33, offset: 71469},
+						pos: position{line: 2295, col: 33, offset: 71881},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2278, col: 34, offset: 71470},
+							pos:  position{line: 2295, col: 34, offset: 71882},
 							name: "IdentifierRest",
 						},
 					},
@@ -17601,20 +17695,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2279, col: 1, offset: 71485},
+			pos:  position{line: 2296, col: 1, offset: 71897},
 			expr: &seqExpr{
-				pos: position{line: 2279, col: 14, offset: 71498},
+				pos: position{line: 2296, col: 14, offset: 71910},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2279, col: 14, offset: 71498},
+						pos:        position{line: 2296, col: 14, offset: 71910},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2279, col: 33, offset: 71517},
+						pos: position{line: 2296, col: 33, offset: 71929},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2279, col: 34, offset: 71518},
+							pos:  position{line: 2296, col: 34, offset: 71930},
 							name: "IdentifierRest",
 						},
 					},
@@ -17625,20 +17719,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAP",
-			pos:  position{line: 2280, col: 1, offset: 71534},
+			pos:  position{line: 2297, col: 1, offset: 71946},
 			expr: &seqExpr{
-				pos: position{line: 2280, col: 14, offset: 71547},
+				pos: position{line: 2297, col: 14, offset: 71959},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2280, col: 14, offset: 71547},
+						pos:        position{line: 2297, col: 14, offset: 71959},
 						val:        "tap",
 						ignoreCase: true,
 						want:       "\"TAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2280, col: 33, offset: 71566},
+						pos: position{line: 2297, col: 33, offset: 71978},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2280, col: 34, offset: 71567},
+							pos:  position{line: 2297, col: 34, offset: 71979},
 							name: "IdentifierRest",
 						},
 					},
@@ -17649,20 +17743,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2281, col: 1, offset: 71582},
+			pos:  position{line: 2298, col: 1, offset: 71994},
 			expr: &seqExpr{
-				pos: position{line: 2281, col: 14, offset: 71595},
+				pos: position{line: 2298, col: 14, offset: 72007},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2281, col: 14, offset: 71595},
+						pos:        position{line: 2298, col: 14, offset: 72007},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2281, col: 33, offset: 71614},
+						pos: position{line: 2298, col: 33, offset: 72026},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2281, col: 34, offset: 71615},
+							pos:  position{line: 2298, col: 34, offset: 72027},
 							name: "IdentifierRest",
 						},
 					},
@@ -17673,20 +17767,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2282, col: 1, offset: 71630},
+			pos:  position{line: 2299, col: 1, offset: 72042},
 			expr: &seqExpr{
-				pos: position{line: 2282, col: 14, offset: 71643},
+				pos: position{line: 2299, col: 14, offset: 72055},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2282, col: 14, offset: 71643},
+						pos:        position{line: 2299, col: 14, offset: 72055},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2282, col: 33, offset: 71662},
+						pos: position{line: 2299, col: 33, offset: 72074},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2282, col: 34, offset: 71663},
+							pos:  position{line: 2299, col: 34, offset: 72075},
 							name: "IdentifierRest",
 						},
 					},
@@ -17697,20 +17791,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2283, col: 1, offset: 71678},
+			pos:  position{line: 2300, col: 1, offset: 72090},
 			expr: &seqExpr{
-				pos: position{line: 2283, col: 14, offset: 71691},
+				pos: position{line: 2300, col: 14, offset: 72103},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2283, col: 14, offset: 71691},
+						pos:        position{line: 2300, col: 14, offset: 72103},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2283, col: 33, offset: 71710},
+						pos: position{line: 2300, col: 33, offset: 72122},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2283, col: 34, offset: 71711},
+							pos:  position{line: 2300, col: 34, offset: 72123},
 							name: "IdentifierRest",
 						},
 					},
@@ -17721,20 +17815,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2284, col: 1, offset: 71726},
+			pos:  position{line: 2301, col: 1, offset: 72138},
 			expr: &seqExpr{
-				pos: position{line: 2284, col: 14, offset: 71739},
+				pos: position{line: 2301, col: 14, offset: 72151},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2284, col: 14, offset: 71739},
+						pos:        position{line: 2301, col: 14, offset: 72151},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2284, col: 33, offset: 71758},
+						pos: position{line: 2301, col: 33, offset: 72170},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2284, col: 34, offset: 71759},
+							pos:  position{line: 2301, col: 34, offset: 72171},
 							name: "IdentifierRest",
 						},
 					},
@@ -17745,20 +17839,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2285, col: 1, offset: 71774},
+			pos:  position{line: 2302, col: 1, offset: 72186},
 			expr: &seqExpr{
-				pos: position{line: 2285, col: 14, offset: 71787},
+				pos: position{line: 2302, col: 14, offset: 72199},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2285, col: 14, offset: 71787},
+						pos:        position{line: 2302, col: 14, offset: 72199},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2285, col: 33, offset: 71806},
+						pos: position{line: 2302, col: 33, offset: 72218},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2285, col: 34, offset: 71807},
+							pos:  position{line: 2302, col: 34, offset: 72219},
 							name: "IdentifierRest",
 						},
 					},
@@ -17769,20 +17863,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2286, col: 1, offset: 71822},
+			pos:  position{line: 2303, col: 1, offset: 72234},
 			expr: &seqExpr{
-				pos: position{line: 2286, col: 14, offset: 71835},
+				pos: position{line: 2303, col: 14, offset: 72247},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2286, col: 14, offset: 71835},
+						pos:        position{line: 2303, col: 14, offset: 72247},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2286, col: 33, offset: 71854},
+						pos: position{line: 2303, col: 33, offset: 72266},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2286, col: 34, offset: 71855},
+							pos:  position{line: 2303, col: 34, offset: 72267},
 							name: "IdentifierRest",
 						},
 					},
@@ -17793,20 +17887,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2287, col: 1, offset: 71871},
+			pos:  position{line: 2304, col: 1, offset: 72283},
 			expr: &seqExpr{
-				pos: position{line: 2287, col: 14, offset: 71884},
+				pos: position{line: 2304, col: 14, offset: 72296},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2287, col: 14, offset: 71884},
+						pos:        position{line: 2304, col: 14, offset: 72296},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2287, col: 33, offset: 71903},
+						pos: position{line: 2304, col: 33, offset: 72315},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2287, col: 34, offset: 71904},
+							pos:  position{line: 2304, col: 34, offset: 72316},
 							name: "IdentifierRest",
 						},
 					},
@@ -17817,20 +17911,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2288, col: 1, offset: 71919},
+			pos:  position{line: 2305, col: 1, offset: 72331},
 			expr: &seqExpr{
-				pos: position{line: 2288, col: 14, offset: 71932},
+				pos: position{line: 2305, col: 14, offset: 72344},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2288, col: 14, offset: 71932},
+						pos:        position{line: 2305, col: 14, offset: 72344},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2288, col: 33, offset: 71951},
+						pos: position{line: 2305, col: 33, offset: 72363},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2288, col: 34, offset: 71952},
+							pos:  position{line: 2305, col: 34, offset: 72364},
 							name: "IdentifierRest",
 						},
 					},
@@ -17841,20 +17935,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2289, col: 1, offset: 71967},
+			pos:  position{line: 2306, col: 1, offset: 72379},
 			expr: &seqExpr{
-				pos: position{line: 2289, col: 14, offset: 71980},
+				pos: position{line: 2306, col: 14, offset: 72392},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2289, col: 14, offset: 71980},
+						pos:        position{line: 2306, col: 14, offset: 72392},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2289, col: 33, offset: 71999},
+						pos: position{line: 2306, col: 33, offset: 72411},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2289, col: 34, offset: 72000},
+							pos:  position{line: 2306, col: 34, offset: 72412},
 							name: "IdentifierRest",
 						},
 					},
@@ -17865,20 +17959,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2290, col: 1, offset: 72015},
+			pos:  position{line: 2307, col: 1, offset: 72427},
 			expr: &seqExpr{
-				pos: position{line: 2290, col: 14, offset: 72028},
+				pos: position{line: 2307, col: 14, offset: 72440},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2290, col: 14, offset: 72028},
+						pos:        position{line: 2307, col: 14, offset: 72440},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2290, col: 33, offset: 72047},
+						pos: position{line: 2307, col: 33, offset: 72459},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2290, col: 34, offset: 72048},
+							pos:  position{line: 2307, col: 34, offset: 72460},
 							name: "IdentifierRest",
 						},
 					},
@@ -17889,20 +17983,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2291, col: 1, offset: 72063},
+			pos:  position{line: 2308, col: 1, offset: 72475},
 			expr: &seqExpr{
-				pos: position{line: 2291, col: 14, offset: 72076},
+				pos: position{line: 2308, col: 14, offset: 72488},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2291, col: 14, offset: 72076},
+						pos:        position{line: 2308, col: 14, offset: 72488},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2291, col: 33, offset: 72095},
+						pos: position{line: 2308, col: 33, offset: 72507},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2291, col: 34, offset: 72096},
+							pos:  position{line: 2308, col: 34, offset: 72508},
 							name: "IdentifierRest",
 						},
 					},
@@ -17913,20 +18007,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2292, col: 1, offset: 72111},
+			pos:  position{line: 2309, col: 1, offset: 72523},
 			expr: &seqExpr{
-				pos: position{line: 2292, col: 14, offset: 72124},
+				pos: position{line: 2309, col: 14, offset: 72536},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2292, col: 14, offset: 72124},
+						pos:        position{line: 2309, col: 14, offset: 72536},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2292, col: 33, offset: 72143},
+						pos: position{line: 2309, col: 33, offset: 72555},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2292, col: 34, offset: 72144},
+							pos:  position{line: 2309, col: 34, offset: 72556},
 							name: "IdentifierRest",
 						},
 					},
@@ -17937,20 +18031,20 @@ var g = &grammar{
 		},
 		{
 			name: "YIELD",
-			pos:  position{line: 2293, col: 1, offset: 72159},
+			pos:  position{line: 2310, col: 1, offset: 72571},
 			expr: &seqExpr{
-				pos: position{line: 2293, col: 14, offset: 72172},
+				pos: position{line: 2310, col: 14, offset: 72584},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2293, col: 14, offset: 72172},
+						pos:        position{line: 2310, col: 14, offset: 72584},
 						val:        "yield",
 						ignoreCase: true,
 						want:       "\"YIELD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2293, col: 33, offset: 72191},
+						pos: position{line: 2310, col: 33, offset: 72603},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2293, col: 34, offset: 72192},
+							pos:  position{line: 2310, col: 34, offset: 72604},
 							name: "IdentifierRest",
 						},
 					},
@@ -18440,7 +18534,7 @@ func (p *parser) callonAggAssignment11() (any, error) {
 	return p.cur.onAggAssignment11(stack["agg"])
 }
 
-func (c *current) onAgg1(op, expr, where any) (any, error) {
+func (c *current) onAgg2(op, expr, where any) (any, error) {
 	agg := &ast.Agg{
 		Kind: "Agg",
 		Name: op.(string),
@@ -18456,10 +18550,25 @@ func (c *current) onAgg1(op, expr, where any) (any, error) {
 
 }
 
-func (p *parser) callonAgg1() (any, error) {
+func (p *parser) callonAgg2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAgg1(stack["op"], stack["expr"], stack["where"])
+	return p.cur.onAgg2(stack["op"], stack["expr"], stack["where"])
+}
+
+func (c *current) onAgg25(cs any) (any, error) {
+	return &ast.Agg{
+		Kind: "Agg",
+		Name: "count",
+		Loc:  cs.(*ast.Call).Loc,
+	}, nil
+
+}
+
+func (p *parser) callonAgg25() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onAgg25(stack["cs"])
 }
 
 func (c *current) onWhereClause1(expr any) (any, error) {
@@ -18485,6 +18594,21 @@ func (p *parser) callonAggAssignments1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggAssignments1(stack["first"], stack["rest"])
+}
+
+func (c *current) onCountStar1() (any, error) {
+	return &ast.Call{
+		Kind: "Call",
+		Name: &ast.ID{Kind: "ID", Name: "count", Loc: ast.NewLoc(c.pos.offset, c.pos.offset+5)},
+		Loc:  loc(c),
+	}, nil
+
+}
+
+func (p *parser) callonCountStar1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCountStar1()
 }
 
 func (c *current) onOperator2(op any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -239,6 +239,13 @@ Agg
       }
       return agg, nil
     }
+  / cs:CountStar {
+      return &ast.Agg{
+          Kind: "Agg",
+          Name: "count",
+          Loc: cs.(*ast.Call).Loc,
+      }, nil
+    }
 
 AggName
   = IdentifierName
@@ -255,6 +262,14 @@ AggAssignments
       }
       return result, nil
     }
+
+CountStar = COUNT __ "(" __ "*" __ ")" {
+    return &ast.Call{
+		Kind: "Call",
+		Name: &ast.ID{Kind:"ID", Name:"count", Loc: ast.NewLoc(c.pos.offset, c.pos.offset+5)},
+        Loc:  loc(c),
+    }, nil
+  }
 
 /// === Operators ===
 
@@ -1065,6 +1080,7 @@ Function
   / !FuncGuard fn:Identifier __ "(" __ args:FunctionArgs __ ")" where:WhereClause? {
       return newCall(c, fn, args, where), nil
     }
+  / CountStar
 
 RegexpPrimitive
   = pat:RegexpPattern { return newPrimitive(c, "string", pat.(string)), nil }
@@ -2211,6 +2227,7 @@ BODY       = "BODY"i            !IdentifierRest
 BY         = "BY"i              !IdentifierRest
 CASE       = "CASE"i            !IdentifierRest
 CONST      = "CONST"i           !IdentifierRest
+COUNT      = "COUNT"i           !IdentifierRest
 CROSS      = "CROSS"i           !IdentifierRest
 CUT        = "CUT"i             !IdentifierRest
 DEBUG      = "DEBUG"i           !IdentifierRest

--- a/runtime/sam/expr/agg/count.go
+++ b/runtime/sam/expr/agg/count.go
@@ -8,8 +8,10 @@ type Count uint64
 
 var _ Function = (*Count)(nil)
 
-func (c *Count) Consume(super.Value) {
-	*c++
+func (c *Count) Consume(val super.Value) {
+	if val.Bytes() != nil {
+		*c++
+	}
 }
 
 func (c Count) Result(*super.Context) super.Value {

--- a/runtime/sam/expr/agg/dcount.go
+++ b/runtime/sam/expr/agg/dcount.go
@@ -25,6 +25,9 @@ func NewDCount() *DCount {
 }
 
 func (d *DCount) Consume(val super.Value) {
+	if val.IsNull() {
+		return
+	}
 	d.scratch = d.scratch[:0]
 	// append type id to vals so we get a unique count where the bytes are same
 	// but the super.Type is different.

--- a/runtime/sam/op/groupby/ztests/null.yaml
+++ b/runtime/sam/op/groupby/ztests/null.yaml
@@ -8,4 +8,4 @@ input: |
   {x:null(time)}
 
 output: |
-  {avg:null(float64),count:5(uint64),dcount:5(uint64),any:null(uint64),max:null(float64),min:null(float64),sum:null(float64)}
+  {avg:null(float64),count:0(uint64),dcount:0(uint64),any:null(uint64),max:null(float64),min:null(float64),sum:null(float64)}

--- a/runtime/ztests/op/summarize/count-star.yaml
+++ b/runtime/ztests/op/summarize/count-star.yaml
@@ -1,0 +1,11 @@
+zed: select count() as c1, count(*) as c2, count(a) as c3
+
+vector: true
+
+input: |
+  {a:"foo"}
+  {b:"foo"}
+  {a:null}
+
+output: |
+  {c1:3(uint64),c2:3(uint64),c3:1(uint64)}


### PR DESCRIPTION
This commit adds syntax support for COUNT(*) and updates the vam/sam count logic to count only values that are not errors or nulls.