### PR TITLE
small refactor to SQL name resolution

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -50,12 +50,12 @@ func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 		id := a.semID(e)
 		if a.scope.schema != nil {
 			if this, ok := id.(*dag.This); ok {
-				path, err := a.scope.resolve(this.Path)
+				out, err := a.scope.resolve(this.Path)
 				if err != nil {
 					a.error(e, err)
 					return badExpr()
 				}
-				return &dag.This{Kind: "This", Path: path}
+				return out
 			}
 		}
 		return id
@@ -405,12 +405,12 @@ func (a *analyzer) semRegexp(b *ast.BinaryExpr) dag.Expr {
 func (a *analyzer) semBinary(e *ast.BinaryExpr) dag.Expr {
 	if path := a.semDotted(e); path != nil {
 		if a.scope.schema != nil {
-			var err error
-			path, err = a.scope.resolve(path)
+			out, err := a.scope.resolve(path)
 			if err != nil {
 				a.error(e, err)
 				return badExpr()
 			}
+			return out
 		}
 		return &dag.This{Kind: "This", Path: path}
 	}

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -553,7 +553,7 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) dag.Seq {
 	switch o := o.(type) {
 	case *ast.Select, *ast.Limit, *ast.OrderBy, *ast.SQLPipe:
 		seq, sch := a.semSQLOp(o, seq)
-		seq, _ = sch.deref(seq, "")
+		seq, _ = derefSchema(sch, "", seq)
 		return seq
 	case *ast.From:
 		seq, _ := a.semFrom(o, seq)

--- a/compiler/semantic/schema.go
+++ b/compiler/semantic/schema.go
@@ -10,12 +10,13 @@ import (
 
 type schema interface {
 	Name() string
-	resolveColumn(col string, path field.Path) (field.Path, error)
-	resolveTable(table string, path field.Path) (field.Path, error)
+	resolveColumn(col string) (field.Path, error)
+	resolveTable(table string) (schema, field.Path, error)
 	// deref adds logic to seq to yield out the value from a SQL-schema-contained
 	// value set and returns the resulting schema.  If name is non-zero, then a new
 	// schema is returned that represents the aliased table name that results.
-	deref(seq dag.Seq, name string) (dag.Seq, schema)
+	// XXX fix cmoment about name semantic
+	deref(name string) (dag.Expr, schema)
 }
 
 type staticSchema struct {
@@ -51,97 +52,104 @@ func badSchema() schema {
 	return &dynamicSchema{}
 }
 
-func (d *dynamicSchema) resolveTable(table string, path field.Path) (field.Path, error) {
-	if strings.EqualFold(d.name, table) {
-		return path, nil
+func (d *dynamicSchema) resolveTable(table string) (schema, field.Path, error) {
+	if table == "" || strings.EqualFold(d.name, table) {
+		return d, nil, nil
 	}
-	return nil, nil
+	return nil, nil, nil
 }
 
-func (*anonSchema) resolveTable(table string, path field.Path) (field.Path, error) {
-	return nil, nil
+func (a *anonSchema) resolveTable(table string) (schema, field.Path, error) {
+	if table == "" {
+		return a, nil, nil
+	}
+	return nil, nil, nil
 }
 
-func (s *staticSchema) resolveTable(table string, path field.Path) (field.Path, error) {
-	if strings.EqualFold(s.name, table) {
-		if len(path) == 0 {
-			return []string{}, nil
+func (s *staticSchema) resolveTable(table string) (schema, field.Path, error) {
+	if table == "" || strings.EqualFold(s.name, table) {
+		return s, nil, nil
+	}
+	return nil, nil, nil
+}
+
+func (s *selectSchema) resolveTable(table string) (schema, field.Path, error) {
+	if table == "" {
+		sch, path, err := s.in.resolveTable(table)
+		if sch != nil {
+			path = append([]string{"in"}, path...)
 		}
-		return s.resolveColumn(path[0], path[1:])
+		return sch, path, err
 	}
-	return nil, nil
-}
-
-func (s *selectSchema) resolveTable(table string, path field.Path) (field.Path, error) {
 	if s.out != nil {
-		target, err := s.out.resolveTable(table, path)
+		sch, path, err := s.out.resolveTable(table)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		if target != nil {
-			return append([]string{"out"}, target...), nil
+		if sch != nil {
+			return sch, append([]string{"out"}, path...), nil
 		}
 	}
-	target, err := s.in.resolveTable(table, path)
+	sch, path, err := s.in.resolveTable(table)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if target != nil {
-		return append([]string{"in"}, target...), nil
+	if sch != nil {
+		return sch, append([]string{"in"}, path...), nil
 	}
-	return nil, nil
+	return nil, nil, nil
 }
 
-func (j *joinSchema) resolveTable(table string, path field.Path) (field.Path, error) {
-	out, err := j.left.resolveTable(table, path)
-	if err != nil {
-		return nil, err
+func (j *joinSchema) resolveTable(table string) (schema, field.Path, error) {
+	if table == "" {
+		return j, nil, nil
 	}
-	if out != nil {
-		chk, err := j.right.resolveTable(table, path)
+	sch, path, err := j.left.resolveTable(table)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sch != nil {
+		chk, _, err := j.right.resolveTable(table)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if chk != nil {
-			return nil, fmt.Errorf("%q: ambiguous table reference", table)
+			return nil, nil, fmt.Errorf("%q: ambiguous table reference", table)
 		}
-		return append([]string{"left"}, out...), nil
+		return sch, append([]string{"left"}, path...), nil
 	}
-	out, err = j.right.resolveTable(table, path)
-	if err != nil {
-		return nil, err
+	sch, path, err = j.right.resolveTable(table)
+	if sch == nil || err != nil {
+		return nil, nil, err
 	}
-	if out != nil {
-		return append([]string{"right"}, out...), nil
-	}
-	return nil, nil
+	return sch, append([]string{"right"}, path...), nil
 }
 
-func (*dynamicSchema) resolveColumn(col string, path field.Path) (field.Path, error) {
-	return append([]string{col}, path...), nil
+func (*dynamicSchema) resolveColumn(col string) (field.Path, error) {
+	return field.Path{col}, nil
 }
 
-func (s *staticSchema) resolveColumn(col string, path field.Path) (field.Path, error) {
+func (s *staticSchema) resolveColumn(col string) (field.Path, error) {
 	for _, c := range s.columns {
 		if c == col {
-			return append([]string{col}, path...), nil
+			return field.Path{col}, nil
 		}
 	}
 	return nil, nil
 }
 
-func (a *anonSchema) resolveColumn(col string, path field.Path) (field.Path, error) {
+func (a *anonSchema) resolveColumn(col string) (field.Path, error) {
 	for _, c := range a.columns {
 		if c == col {
-			return append([]string{col}, path...), nil
+			return field.Path{col}, nil
 		}
 	}
 	return nil, nil
 }
 
-func (s *selectSchema) resolveColumn(col string, path field.Path) (field.Path, error) {
+func (s *selectSchema) resolveColumn(col string) (field.Path, error) {
 	if s.out != nil {
-		resolved, err := s.out.resolveColumn(col, path)
+		resolved, err := s.out.resolveColumn(col)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +157,7 @@ func (s *selectSchema) resolveColumn(col string, path field.Path) (field.Path, e
 			return append([]string{"out"}, resolved...), nil
 		}
 	}
-	resolved, err := s.in.resolveColumn(col, path)
+	resolved, err := s.in.resolveColumn(col)
 	if err != nil {
 		return nil, err
 	}
@@ -159,13 +167,13 @@ func (s *selectSchema) resolveColumn(col string, path field.Path) (field.Path, e
 	return nil, nil
 }
 
-func (j *joinSchema) resolveColumn(col string, path field.Path) (field.Path, error) {
-	out, err := j.left.resolveColumn(col, path)
+func (j *joinSchema) resolveColumn(col string) (field.Path, error) {
+	out, err := j.left.resolveColumn(col)
 	if err != nil {
 		return nil, err
 	}
 	if out != nil {
-		chk, err := j.right.resolveColumn(col, path)
+		chk, err := j.right.resolveColumn(col)
 		if err != nil {
 			return nil, err
 		}
@@ -174,7 +182,7 @@ func (j *joinSchema) resolveColumn(col string, path field.Path) (field.Path, err
 		}
 		return append([]string{"left"}, out...), nil
 	}
-	out, err = j.right.resolveColumn(col, path)
+	out, err = j.right.resolveColumn(col)
 	if err != nil {
 		return nil, err
 	}
@@ -184,25 +192,25 @@ func (j *joinSchema) resolveColumn(col string, path field.Path) (field.Path, err
 	return nil, nil
 }
 
-func (d *dynamicSchema) deref(seq dag.Seq, name string) (dag.Seq, schema) {
+func (d *dynamicSchema) deref(name string) (dag.Expr, schema) {
 	if name != "" {
 		d = &dynamicSchema{name: name}
 	}
-	return seq, d
+	return nil, d
 }
 
-func (s *staticSchema) deref(seq dag.Seq, name string) (dag.Seq, schema) {
+func (s *staticSchema) deref(name string) (dag.Expr, schema) {
 	if name != "" {
 		s = &staticSchema{name: name, columns: s.columns}
 	}
-	return seq, s
+	return nil, s
 }
 
-func (a *anonSchema) deref(seq dag.Seq, name string) (dag.Seq, schema) {
-	return seq, a
+func (a *anonSchema) deref(name string) (dag.Expr, schema) {
+	return nil, a
 }
 
-func (s *selectSchema) deref(seq dag.Seq, name string) (dag.Seq, schema) {
+func (s *selectSchema) deref(name string) (dag.Expr, schema) {
 	if name == "" {
 		// postgres and duckdb oddly do this
 		name = "unamed_subquery"
@@ -216,31 +224,35 @@ func (s *selectSchema) deref(seq dag.Seq, name string) (dag.Seq, schema) {
 		// This is a select value.
 		// XXX we should eventually have a way to propagate schema info here,
 		// e.g., record expression with fixed columns as an anonSchema.
-		outSchema = &dynamicSchema{}
+		outSchema = &dynamicSchema{name: name}
 	}
-	return append(seq, &dag.Yield{
-		Kind:  "Yield",
-		Exprs: []dag.Expr{pathOf("out")},
-	}), outSchema
+	return pathOf("out"), outSchema
 }
 
-func (j *joinSchema) deref(seq dag.Seq, name string) (dag.Seq, schema) {
+func (j *joinSchema) deref(name string) (dag.Expr, schema) {
 	// spread left/right join legs into "this"
-	e := &dag.RecordExpr{
+	return joinSpread(nil, nil), &dynamicSchema{name: name}
+}
+
+// spread left/right join legs into "this"
+func joinSpread(left, right dag.Expr) *dag.RecordExpr {
+	if left == nil {
+		left = &dag.This{Kind: "This"}
+	}
+	if right == nil {
+		right = &dag.This{Kind: "This"}
+	}
+	return &dag.RecordExpr{
 		Kind: "RecordExpr",
 		Elems: []dag.RecordElem{
 			&dag.Spread{
 				Kind: "Spread",
-				Expr: &dag.This{Kind: "This", Path: []string{"left"}},
+				Expr: left,
 			},
 			&dag.Spread{
 				Kind: "Spread",
-				Expr: &dag.This{Kind: "This", Path: []string{"right"}},
+				Expr: right,
 			},
 		},
 	}
-	return append(seq, &dag.Yield{
-		Kind:  "Yield",
-		Exprs: []dag.Expr{e},
-	}), &dynamicSchema{name: name}
 }

--- a/compiler/semantic/schema.go
+++ b/compiler/semantic/schema.go
@@ -12,10 +12,6 @@ type schema interface {
 	Name() string
 	resolveColumn(col string) (field.Path, error)
 	resolveTable(table string) (schema, field.Path, error)
-	// deref adds logic to seq to yield out the value from a SQL-schema-contained
-	// value set and returns the resulting schema.  If name is non-zero, then a new
-	// schema is returned that represents the aliased table name that results.
-	// XXX fix cmoment about name semantic
 	deref(name string) (dag.Expr, schema)
 }
 


### PR DESCRIPTION
This commit refactors the logic that performs name resolution for SQL names so that path concatenation is separated from the table/column lookups making the logic a bit more clear.  We also changed the return value of resolve() to an expression instead of path to make it more general. This will be needed by a forthcoming PR providing expression access to the "this" concept within SQL scopes.