### PR TITLE
parquet: Fix issue with incorrect null length

### DIFF
--- a/zio/parquetio/vectorreader.go
+++ b/zio/parquetio/vectorreader.go
@@ -319,14 +319,15 @@ func makeNulls(a arrow.Array) *vector.Bool {
 	if len(bytes) == 0 {
 		return nil
 	}
-	bits := make([]uint64, (len(bytes)+7)/8)
+	n := a.Len()
+	bits := make([]uint64, (n+63)/64)
 	bitsAsBytes := reinterpretSlice[byte](bits)
 	copy(bitsAsBytes, bytes)
 	for i := range bits {
 		// Flip bits
 		bits[i] ^= ^uint64(0)
 	}
-	return vector.NewBool(bits, uint32(a.Len()), nil)
+	return vector.NewBool(bits, uint32(n), nil)
 }
 
 func convertSlice[Out, In uint8 | uint16 | uint32 | uint64 | int8 | int16 | int32 | int64 | float32 | float64](in []In) []Out {


### PR DESCRIPTION
It appears on some datasets a parquet writer / arrow reader over allocates the number of bytes for a column's validity map. This can cause problems downstream in the vector runtime when comparing nulls from different vectors. Fix this by using the length of the output vector for creating the nulls bitmap slice.

Closes #5515