### PR TITLE
vector: Fix union nulls

### DIFF
--- a/vector/union.go
+++ b/vector/union.go
@@ -26,13 +26,13 @@ func (u *Union) Type() super.Type {
 func (u *Union) Serialize(b *zcode.Builder, slot uint32) {
 	if u.Nulls.Value(slot) {
 		b.Append(nil)
-	} else {
-		b.BeginContainer()
-		tag := u.Typ.TagOf(u.TypeOf(slot))
-		b.Append(super.EncodeInt(int64(tag)))
-		u.Dynamic.Serialize(b, slot)
-		b.EndContainer()
+		return
 	}
+	b.BeginContainer()
+	tag := u.Typ.TagOf(u.TypeOf(slot))
+	b.Append(super.EncodeInt(int64(tag)))
+	u.Dynamic.Serialize(b, slot)
+	b.EndContainer()
 }
 
 func (u *Union) AppendKey(b []byte, slot uint32) []byte {

--- a/vector/union.go
+++ b/vector/union.go
@@ -24,11 +24,15 @@ func (u *Union) Type() super.Type {
 }
 
 func (u *Union) Serialize(b *zcode.Builder, slot uint32) {
-	b.BeginContainer()
-	tag := u.Typ.TagOf(u.TypeOf(slot))
-	b.Append(super.EncodeInt(int64(tag)))
-	u.Dynamic.Serialize(b, slot)
-	b.EndContainer()
+	if u.Nulls.Value(slot) {
+		b.Append(nil)
+	} else {
+		b.BeginContainer()
+		tag := u.Typ.TagOf(u.TypeOf(slot))
+		b.Append(super.EncodeInt(int64(tag)))
+		u.Dynamic.Serialize(b, slot)
+		b.EndContainer()
+	}
 }
 
 func (u *Union) AppendKey(b []byte, slot uint32) []byte {


### PR DESCRIPTION
This commit fixes nulls in vector Unions by added a const null vector of union type into the Union dynamic.