### PR TITLE
Fix vam bug affecting count by string with where clause

### DIFF
--- a/runtime/vam/op/summarize/summarize.go
+++ b/runtime/vam/op/summarize/summarize.go
@@ -104,7 +104,8 @@ func (s *Summarize) consume(keys []vector.Any, vals []vector.Any) {
 
 func (s *Summarize) newAggTable(keyTypes []super.Type) aggTable {
 	// Check if we can us an optimized table, else go slow path.
-	if s.isCountByString(keyTypes) {
+	if s.isCountByString(keyTypes) && len(s.aggs) == 1 && s.aggs[0].Where == nil {
+		// countByString.update does not handle nulls in its vals param.
 		return newCountByString(s.builder, s.partialsIn)
 	}
 	return &superTable{

--- a/runtime/vam/op/ztests/agg-count-by-string.yaml
+++ b/runtime/vam/op/ztests/agg-count-by-string.yaml
@@ -10,6 +10,7 @@ script: |
   super dev vector query -z 'count() by x' t.csup
   super dev vector query -z 'count() by y' t.csup | super -z -c 'sort y' -
   super dev vector query -z 'count() by z' t.csup | super -z -c 'z=="257"' -
+  super dev vector query -z 'count() where y=="1" by z' t.csup | super -z -c 'z=="257"' -
 
 outputs:
   - name: stdout
@@ -18,3 +19,4 @@ outputs:
       {y:"1",count:257(uint64)}
       {y:"2",count:257(uint64)}
       {z:"257",count:2(uint64)}
+      {z:"257",count:1(uint64)}


### PR DESCRIPTION
Vam does not honor the where clause in "count() where <expr> by <string_valued_expr>".  Fix by using
runtime/vam/op/summarize.countbyString only when no where clause is present.

Fixes #5559.