### PR TITLE
Remove parentheses from grep() error string

### DIFF
--- a/runtime/sam/expr/function/grep.go
+++ b/runtime/sam/expr/function/grep.go
@@ -15,7 +15,7 @@ type Grep struct {
 func (g *Grep) Call(_ super.Allocator, vals []super.Value) super.Value {
 	patternVal, inputVal := vals[0], vals[1]
 	if super.TypeUnder(patternVal.Type()) != super.TypeString {
-		return g.zctx.WrapError("grep(): pattern argument must be a string", patternVal)
+		return g.zctx.WrapError("grep: pattern argument must be a string", patternVal)
 	}
 	if patternVal.IsNull() {
 		return super.NullBool

--- a/runtime/vam/expr/function/grep.go
+++ b/runtime/vam/expr/function/grep.go
@@ -16,7 +16,7 @@ type Grep struct {
 func (g *Grep) Call(args ...vector.Any) vector.Any {
 	patternVec, inputVec := args[0], args[1]
 	if patternVec.Type().ID() != super.IDString {
-		return vector.NewWrappedError(g.zctx, "grep(): pattern argument must be a string", patternVec)
+		return vector.NewWrappedError(g.zctx, "grep: pattern argument must be a string", patternVec)
 	}
 	if inputVec.Len() == 0 {
 		return vector.NewBoolEmpty(0, nil)

--- a/runtime/ztests/expr/function/grep.yaml
+++ b/runtime/ztests/expr/function/grep.yaml
@@ -24,5 +24,5 @@ output: |
   [true,false]
   [true,true]
   [true,false]
-  [error({message:"grep(): pattern argument must be a string",on:1}),error({message:"grep(): pattern argument must be a string",on:1})]
+  [error({message:"grep: pattern argument must be a string",on:1}),error({message:"grep: pattern argument must be a string",on:1})]
   [null(bool),null(bool)]


### PR DESCRIPTION
Error strings for nearly all other functions don't have them.