### PR TITLE
Set expectations in README and first docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # SuperDB [![Tests][tests-img]][tests] [![GoPkg][gopkg-img]][gopkg]
 
+> 🔴 **NOTICE OF PROJECT READINESS** 🔴
+>
+> SuperDB is still under development so there's not yet a GA release.
+> You're welcome to [try it out](#try-it) in its early form (i.e.,
+> tip-of-`main`) and we'd love to hear your feedback. Read on for more info!
+
 SuperDB is a new analytics database that supports relational tables and JSON
 on an equal footing.  It shines when it comes to data wrangling where
 you need to explore or process large eclectic data sets.  It's also pretty

--- a/README.md
+++ b/README.md
@@ -67,34 +67,44 @@ representation of Super JSON (a bit like Parquet).
 Even though SuperDB is based on these super-structured data formats, it can read and write
 most common data formats.
 
-## Try It
-
-Trying out SuperDB is super easy: just [install](https://superdb.org/docs/install)
-the command-line tool [`super`](https://superdb.org/docs/commands/super).
-
-Detailed documentation for the entire SuperDB system and its piped SQL syntax
-is available on the [SuperDB docs site](https://superdb.org/docs).
-
-The SuperDB query engine can run locally without a storage engine by accessing
-files, HTTP endpoints, or S3 paths using the `super` command. While
-[earlier in its development](https://superdb.org/docs/commands/super-db/#status),
-SuperDB can also run on a
-[super-structured data lake](https://superdb.org/docs/commands/super-db/#the-lake-model)
-using the `super db` sub-commands.
-
 ## Project Status
 
 Our long-term goal for SuperSQL is to be Postgres-compatible and interoperate
 with existing SQL tooling. In the meantime, SuperSQL is a bit of a moving 
-target and we would love community engagement to evolve and fine tune its
+target and we would love [community engagement](#join-the-community) to evolve and fine tune its
 syntax and semantics.
 
 Our areas of active development include:
 * the SuperSQL query language,
 * the type-based query compiler and optimizer,
 * fast, vectorized ingest of common file formats,
-* a complete vectorized runtme, and
+* a complete vectorized runtime, and
 * a data lake based on super-structured data.
+
+## Try It
+
+As SuperDB is still under construction, GA releases are not yet available.
+However, you can [install](https://superdb.org/docs/install) a build of the
+[`super`](https://superdb.org/docs/commands/super) command-line tool based on
+code that's under active development to start tinkering. Detailed documentation
+for the SuperDB system and its piped SQL syntax is available on the
+[SuperDB docs site](https://superdb.org/docs).
+
+As the code and docs are evolving, we recommend focusing first on what's in the
+[`super` command doc](https://superdb.org/docs/commands/super). Feel free to
+explore other docs and try things out, but please don't be shocked if you hit
+speedbumps in the near term, particularly in areas like performance and full
+SQL coverage. We're working on it! :wink:
+
+Once you've tried it out, we'd love to hear your feedback via our
+[community Slack](https://www.brimdata.io/join-slack/). 
+
+>**NOTE:** The SuperDB query engine can run locally without a storage engine by accessing
+>files, HTTP endpoints, or S3 paths using the `super` command. While
+>[earlier in its development](https://superdb.org/docs/commands/super-db/#status),
+>SuperDB can also run on a
+>[super-structured data lake](https://superdb.org/docs/commands/super-db/#the-lake-model)
+>using the `super db` sub-commands.
 
 ### SuperDB Desktop - Coming Soon
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -15,6 +15,21 @@ without giving up JSON's uncanny ability to represent eclectic data.
 Trying out SuperDB is easy: just [install](install.md) the command-line tool
 [`super`](commands/super.md) and run through its [usage documentation](commands/super.md).
 
+{{% tip "Note" %}}
+
+The SuperDB code and docs are still under construction. Once you've
+[installed](install.md) `super` we
+recommend focusing first on the functionality shown in the
+[`super` command doc](commands/super.md). Feel free to explore other docs and
+try things out, but please don't be shocked if you hit speedbumps in the near
+term, particularly in areas like performance and full SQL coverage. We're
+working on it! 😉
+
+Once you've tried it out, we'd love to hear your feedback via
+our [community Slack](https://www.brimdata.io/join-slack/).
+
+{{% /tip %}}
+
 Compared to putting JSON data in a relational column, the
 [super-structured data model](formats/zed.md) makes it really easy to
 mash up JSON with your relational tables.  The `super` command is a little
@@ -29,7 +44,7 @@ packaged up in the easy-to-understand
 [Super JSON data format](formats/jsup.md) and
 [SuperSQL language](language/_index.md).
 
-While `super` and its accompanying data formats are production quality, the project's
+While `super` and its accompanying data formats are production quality for some use cases, the project's
 [SuperDB data lake](commands/super-db.md) is a bit earlier in development.
 
 ## Terminology

--- a/docs/commands/super.md
+++ b/docs/commands/super.md
@@ -10,6 +10,19 @@ title: super
 > [Parquet](https://github.com/apache/parquet-format), or
 > [Arrow](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format).
 
+{{% tip "Note" %}}
+
+The SuperDB code and docs are still under construction. Once you've [installed](../install.md) `super` we
+recommend focusing first on the functionality shown in this page. Feel free to
+explore other docs and try things out, but please don't be shocked if you hit
+speedbumps in the near term, particularly in areas like performance and full
+SQL coverage. We're working on it! 😉
+
+Once you've tried it out, we'd love to
+hear your feedback via our [community Slack](https://www.brimdata.io/join-slack/).
+
+{{% /tip %}}
+
 ## Usage
 
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,13 +2,30 @@
 title: Installation
 ---
 
-Several options for installing `super` are available:
+Because SuperDB is still under construction, GA releases are not yet available.
+However, you can install a build of the [`super`](https://superdb.org/docs/commands/super)
+command-line tool based on code that's under active development to start
+tinkering.
+
+Multiple options for installing `super` are available:
 * [Homebrew](#homebrew) for Mac or Linux,
-* [Binary download](#binary-download), or
 * [Build from source](#building-from-source).
 
 To install the SuperDB Python client, see the
 [Python library documentation](libraries/python.md).
+
+{{% tip "Note" %}}
+
+Once you've installed `super` we recommend focusing first on the functionality
+shown in the [`super` command doc](commands/super.md). Feel free to explore
+other docs and try things out, but please don't be shocked if you hit
+speedbumps in the near term, particularly in areas like performance and full
+SQL coverage. We're working on it! 😉
+
+Once you've tried it out, we'd love to hear your feedback via
+our [community Slack](https://www.brimdata.io/join-slack/).
+
+{{% /tip %}}
 
 ## Homebrew
 
@@ -20,19 +37,12 @@ brew install brimdata/tap/super
 
 Once installed, run a [quick test](#quick-tests).
 
-## Binary Download
-
-We offer pre-built binaries for macOS, Windows and Linux for both amd64/x86 and arm
-architectures in the super [GitHub Release page](https://github.com/brimdata/super/releases).
-
-Once the `super` binary is unpacked from a downloaded package, run a [quick test](#quick-tests).
-
 ## Building From Source
 
 If you have Go installed, you can easily build `super` from source:
 
 ```bash
-go install github.com/brimdata/super/cmd/super@latest
+go install github.com/brimdata/super/cmd/super@main
 ```
 
 This installs the `super` binary in your `$GOPATH/bin`.


### PR DESCRIPTION
As @mccanne has plans to start introducing some new audiences to SuperDB, we want to be careful in setting expectations, since those users may arrive at the project README and/or docs pages ready to tinker and we want their first impressions to be in line with the project's status. To that end, the changes in this branch adjust the tone of the README and some of the first docs pages from something like "come 'n' get it!" to something more like "try it... expect some speedbumps... we welcome your feedback".

You can see the rendered version of the key part of the README [here](https://github.com/brimdata/super/blob/setting-expectations/README.md#try-it), and the rendered change in one of the docs pages looks like the bottom box shown in this screenshot:

![image](https://github.com/user-attachments/assets/c5cc9d3e-1d51-42a0-b4d3-da52891c3ba5)

Once we've got consensus on the language used here or some adjusted variation, I plan to do two immediate follow-on changes:

1. I'd put up a PR to propose some similar adjustments in the https://superdb.org front page, as that also has a bit of "come 'n' get it!" tone at the moment.

2. I'd hide the **Releases** area circled in red in the following screenshot, since (in line with the text) we're not yet offering GA releases of SuperDB, and we don't want to confuse new users if they should stumble across the releases from the older "Zed" project from which SuperDB evolved in this same repo. We have many legacy users that still use Zed and there's links to the releases from blog articles and other web sites, and hiding that **Releases** area does _not_ disable the actual https://github.com/brimdata/super/releases page or release artifacts if the user happens to access them by URL. Indeed, at the moment we still mention the availability of the older Zed releases at https://www.brimdata.io and this approach allows the links to the various artifacts from the [Download](https://www.brimdata.io/download/) page to remain active. Perhaps at some point we may choose to separate from all history of the Zed project to eliminate any possible confusion among the new SuperDB user base. However, as we intend to help those users transition to SuperDB if possible, I believe we have consensus on the "hide" approach for now.

![image](https://github.com/user-attachments/assets/b7674479-2863-4c0d-9317-6d84ef9d7af8)
