### PR TITLE
Fix URL in curl for running super cmd perf script

### DIFF
--- a/scripts/super-cmd-perf/README.md
+++ b/scripts/super-cmd-perf/README.md
@@ -28,7 +28,7 @@ Assuming a freshly-created `m6idn.2xlarge` instance running Ubuntu 24.04, to
 start the run:
 
 ```
-curl -s https://github.com/brimdata/super/blob/main/scripts/super-cmd-perf/benchmark.sh | bash -xv 2>&1 | tee runlog.txt
+curl -s https://raw.githubusercontent.com/brimdata/super/refs/heads/main/scripts/super-cmd-perf/benchmark.sh | bash -xv 2>&1 | tee runlog.txt
 ```
 
 The run proceeds in three phases:


### PR DESCRIPTION
In finalizing #5506 it turns out I made a mistake when adjusting this URL from that PR's branch to the appropriate file on `main`. This fixes that.