### PR TITLE
Update the executables in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "zed",
-  "version": "0.33.0-dev",
+  "name": "super",
+  "version": "0.0.1-dev",
   "scripts": {
     "prepack": "make build"
   },
@@ -10,10 +10,8 @@
   ],
   "publishConfig": {
     "executableFiles": [
-      "./dist/zq",
-      "./dist/zq.exe",
-      "./dist/zed",
-      "./dist/zed.exe"
+      "./dist/super",
+      "./dist/super.exe",
     ]
   },
   "directories": {


### PR DESCRIPTION
This is required to allow the super command to have executable permissions when we download it.