### PR TITLE
vam: Aggregation panic on named types

### DIFF
--- a/runtime/vam/expr/agg/avg.go
+++ b/runtime/vam/expr/agg/avg.go
@@ -14,6 +14,7 @@ type avg struct {
 var _ Func = (*avg)(nil)
 
 func (a *avg) Consume(vec vector.Any) {
+	vec = vector.Under(vec)
 	if !super.IsNumber(vec.Type().ID()) {
 		return
 	}

--- a/runtime/vam/expr/agg/math.go
+++ b/runtime/vam/expr/agg/math.go
@@ -38,6 +38,7 @@ func (m *mathReducer) Result(*super.Context) super.Value {
 }
 
 func (m *mathReducer) Consume(vec vector.Any) {
+	vec = vector.Under(vec)
 	typ := vec.Type()
 	var id int
 	if m.math != nil {

--- a/runtime/ztests/op/summarize/named-values.yaml
+++ b/runtime/ztests/op/summarize/named-values.yaml
@@ -1,0 +1,24 @@
+zed: count(), sum(this), min(this), max(this), avg(this), collect(this), any(this), dcount(this)
+
+vector: true
+
+input: | 
+  1(=named)
+  2(=named)
+
+output-flags: -pretty=4
+
+output: |
+  {
+      count: 2 (uint64),
+      sum: 3,
+      min: 1,
+      max: 2,
+      avg: 1.5,
+      collect: [
+          1,
+          2
+      ],
+      any: 1 (=named),
+      dcount: 2 (uint64)
+  }


### PR DESCRIPTION
Fix issue where some vector runtime aggregations would panic when fed named type vectors.

Closes #5643