### PR TITLE
Hyperlink fixes

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https://suricata.io"
+    },
+    {
+      "pattern": "^https://github.com/brimdata/super/blob/main/scripts/super-cmd-perf/queries/search"
     }
   ],
   "retryOn429": true,

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A SuperDB data lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `super db serve`
 at the copy of the lake.

--- a/docs/commands/super.md
+++ b/docs/commands/super.md
@@ -793,7 +793,7 @@ WHERE id LIKE '%in case you have any feedback 😊%'
   OR payload.member.type LIKE '%in case you have any feedback 😊%'
 ```
 There are 486 such fields.  You can review the entire query in
-[`search+.sql`](https://github.com/brimdata/super/blob/main/scripts/super-cmd-perf/search%2B.sql).
+[`search+.sql`](https://github.com/brimdata/super/blob/main/scripts/super-cmd-perf/queries/search%2B.sql).
 
 In SuperSQL, `grep` allows for a much shorter query.
 ```sql


### PR DESCRIPTION
## tl;dr

Make some link checker failures go away.

## Details

I made a mistake in one of my aspirational "it'll start working once it merges" hyperlinks in #5506, so I tried fixing that here. That revealed that the markdown link checker we've been using also seems to have some kind of bug with hyperlinks containing [percent encoding](https://en.wikipedia.org/wiki/Percent-encoding). I just added a [comment](https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/102#issuecomment-2504463659) to an existing issue with a simple repro example, but for now I've added an exclusion in our link checker config. This also led me to notice that the guy who maintained that markdown link checker has a new tool [linkspector](https://github.com/UmbrellaDocs/linkspector) that seems to be more actively maintained, so I'll separately look into whether we can move over to that one and maybe not have to do exclusions.

While I'm at it, I'm also adjusting the hyperlink for an Apache Hive reference. Their design docs happen to be on a public Confluence site and it must not be built for scale because it seems like 50% of the time our link checker experiences some kind of timeout trying to crawl it. Rather than drop the hyperlink entirely or add an exclusion to the link checker I'm opting to just point to something one link further back in their "real" web site.