### PR TITLE
Allow sequence index expression on array or set to return null

### DIFF
--- a/runtime/sam/expr/dot.go
+++ b/runtime/sam/expr/dot.go
@@ -47,7 +47,11 @@ func (d *DotExpr) Eval(ectx Context, this super.Value) super.Value {
 		if !ok {
 			return d.zctx.Missing()
 		}
-		return super.NewValue(typ.Fields[i].Type, getNthFromContainer(val.Bytes(), i))
+		bytes, ok := getNthFromContainer(val.Bytes(), i)
+		if !ok {
+			return d.zctx.Missing()
+		}
+		return super.NewValue(typ.Fields[i].Type, bytes)
 	case *super.TypeMap:
 		return indexMap(d.zctx, ectx, typ, val.Bytes(), super.NewString(d.field))
 	case *super.TypeOfType:

--- a/runtime/sam/expr/eval.go
+++ b/runtime/sam/expr/eval.go
@@ -601,7 +601,7 @@ func (u *UnaryMinus) Eval(ectx Context, this super.Value) super.Value {
 	return u.zctx.WrapError("type incompatible with unary '-' operator", val)
 }
 
-func getNthFromContainer(container zcode.Bytes, idx int) zcode.Bytes {
+func getNthFromContainer(container zcode.Bytes, idx int) (zcode.Bytes, bool) {
 	if idx < 0 {
 		var length int
 		for it := container.Iter(); !it.Done(); it.Next() {
@@ -609,16 +609,16 @@ func getNthFromContainer(container zcode.Bytes, idx int) zcode.Bytes {
 		}
 		idx = length + idx
 		if idx < 0 || idx >= length {
-			return nil
+			return nil, false
 		}
 	}
 	for i, it := 0, container.Iter(); !it.Done(); i++ {
 		zv := it.Next()
 		if i == idx {
-			return zv
+			return zv, true
 		}
 	}
-	return nil
+	return nil, false
 }
 
 func lookupKey(mapBytes, target zcode.Bytes) (zcode.Bytes, bool) {
@@ -673,11 +673,11 @@ func indexVector(zctx *super.Context, ectx Context, inner super.Type, vector zco
 	} else {
 		idx = int(index.Uint())
 	}
-	zv := getNthFromContainer(vector, idx)
-	if zv == nil {
+	bytes, ok := getNthFromContainer(vector, idx)
+	if !ok {
 		return zctx.Missing()
 	}
-	return deunion(ectx, inner, zv)
+	return deunion(ectx, inner, bytes)
 }
 
 func indexRecord(zctx *super.Context, ectx Context, typ *super.TypeRecord, record zcode.Bytes, index super.Value) super.Value {

--- a/runtime/sam/expr/function/ip.go
+++ b/runtime/sam/expr/function/ip.go
@@ -82,8 +82,6 @@ type CIDRMatch struct {
 var errMatch = errors.New("match")
 
 func (c *CIDRMatch) Call(_ super.Allocator, args []super.Value) super.Value {
-	//fmt.Println(zson.FormatValue(args[0]))
-	//fmt.Println(zson.FormatValue(args[1]))
 	maskVal := args[0]
 	if maskVal.Type().ID() != super.IDNet {
 		return c.zctx.WrapError("cidr_match: not a net", maskVal)

--- a/runtime/sam/expr/function/ip.go
+++ b/runtime/sam/expr/function/ip.go
@@ -82,6 +82,8 @@ type CIDRMatch struct {
 var errMatch = errors.New("match")
 
 func (c *CIDRMatch) Call(_ super.Allocator, args []super.Value) super.Value {
+	//fmt.Println(zson.FormatValue(args[0]))
+	//fmt.Println(zson.FormatValue(args[1]))
 	maskVal := args[0]
 	if maskVal.Type().ID() != super.IDNet {
 		return c.zctx.WrapError("cidr_match: not a net", maskVal)

--- a/runtime/sam/expr/shaper.go
+++ b/runtime/sam/expr/shaper.go
@@ -527,7 +527,7 @@ func (s *step) buildRecord(zctx *super.Context, ectx Context, in zcode.Bytes, b 
 		// reordering) would be make direct use of a
 		// zcode.Iter along with keeping track of our
 		// position.
-		bytes := getNthFromContainer(in, child.fromIndex)
+		bytes, _ := getNthFromContainer(in, child.fromIndex)
 		typ := child.build(zctx, ectx, bytes, b)
 		if super.TypeUnder(typ) == super.TypeUnder(child.toType) {
 			// Prefer child.toType in case it's a named type.

--- a/runtime/ztests/expr/index.yaml
+++ b/runtime/ztests/expr/index.yaml
@@ -7,6 +7,7 @@ input: |
   {val:[1,2,3,"foo"],idx:-1}
   {val:[1,2,3,"bar"],idx:1(uint8)}
   {val:[1,2,3,"foo"],idx:-4}
+  {val:[1,2,3,null],idx:3}
   {val:[1,2,3,"foo"],idx:-5}
   {val:null([(int64,string)]),idx:-5}
   {val:[1,2,3,"foo"],idx:null(int64)}
@@ -15,6 +16,7 @@ input: |
   {val:|[1,2,3,"foo"]|,idx:-1}
   {val:|[1,2,3,"bar"]|,idx:1}
   {val:|[1,2,3,"foo"]|,idx:-4}
+  {val:[1,2,3,null],idx:3}
   {val:|[1,2,3,"foo"]|,idx:-5}
   {val:|[1,2,3,"foo"]|,idx:"hi"}
   // record
@@ -27,6 +29,7 @@ output: |
   "foo"
   2
   1
+  null(int64)
   error("missing")
   error("missing")
   error("missing")
@@ -34,6 +37,7 @@ output: |
   "foo"
   2
   1
+  null(int64)
   error("missing")
   error({message:"index is not an integer",on:"hi"})
   "foo"


### PR DESCRIPTION
In the sequence runtime, indexing a null value inside a non-null array
or set returns error("missing").  Return the null value instead both for
consistency with the vector runtime and because it's less surprising.