### PR TITLE
Remove runtime/sam/op/join.New error return param

### DIFF
--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -662,10 +662,7 @@ func (b *Builder) compile(o dag.Op, parents []zbuf.Puller) ([]zbuf.Puller, error
 		default:
 			return nil, fmt.Errorf("unknown kind of join: '%s'", o.Style)
 		}
-		join, err := join.New(b.rctx, anti, inner, leftParent, rightParent, leftKey, rightKey, leftDir, rightDir, lhs, rhs, b.resetters)
-		if err != nil {
-			return nil, err
-		}
+		join := join.New(b.rctx, anti, inner, leftParent, rightParent, leftKey, rightKey, leftDir, rightDir, lhs, rhs, b.resetters)
 		return []zbuf.Puller{join}, nil
 	case *dag.Merge:
 		b.resetResetters()

--- a/runtime/sam/op/join/join.go
+++ b/runtime/sam/op/join/join.go
@@ -34,7 +34,7 @@ type Op struct {
 }
 
 func New(rctx *runtime.Context, anti, inner bool, left, right zbuf.Puller, leftKey, rightKey expr.Evaluator,
-	leftDir, rightDir order.Direction, lhs []*expr.Lval, rhs []expr.Evaluator, resetter expr.Resetter) (*Op, error) {
+	leftDir, rightDir order.Direction, lhs []*expr.Lval, rhs []expr.Evaluator, resetter expr.Resetter) *Op {
 	var o order.Which
 	switch {
 	case leftDir != order.Unknown:
@@ -66,7 +66,7 @@ func New(rctx *runtime.Context, anti, inner bool, left, right zbuf.Puller, leftK
 		compare:     expr.NewValueCompareFn(o, true),
 		cutter:      expr.NewCutter(rctx.Zctx, lhs, rhs),
 		types:       make(map[int]map[int]*super.TypeRecord),
-	}, nil
+	}
 }
 
 // Pull implements the merge logic for returning data from the upstreams.


### PR DESCRIPTION
It's always nil.