### PR TITLE
Handle dag.DefaultScan in kernel.Builder.compileVamLeaf

### DIFF
--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -87,9 +87,6 @@ func (b *Builder) Build(seq dag.Seq, readers ...zio.Reader) (map[string]zbuf.Pul
 	}
 	b.readers = readers
 	if b.env.UseVAM() {
-		if len(readers) > 0 {
-			return nil, errors.New("vector runtime does not support internal readers")
-		}
 		if _, err := b.compileVamSeq(seq, nil); err != nil {
 			return nil, err
 		}

--- a/compiler/kernel/vop.go
+++ b/compiler/kernel/vop.go
@@ -176,6 +176,12 @@ func (b *Builder) compileVamLeaf(o dag.Op, parent vector.Puller) (vector.Puller,
 			return nil, err
 		}
 		return vamop.NewYield(b.zctx(), parent, []vamexpr.Evaluator{e}), nil
+	case *dag.DefaultScan:
+		zbufPuller, err := b.compileLeaf(o, nil)
+		if err != nil {
+			return nil, err
+		}
+		return vam.NewDematerializer(zbufPuller), nil
 	case *dag.Drop:
 		fields := make(field.List, 0, len(o.Args))
 		for _, e := range o.Args {


### PR DESCRIPTION
This allows the super command to read from files specified on the command line (e.g., "super f.zson") when using the vector runtime.

Depends on #5581.