### PR TITLE
Allow sequence index expression on record to return null

### DIFF
--- a/runtime/ztests/expr/index.yaml
+++ b/runtime/ztests/expr/index.yaml
@@ -20,6 +20,7 @@ input: |
   // record
   {val:{a:"foo",b:"bar"},idx:"a"}
   {val:{a:"bar",b:"baz"},idx:"b"}
+  {val:{a:"bar",b:null},idx:"b"}
   {val:{a:"foo",b:"bar"},idx:1.}
   {val:{a:"bar",b:"baz"},idx:"doesnotexist"}
 
@@ -38,5 +39,6 @@ output: |
   error({message:"index is not an integer",on:"hi"})
   "foo"
   "baz"
+  null
   error({message:"record index is not a string",on:1.})
   error("missing")

--- a/value.go
+++ b/value.go
@@ -339,15 +339,15 @@ func (r Value) Walk(rv Visitor) error {
 	return Walk(r.Type(), r.Bytes(), rv)
 }
 
-func (r Value) nth(n int) zcode.Bytes {
+func (r Value) nth(n int) (zcode.Bytes, bool) {
 	var zv zcode.Bytes
 	for i, it := 0, r.Bytes().Iter(); i <= n; i++ {
 		if it.Done() {
-			return nil
+			return nil, false
 		}
 		zv = it.Next()
 	}
-	return zv
+	return zv, true
 }
 
 func (r Value) Fields() []Field {
@@ -356,7 +356,7 @@ func (r Value) Fields() []Field {
 
 func (v *Value) DerefByColumn(col int) *Value {
 	if v != nil {
-		if bytes := v.nth(col); bytes != nil {
+		if bytes, ok := v.nth(col); ok {
 			return NewValue(v.Fields()[col].Type, bytes).Ptr()
 		}
 	}


### PR DESCRIPTION
In the sequence runtime, indexing a null value inside a non-null record returns error("missing").  Return the null value instead both for consistency with the vector runtime and because it's less surprising.

Fixes #5583.