### PR TITLE
ztest: Skip Zed-style tests when ZTEST_PATH is set

### DIFF
--- a/runtime/sam/expr/expr_test.go
+++ b/runtime/sam/expr/expr_test.go
@@ -19,7 +19,7 @@ func testSuccessful(t *testing.T, e, input, expected string) {
 		Input:  input,
 		Output: expected + "\n",
 	}
-	if err := zt.RunInternal(""); err != nil {
+	if err := zt.RunInternal(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -30,7 +30,7 @@ func testError(t *testing.T, e string, expectErr error) {
 		Zed:   fmt.Sprintf("yield %s", e),
 		Error: expectErr.Error() + "\n",
 	}
-	if err := zt.RunInternal(""); err != nil {
+	if err := zt.RunInternal(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/ztest/ztest_test.go
+++ b/ztest/ztest_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestShouldSkip(t *testing.T) {
+	assert.Equal(t, "in-process test on script run", (&ZTest{Zed: "x"}).ShouldSkip("y"))
 	assert.Equal(t, "script test on in-process run", (&ZTest{Script: "x"}).ShouldSkip(""))
 	assert.Equal(t, "reason", (&ZTest{Skip: "reason"}).ShouldSkip(""))
 	assert.Equal(t, `tag "x" does not match ZTEST_TAG=""`, (&ZTest{Tag: "x"}).ShouldSkip(""))


### PR DESCRIPTION
When running script-style tests (i.e., when ZTEST_PATH is set), ztest.Run uses the super command to run Zed-style tests out-of-process. Skip them instead.