### PR TITLE
add -f line

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -72,7 +72,7 @@ func (f *Flags) SetFormatFlags(fs *flag.FlagSet) {
 	if f.DefaultFormat == "" {
 		f.DefaultFormat = "bsup"
 	}
-	fs.StringVar(&f.Format, "f", f.DefaultFormat, "format for output data [arrows,bsup,csup,csv,json,jsup,lake,parquet,table,text,tsv,zeek,zjson]")
+	fs.StringVar(&f.Format, "f", f.DefaultFormat, "format for output data [arrows,bsup,csup,csv,json,jsup,lake,line,parquet,table,text,tsv,zeek,zjson]")
 	fs.BoolVar(&f.forceBinary, "B", false, "allow Super Binary to be sent to a terminal output")
 	fs.BoolVar(&f.jsonPretty, "J", false, "use formatted JSON output independent of -f option")
 	fs.BoolVar(&f.jsonShortcut, "j", false, "use line-oriented JSON output independent of -f option")

--- a/zio/anyio/writer.go
+++ b/zio/anyio/writer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/super/zio/csvio"
 	"github.com/brimdata/super/zio/jsonio"
 	"github.com/brimdata/super/zio/lakeio"
+	"github.com/brimdata/super/zio/lineio"
 	"github.com/brimdata/super/zio/parquetio"
 	"github.com/brimdata/super/zio/tableio"
 	"github.com/brimdata/super/zio/textio"
@@ -48,6 +49,8 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) (zio.WriteCloser, error) {
 		return jsonio.NewWriter(w, opts.JSON), nil
 	case "lake":
 		return lakeio.NewWriter(w, opts.Lake), nil
+	case "line":
+		return lineio.NewWriter(w), nil
 	case "null":
 		return &nullWriter{}, nil
 	case "parquet":

--- a/zio/lineio/writer.go
+++ b/zio/lineio/writer.go
@@ -1,0 +1,34 @@
+package lineio
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/zson"
+)
+
+type Writer struct {
+	writer io.WriteCloser
+}
+
+func NewWriter(w io.WriteCloser) *Writer {
+	return &Writer{
+		writer: w,
+	}
+}
+
+func (w *Writer) Close() error {
+	return w.writer.Close()
+}
+
+func (w *Writer) Write(val super.Value) error {
+	var s string
+	if _, ok := super.TypeUnder(val.Type()).(*super.TypeOfString); ok {
+		s = super.DecodeString(val.Bytes())
+	} else {
+		s = zson.FormatValue(val)
+	}
+	_, err := fmt.Fprintln(w.writer, s)
+	return err
+}

--- a/zio/lineio/ztests/writer.yaml
+++ b/zio/lineio/ztests/writer.yaml
@@ -1,0 +1,14 @@
+zed: pass
+
+output-flags: -f line
+
+input: |
+  "a"
+  "b\nc"
+  {x:1}
+
+output: |
+  a
+  b
+  c
+  {x:1}


### PR DESCRIPTION
This commit adds line output, which is the inverse of line input. Each value of type string is emitted "as is" on its own line without further formatting.  Non-string values are formatted as Super JSON.