### PR TITLE
Mention Line output format in API MIME type table

### DIFF
--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -549,7 +549,7 @@ The following table shows the supported MIME types and where they can be used.
 | Arrow IPC Stream | yes       | yes      | `application/vnd.apache.arrow.stream` |
 | CSV              | yes       | yes      | `text/csv`                            |
 | JSON             | yes       | yes      | `application/json`                    |
-| Line             | yes       | no       | `application/x-line`                  |
+| Line             | yes       | yes      | `application/x-line`                  |
 | NDJSON           | no        | yes      | `application/x-ndjson`                |
 | Parquet          | yes       | yes      | `application/x-parquet`               |
 | TSV              | yes       | yes      | `text/tab-separated-values`           |


### PR DESCRIPTION
I've confirmed that the changes in #5570 also allow getting `line` format query responses via the lake API, so this PR updates the MIME type table in the docs to reflect that.

```
$ curl -X POST -H 'Accept: application/x-jsup' -H 'Content-Type: application/json' http://localhost:9867/query -d '{"query":"from bar | yield a"}'
"hello\nworld"

$ curl -X POST -H 'Accept: application/x-line' -H 'Content-Type: application/json' http://localhost:9867/query -d '{"query":"from bar | yield a"}'
hello
world
```