### PR TITLE
Remove vector.Any.AppendKey and use Serialize instead

### DIFF
--- a/runtime/vam/op/summarize/agg.go
+++ b/runtime/vam/op/summarize/agg.go
@@ -39,13 +39,14 @@ type aggRow struct {
 func (s *superTable) update(keys []vector.Any, args []vector.Any) {
 	m := make(map[string][]uint32)
 	if len(keys) > 0 {
-		var keyBytes []byte
+		var b zcode.Builder
 		for slot := range keys[0].Len() {
-			keyBytes = keyBytes[:0]
+			b.Truncate()
 			for _, key := range keys {
-				keyBytes = key.AppendKey(keyBytes, slot)
+				key.Serialize(&b, slot)
 			}
-			m[string(keyBytes)] = append(m[string(keyBytes)], slot)
+			keyStr := string(b.Bytes())
+			m[keyStr] = append(m[keyStr], slot)
 		}
 	} else {
 		m[""] = nil

--- a/vector/any.go
+++ b/vector/any.go
@@ -9,7 +9,6 @@ type Any interface {
 	Type() super.Type
 	Len() uint32
 	Serialize(*zcode.Builder, uint32)
-	AppendKey([]byte, uint32) []byte
 }
 
 type Promotable interface {

--- a/vector/array.go
+++ b/vector/array.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"encoding/binary"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/zcode"
 )
@@ -39,19 +37,6 @@ func (a *Array) Serialize(b *zcode.Builder, slot uint32) {
 		a.Values.Serialize(b, off)
 	}
 	b.EndContainer()
-}
-
-func (a *Array) AppendKey(b []byte, slot uint32) []byte {
-	b = binary.NativeEndian.AppendUint64(b, uint64(a.Typ.ID()))
-	if a.Nulls.Value(slot) {
-		return append(b, 0)
-	}
-	off := a.Offsets[slot]
-	for end := a.Offsets[slot+1]; off < end; off++ {
-		b = append(b, 0)
-		b = a.Values.AppendKey(b, off)
-	}
-	return b
 }
 
 func ContainerOffset(val Any, slot uint32) (uint32, uint32, bool) {

--- a/vector/bool.go
+++ b/vector/bool.go
@@ -66,14 +66,6 @@ func (b *Bool) Serialize(builder *zcode.Builder, slot uint32) {
 	}
 }
 
-func (b *Bool) AppendKey(bytes []byte, slot uint32) []byte {
-	var v byte
-	if b.Value(slot) {
-		v = 1
-	}
-	return append(bytes, v)
-}
-
 func (b *Bool) TrueCount() uint32 {
 	if b == nil {
 		return 0

--- a/vector/bytes.go
+++ b/vector/bytes.go
@@ -45,13 +45,6 @@ func (b *Bytes) Value(slot uint32) []byte {
 	return b.Bytes[b.Offs[slot]:b.Offs[slot+1]]
 }
 
-func (b *Bytes) AppendKey(bytes []byte, slot uint32) []byte {
-	if b.Nulls.Value(slot) {
-		return append(bytes, 0)
-	}
-	return append(bytes, b.Bytes[b.Offs[slot]:b.Offs[slot+1]]...)
-}
-
 func BytesValue(val Any, slot uint32) ([]byte, bool) {
 	switch val := val.(type) {
 	case *Bytes:

--- a/vector/const.go
+++ b/vector/const.go
@@ -45,13 +45,6 @@ func (c *Const) Serialize(b *zcode.Builder, slot uint32) {
 	}
 }
 
-func (c *Const) AppendKey(bytes []byte, slot uint32) []byte {
-	if c.Nulls.Value(slot) {
-		return append(bytes, 0)
-	}
-	return append(bytes, c.val.Bytes()...)
-}
-
 func (c *Const) AsBytes() ([]byte, bool) {
 	return c.val.Bytes(), c.val.Type().ID() == super.IDBytes
 }

--- a/vector/dict.go
+++ b/vector/dict.go
@@ -29,13 +29,6 @@ func (d *Dict) Serialize(builder *zcode.Builder, slot uint32) {
 	}
 }
 
-func (d *Dict) AppendKey(bytes []byte, slot uint32) []byte {
-	if d.Nulls.Value(slot) {
-		return append(bytes, 0)
-	}
-	return d.Any.AppendKey(bytes, uint32(d.Index[slot]))
-}
-
 // RebuildDropIndex rebuilds the dictionary Index, Count and Nulls values with
 // the passed in tags removed.
 func (d *Dict) RebuildDropTags(tags ...uint32) ([]byte, []uint32, *Bool, []uint32) {

--- a/vector/dynamic.go
+++ b/vector/dynamic.go
@@ -45,7 +45,3 @@ func (d *Dynamic) Len() uint32 {
 func (d *Dynamic) Serialize(b *zcode.Builder, slot uint32) {
 	d.Values[d.Tags[slot]].Serialize(b, d.TagMap.Forward[slot])
 }
-
-func (d *Dynamic) AppendKey(b []byte, slot uint32) []byte {
-	return d.Values[d.Tags[slot]].AppendKey(b, d.TagMap.Forward[slot])
-}

--- a/vector/error.go
+++ b/vector/error.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"encoding/binary"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/zcode"
 )
@@ -36,14 +34,6 @@ func (e *Error) Serialize(b *zcode.Builder, slot uint32) {
 	}
 	e.Vals.Serialize(b, slot)
 
-}
-
-func (e *Error) AppendKey(bytes []byte, slot uint32) []byte {
-	bytes = binary.NativeEndian.AppendUint32(bytes, uint32(e.Typ.ID()))
-	if e.Nulls.Value(slot) {
-		return append(bytes, 0)
-	}
-	return e.Vals.AppendKey(bytes, slot)
 }
 
 func NewStringError(zctx *super.Context, msg string, len uint32) *Error {

--- a/vector/float.go
+++ b/vector/float.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"math"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/zcode"
 )
@@ -54,21 +52,6 @@ func (f *Float) Serialize(b *zcode.Builder, slot uint32) {
 	default:
 		panic(f.Typ)
 	}
-}
-
-func (f *Float) AppendKey(b []byte, slot uint32) []byte {
-	if f.Nulls.Value(slot) {
-		b = append(b, 0)
-	}
-	val := math.Float64bits(f.Values[slot])
-	b = append(b, byte(val>>(8*7)))
-	b = append(b, byte(val>>(8*6)))
-	b = append(b, byte(val>>(8*5)))
-	b = append(b, byte(val>>(8*4)))
-	b = append(b, byte(val>>(8*3)))
-	b = append(b, byte(val>>(8*2)))
-	b = append(b, byte(val>>(8*1)))
-	return append(b, byte(val>>(8*0)))
 }
 
 func FloatValue(vec Any, slot uint32) (float64, bool) {

--- a/vector/int.go
+++ b/vector/int.go
@@ -46,21 +46,6 @@ func (i *Int) Serialize(b *zcode.Builder, slot uint32) {
 	}
 }
 
-func (i *Int) AppendKey(b []byte, slot uint32) []byte {
-	if i.Nulls.Value(slot) {
-		b = append(b, 0)
-	}
-	val := i.Values[slot]
-	b = append(b, byte(val>>(8*7)))
-	b = append(b, byte(val>>(8*6)))
-	b = append(b, byte(val>>(8*5)))
-	b = append(b, byte(val>>(8*4)))
-	b = append(b, byte(val>>(8*3)))
-	b = append(b, byte(val>>(8*2)))
-	b = append(b, byte(val>>(8*1)))
-	return append(b, byte(val>>(8*0)))
-}
-
 func (i *Int) Promote(typ super.Type) Promotable {
 	return &Int{typ, i.Values, i.Nulls}
 }

--- a/vector/ip.go
+++ b/vector/ip.go
@@ -34,13 +34,6 @@ func (i *IP) Serialize(b *zcode.Builder, slot uint32) {
 	}
 }
 
-func (i *IP) AppendKey(b []byte, slot uint32) []byte {
-	if i.Nulls.Value(slot) {
-		return append(b, 0)
-	}
-	return super.AppendIP(b, i.Values[slot])
-}
-
 func IPValue(val Any, slot uint32) (netip.Addr, bool) {
 	switch val := val.(type) {
 	case *IP:

--- a/vector/map.go
+++ b/vector/map.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"encoding/binary"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/zcode"
 )
@@ -42,18 +40,4 @@ func (m *Map) Serialize(b *zcode.Builder, slot uint32) {
 	}
 	b.TransformContainer(super.NormalizeMap)
 	b.EndContainer()
-}
-
-func (m *Map) AppendKey(b []byte, slot uint32) []byte {
-	b = binary.NativeEndian.AppendUint64(b, uint64(m.Typ.ID()))
-	if m.Nulls.Value(slot) {
-		return append(b, 0)
-	}
-	off := m.Offsets[slot]
-	for end := m.Offsets[slot+1]; off < end; off++ {
-		b = append(b, 0)
-		b = m.Keys.AppendKey(b, off)
-		b = m.Values.AppendKey(b, off)
-	}
-	return b
 }

--- a/vector/net.go
+++ b/vector/net.go
@@ -34,13 +34,6 @@ func (n *Net) Serialize(b *zcode.Builder, slot uint32) {
 	}
 }
 
-func (n *Net) AppendKey(b []byte, slot uint32) []byte {
-	if n.Nulls.Value(slot) {
-		return append(b, 0)
-	}
-	return super.AppendNet(b, n.Values[slot])
-}
-
 func NetValue(val Any, slot uint32) (netip.Prefix, bool) {
 	switch val := val.(type) {
 	case *Net:

--- a/vector/record.go
+++ b/vector/record.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"encoding/binary"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/zcode"
 )
@@ -38,16 +36,4 @@ func (r *Record) Serialize(b *zcode.Builder, slot uint32) {
 		f.Serialize(b, slot)
 	}
 	b.EndContainer()
-}
-
-func (r *Record) AppendKey(b []byte, slot uint32) []byte {
-	b = binary.NativeEndian.AppendUint64(b, uint64(r.Typ.ID()))
-	if r.Nulls.Value(slot) {
-		return append(b, 0)
-	}
-	for _, f := range r.Fields {
-		b = append(b, 0)
-		b = f.AppendKey(b, slot)
-	}
-	return b
 }

--- a/vector/set.go
+++ b/vector/set.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"encoding/binary"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/zcode"
 )
@@ -40,17 +38,4 @@ func (s *Set) Serialize(b *zcode.Builder, slot uint32) {
 	}
 	b.TransformContainer(super.NormalizeSet)
 	b.EndContainer()
-}
-
-func (s *Set) AppendKey(b []byte, slot uint32) []byte {
-	b = binary.NativeEndian.AppendUint64(b, uint64(s.Typ.ID()))
-	if s.Nulls.Value(slot) {
-		return append(b, 0)
-	}
-	off := s.Offsets[slot]
-	for end := s.Offsets[slot+1]; off < end; off++ {
-		b = append(b, 0)
-		b = s.Values.AppendKey(b, off)
-	}
-	return b
 }

--- a/vector/string.go
+++ b/vector/string.go
@@ -46,13 +46,6 @@ func (s *String) Serialize(b *zcode.Builder, slot uint32) {
 	}
 }
 
-func (s *String) AppendKey(bytes []byte, slot uint32) []byte {
-	if s.Nulls.Value(slot) {
-		return append(bytes, 0)
-	}
-	return append(bytes, s.Bytes[s.Offsets[slot]:s.Offsets[slot+1]]...)
-}
-
 func StringValue(val Any, slot uint32) (string, bool) {
 	switch val := val.(type) {
 	case *String:

--- a/vector/type.go
+++ b/vector/type.go
@@ -46,13 +46,6 @@ func (t *TypeValue) Serialize(b *zcode.Builder, slot uint32) {
 	}
 }
 
-func (t *TypeValue) AppendKey(b []byte, slot uint32) []byte {
-	if t.Nulls.Value(slot) {
-		return append(b, 0)
-	}
-	return append(b, t.Value(slot)...)
-}
-
 func TypeValueValue(val Any, slot uint32) ([]byte, bool) {
 	switch val := val.(type) {
 	case *TypeValue:

--- a/vector/uint.go
+++ b/vector/uint.go
@@ -46,21 +46,6 @@ func (u *Uint) Serialize(b *zcode.Builder, slot uint32) {
 	}
 }
 
-func (u *Uint) AppendKey(b []byte, slot uint32) []byte {
-	if u.Nulls.Value(slot) {
-		b = append(b, 0)
-	}
-	val := u.Values[slot]
-	b = append(b, byte(val>>(8*7)))
-	b = append(b, byte(val>>(8*6)))
-	b = append(b, byte(val>>(8*5)))
-	b = append(b, byte(val>>(8*4)))
-	b = append(b, byte(val>>(8*3)))
-	b = append(b, byte(val>>(8*2)))
-	b = append(b, byte(val>>(8*1)))
-	return append(b, byte(val>>(8*0)))
-}
-
 func (u *Uint) Promote(typ super.Type) Promotable {
 	return &Uint{typ, u.Values, u.Nulls}
 }

--- a/vector/union.go
+++ b/vector/union.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"encoding/binary"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/zcode"
 )
@@ -33,14 +31,6 @@ func (u *Union) Serialize(b *zcode.Builder, slot uint32) {
 	b.Append(super.EncodeInt(int64(tag)))
 	u.Dynamic.Serialize(b, slot)
 	b.EndContainer()
-}
-
-func (u *Union) AppendKey(b []byte, slot uint32) []byte {
-	b = binary.NativeEndian.AppendUint64(b, uint64(u.Typ.ID()))
-	if u.Nulls.Value(slot) {
-		return append(b, 0)
-	}
-	return u.Dynamic.AppendKey(b, slot)
 }
 
 func Deunion(vec Any) Any {

--- a/vector/view.go
+++ b/vector/view.go
@@ -109,7 +109,3 @@ func (v *View) Len() uint32 {
 func (v *View) Serialize(b *zcode.Builder, slot uint32) {
 	v.Any.Serialize(b, v.Index[slot])
 }
-
-func (v *View) AppendKey(b []byte, slot uint32) []byte {
-	return v.Any.AppendKey(b, v.Index[slot])
-}


### PR DESCRIPTION
Const.AppendKey sometimes returns a different result from the other primitive type implementations (particularly those of Int and Uint) because it uses super.Value.Bytes internally and the others do not. This can cause the summarize operator to emit two partial values for a single group, leading to a panic in or incorrect results from runtime/vam/expr/agg.Func.ConsumeAsPartial implementations because they expect exactly one partial value per call.

Rather than fixing this, remove AppendKey and use Any.Serialize in runtime/vam/op.summarize.superTable.update instead.

Fixes #5645.