### PR TITLE
Add SPQ tests to mdtest

### DIFF
--- a/mdtest/mdtest.go
+++ b/mdtest/mdtest.go
@@ -53,7 +53,7 @@
 // an SPQ program, the second contains input provided to the program when the
 // test runs, and the third contains the program's expected output.
 //
-//	```mdtest-sqp
+//	```mdtest-spq
 //	# spq
 //	yield a
 //	# input

--- a/mdtest/mdtest.go
+++ b/mdtest/mdtest.go
@@ -44,6 +44,23 @@
 //	hello
 //	...
 //	```
+//
+// # SPQ tests
+//
+// A fenced code block with mdtest-spq as the first word of its info string
+// contains an SPQ test.  The content of the block must comprise three sections,
+// each preceeded by one or more "#"-prefixed lines.  The first section contains
+// an SPQ program, the second contains input provided to the program when the
+// test runs, and the third contains the program's expected output.
+//
+//	```mdtest-sqp
+//	# spq
+//	yield a
+//	# input
+//	{a:1}
+//	# expected output
+//	1
+//	```
 package mdtest
 
 import (
@@ -53,6 +70,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -131,6 +149,9 @@ func (f *File) Run(t *testing.T) {
 	}
 }
 
+// Matches one or more "#"-prefixed lines.
+var spqSeparatorRE = regexp.MustCompile(`(?m:^#.*\n)+`)
+
 func parseMarkdown(source []byte) (map[string]string, []*Test, error) {
 	var commandFCB *ast.FencedCodeBlock
 	var inputs map[string]string
@@ -196,6 +217,23 @@ func parseMarkdown(source []byte) (map[string]string, []*Test, error) {
 			tests = append(tests, &Test{
 				GoExample: fcbLines(fcb, source),
 				Line:      fcbLineNumber(fcb, source),
+			})
+		case "mdtest-spq":
+			lines := fcbLines(fcb, source)
+			if !strings.HasPrefix(lines, "#") {
+				return ast.WalkStop, fcbError(fcb, source, "mdtest-spq content must begin with '#'")
+			}
+			sections := spqSeparatorRE.Split(lines, -1)
+			// Ignore sections[0].
+			if n := len(sections); n != 4 {
+				msg := fmt.Sprintf("mdtest-spq content has %d '#'-prefixed sections (expected 3)", n-1)
+				return ast.WalkStop, fcbError(fcb, source, msg)
+			}
+			tests = append(tests, &Test{
+				Expected: sections[3],
+				Line:     fcbLineNumber(fcb, source),
+				Input:    sections[2],
+				SPQ:      sections[1],
 			})
 		}
 		return ast.WalkContinue, nil

--- a/mdtest/mdtest_test.go
+++ b/mdtest/mdtest_test.go
@@ -162,6 +162,66 @@ block 2
 				{Command: "block 1\n", Expected: "block 2\n...\n", Line: 2},
 			},
 		},
+		{
+			name: "mdtest-spq",
+			markdown: `
+~~~mdtest-spq
+# Multiple '#' lines are allowed.
+#
+spq
+#
+input
+#
+expected
+~~~
+`,
+			tests: []*Test{
+				{Expected: "expected\n", Line: 2, Input: "input\n", SPQ: "spq\n"},
+			},
+		},
+		{
+			name: "mdtest-spq with leading garbage",
+			markdown: `
+~~~mdtest-spq
+garbage
+#
+spq
+#
+input
+#
+expected
+~~~
+	`,
+			strerror: `line 2: mdtest-spq content must begin with '#'`,
+		},
+		{
+			name: "mdtest-spq with too many sections",
+			markdown: `
+~~~mdtest-spq
+#
+spq
+#
+input
+#
+expected
+#
+extra
+~~~
+	`,
+			strerror: `line 2: mdtest-spq content has 4 '#'-prefixed sections (expected 3)`,
+		},
+		{
+			name: "mdtest-spq with too few sections",
+			markdown: `
+~~~mdtest-spq
+#
+spq
+#
+input
+~~~
+	`,
+			strerror: `line 2: mdtest-spq content has 2 '#'-prefixed sections (expected 3)`,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/mdtest/test.go
+++ b/mdtest/test.go
@@ -20,6 +20,10 @@ type Test struct {
 	Head      bool
 	Line      int
 	GoExample string
+
+	// For SPQ tests
+	Input string
+	SPQ   string
 }
 
 // Run runs the test, returning nil on success.
@@ -27,9 +31,15 @@ func (t *Test) Run() error {
 	if t.GoExample != "" {
 		return t.vetGoExample()
 	}
-	c := exec.Command("bash", "-e", "-o", "pipefail")
-	c.Dir = t.Dir
-	c.Stdin = strings.NewReader(t.Command)
+	var c *exec.Cmd
+	if t.SPQ != "" {
+		c = exec.Command("super", "-z", "-c", t.SPQ, "-")
+		c.Stdin = strings.NewReader(t.Input)
+	} else {
+		c = exec.Command("bash", "-e", "-o", "pipefail")
+		c.Dir = t.Dir
+		c.Stdin = strings.NewReader(t.Command)
+	}
 	outBytes, err := c.CombinedOutput()
 	out := string(outBytes)
 	if t.Fails {


### PR DESCRIPTION
A Markdown fenced code block with mdtest-spq as the first word of its info string contains an SPQ test.  The content of the block must comprise three sections, each preceeded by one or more "#"-prefixed lines.  The first section contains an SPQ program, the second contains input provided to the program when the test runs, and the third contains the program's expected output.