### PR TITLE
Avoid creating empty vectors in vector.Apply

### DIFF
--- a/vector/apply.go
+++ b/vector/apply.go
@@ -18,7 +18,11 @@ func Apply(ripUnions bool, eval func(...Any) Any, vecs ...Any) Any {
 	}
 	var results []Any
 	for _, ripped := range rip(vecs, d) {
-		results = append(results, Apply(ripUnions, eval, ripped...))
+		var result Any
+		if len(ripped) > 0 {
+			result = Apply(ripUnions, eval, ripped...)
+		}
+		results = append(results, result)
 	}
 	return stitch(d.Tags, results)
 }
@@ -36,11 +40,13 @@ func rip(vecs []Any, d *Dynamic) [][]Any {
 	var ripped [][]Any
 	for j, rev := range d.TagMap.Reverse {
 		var newVecs []Any
-		for _, vec := range vecs {
-			if vec == d {
-				newVecs = append(newVecs, d.Values[j])
-			} else {
-				newVecs = append(newVecs, NewView(vec, rev))
+		if len(rev) > 0 {
+			for _, vec := range vecs {
+				if vec == d {
+					newVecs = append(newVecs, d.Values[j])
+				} else {
+					newVecs = append(newVecs, NewView(vec, rev))
+				}
 			}
 		}
 		ripped = append(ripped, newVecs)

--- a/vector/tagmap.go
+++ b/vector/tagmap.go
@@ -13,7 +13,11 @@ type TagMap struct {
 func NewTagMap(tags []uint32, vals []Any) *TagMap {
 	lens := make([]uint32, 0, len(vals))
 	for _, v := range vals {
-		lens = append(lens, uint32(v.Len()))
+		var length uint32
+		if v != nil {
+			length = v.Len()
+		}
+		lens = append(lens, length)
 	}
 	return NewTagMapFromLens(tags, lens)
 }


### PR DESCRIPTION
vector.Apply can create a large number of empty (zero-length) vectors through calls to vector.rip, generating substantial garbage.  Fix that by changing rip to return nil instead of a slice of empty vectors, changing Apply to skip the recursive call when it sees a nil from rip and substitute a nil vector in place of the skipped call's result, and changing NewTagMap to tolerate nil vectors so NewDynamic will as well.