### PR TITLE
ztest: Allow vector script-style tests

### DIFF
--- a/ztest/shell.go
+++ b/ztest/shell.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 )
 
-func RunShell(dir, bindir, script string, stdin io.Reader, useenvs []string) (string, string, error) {
+func RunShell(dir, bindir, script string, stdin io.Reader, useenvs, extraenvs []string) (string, string, error) {
 	// "-e -o pipefile" ensures a test will fail if any command
 	// fails unexpectedly.
 	cmd := exec.Command("bash", "-e", "-o", "pipefail", "-c", script)
@@ -26,6 +26,7 @@ func RunShell(dir, bindir, script string, stdin io.Reader, useenvs []string) (st
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", env, v))
 		}
 	}
+	cmd.Env = append(cmd.Env, extraenvs...)
 	cmd.Stdin = stdin
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/ztest/ztest_test.go
+++ b/ztest/ztest_test.go
@@ -40,14 +40,14 @@ func TestRunScript(t *testing.T) {
 				{Name: "testdirfile"},
 				{Name: "testdirfile2", Source: "testdirfile"},
 			},
-		}).RunScript("", testDir, t.TempDir())
+		}).RunScript("", testDir, t.TempDir)
 		assert.NoError(t, err)
 	})
 	t.Run("error", func(t *testing.T) {
 		err := (&ZTest{
 			Script:  "echo 1; echo 2 >&2; exit 3",
 			Outputs: []File{},
-		}).RunScript("", "", "")
+		}).RunScript("", "", func() string { return "" })
 		assert.EqualError(t, err, "script failed: exit status 3\n=== stdout ===\n1\n=== stderr ===\n2\n")
 	})
 }


### PR DESCRIPTION
When "vector: true" appears in a script-style test, run the test once with the sequence runtime and then again with the vector runtime by including SUPER_VAM=1 in the shell environment.