### PR TITLE
csup: Store dict values in data section

### DIFF
--- a/runtime/vcache/project.go
+++ b/runtime/vcache/project.go
@@ -38,6 +38,12 @@ func project(zctx *super.Context, paths Path, s shadow) vector.Any {
 			return vector.NewMissing(zctx, s.length())
 		}
 		return s.vec
+	case *dict:
+		if len(paths) > 0 {
+			return vector.NewMissing(zctx, s.length())
+		}
+		vals := project(zctx, paths, s.vals)
+		return vector.NewDict(vals, s.index, s.counts, s.nulls.flat)
 	case *error_:
 		v := project(zctx, paths, s.vals)
 		typ := zctx.LookupTypeError(v.Type())

--- a/runtime/vcache/shadow.go
+++ b/runtime/vcache/shadow.go
@@ -99,6 +99,16 @@ type const_ struct {
 	nulls nulls
 }
 
+type dict struct {
+	mu sync.Mutex
+	count
+	vng    *vng.Dict
+	nulls  nulls
+	vals   shadow
+	counts []uint32
+	index  []byte
+}
+
 type error_ struct {
 	vals  shadow
 	nulls nulls
@@ -206,6 +216,13 @@ func newShadow(m vng.Metadata, n *vng.Nulls, nullsCnt uint32) shadow {
 		return &const_{
 			count: count{m.Len(), nullsCnt},
 			val:   m.Value,
+			nulls: nulls{meta: n},
+		}
+	case *vng.Dict:
+		return &dict{
+			vals:  newShadow(m.Values, nil, 0),
+			count: count{m.Len(), nullsCnt},
+			vng:   m,
 			nulls: nulls{meta: n},
 		}
 	default:

--- a/vng/dict.go
+++ b/vng/dict.go
@@ -1,0 +1,143 @@
+package vng
+
+import (
+	"io"
+	"math"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/zcode"
+	"golang.org/x/sync/errgroup"
+)
+
+type DictEncoder struct {
+	typ    super.Type
+	tags   map[string]byte
+	index  []byte
+	counts *Uint32Encoder
+	values Encoder
+}
+
+func NewDictEncoder(typ super.Type, values Encoder) *DictEncoder {
+	if _, ok := values.(resetter); !ok {
+		panic("Dict values encoder must be resettable")
+	}
+	var tags map[string]byte
+	if id := typ.ID(); id != super.IDUint8 && id != super.IDInt8 && id != super.IDBool {
+		// Don't bother using a dictionary (which takes 8-bit tags) to encode
+		// other 8-bit values.
+		tags = make(map[string]byte)
+	}
+	return &DictEncoder{
+		typ:    typ,
+		tags:   tags,
+		values: values,
+	}
+}
+
+func (d *DictEncoder) Write(body zcode.Bytes) {
+	d.values.Write(body)
+	if d.tags != nil {
+		tag, ok := d.tags[string(body)]
+		if !ok {
+			len := len(d.tags)
+			if len > math.MaxUint8 {
+				d.tags = nil
+				return
+			}
+			tag = byte(len)
+			d.tags[string(body)] = tag
+		}
+		d.index = append(d.index, tag)
+	}
+}
+
+func (d *DictEncoder) Const() *Const {
+	if len(d.tags) != 1 {
+		return nil
+	}
+	var bytes zcode.Bytes
+	for b := range d.tags {
+		bytes = []byte(b)
+	}
+	return &Const{
+		Value: super.NewValue(d.typ, bytes),
+		Count: uint32(len(d.index)),
+	}
+}
+
+func (d *DictEncoder) isValid() bool {
+	return d.tags != nil && len(d.tags) >= 1 && len(d.index) > len(d.tags)
+}
+
+func (d *DictEncoder) Encode(group *errgroup.Group) {
+	if !d.isValid() {
+		d.values.Encode(group)
+		return
+	}
+	// If len == 1 then this is a const so do not encode anything.
+	if len(d.tags) == 1 {
+		return
+	}
+	d.encodeValues(group)
+	d.encodeCounts(group)
+}
+
+func (d *DictEncoder) encodeValues(group *errgroup.Group) {
+	byteSlices := make([]zcode.Bytes, len(d.tags))
+	for key, tag := range d.tags {
+		byteSlices[tag] = zcode.Bytes(key)
+	}
+	d.values.(resetter).reset()
+	for _, v := range byteSlices {
+		d.values.Write(v)
+	}
+	d.values.Encode(group)
+}
+
+func (d *DictEncoder) encodeCounts(group *errgroup.Group) {
+	counts := make([]uint32, len(d.tags))
+	for _, v := range d.index {
+		counts[v]++
+	}
+	d.counts = &Uint32Encoder{vals: counts}
+	d.counts.Encode(group)
+}
+
+func (d *DictEncoder) Metadata(off uint64) (uint64, Metadata) {
+	if !d.isValid() {
+		return d.values.Metadata(off)
+	}
+	if c := d.Const(); c != nil {
+		return off, c
+	}
+	meta := &Dict{Length: uint32(len(d.index))}
+	off, meta.Values = d.values.Metadata(off)
+	off, meta.Counts = d.counts.Segment(off)
+	len := uint64(len(d.index))
+	meta.Index = Segment{
+		Offset:    off,
+		Length:    len,
+		MemLength: len,
+	}
+	return off + len, meta
+}
+
+func (d *DictEncoder) Emit(w io.Writer) error {
+	if !d.isValid() {
+		return d.values.Emit(w)
+	}
+	if len(d.tags) == 1 {
+		return nil
+	}
+	if err := d.values.Emit(w); err != nil {
+		return err
+	}
+	if err := d.counts.Emit(w); err != nil {
+		return err
+	}
+	var err error
+	if len(d.index) > 0 {
+		_, err = w.Write(d.index)
+	}
+	return err
+}

--- a/vng/encoder.go
+++ b/vng/encoder.go
@@ -47,13 +47,17 @@ func NewEncoder(typ super.Type) Encoder {
 	case *super.TypeUnion:
 		return NewNullsEncoder(NewUnionEncoder(typ))
 	case *super.TypeEnum:
-		return NewNullsEncoder(NewPrimitiveEncoder(typ, false))
+		return NewNullsEncoder(NewPrimitiveEncoder(typ))
 	default:
 		if !super.IsPrimitiveType(typ) {
 			panic(fmt.Sprintf("unsupported type in VNG file: %T", typ))
 		}
-		return NewNullsEncoder(NewPrimitiveEncoder(typ, true))
+		return NewNullsEncoder(NewDictEncoder(typ, NewPrimitiveEncoder(typ)))
 	}
+}
+
+type resetter interface {
+	reset()
 }
 
 type NamedEncoder struct {

--- a/vng/header.go
+++ b/vng/header.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Version     = 6
+	Version     = 7
 	HeaderSize  = 24
 	MaxMetaSize = 100 * 1024 * 1024
 	MaxDataSize = 2 * 1024 * 1024 * 1024

--- a/vng/metadata.go
+++ b/vng/metadata.go
@@ -159,15 +159,9 @@ func (e *Error) Len() uint32 {
 	return e.Values.Len()
 }
 
-type DictEntry struct {
-	Value super.Value
-	Count uint32
-}
-
 type Primitive struct {
 	Typ      super.Type `zed:"Type"`
 	Location Segment
-	Dict     []DictEntry
 	Min      *super.Value
 	Max      *super.Value
 	Count    uint32
@@ -208,6 +202,21 @@ func (c *Const) Len() uint32 {
 	return c.Count
 }
 
+type Dict struct {
+	Values Metadata
+	Counts Segment
+	Index  Segment
+	Length uint32
+}
+
+func (d *Dict) Type(zctx *super.Context) super.Type {
+	return d.Values.Type(zctx)
+}
+
+func (d *Dict) Len() uint32 {
+	return d.Length
+}
+
 type Dynamic struct {
 	Tags   Segment
 	Values []Metadata
@@ -235,5 +244,6 @@ var Template = []interface{}{
 	Error{},
 	Nulls{},
 	Const{},
+	Dict{},
 	Dynamic{},
 }

--- a/vng/primitive.go
+++ b/vng/primitive.go
@@ -2,7 +2,6 @@ package vng
 
 import (
 	"io"
-	"sort"
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/order"
@@ -14,32 +13,28 @@ import (
 const MaxDictSize = 256
 
 type PrimitiveEncoder struct {
-	typ      super.Type
-	bytes    zcode.Bytes
+	typ   super.Type
+	bytes zcode.Bytes
+	cmp   expr.CompareFn
+	min   *super.Value
+	max   *super.Value
+	count uint32
+
+	// fields used after Encode is called
 	bytesLen uint64
 	format   uint8
 	out      []byte
-	dict     map[string]uint32
-	cmp      expr.CompareFn
-	min      *super.Value
-	max      *super.Value
-	count    uint32
 }
 
-func NewPrimitiveEncoder(typ super.Type, useDict bool) *PrimitiveEncoder {
-	var dict map[string]uint32
-	if useDict {
-		// Don't bother using a dictionary (which takes 8-bit tags) to encode
-		// other 8-bit values.
-		if id := typ.ID(); id != super.IDUint8 && id != super.IDInt8 && id != super.IDBool {
-			dict = make(map[string]uint32)
-		}
-	}
+func NewPrimitiveEncoder(typ super.Type) *PrimitiveEncoder {
 	return &PrimitiveEncoder{
-		typ:  typ,
-		dict: dict,
-		cmp:  expr.NewValueCompareFn(order.Asc, false),
+		typ: typ,
+		cmp: expr.NewValueCompareFn(order.Asc, false),
 	}
+}
+
+func (p *PrimitiveEncoder) reset() {
+	p.bytes, p.min, p.max, p.count = nil, nil, nil, 0
 }
 
 func (p *PrimitiveEncoder) Write(body zcode.Bytes) {
@@ -59,19 +54,10 @@ func (p *PrimitiveEncoder) update(body zcode.Bytes) {
 	if p.max == nil || p.cmp(val, *p.max) > 0 {
 		p.max = val.Copy().Ptr()
 	}
-	if p.dict != nil {
-		p.dict[string(body)]++
-		if len(p.dict) > MaxDictSize {
-			p.dict = nil
-		}
-	}
 }
 
 func (p *PrimitiveEncoder) Encode(group *errgroup.Group) {
 	group.Go(func() error {
-		if p.dict != nil {
-			p.bytes = p.makeDictVector()
-		}
 		fmt, out, err := compressBuffer(p.bytes)
 		if err != nil {
 			return err
@@ -84,61 +70,7 @@ func (p *PrimitiveEncoder) Encode(group *errgroup.Group) {
 	})
 }
 
-func (p *PrimitiveEncoder) makeDictVector() []byte {
-	dict := p.makeDict()
-	pos := make(map[string]byte)
-	for off, entry := range dict {
-		if bytes := entry.Value.Bytes(); bytes != nil {
-			pos[string(bytes)] = byte(off)
-		}
-	}
-	out := make([]byte, 0, p.count)
-	for it := p.bytes.Iter(); !it.Done(); {
-		bytes := it.Next()
-		if bytes == nil {
-			// null is always the first dict entry if it exists
-			out = append(out, 0)
-			continue
-		}
-		off, ok := pos[string(bytes)]
-		if !ok {
-			panic("bad dict entry") //XXX
-		}
-		out = append(out, off)
-	}
-	return out
-}
-
-func (p *PrimitiveEncoder) Const() *Const {
-	if len(p.dict) != 1 {
-		return nil
-	}
-	var bytes zcode.Bytes
-	if len(p.dict) == 1 {
-		for b := range p.dict {
-			bytes = []byte(b)
-		}
-	}
-	return &Const{
-		Value: super.NewValue(p.typ, bytes),
-		Count: p.count,
-	}
-}
-
 func (p *PrimitiveEncoder) Metadata(off uint64) (uint64, Metadata) {
-	var dict []DictEntry
-	if p.dict != nil {
-		if cnt := len(p.dict); cnt != 0 {
-			if cnt == 1 {
-				// A Const vector takes no space in the data area so we
-				// return off unmodified.  We also clear the output so
-				// Emit does not write the one value in the vector.
-				p.out = nil
-				return off, p.Const()
-			}
-			dict = p.makeDict()
-		}
-	}
 	loc := Segment{
 		Offset:            off,
 		Length:            uint64(len(p.out)),
@@ -149,7 +81,6 @@ func (p *PrimitiveEncoder) Metadata(off uint64) (uint64, Metadata) {
 	return off, &Primitive{
 		Typ:      p.typ,
 		Location: loc,
-		Dict:     dict,
 		Count:    p.count,
 		Min:      p.min,
 		Max:      p.max,
@@ -162,22 +93,4 @@ func (p *PrimitiveEncoder) Emit(w io.Writer) error {
 		_, err = w.Write(p.out)
 	}
 	return err
-}
-
-func (p *PrimitiveEncoder) makeDict() []DictEntry {
-	dict := make([]DictEntry, 0, len(p.dict))
-	for key, cnt := range p.dict {
-		dict = append(dict, DictEntry{
-			super.NewValue(p.typ, zcode.Bytes(key)),
-			cnt,
-		})
-	}
-	sortDict(dict, expr.NewValueCompareFn(order.Asc, false))
-	return dict
-}
-
-func sortDict(entries []DictEntry, cmp expr.CompareFn) {
-	sort.Slice(entries, func(i, j int) bool {
-		return cmp(entries[i].Value, entries[j].Value) < 0
-	})
 }

--- a/vng/ztests/const.yaml
+++ b/vng/ztests/const.yaml
@@ -12,5 +12,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {Version:6(uint32),MetaSize:35(uint64),DataSize:0(uint64)}
+      {Version:7(uint32),MetaSize:35(uint64),DataSize:0(uint64)}
       {Value:1,Count:3(uint32)}(=Const)

--- a/vng/ztests/dict.yaml
+++ b/vng/ztests/dict.yaml
@@ -1,33 +1,18 @@
 script: |
   super -f csup -o out.csup -
-  super dev csup out.csup | super -Z -c "over Fields |> yield Values.Dict" -
+  super dev csup out.csup | super -Z -c 'over Fields |> yield nameof(Values)' -
+  
 
 inputs:
   - name: stdin
     data: |
       {a:"hello",b:1}
       {a:"world",b:2}
+      {a:"hello",b:1}
+      {a:"world",b:2}
 
 outputs:
   - name: stdout
     data: |
-      [
-          {
-              Value: "hello",
-              Count: 1 (uint32)
-          } (=DictEntry),
-          {
-              Value: "world",
-              Count: 1
-          } (DictEntry)
-      ]
-      [
-          {
-              Value: 1,
-              Count: 1 (uint32)
-          } (=DictEntry),
-          {
-              Value: 2,
-              Count: 1
-          } (DictEntry)
-      ]
+      "Dict"
+      "Dict"

--- a/vng/ztests/no-dict.yaml
+++ b/vng/ztests/no-dict.yaml
@@ -1,8 +1,8 @@
 script: |
-  seq 1000 | super -f csup -o out.csup -c "{x:this}" -
-  super dev csup out.csup | super -Z -c "over Fields |> yield Values.Dict" -
+  seq 100 | super -f csup -o out.csup -c "{x:this}" -
+  super dev csup out.csup | super -Z -c "over Fields |> yield nameof(Values)" -
 
 outputs:
   - name: stdout
     data: |
-      null ([DictEntry={Value:{typ:null,base:uint8,len:uint64},Count:uint32}])
+      "Primitive"


### PR DESCRIPTION
This pr change the structure of how dicts in CSUP files are store so that the values in a dictionary are no longer stored in the dictionary's metadata but rather in it's data section.