### PR TITLE
In Actions workflows, move from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
       - run: go build -o dist ./cmd/...
       - run: go test -v ./mdtest
   output-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   markdown-link:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Lint

--- a/.github/workflows/notify-docs-update.yaml
+++ b/.github/workflows/notify-docs-update.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Send dispatch event
       run: |

--- a/.github/workflows/notify-downstream-merge.yaml
+++ b/.github/workflows/notify-downstream-merge.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         repo: [brimcap, zui]

--- a/.github/workflows/notify-main-failure.yaml
+++ b/.github/workflows/notify-main-failure.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   slackNotify:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Notify Brim HQ of failure on main
         uses: tiloio/slack-webhook-action@v1.1.2

--- a/.github/workflows/perf-compare.yaml
+++ b/.github/workflows/perf-compare.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   perf-compare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - v*
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## What's Changing

In our Actions workflows, this moves us from using `ubuntu-20.04` to `ubuntu-22.04`.

## Why

Per https://github.com/actions/runner-images/issues/11101, `ubuntu-20.04` is set to be deprecated soon. This includes planned "brownouts" in March in which they'll intentionally cause failure of some jobs still using `ubuntu-20.04` to alert users of the change. The changes in this PR get ahead of that.

## Details

I've always been a fan of pointing at specific/old runner versions (as opposed to `-latest`) so that way we can have more confidence in a support statement that says we can run on platforms older than the very latest. However, this requires moving the pointers periodically. Thankfully they give us plenty of advance warning.