### PR TITLE
Rework field selection for projection pushdown (aka demand)

### DIFF
--- a/compiler/optimizer/demand.go
+++ b/compiler/optimizer/demand.go
@@ -5,132 +5,240 @@ import (
 	"github.com/brimdata/super/compiler/optimizer/demand"
 )
 
-func insertDemand(seq dag.Seq) dag.Seq {
-	demands := InferDemandSeqOut(seq)
-	return walk(seq, true, func(seq dag.Seq) dag.Seq {
-		for _, op := range seq {
-			switch op := op.(type) {
-			case *dag.FileScan:
-				op.Fields = demand.Fields(demands[op])
-			case *dag.SeqScan:
-				op.Fields = demand.Fields(demands[op])
-			}
-		}
-		return seq
-	})
-}
-
-// Returns a map from op to the demand on the output of that op.
-func InferDemandSeqOut(seq dag.Seq) map[dag.Op]demand.Demand {
-	demands := make(map[dag.Op]demand.Demand)
-	inferDemandSeqOutWith(demands, demand.All(), seq)
-	for _, d := range demands {
-		if !demand.IsValid(d) {
-			panic("Invalid demand")
-		}
-	}
-	return demands
-}
-
-func inferDemandSeqOutWith(demands map[dag.Op]demand.Demand, demandSeqOut demand.Demand, seq dag.Seq) {
-	demandOpOut := demandSeqOut
+func DemandForSeq(seq dag.Seq, downstream demand.Demand) demand.Demand {
 	for i := len(seq) - 1; i >= 0; i-- {
-		op := seq[i]
-		if _, ok := demands[op]; ok {
-			panic("Duplicate op value")
-		}
-		demands[op] = demandOpOut
-
-		// Infer the demand that `op` places on it's input.
-		var demandOpIn demand.Demand
-		switch op := op.(type) {
-		case *dag.FileScan:
-			demandOpIn = demand.Union(demandOpOut, inferDemandExprIn(demand.All(), op.Filter))
-			demands[op] = demandOpIn
-		case *dag.Filter:
-			demandOpIn = demand.Union(
-				// Everything that downstream operations need.
-				demandOpOut,
-				// Everything that affects the outcome of this filter.
-				inferDemandExprIn(demand.All(), op.Expr),
-			)
-		case *dag.SeqScan:
-			demandOpIn = demand.Union(demandOpOut, inferDemandExprIn(demand.All(), op.Filter))
-			demands[op] = demandOpIn
-		case *dag.Summarize:
-			demandOpIn = demand.None()
-			// TODO If LHS not in demandOut, we can ignore RHS
-			for _, assignment := range op.Keys {
-				demandOpIn = demand.Union(demandOpIn, inferDemandExprIn(demand.All(), assignment.RHS))
-			}
-			for _, assignment := range op.Aggs {
-				demandOpIn = demand.Union(demandOpIn, inferDemandExprIn(demand.All(), assignment.RHS))
-			}
-		case *dag.Yield:
-			demandOpIn = demand.None()
-			for _, expr := range op.Exprs {
-				demandOpIn = demand.Union(demandOpIn, inferDemandExprIn(demandOpOut, expr))
-			}
-		default:
-			// Conservatively assume that `op` uses it's entire input, regardless of output demand.
-			demandOpIn = demand.All()
-		}
-		demandOpOut = demandOpIn
+		downstream = demandForOp(seq[i], downstream)
 	}
+	return downstream
 }
 
-func inferDemandExprIn(demandOut demand.Demand, expr dag.Expr) demand.Demand {
-	if demand.IsNone(demandOut) {
-		return demand.None()
-	}
-	if expr == nil {
-		return demand.None()
-	}
-	var demandIn demand.Demand
-	switch expr := expr.(type) {
-	case *dag.Agg:
-		// Since we don't know how the expr.Name will transform the inputs, we have to assume demand.All.
-		return demand.Union(
-			inferDemandExprIn(demand.All(), expr.Expr),
-			inferDemandExprIn(demand.All(), expr.Where),
-		)
-	case *dag.BinaryExpr:
-		// Since we don't know how the expr.Op will transform the inputs, we have to assume demand.All.
-		demandIn = demand.Union(
-			inferDemandExprIn(demand.All(), expr.LHS),
-			inferDemandExprIn(demand.All(), expr.RHS),
-		)
-	case *dag.Dot:
-		demandIn = demand.Key(expr.RHS, inferDemandExprIn(demandOut, expr.LHS))
-	case *dag.Literal:
-		demandIn = demand.None()
-	case *dag.MapExpr:
-		demandIn = demand.None()
-		for _, entry := range expr.Entries {
-			demandIn = demand.Union(demandIn, inferDemandExprIn(demand.All(), entry.Key))
-			demandIn = demand.Union(demandIn, inferDemandExprIn(demand.All(), entry.Value))
+func demandForOp(op dag.Op, downstream demand.Demand) demand.Demand {
+	switch op := op.(type) {
+	case *dag.Combine:
+		return downstream
+	case *dag.Cut:
+		return demandForAssignments(op.Args, demand.None())
+	case *dag.Drop:
+		return downstream
+	case *dag.Explode:
+		d := demand.None()
+		for _, a := range op.Args {
+			d = demand.Union(d, demandForExpr(a))
 		}
+		return d
+	case *dag.Filter:
+		return demand.Union(downstream, demandForExpr(op.Expr))
+	case *dag.Fork:
+		d := demand.None()
+		for _, p := range op.Paths {
+			d = demand.Union(d, DemandForSeq(p, downstream))
+		}
+		return d
+	case *dag.Fuse:
+		return demand.All()
+	case *dag.Head:
+		return downstream
+	case *dag.Join:
+		d := downstream
+		d = demand.Union(d, demandForExpr(op.LeftKey))
+		d = demand.Union(d, demandForExpr(op.RightKey))
+		return demandForAssignments(op.Args, d)
+	case *dag.Load:
+		return demand.All()
+	case *dag.Merge:
+		return demand.Union(downstream, demandForExpr(op.Expr))
+	case *dag.Mirror:
+		return demand.Union(DemandForSeq(op.Main, demand.All()),
+			DemandForSeq(op.Mirror, demand.All()))
+	case *dag.Output:
+		return demand.All()
+	case *dag.Over:
+		d := demand.None()
+		for _, def := range op.Defs {
+			d = demand.Union(d, demandForExpr(def.Expr))
+		}
+		for _, e := range op.Exprs {
+			d = demand.Union(d, demandForExpr(e))
+		}
+		return d
+	case *dag.Pass:
+		return downstream
+	case *dag.Put:
+		return demandForAssignments(op.Args, downstream)
+	case *dag.Rename:
+		return demandForAssignments(op.Args, downstream)
+	case *dag.Scatter:
+		d := demand.None()
+		for _, p := range op.Paths {
+			d = demand.Union(d, DemandForSeq(p, downstream))
+		}
+		return d
+	case *dag.Scope:
+		return DemandForSeq(op.Body, downstream)
+	case *dag.Shape, *dag.Sort:
+		return downstream
+	case *dag.Summarize:
+		d := demand.None()
+		for _, assignment := range op.Keys {
+			d = demand.Union(d, demandForExpr(assignment.RHS))
+		}
+		for _, assignment := range op.Aggs {
+			d = demand.Union(d, demandForExpr(assignment.RHS))
+		}
+		return d
+	case *dag.Switch:
+		d := demandForExpr(op.Expr)
+		for _, c := range op.Cases {
+			d = demand.Union(d, demandForExpr(c.Expr))
+			d = demand.Union(d, DemandForSeq(c.Path, downstream))
+		}
+		return d
+	case *dag.Tail, *dag.Top, *dag.Uniq:
+		return downstream
+	case *dag.Vectorize:
+		return DemandForSeq(op.Body, downstream)
+	case *dag.Yield:
+		d := demand.None()
+		for _, e := range op.Exprs {
+			d = demand.Union(d, demandForExpr(e))
+		}
+		return d
+
+	case *dag.CommitMetaScan, *dag.DefaultScan, *dag.Deleter, *dag.DeleteScan, *dag.LakeMetaScan:
+		return demand.None()
+	case *dag.FileScan:
+		d := demand.Union(downstream, demandForExpr(op.Filter))
+		op.Fields = demand.Fields(d)
+		return demand.None()
+	case *dag.HTTPScan, *dag.Lister, *dag.NullScan, *dag.PoolMetaScan, *dag.PoolScan:
+		return demand.None()
+	case *dag.RobotScan:
+		return demandForExpr(op.Expr)
+	case *dag.SeqScan:
+		d := demand.Union(downstream, demandForExpr(op.Filter))
+		d = demand.Union(d, demandForExpr(op.KeyPruner))
+		op.Fields = demand.Fields(d)
+		return demand.None()
+	case *dag.Slicer:
+		return demand.None()
+	}
+	panic(op)
+}
+
+func demandForExpr(expr dag.Expr) demand.Demand {
+	switch expr := expr.(type) {
+	case nil:
+		return demand.None()
+	case *dag.Agg:
+		return demand.Union(demandForExpr(expr.Expr), demandForExpr(expr.Where))
+	case *dag.ArrayExpr:
+		return demandForArrayOrSetExpr(expr.Elems)
+	case *dag.BinaryExpr:
+		return demand.Union(demandForExpr(expr.LHS), demandForExpr(expr.RHS))
+	case *dag.Call:
+		d := demand.None()
+		if expr.Name == "every" {
+			d = demand.Key("ts", demand.All())
+		}
+		for _, a := range expr.Args {
+			d = demand.Union(d, demandForExpr(a))
+		}
+		return d
+	case *dag.Conditional:
+		return demand.Union(demandForExpr(expr.Cond),
+			demand.Union(demandForExpr(expr.Then), demandForExpr(expr.Else)))
+	case *dag.Dot:
+		return demandForExpr(expr.LHS)
+	case *dag.Func:
+		// return demand.All()
+	case *dag.IndexExpr:
+		return demand.Union(demandForExpr(expr.Expr), demandForExpr(expr.Index))
+	case *dag.IsNullExpr:
+		return demandForExpr(expr.Expr)
+	case *dag.Literal:
+		return demand.None()
+	case *dag.MapCall:
+		return demandForExpr(expr.Expr)
+	case *dag.MapExpr:
+		d := demand.None()
+		for _, e := range expr.Entries {
+			d = demand.Union(d, demandForExpr(e.Key))
+			d = demand.Union(d, demandForExpr(e.Value))
+		}
+		return d
+	case *dag.OverExpr:
+		d := demand.None()
+		for _, def := range expr.Defs {
+			d = demand.Union(d, demandForExpr(def.Expr))
+		}
+		for _, e := range expr.Exprs {
+			d = demand.Union(d, demandForExpr(e))
+		}
+		return d
 	case *dag.RecordExpr:
-		demandIn = demand.None()
-		for _, elem := range expr.Elems {
-			switch elem := elem.(type) {
+		d := demand.None()
+		for _, e := range expr.Elems {
+			switch e := e.(type) {
 			case *dag.Field:
-				demandValueOut := demand.GetKey(demandOut, elem.Name)
-				if !demand.IsNone(demandValueOut) {
-					demandIn = demand.Union(demandIn, inferDemandExprIn(demandValueOut, elem.Value))
-				}
+				d = demand.Union(d, demandForExpr(e.Value))
 			case *dag.Spread:
-				demandIn = demand.Union(demandIn, inferDemandExprIn(demand.All(), elem.Expr))
+				d = demand.Union(d, demandForExpr(e.Expr))
+			default:
+				panic(e)
 			}
 		}
+		return d
+	case *dag.RegexpMatch:
+		return demandForExpr(expr.Expr)
+	case *dag.RegexpSearch:
+		return demandForExpr(expr.Expr)
+	case *dag.Search:
+		return demandForExpr(expr.Expr)
+	case *dag.SetExpr:
+		return demandForArrayOrSetExpr(expr.Elems)
+	case *dag.SliceExpr:
+		return demand.Union(demandForExpr(expr.Expr),
+			demand.Union(demandForExpr(expr.From), demandForExpr(expr.To)))
 	case *dag.This:
-		demandIn = demandOut
+		d := demand.All()
 		for i := len(expr.Path) - 1; i >= 0; i-- {
-			demandIn = demand.Key(expr.Path[i], demandIn)
+			d = demand.Key(expr.Path[i], d)
 		}
-	default:
-		// Conservatively assume that `expr` uses it's entire input, regardless of output demand.
-		demandIn = demand.All()
+		return d
+	case *dag.UnaryExpr:
+		return demandForExpr(expr.Operand)
+	case *dag.Var:
+		return demand.None()
 	}
-	return demandIn
+	panic(expr)
+}
+
+func demandForArrayOrSetExpr(elems []dag.VectorElem) demand.Demand {
+	d := demand.None()
+	for _, e := range elems {
+		switch e := e.(type) {
+		case *dag.Spread:
+			d = demand.Union(d, demandForExpr(e.Expr))
+		case *dag.VectorValue:
+			d = demand.Union(d, demandForExpr(e.Expr))
+		default:
+			panic(e)
+		}
+	}
+	return d
+}
+
+func demandForAssignments(assignments []dag.Assignment, downstream demand.Demand) demand.Demand {
+	d := downstream
+	for _, a := range assignments {
+		if _, ok := a.LHS.(*dag.This); ok {
+			// Assignment clobbers a static field.
+			d = demand.Delete(d, demandForExpr(a.LHS))
+		} else {
+			// Add anything needed by a dynamic field.
+			d = demand.Union(d, demandForExpr(a.LHS))
+		}
+		d = demand.Union(d, demandForExpr(a.RHS))
+	}
+	return d
 }

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/brimdata/super/compiler/dag"
+	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/lake"
 	"github.com/brimdata/super/order"
 	"github.com/brimdata/super/pkg/field"
@@ -152,8 +153,8 @@ func (o *Optimizer) Optimize(seq dag.Seq) (dag.Seq, error) {
 	if err != nil {
 		return nil, err
 	}
-	seq = insertDemand(seq)
 	seq = removePassOps(seq)
+	DemandForSeq(seq, demand.All())
 	return seq, nil
 }
 

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -115,8 +115,7 @@ func RunQuery(t testing.TB, zctx *super.Context, readers []zio.Reader, querySour
 		t.Skipf("%v", err)
 	}
 	if len(dag) > 0 {
-		demands := optimizer.InferDemandSeqOut(dag)
-		demand := demands[dag[0]]
+		demand := optimizer.DemandForSeq(dag, demand.All())
 		useDemand(demand)
 	}
 


### PR DESCRIPTION
Simplify compiler/optimizer/demand.go and extend it to handle all DAG expressions and operators.

I'm not sure how precise this is, but in an attempt to verify that it doesn't omit any required fields, I tested it with the following diff, which adds a cut operator after every scan when a field list is available. `make test-unit test-system test-heavy` succeeds with it.

```diff
diff --git a/compiler/dag/op.go b/compiler/dag/op.go
index c8149b0e6..20cb35018 100644
--- a/compiler/dag/op.go
+++ b/compiler/dag/op.go
@@ -202,6 +202,7 @@ type (
 	// DefaultScan scans an input stream provided by the runtime.
 	DefaultScan struct {
 		Kind     string         `json:"kind" unpack:""`
+		Fields   []field.Path   `json:"fields"`
 		Filter   Expr           `json:"filter"`
 		SortKeys order.SortKeys `json:"sort_keys"`
 	}
diff --git a/compiler/kernel/op.go b/compiler/kernel/op.go
index 5ace22a2c..9f0a00b05 100644
--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -280,7 +280,11 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		body := strings.NewReader(v.Body)
 		return b.env.OpenHTTP(b.rctx.Context, b.zctx(), v.URL, v.Format, v.Method, v.Headers, body, nil)
 	case *dag.FileScan:
-		return b.env.Open(b.rctx.Context, b.zctx(), v.Path, v.Format, v.Fields, b.PushdownOf(v.Filter))
+		p, err := b.env.Open(b.rctx.Context, b.zctx(), v.Path, v.Format, v.Fields, b.PushdownOf(v.Filter))
+		if err != nil {
+			return nil, err
+		}
+		return b.cutFields(p, v.Fields)
 	case *dag.RobotScan:
 		e, err := compileExpr(v.Expr)
 		if err != nil {
@@ -290,7 +294,11 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 	case *dag.DefaultScan:
 		pushdown := b.PushdownOf(v.Filter)
 		if len(b.readers) == 1 {
-			return zbuf.NewScanner(b.rctx.Context, b.readers[0], pushdown)
+			p, err := zbuf.NewScanner(b.rctx.Context, b.readers[0], pushdown)
+			if err != nil {
+				return nil, err
+			}
+			return b.cutFields(p, v.Fields)
 		}
 		scanners := make([]zbuf.Scanner, 0, len(b.readers))
 		for _, r := range b.readers {
@@ -300,7 +308,7 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 			}
 			scanners = append(scanners, scanner)
 		}
-		return zbuf.MultiScanner(scanners...), nil
+		return b.cutFields(zbuf.MultiScanner(scanners...), v.Fields)
 	case *dag.NullScan:
 		//XXX we need something that implements the done protocol and restarst
 		return zbuf.NewPuller(zbuf.NewArray([]super.Value{super.Null})), nil
@@ -334,7 +342,7 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 				return nil, err
 			}
 		}
-		return meta.NewSequenceScanner(b.rctx, parent, pool, b.PushdownOf(v.Filter), pruner, b.progress), nil
+		return b.cutFields(meta.NewSequenceScanner(b.rctx, parent, pool, b.PushdownOf(v.Filter), pruner, b.progress), v.Fields)
 	case *dag.Deleter:
 		pool, err := b.lookupPool(v.Pool)
 		if err != nil {
@@ -388,6 +396,29 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 	}
 }
 
+func (b *Builder) cutFields(parent zbuf.Puller, fields []field.Path) (zbuf.Puller, error) {
+	if len(fields) == 0 {
+		return parent, nil
+	}
+	var assignments []dag.Assignment
+	for _, f := range fields {
+		this := &dag.This{
+			Kind: "This",
+			Path: f,
+		}
+		assignments = append(assignments, dag.Assignment{
+			Kind: "Assignment",
+			LHS:  this,
+			RHS:  this,
+		})
+	}
+	cut := &dag.Cut{
+		Kind: "Cut",
+		Args: assignments,
+	}
+	return b.compileLeaf(cut, parent)
+}
+
 func (b *Builder) compileDefs(defs []dag.Def) ([]string, []expr.Evaluator, error) {
 	exprs := make([]expr.Evaluator, 0, len(defs))
 	names := make([]string, 0, len(defs))
diff --git a/compiler/optimizer/demand.go b/compiler/optimizer/demand.go
index f6f68f6b5..f174dd934 100644
--- a/compiler/optimizer/demand.go
+++ b/compiler/optimizer/demand.go
@@ -104,7 +104,11 @@ func demandForOp(op dag.Op, downstream demand.Demand) demand.Demand {
 		}
 		return d
 
-	case *dag.CommitMetaScan, *dag.DefaultScan, *dag.Deleter, *dag.DeleteScan, *dag.LakeMetaScan:
+	case *dag.CommitMetaScan, *dag.Deleter, *dag.DeleteScan, *dag.LakeMetaScan:
+		return demand.None()
+	case *dag.DefaultScan:
+		d := demand.Union(downstream, demandForExpr(op.Filter))
+		op.Fields = demand.Fields(d)
 		return demand.None()
 	case *dag.FileScan:
 		d := demand.Union(downstream, demandForExpr(op.Filter))
diff --git a/runtime/ztests/expr/array-expr.yaml b/runtime/ztests/expr/array-expr.yaml
index 0ef22d0d2..7124fbc54 100644
--- a/runtime/ztests/expr/array-expr.yaml
+++ b/runtime/ztests/expr/array-expr.yaml
@@ -1,3 +1,5 @@
+skip: Adding a cut operator changes error("quiet") to error("missing")
+
 zed: yield [a,b,c]
 
 vector: true
```
