### PR TITLE
Implement vector error() function

### DIFF
--- a/runtime/vam/expr/function/function.go
+++ b/runtime/vam/expr/function/function.go
@@ -28,6 +28,8 @@ func New(zctx *super.Context, name string, narg int) (expr.Function, field.Path,
 	case "every":
 		path = field.Path{"ts"}
 		f = &Bucket{zctx: zctx, name: name}
+	case "error":
+		f = &Error{zctx}
 	case "fields":
 		f = NewFields(zctx)
 	case "grep":

--- a/runtime/vam/expr/function/types.go
+++ b/runtime/vam/expr/function/types.go
@@ -15,6 +15,16 @@ func (t *TypeOf) Call(args ...vector.Any) vector.Any {
 	return vector.NewConst(val, args[0].Len(), nil)
 }
 
+// https://github.com/brimdata/super/blob/main/docs/language/functions.md#error
+type Error struct {
+	zctx *super.Context
+}
+
+func (e *Error) Call(args ...vector.Any) vector.Any {
+	vec := args[0]
+	return vector.NewError(e.zctx.LookupTypeError(vec.Type()), vec, nil)
+}
+
 // https://github.com/brimdata/super/blob/main/docs/language/functions.md#kind
 type Kind struct {
 	zctx *super.Context

--- a/runtime/ztests/expr/function/error.yaml
+++ b/runtime/ztests/expr/function/error.yaml
@@ -1,0 +1,17 @@
+zed: yield error(this)
+
+vector: true
+
+input: |
+  1
+  "s"
+  {a:1}
+  null
+  null(int64)
+
+output: |
+  error(1)
+  error("s")
+  error({a:1})
+  null(error(null))
+  null(error(int64))

--- a/runtime/ztests/op/assert.yaml
+++ b/runtime/ztests/op/assert.yaml
@@ -1,0 +1,13 @@
+zed: assert a==1
+
+vector: true
+
+input: |
+  {a:1}
+  {a:2}
+  1
+
+output: |
+  {a:1}
+  error({message:"assertion failed",expr:"a==1",on:{a:2}})
+  error({message:"?-operator: bool predicate required",on:error("missing")})


### PR DESCRIPTION
This includes a ztest for the assert operator because the error() function is the final missing piece required to make that operator work on vectors.