### PR TITLE
Don't wrap errors in vector put operator

### DIFF
--- a/runtime/vam/expr/putter.go
+++ b/runtime/vam/expr/putter.go
@@ -23,7 +23,10 @@ func (p *Putter) Eval(vec vector.Any) vector.Any {
 
 func (p *Putter) eval(vecs ...vector.Any) vector.Any {
 	vec := vecs[0]
-	if vec.Type().Kind() != super.RecordKind {
+	if k := vec.Type().Kind(); k != super.RecordKind {
+		if k == super.ErrorKind {
+			return vec
+		}
 		return vector.NewWrappedError(p.zctx, "put: not a record", vec)
 	}
 	return p.recordExpr.Eval(vec)

--- a/runtime/ztests/op/put-non-record.yaml
+++ b/runtime/ztests/op/put-non-record.yaml
@@ -4,6 +4,8 @@ vector: true
 
 input: |
   0
+  error("kaboom")
 
 output: |
   error({message:"put: not a record",on:0})
+  error("kaboom")


### PR DESCRIPTION
The sequence put operator passes errors along unmodified while the vector operator wraps them inside another error.  Make the vector implementation behave like the sequence implementation.