### PR TITLE
Use a more stable hyperlink for "screen"

### DIFF
--- a/scripts/super-cmd-perf/README.md
+++ b/scripts/super-cmd-perf/README.md
@@ -42,7 +42,7 @@ on AWS because when we attempted to load data to this type on our Macbooks
 that have 16 GB of RAM it consistently failed with a "too many open files"
 error.
 
-As the benchmarks may take a long time to run, the use of [`screen`](https://www.gnu.org/software/screen/)
+As the benchmarks may take a long time to run, the use of [`screen`](https://en.wikipedia.org/wiki/GNU_Screen)
 or a similar "detachable" terminal tool is recommended in case your remote
 network connection drops during a run.
 


### PR DESCRIPTION
For some reason, in the past week the link I'd used to the GNU site has frequently hit 30-second timeouts when our link checker runs, though it always comes up fine when I check it manually afterwards. To spare us the excess CI failures here I'm just linking to Wikipedia since that should surely be more reliable.