### PR TITLE
Another iteration on the Introduction doc

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -13,7 +13,7 @@ without giving up JSON's uncanny ability to represent eclectic data.
 ## Getting Started
 
 Trying out SuperDB is easy: just [install](install.md) the command-line tool
-[`super`](commands/super.md) and run through the [tutorial](tutorials/zq.md).
+[`super`](commands/super.md) and run through its [usage documentation](commands/super.md).
 
 Compared to putting JSON data in a relational column, the
 [super-structured data model](formats/zed.md) makes it really easy to
@@ -27,7 +27,7 @@ while for a technical user, SuperDB exposes its technical underpinnings
 in a gradual slope, providing as much detail as desired,
 packaged up in the easy-to-understand
 [Super JSON data format](formats/jsup.md) and
-[SuperPipe language](language/_index.md).
+[SuperSQL language](language/_index.md).
 
 While `super` and its accompanying data formats are production quality, the project's
 [SuperDB data lake](commands/super-db.md) is a bit earlier in development.
@@ -38,30 +38,28 @@ While `super` and its accompanying data formats are production quality, the proj
 a number of different elements of the system:
 * The [super data model](formats/zed.md) is the abstract definition of the data types and semantics
 that underlie the super-structured data formats.
-* The [super data formats](formats/_index.md) are a family of
+* The [super-structured data formats](formats/_index.md) are a family of
 [human-readable (Super JSON, JSUP)](formats/jsup.md),
 [sequential (Super Binary, BSUP)](formats/bsup.md), and
 [columnar (Super Columnar, CSUP)](formats/csup.md) formats that all adhere to the
 same abstract super data model.
-* The [SuperPipe language](language/_index.md) is the system's pipeline language for performing
+* [SuperSQL](language/_index.md) is the system's language for performing
 queries, searches, analytics, transformations, or any of the above combined together.
-* A  [SuperPipe query](language/overview.md) is a script that performs
-search and/or analytics.
-* A [SuperPipe shaper](language/shaping.md) is a script that performs
-data transformation to _shape_
-the input data into the desired set of organizing super-structured data types called "shapes",
-which are traditionally called _schemas_ in relational systems but are
-much more flexible in SuperDB.
+* A [SuperSQL pipe query (SPQ)](language/overview.md) is a query that
+employs SuperSQL's unique pipeline extensions and shortcuts to perform data
+operations that are difficult or impossible in standard SQL.
 * A [SuperDB data lake](commands/super-db.md) is a collection of super-structured data stored
 across one or more [data pools](commands/super-db.md#data-pools) with ACID commit semantics and
 accessed via a [Git](https://git-scm.com/)-like API.
 
 ## Digging Deeper
 
-The [SuperPipe language documentation](language/_index.md)
-is the best way to learn about `super` in depth.
-All of its examples use `super` commands run on the command line.
-Run `super -h` for a list of command options and online help.
+The [SuperSQL language documentation](language/_index.md)
+is the best way to learn about `super` in depth. Most
+[examples](commands/super.md#examples) that appear throughout the docs can be
+executed right in your browser and can easily be copied to the command line
+for execution with `super`. Run `super -h` for a list of command options and
+brief help.
 
 The [`super db` documentation](commands/super-db.md)
 is the best way to learn about the SuperDB data lake.
@@ -77,10 +75,10 @@ built from self-describing data structures.  Everything in a SuperDB data lake
 is built from super-structured data and each system component can be run and tested in isolation.
 
 Since super-structured data is self-describing, this approach makes stream composition
-very easy.  Data from a SuperPipe query can trivially be piped to a local
+very easy.  Data from a query can trivially be piped to a local
 instance of `super` by feeding the resulting output stream to stdin of `super`, for example,
 ```
-super db query "from pool | ...remote query..." | super "...local query..." -
+super db query "from pool | ...remote query..." | super -c "...local query..." -
 ```
 There is no need to configure the SuperDB entities with schema information
 like [protobuf configs](https://developers.google.com/protocol-buffers/docs/proto3)
@@ -95,7 +93,7 @@ at the copy of the lake.
 
 Functionality like [data compaction](commands/super-db.md#manage) and retention are all API-driven.
 
-Bite-sized components are unified by the super-structured data, usually in the SUPZ format:
+Bite-sized components are unified by the super-structured data, usually in the BSUP format:
 * All lake meta-data is available via meta-queries.
 * All lake operations available through the service API are also available
 directly via the `super db` command.


### PR DESCRIPTION
As I confront the need to get back to de-Zed-ifying the docs, I'm inclined to take it from the top again. The last time I revised this "Introduction" doc we were in the brief phase when we were saying "SuperPipe", so I yank that out here along with a few other adjustments that feel appropriate now that things have settled a bit more.

I recognize the whole "Design Philosophy" section is still somewhat suspect since we're not heavily emphasizing the lake at the moment, but I'm inclined to leave it where it is until we have a better sense of its fate.