### PR TITLE
Fix EOS handling in vector summarize operator

### DIFF
--- a/runtime/vam/op/summarize/summarize.go
+++ b/runtime/vam/op/summarize/summarize.go
@@ -63,7 +63,7 @@ func (s *Summarize) Pull(done bool) (vector.Any, error) {
 			for _, t := range s.tables {
 				s.results = append(s.results, t)
 			}
-			s.tables = nil
+			clear(s.tables)
 			return s.next(), nil
 		}
 		var keys, vals []vector.Any
@@ -124,6 +124,7 @@ func (s *Summarize) isCountByString(keyTypes []super.Type) bool {
 
 func (s *Summarize) next() vector.Any {
 	if len(s.results) == 0 {
+		s.results = nil
 		return nil
 	}
 	t := s.results[0]

--- a/runtime/ztests/op/over-summarize.yaml
+++ b/runtime/ztests/op/over-summarize.yaml
@@ -1,5 +1,7 @@
 zed: over a => (sum(this))
 
+vector: true
+
 input: |
   {a:null([int64])}
   {a:[6,5,4]}


### PR DESCRIPTION
The summarize operator doesn't reset itself upon receives EOS from its parent, preventing it from working properly inside a scoped over operator (i.e., "over x => (summarize ...)").  Fix that.