### PR TITLE
Use a Hive hyperlink that's more stable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ or connections to
 [schema registries](https://docs.confluent.io/platform/current/schema-registry/index.html).
 
 A SuperDB data lake is completely self-contained, requiring no auxiliary databases
-(like the [Hive metastore](https://cwiki.apache.org/confluence/display/hive/design))
+(like the [Hive metastore](https://hive.apache.org/development/gettingstarted))
 or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `super db serve`
 at the copy of the lake.


### PR DESCRIPTION
The Apache Hive design docs happen to be on a public Confluence site and it must not be built for scale because it seems like 50% of the time our link checker experiences some kind of timeout trying to crawl it. Rather than drop the hyperlink entirely or add an exclusion to the link checker I'm opting to just point to something one link further back in their "real" web site.