### PR TITLE
Refactor record field name matching in runtime/sam/expr

### DIFF
--- a/runtime/sam/expr/ztests/search-nested-field-regexp.yaml
+++ b/runtime/sam/expr/ztests/search-nested-field-regexp.yaml
@@ -4,7 +4,13 @@ input: |
   {a:[{bar:"foo"}]}
   {a:[{car:"foo"}]}
   {a:[{c:"foo"},{b:1}]}
+  null({a:[{bar:null}]})
+  null({a:[{b:null}]})
+  {a:[]([{bar:null}])}
+  {a:[]([{b:null}])}
 
 output: |
   {a:[{bar:"foo"}]}
   {a:[{car:"foo"}]}
+  null({a:[{bar:null}]})
+  {a:[]([{bar:null}])}

--- a/runtime/sam/expr/ztests/search-nested-field.yaml
+++ b/runtime/sam/expr/ztests/search-nested-field.yaml
@@ -4,7 +4,13 @@ input: |
   {a:[{b:"foo"}]}
   {a:[{c:"foo"}]}
   {a:[{c:"foo"},{b:1}]}
+  null({a:[{b:null}]})
+  null({a:[{c:null}]})
+  {a:[]([{b:null}])}
+  {a:[]([{c:null}])}
 
 output: |
   {a:[{b:"foo"}]}
   {a:[{c:"foo"},{b:1}]}
+  null({a:[{b:null}]})
+  {a:[]([{b:null}])}


### PR DESCRIPTION
Introduce FieldNameMatcher and use it for all record field name matching.  It will also see use in runtime/vam/expr when we add field name matching there.

The new code fixes a bug in the existing implementation: It now matches fields names inside empty values and null values.