### PR TITLE
Fix pkg/skim.Scanner bug on single byte followed by EOF

### DIFF
--- a/pkg/skim/skim.go
+++ b/pkg/skim/skim.go
@@ -199,7 +199,7 @@ func (s *Scanner) ScanLine() ([]byte, error) {
 			if line == nil {
 				return nil, nil
 			}
-			if len(line) <= 1 {
+			if string(line) == "\n" {
 				// blank line, keep going
 				s.BlankLines++
 				continue

--- a/pkg/skim/skim_test.go
+++ b/pkg/skim/skim_test.go
@@ -3,6 +3,7 @@ package skim_test
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/brimdata/super/pkg/skim"
@@ -70,6 +71,14 @@ func TestSkimNoNewLine(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	require.Equal(t, []byte(nil), line)
+
+	scanner = skim.NewScanner(strings.NewReader("x"), buf, MaxLineSize)
+	line, err = scanner.ScanLine()
+	require.NoError(t, err)
+	require.Equal(t, "x", string(line))
+	line, err = scanner.ScanLine()
+	require.NoError(t, err)
 	require.Equal(t, []byte(nil), line)
 }
 

--- a/zio/anyio/ztests/single-digit-no-newline.yaml
+++ b/zio/anyio/ztests/single-digit-no-newline.yaml
@@ -1,0 +1,6 @@
+zed: pass
+
+input: '1'
+
+output: |
+  1


### PR DESCRIPTION
"printf 1 | super -" produces no output because Scanner.ScanLine treats a single byte followed by EOF as a blank line.  Fix by checking for a newline.