### PR TITLE
Use CSUP files in vector runtime

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -237,8 +237,13 @@ func (a *analyzer) formatArg(args ast.FromArgs) string {
 
 func (a *analyzer) semFile(name string, args ast.FromArgs) dag.Op {
 	format := a.formatArg(args)
-	if format == "" && strings.HasSuffix(name, ".parquet") {
-		format = "parquet"
+	if format == "" {
+		switch filepath.Ext(name) {
+		case ".parquet":
+			format = "parquet"
+		case ".csup":
+			format = "csup"
+		}
 	}
 	return &dag.FileScan{
 		Kind:   "FileScan",

--- a/zio/vngio/vectorreader.go
+++ b/zio/vngio/vectorreader.go
@@ -1,0 +1,75 @@
+package vngio
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/pkg/field"
+	"github.com/brimdata/super/runtime/vcache"
+	"github.com/brimdata/super/vector"
+	"github.com/brimdata/super/vng"
+)
+
+type VectorReader struct {
+	ctx  context.Context
+	zctx *super.Context
+
+	activeReaders *atomic.Int64
+	nextObject    *atomic.Int64
+	objects       []*vng.Object
+	projection    vcache.Path
+	readerAt      io.ReaderAt
+}
+
+func NewVectorReader(ctx context.Context, zctx *super.Context, r io.Reader, fields []field.Path) (*VectorReader, error) {
+	ra, ok := r.(io.ReaderAt)
+	if !ok {
+		return nil, errors.New("Super Columnar requires a seekable input")
+	}
+	objects, err := readObjects(ra)
+	if err != nil {
+		return nil, err
+	}
+	return &VectorReader{
+		ctx:           ctx,
+		zctx:          zctx,
+		activeReaders: &atomic.Int64{},
+		nextObject:    &atomic.Int64{},
+		objects:       objects,
+		projection:    vcache.NewProjection(fields),
+		readerAt:      ra,
+	}, nil
+}
+
+func (v *VectorReader) NewConcurrentPuller() vector.Puller {
+	v.activeReaders.Add(1)
+	return v
+}
+
+func (v *VectorReader) Pull(done bool) (vector.Any, error) {
+	if done {
+		return nil, v.close()
+	}
+	if err := v.ctx.Err(); err != nil {
+		v.close()
+		return nil, err
+	}
+	n := int(v.nextObject.Add(1) - 1)
+	if n >= len(v.objects) {
+		return nil, v.close()
+	}
+	o := v.objects[n]
+	return vcache.NewObjectFromVNG(o).Fetch(v.zctx, v.projection)
+}
+
+func (v *VectorReader) close() error {
+	if v.activeReaders.Add(-1) <= 0 {
+		if closer, ok := v.readerAt.(io.Closer); ok {
+			return closer.Close() // coffee is for closers
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
The commit adds the ability to use CSUP files in vector runtime. It also implements the NewConcurrentPuller protocol to enable parallel read of a CSUP file in vector runtime.