### PR TITLE
Fix bug in vector in expression with list or set RHS

### DIFF
--- a/runtime/vam/expr/logic.go
+++ b/runtime/vam/expr/logic.go
@@ -281,7 +281,7 @@ func (i *In) evalForList(lhs, rhs vector.Any, offsets, index []uint32) *vector.B
 		lhsIndex = slices.Grow(lhsIndex[:0], int(n))[:n]
 		rhsIndex = slices.Grow(rhsIndex[:0], int(n))[:n]
 		for k := range n {
-			lhsIndex[k] = k
+			lhsIndex[k] = j
 			rhsIndex[k] = k + start
 		}
 		lhsView := vector.NewView(lhs, lhsIndex)

--- a/runtime/ztests/expr/in-issue-5554.yaml
+++ b/runtime/ztests/expr/in-issue-5554.yaml
@@ -1,0 +1,14 @@
+zed: |
+  yield this in [1, 3]
+
+vector: true
+
+input: |
+  1
+  2
+  3
+
+output: |
+  true
+  false
+  true


### PR DESCRIPTION
The vector runtime can produce incorrect results for "a in b" when b is a list or set.

Fixes #5554.