### PR TITLE
Add mdtest-spq "fails" option

### DIFF
--- a/mdtest/mdtest.go
+++ b/mdtest/mdtest.go
@@ -53,7 +53,12 @@
 // an SPQ program, the second contains input provided to the program when the
 // test runs, and the third contains the program's expected output.
 //
-//	```mdtest-spq
+// SPQ tests are run via the super command.  The command's exit status must
+// indicate success (i.e., be zero) unless the mdtest-spq block's info string
+// contains the word "fails", in which case the exit status must indicate
+// failure (i.e. be nonzero).
+//
+//	```mdtest-spq [fails]
 //	# spq
 //	yield a
 //	# input
@@ -219,6 +224,12 @@ func parseMarkdown(source []byte) (map[string]string, []*Test, error) {
 				Line:      fcbLineNumber(fcb, source),
 			})
 		case "mdtest-spq":
+			var fails bool
+			for _, word := range fcbInfoWords(fcb, source)[1:] {
+				if word == "fails" {
+					fails = true
+				}
+			}
 			lines := fcbLines(fcb, source)
 			if !strings.HasPrefix(lines, "#") {
 				return ast.WalkStop, fcbError(fcb, source, "mdtest-spq content must begin with '#'")
@@ -231,6 +242,7 @@ func parseMarkdown(source []byte) (map[string]string, []*Test, error) {
 			}
 			tests = append(tests, &Test{
 				Expected: sections[3],
+				Fails:    fails,
 				Line:     fcbLineNumber(fcb, source),
 				Input:    sections[2],
 				SPQ:      sections[1],

--- a/mdtest/mdtest_test.go
+++ b/mdtest/mdtest_test.go
@@ -180,6 +180,23 @@ expected
 			},
 		},
 		{
+			name: "mdtest-spq with fails",
+			markdown: `
+~~~mdtest-spq fails
+# Multiple '#' lines are allowed.
+#
+spq
+#
+input
+#
+expected
+~~~
+`,
+			tests: []*Test{
+				{Expected: "expected\n", Fails: true, Line: 2, Input: "input\n", SPQ: "spq\n"},
+			},
+		},
+		{
 			name: "mdtest-spq with leading garbage",
 			markdown: `
 ~~~mdtest-spq


### PR DESCRIPTION
Mdtest SPQ tests are run via the super command.  The command's exit status must indicate success (i.e., be zero) unless the mdtest-spq block's info string contains the word "fails", in which case the exit status must indicate failure (i.e. be nonzero).