### PR TITLE
De-Zed the Data Model doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 * Prevent the creation of multi-key pools in Zed lakes (support for this will be added later) (#4903)
 * Zed CLI help can now be invoked via `--help` and is printed to stdout instead of stderr (#4907)
 * Symbols (e.g., `const` and `type`) may no longer be redefined within the same scope (#4930)
-* [Set types](docs/formats/zed.md#23-set) can now be [sliced](docs/language/expressions.md#slices) (#4939)
+* [Set types](docs/formats/data-model.md#23-set) can now be [sliced](docs/language/expressions.md#slices) (#4939)
 * Canceled client requests to the Zed lake API are now logged at `info` level without stack traces (#4947)
 * Add support for [TSV](https://en.wikipedia.org/wiki/Tab-separated_values) input/output (useful for spreadsheet data) (#4891, #4913, #4912)
 * Add a [`grok()` function](docs/language/functions/grok.md) for parsing text lines (such as logs) into records (#4827)
@@ -100,7 +100,7 @@
 * Fix an issue where `null` values could cause [`join`](docs/language/operators/join.md) to produce incorrect output (#4801)
 * Fix a `zq` where a call to a [user-defined operator](docs/language/statements.md#operator-statements) included via `-I` could fail (#4808)
 * Fix an issue where running `zed` commands on a system with many CPU cores caused an internal error (#4826)
-* Fix an encoding issue that caused different [map values](docs/formats/zed.md#24-map) to be rendered the same in Zui (#4853)
+* Fix an encoding issue that caused different [map values](docs/formats/data-model.md#24-map) to be rendered the same in Zui (#4853)
 
 ## v1.10.0
 * Sorting is now performed automatically on [`join`](docs/language/operators/join.md) inputs when needed (explicit [`sort`](docs/language/operators/sort.md) no longer required) (#4770)
@@ -145,7 +145,7 @@
 * Add a [`load` operator](docs/language/operators/load.md) that can be invoked in a Zed pipeline to commit data to a pool (#4471)
 * Fix an issue where certain ZNG files could not be read and caused a `control` error (#4579)
 * Fix an issue where `zed serve` would exit if it tried to write to a closed socket (#4587)
-* Improve JSON output for Zed [maps](docs/formats/zed.md#24-map) (#4589)
+* Improve JSON output for Zed [maps](docs/formats/data-model.md#24-map) (#4589)
 * Add the [`zed vacuum`](docs/commands/super-db.md#vacuum) command (#4577, #4598, #4600)
 
 ## v1.7.0
@@ -171,7 +171,7 @@
 * Branch-level [meta-queries](docs/commands/super-db.md#meta-queries) on the `main` branch no longer require an explicit `@main` reference (#4377, #4394)
 * Add `-defaultfmt` flag to `zed serve` to specify the lake API's default response format (#4379, #4396)
 * Zed queries now appear in the lake log when `zed serve` is run at `-log.level debug` (#4385)
-* Fix an issue where elements of complex [named types](docs/formats/zed.md#3-named-type) could not be accessed (#4391)
+* Fix an issue where elements of complex [named types](docs/formats/data-model.md#3-named-type) could not be accessed (#4391)
 * Add docs for the [`pass` operator](docs/language/operators/pass.md) and an example of [`join` on more than two inputs](docs/tutorials/join.md#joining-more-than-two-inputs) (#4403)
 * When the result of [`summarize`](docs/language/operators/summarize.md) is a single value and there is no field name specified, the output is now that single value rather than a single-field record containing that value (#4420)
 
@@ -207,7 +207,7 @@
 * Add [`regexp()`](docs/language/functions/regexp.md) function for regular expression searches and capture groups (#4145, #4158)
 * Add [`coalesce()`](docs/language/functions/coalesce.md) function for locating non-null/non-error values (#4172)
 * Add `line` format for sourcing newline-delimited input as strings (#4175)
-* Add [`collect_map()` aggregation function](docs/language/aggregates/collect_map.md) for constructing [maps](docs/formats/zed.md#24-map) #4173
+* Add [`collect_map()` aggregation function](docs/language/aggregates/collect_map.md) for constructing [maps](docs/formats/data-model.md#24-map) #4173
 
 ## v1.2.0
 * Compress index values (#3974)

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -31,7 +31,7 @@ our [community Slack](https://www.brimdata.io/join-slack/).
 {{% /tip %}}
 
 Compared to putting JSON data in a relational column, the
-[super-structured data model](formats/zed.md) makes it really easy to
+[super-structured data model](formats/data-model.md) makes it really easy to
 mash up JSON with your relational tables.  The `super` command is a little
 like [DuckDB](https://duckdb.org/) and a little like
 [`jq`](https://stedolan.github.io/jq/) but super-structured data ties the
@@ -51,7 +51,7 @@ While `super` and its accompanying data formats are production quality for some 
 
 "Super" is an umbrella term that describes
 a number of different elements of the system:
-* The [super data model](formats/zed.md) is the abstract definition of the data types and semantics
+* The [super data model](formats/data-model.md) is the abstract definition of the data types and semantics
 that underlie the super-structured data formats.
 * The [super-structured data formats](formats/_index.md) are a family of
 [human-readable (Super JSON, JSUP)](formats/jsup.md),

--- a/docs/commands/super-db.md
+++ b/docs/commands/super-db.md
@@ -34,7 +34,7 @@ Enhanced scalability with self-tuning configuration is under development.
 A SuperDB data lake is a cloud-native arrangement of data, optimized for search,
 analytics, ETL, data discovery, and data preparation
 at scale based on data represented in accordance
-with the [super data model](../formats/zed.md).
+with the [super data model](../formats/data-model.md).
 
 A lake is organized into a collection of data pools forming a single
 administrative domain.  The current implementation supports
@@ -267,7 +267,7 @@ which is the sort key for all data stored in the lake.  Different data pools
 can have different pool keys but all of the data in a pool must have the same
 pool key.
 
-As pool data is often comprised of [records](../formats/zed.md#21-record) (analogous to JSON objects),
+As pool data is often comprised of [records](../formats/data-model.md#21-record) (analogous to JSON objects),
 the pool key is typically a field of the stored records.
 When pool data is not structured as records/objects (e.g., scalar or arrays or other
 non-record types), then the pool key would typically be configured

--- a/docs/commands/super.md
+++ b/docs/commands/super.md
@@ -44,7 +44,7 @@ check out the [`super db`](super-db.md) set of commands.
 By invoking the `-c` option, a query expressed in the [SuperSQL language](../language/_index.md)
 may be specified and applied to the input stream.
 
-The [super data model](../formats/zed.md) is based on [super-structured data](../formats/_index.md#2-a-super-structured-pattern), meaning that all data
+The [super data model](../formats/data-model.md) is based on [super-structured data](../formats/_index.md#2-a-super-structured-pattern), meaning that all data
 is both strongly _and_ dynamically typed and need not conform to a homogeneous
 schema.  The type structure is self-describing so it's easy to daisy-chain
 queries and inspect data at any point in a complex query or data pipeline.
@@ -447,8 +447,8 @@ world
 ```
 
 In `text` output, minimal formatting is applied, e.g., strings are shown
-without quotes and brackets are dropped from [arrays](../formats/zed.md#22-array)
-and [sets](../formats/zed.md#23-set). [Records](../formats/zed.md#21-record)
+without quotes and brackets are dropped from [arrays](../formats/data-model.md#22-array)
+and [sets](../formats/data-model.md#23-set). [Records](../formats/data-model.md#21-record)
 are printed as tab-separated field values without their corresponding field
 names. For example:
 

--- a/docs/formats/_index.md
+++ b/docs/formats/_index.md
@@ -6,7 +6,7 @@ weight: 5
 > **TL;DR** The super data model defines a new and easy way to manage, store,
 > and process data utilizing an emerging concept called
 [super-structured data](#2-a-super-structured-pattern).
-> The [data model specification](zed.md) defines the high-level model that is realized
+> The [data model specification](data-model.md) defines the high-level model that is realized
 > in a [family of interoperable serialization formats](#3-the-data-model-and-formats),
 > providing a unified approach to row, columnar, and human-readable formats. Together these
 > represent a superset of both the dataframe/table model of relational systems and the
@@ -264,7 +264,7 @@ can be debugged by observing the location of errors in the output results.
 ## 3. The Data Model and Formats
 
 The concept of super-structured data and first-class types and errors
-is solidified in the [data model specification](zed.md),
+is solidified in the [data model specification](data-model.md),
 which defines the model but not the serialization formats.
 
 A set of companion documents define a family of tightly integrated

--- a/docs/formats/bsup.md
+++ b/docs/formats/bsup.md
@@ -7,7 +7,7 @@ heading: Super Binary Specification
 ## 1. Introduction
 
 Super Binary is an efficient, sequence-oriented serialization format for any data
-conforming to the [super data model](zed.md).
+conforming to the [super data model](data-model.md).
 
 Super Binary is "row oriented" and
 analogous to [Apache Avro](https://avro.apache.org) but does not
@@ -313,7 +313,7 @@ existing type ID `<type-id>`.  `<type-id>` is encoded as a `uvarint` and `<name>
 is encoded as a `uvarint` representing the length of the name in bytes,
 followed by that many bytes of UTF-8 string.
 
-As indicated in the [data model](zed.md),
+As indicated in the [data model](data-model.md),
 it is an error to define a type name that has the same name as a primitive type,
 and it is permissible to redefine a previously defined type name with a
 type that differs from the previous definition.

--- a/docs/formats/csup.md
+++ b/docs/formats/csup.md
@@ -5,7 +5,7 @@ heading: Super Columnar Specification
 ---
 
 Super Columnar is a file format based on
-the [super data model](zed.md) where data is stacked to form columns.
+the [super data model](data-model.md) where data is stacked to form columns.
 Its purpose is to provide for efficient analytics and search over
 bounded-length sequences of [super-structured data](./_index.md#2-a-super-structured-pattern) that is stored in columnar form.
 
@@ -78,7 +78,7 @@ merging them together (or even leaving the Super Columnar entity as separate fil
 The data section contains raw data values organized into _segments_,
 where a segment is a seek offset and byte length relative to the
 data section.  Each segment contains a sequence of
-[primitive-type values](zed.md#1-primitive-types),
+[primitive-type values](data-model.md#1-primitive-types),
 encoded as counted-length byte sequences where the counted-length is
 variable-length encoded as in the [Super Binary specification](bsup.md).
 Segments may be compressed.

--- a/docs/formats/data-model.md
+++ b/docs/formats/data-model.md
@@ -102,7 +102,7 @@ is distinct from type `{b:string,a:string}`.
 
 A field name is any UTF-8 string.
 
-A field value is any value of any type.
+A field value is a value of any type.
 
 In contrast to many schema-oriented data formats, the super data model has no way to specify
 a field as "optional" since any field value can be a null value.

--- a/docs/formats/data-model.md
+++ b/docs/formats/data-model.md
@@ -3,7 +3,7 @@ weight: 1
 title: Data Model
 ---
 
-Zed data is defined as an ordered sequence of one or more typed data values.
+Super-structured data is defined as an ordered sequence of one or more typed data values.
 Each value's type is either a "primitive type", a "complex type", the "type type",
 a "named type", or the "null type".
 
@@ -45,29 +45,33 @@ There are 30 types of primitive values with syntax defined as follows:
 | `string`   | a UTF-8 string |
 | `ip`       | an IPv4 or IPv6 address |
 | `net`      | an IPv4 or IPv6 address and net mask |
-| `type`     | a Zed type value |
+| `type`     | a type value |
 | `null`     | the null type |
 
-The _type_ type  provides for first-class types and even though a type value can
+The _type_ type  provides for first-class types. Even though a type value can
 represent a complex type, the value itself is a singleton.
 
 Two type values are equivalent if their underlying types are equal.  Since
-every type in the Zed type system is uniquely defined, type values are equal
+every type in the type system is uniquely defined, type values are equal
 if and only if their corresponding types are uniquely equal.
 
 The _null_ type is a primitive type representing only a `null` value.
 A `null` value can have any type.
 
-> Note that `time` values correspond to 64-bit epoch nanoseconds and thus
-> not every valid RFC 3339 date and time string represents a valid Zed time.
-> In addition, nanosecond epoch times overflow on April 11, 2262.
-> For the world of 2262, a new epoch can be created well in advance
-> and the old time epoch and new time epoch can live side by side with
-> the old using a named type for the new epoch time referring to the old `time`.
-> An app that wants more than 64 bits of timestamp precision can always use
-> a named type of a `bytes` type and do its own conversions to and from the
-> corresponding bytes values.  A time with a local time zone can be represented
-> as a Zed record of a time field and a zone field
+{{% tip "Note" %}}
+
+`time` values correspond to 64-bit epoch nanoseconds and thus
+not every valid RFC 3339 date and time string represents a valid time.
+In addition, nanosecond epoch times overflow on April 11, 2262.
+For the world of 2262, a new epoch can be created well in advance
+and the old time epoch and new time epoch can live side by side with
+the old using a [named type](#3-named-type) for the new epoch time referring to the old `time`.
+An app that wants more than 64 bits of timestamp precision can always use
+a named type of a `bytes` type and do its own conversions to and from the
+corresponding bytes values.  A time with a local time zone can be represented
+as a record of a `time` field and a zone field.
+
+{{% /tip %}}
 
 ## 2. Complex Types
 
@@ -98,9 +102,9 @@ is distinct from type `{b:string,a:string}`.
 
 A field name is any UTF-8 string.
 
-A field value is any Zed value.
+A field value is any value of any type.
 
-In contrast to many schema-oriented data formats, Zed has no way to specify
+In contrast to many schema-oriented data formats, the super data model has no way to specify
 a field as "optional" since any field value can be a null value.
 
 If an instance of a record value omits a value
@@ -117,8 +121,8 @@ The type order of two records is as follows:
 
 ### 2.2 Array
 
-An array is an ordered sequence of zero or more Zed values called "elements"
-all conforming to the same Zed type.
+An array is an ordered sequence of zero or more values called "elements"
+all conforming to the same type.
 
 An array value may be empty.  An empty array may have element type `null`.
 
@@ -127,18 +131,18 @@ An array type is uniquely defined by its single element type.
 The type order of two arrays is defined as the type order of the
 two array element types.
 
-> Note that mixed-type JSON arrays are representable as a Zed array with
-> elements of type union.
+An array of mixed-type values (such a mixed-type JSON array) is representable
+as an array with elements of type `union`.
 
 ### 2.3 Set
 
-A set is an unordered sequence of zero or more Zed values called "elements"
-all conforming to the same Zed type.
+A set is an unordered sequence of zero or more values called "elements"
+all conforming to the same type.
 
 A set may be empty.  An empty set may have element type `null`.
 
-A set of mixed-type values is representable as a Zed set with
-elements of type union.
+A set of mixed-type values is representable as a set with
+elements of type `union`.
 
 A set type is uniquely defined by its single element type.
 
@@ -148,7 +152,7 @@ two set element types.
 ### 2.4 Map
 
 A map represents a list of zero or more key-value pairs, where the keys
-have a common Zed type and the values have a common Zed type.
+have a common type and the values have a common type.
 
 Each key across an instance of a map value must be a unique value.
 
@@ -163,10 +167,10 @@ The type order of two map types is as follows:
 ### 2.5 Union
 
 A union represents a value that may be any one of a specific enumeration
-of two or more unique Zed types that comprise its "union type".
+of two or more unique data types that comprise its "union type".
 
 A union type is uniquely defined by an ordered set of unique types (which may be
-other union types) where the order corresponds to the Zed type system's total order.
+other union types) where the order corresponds to the type system's total order.
 
 Union values are tagged in that
 any instance of a union value explicitly conforms to exactly one of the union's types.
@@ -200,7 +204,7 @@ The type order of an error is the type order of the type of its contained value.
 
 ## 3. Named Type
 
-A _named type_ is a name for a specific Zed type.
+A _named type_ is a name for a specific data type.
 Any value can have a named type and the named type is a distinct type
 from the underlying type.  A named type can refer to another named type.
 
@@ -218,21 +222,25 @@ exceptions:
 * A named type is ordered after its underlying type.
 * Named types sharing an underlying type are ordered lexicographically by name.
 
-> While the Zed data model does not include explicit support for schema versioning,
-> named types provide a flexible mechanism to implement versioning
-> on top of the Zed serialization formats.  For example, a Zed-based system
-> could define a naming convention of the form `<type>.<version>`
-> where `<type>` is the type name of a record representing the schema
-> and `<version>` is a decimal string indicating the version of that schema.
-> Since types need only be parsed once per stream
-> in the Zed binary serialization formats, a Zed type implementation could
-> efficiently support schema versioning using such a convention.
+{{% tip "Note" %}}
+
+While the data model does not include explicit support for schema versioning,
+named types provide a flexible mechanism to implement versioning
+on top of the super-structured serialization formats.  For example, a system
+could define a naming convention of the form `<type>.<version>`
+where `<type>` is the type name of a record representing the schema
+and `<version>` is a decimal string indicating the version of that schema.
+Since types need only be parsed once per stream
+in the serialization formats, a super-structured type implementation could
+efficiently support schema versioning using such a convention.
+
+{{% /tip %}}
 
 ## 4. Null Values
 
-All Zed types have a null representation.  It is up to an
+All data types have a null representation.  It is up to an
 implementation to decide how external data structures map into and
 out of values with nulls.  Typically, a null value is either the
 zero value or, in the case of record fields, an optional field whose
 value is not present, though these semantics are not explicitly
-defined by the Zed data model.
+defined by the super data model.

--- a/docs/formats/jsup.md
+++ b/docs/formats/jsup.md
@@ -7,7 +7,7 @@ heading: Super JSON Specification
 ## 1. Introduction
 
 Super JSON is the human-readable, text-based serialization format of
-the [super data model](zed.md).
+the [super data model](data-model.md).
 
 Super JSON builds upon the elegant simplicity of JSON with "type decorators".
 Where the type of a value is not implied by its syntax, a parenthesized
@@ -90,7 +90,7 @@ same name, from the case that an existing named type is merely decorating the va
 ### 2.3 Primitive Values
 
 The type names and format for
-[primitive values](zed.md#1-primitive-types) is as follows:
+[primitive values](data-model.md#1-primitive-types) is as follows:
 
 | Type       | Value Format                                                  |
 |------------|---------------------------------------------------------------|
@@ -225,13 +225,13 @@ record types as well as enum symbols.
 
 Complex values are built from primitive values and/or other complex values
 and conform to the super data model's complex types:
-[record](zed.md#21-record),
-[array](zed.md#22-array),
-[set](zed.md#23-set),
-[map](zed.md#24-map),
-[union](zed.md#25-union),
-[enum](zed.md#26-enum), and
-[error](zed.md#27-error).
+[record](data-model.md#21-record),
+[array](data-model.md#22-array),
+[set](data-model.md#23-set),
+[map](data-model.md#24-map),
+[union](data-model.md#25-union),
+[enum](data-model.md#26-enum), and
+[error](data-model.md#27-error).
 
 Complex values have an implied type when their constituent values all have
 implied types.

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -6,7 +6,7 @@ heading: ZJSON Specification
 
 ## 1. Introduction
 
-The [super data model](zed.md)
+The [super data model](data-model.md)
 is based on richly typed records with a deterministic field order,
 as is implemented by the [Super JSON](jsup.md), [Super Binary](bsup.md), and [Super Columnar](csup.md) formats.
 Given the ubiquity of JSON, it is desirable to also be able to serialize
@@ -92,7 +92,7 @@ The type and value fields are encoded as defined below.
 
 ### 2.1 Type Encoding
 
-The type encoding for a primitive type is simply its [type name](zed.md#1-primitive-types)
+The type encoding for a primitive type is simply its [type name](data-model.md#1-primitive-types)
 e.g., "int32" or "string".
 
 Complex types are encoded with small-integer identifiers.

--- a/docs/integrations/fluentd.md
+++ b/docs/integrations/fluentd.md
@@ -190,7 +190,7 @@ produced the following response:
 ## Shaping Example
 
 The query result just shown reflects the minimal data typing available in JSON
-format. Meanwhile, the [Zed data model](../formats/zed.md) provides much
+format. Meanwhile, the [Zed data model](../formats/data-model.md) provides much
 richer data typing options, including some types well-suited to Zeek data such
 as `ip`, `time`, and `duration`. In Zed, the task of cleaning up data to
 improve its typing is known as [shaping](../language/shaping.md).

--- a/docs/integrations/zeek/data-type-compatibility.md
+++ b/docs/integrations/zeek/data-type-compatibility.md
@@ -3,7 +3,7 @@ weight: 2
 title: Zed/Zeek Data Type Compatibility
 ---
 
-As the [super data model](../../formats/zed.md) was in many ways inspired by the
+As the [super data model](../../formats/data-model.md) was in many ways inspired by the
 [Zeek TSV log format](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs),
 SuperDB's rich storage formats ([Super JSON](../../formats/jsup.md),
 [Super Binary](../../formats/bsup.md), etc.) maintain comprehensive interoperability
@@ -34,20 +34,20 @@ applicable to handling certain types.
 
 | Zeek Type  | Zed Type   | Additional Detail |
 |------------|------------|-------------------|
-| [`bool`](https://docs.zeek.org/en/current/script-reference/types.html#type-bool)         | [`bool`](../../formats/zed.md#1-primitive-types)     | |
-| [`count`](https://docs.zeek.org/en/current/script-reference/types.html#type-count)       | [`uint64`](../../formats/zed.md#1-primitive-types)   | |
-| [`int`](https://docs.zeek.org/en/current/script-reference/types.html#type-int)           | [`int64`](../../formats/zed.md#1-primitive-types)    | |
-| [`double`](https://docs.zeek.org/en/current/script-reference/types.html#type-double)     | [`float64`](../../formats/zed.md#1-primitive-types)  | See [`double` details](#double) |
-| [`time`](https://docs.zeek.org/en/current/script-reference/types.html#type-time)         | [`time`](../../formats/zed.md#1-primitive-types)     | |
-| [`interval`](https://docs.zeek.org/en/current/script-reference/types.html#type-interval) | [`duration`](../../formats/zed.md#1-primitive-types) | |
-| [`string`](https://docs.zeek.org/en/current/script-reference/types.html#type-string)     | [`string`](../../formats/zed.md#1-primitive-types)   | See [`string` details about escaping](#string) |
-| [`port`](https://docs.zeek.org/en/current/script-reference/types.html#type-port)         | [`uint16`](../../formats/zed.md#1-primitive-types)   | See [`port` details](#port) |
-| [`addr`](https://docs.zeek.org/en/current/script-reference/types.html#type-addr)         | [`ip`](../../formats/zed.md#1-primitive-types)       | |
-| [`subnet`](https://docs.zeek.org/en/current/script-reference/types.html#type-subnet)     | [`net`](../../formats/zed.md#1-primitive-types)      | |
-| [`enum`](https://docs.zeek.org/en/current/script-reference/types.html#type-enum)         | [`string`](../../formats/zed.md#1-primitive-types)   | See [`enum` details](#enum) |
-| [`set`](https://docs.zeek.org/en/current/script-reference/types.html#type-set)           | [`set`](../../formats/zed.md#23-set)                 | See [`set` details](#set) |
-| [`vector`](https://docs.zeek.org/en/current/script-reference/types.html#type-vector)     | [`array`](../../formats/zed.md#22-array              | |
-| [`record`](https://docs.zeek.org/en/current/script-reference/types.html#type-record)     | [`record`](../../formats/zed.md#21-record            | See [`record` details](#record) |
+| [`bool`](https://docs.zeek.org/en/current/script-reference/types.html#type-bool)         | [`bool`](../../formats/data-model.md#1-primitive-types)     | |
+| [`count`](https://docs.zeek.org/en/current/script-reference/types.html#type-count)       | [`uint64`](../../formats/data-model.md#1-primitive-types)   | |
+| [`int`](https://docs.zeek.org/en/current/script-reference/types.html#type-int)           | [`int64`](../../formats/data-model.md#1-primitive-types)    | |
+| [`double`](https://docs.zeek.org/en/current/script-reference/types.html#type-double)     | [`float64`](../../formats/data-model.md#1-primitive-types)  | See [`double` details](#double) |
+| [`time`](https://docs.zeek.org/en/current/script-reference/types.html#type-time)         | [`time`](../../formats/data-model.md#1-primitive-types)     | |
+| [`interval`](https://docs.zeek.org/en/current/script-reference/types.html#type-interval) | [`duration`](../../formats/data-model.md#1-primitive-types) | |
+| [`string`](https://docs.zeek.org/en/current/script-reference/types.html#type-string)     | [`string`](../../formats/data-model.md#1-primitive-types)   | See [`string` details about escaping](#string) |
+| [`port`](https://docs.zeek.org/en/current/script-reference/types.html#type-port)         | [`uint16`](../../formats/data-model.md#1-primitive-types)   | See [`port` details](#port) |
+| [`addr`](https://docs.zeek.org/en/current/script-reference/types.html#type-addr)         | [`ip`](../../formats/data-model.md#1-primitive-types)       | |
+| [`subnet`](https://docs.zeek.org/en/current/script-reference/types.html#type-subnet)     | [`net`](../../formats/data-model.md#1-primitive-types)      | |
+| [`enum`](https://docs.zeek.org/en/current/script-reference/types.html#type-enum)         | [`string`](../../formats/data-model.md#1-primitive-types)   | See [`enum` details](#enum) |
+| [`set`](https://docs.zeek.org/en/current/script-reference/types.html#type-set)           | [`set`](../../formats/data-model.md#23-set)                 | See [`set` details](#set) |
+| [`vector`](https://docs.zeek.org/en/current/script-reference/types.html#type-vector)     | [`array`](../../formats/data-model.md#22-array              | |
+| [`record`](https://docs.zeek.org/en/current/script-reference/types.html#type-record)     | [`record`](../../formats/data-model.md#21-record            | See [`record` details](#record) |
 
 {{% tip "Note" %}}
 
@@ -153,7 +153,7 @@ formats (should they exist) may handle these differently.
 
 Multiple Zeek types discussed below are represented via a
 [type definition](../../formats/jsup.md#22-type-decorators) to one of Zed's
-[primitive types](../../formats/zed.md#1-primitive-types). The Zed type
+[primitive types](../../formats/data-model.md#1-primitive-types). The Zed type
 definitions maintain the history of the field's original Zeek type name
 such that `zq` may restore it if the field is later output in
 Zeek TSV format. Knowledge of its original Zeek type may also enable special
@@ -206,7 +206,7 @@ _not_ intended to be read or presented as such. Meanwhile, another Zeek
 UTF-8. These details are currently only captured within the Zeek source code
 itself that defines how these values are generated.
 
-Zed includes a [primitive type](../../formats/zed.md#1-primitive-types)
+Zed includes a [primitive type](../../formats/data-model.md#1-primitive-types)
 called `bytes` that's suited to storing the former "always binary" case and a
 `string` type for the latter "always printable" case. However, Zeek logs do
 not currently communicate details that would allow an implementation to know

--- a/docs/integrations/zeek/reading-zeek-log-formats.md
+++ b/docs/integrations/zeek/reading-zeek-log-formats.md
@@ -72,7 +72,7 @@ and therefore such records typically need no adjustment to their data types
 once they've been read in as is. The
 [Zed/Zeek Data Type Compatibility](data-type-compatibility.md) document
 provides further detail on how the rich data types in Zeek TSV map to the
-equivalent [rich types in Zed](../../formats/zed.md#1-primitive-types).
+equivalent [rich types in Zed](../../formats/data-model.md#1-primitive-types).
 
 ## Zeek JSON
 

--- a/docs/language/data-types.md
+++ b/docs/language/data-types.md
@@ -4,7 +4,7 @@ title: Data Types
 ---
 
 The SuperPipe language includes most data types of a typical programming language
-as defined in the [super data model](../formats/zed.md).
+as defined in the [super data model](../formats/data-model.md).
 
 The syntax of individual literal values generally follows
 the [Super JSON syntax](../formats/jsup.md) with the exception that
@@ -25,7 +25,7 @@ As in the super data model, the SuperPipe language has first-class types:
 any type may be used as a value.
 
 The primitive types are listed in the
-[data model specification](../formats/zed.md#1-primitive-types)
+[data model specification](../formats/data-model.md#1-primitive-types)
 and have the same syntax in SuperPipe.  Complex types also follow
 the Super JSON syntax.  Note that the type of a type value is simply `type`.
 
@@ -220,7 +220,7 @@ to work.
 ## First-class Errors
 
 As with types, errors in SuperPipe are first-class: any value can be transformed
-into an error by wrapping it in an [`error` type](../formats/zed.md#27-error).
+into an error by wrapping it in an [`error` type](../formats/data-model.md#27-error).
 
 In general, expressions and functions that result in errors simply return
 a value of type `error` as a result.  This encourages a powerful flow-style

--- a/docs/language/functions/_index.md
+++ b/docs/language/functions/_index.md
@@ -9,7 +9,7 @@ the built-in functions listed below, Zed also allows for the creation of
 [user-defined functions](../statements.md#func-statements).
 
 A function-style syntax is also available for converting values to each of
-Zed's [primitive types](../../formats/zed.md#1-primitive-types), e.g.,
+Zed's [primitive types](../../formats/data-model.md#1-primitive-types), e.g.,
 `uint8()`, `time()`, etc. For details and examples, read about the
 [`cast` function](cast.md) and how it is [used in expressions](../expressions.md#casts).
 

--- a/docs/language/functions/cast.md
+++ b/docs/language/functions/cast.md
@@ -11,8 +11,8 @@ cast(val: any, name: string) -> any
 
 ### Description
 
-The _cast_ function performs type casts but handles both [primitive types](../../formats/zed.md#1-primitive-types) and
-[complex types](../../formats/zed.md#2-complex-types).  If the input type `t` is a primitive type, then the result
+The _cast_ function performs type casts but handles both [primitive types](../../formats/data-model.md#1-primitive-types) and
+[complex types](../../formats/data-model.md#2-complex-types).  If the input type `t` is a primitive type, then the result
 is equivalent to
 ```
 t(val)

--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -17,7 +17,7 @@ However, in Zed, the entities that transform data are called
 "[operators](operators/_index.md)" instead of "commands" and unlike Unix pipelines,
 the streams of data in a Zed query
 are typed data sequences that adhere to the
-[Zed data model](../formats/zed.md).
+[Zed data model](../formats/data-model.md).
 Moreover, Zed sequences can be forked and joined:
 ```
 operator

--- a/docs/language/pipeline-model.md
+++ b/docs/language/pipeline-model.md
@@ -162,7 +162,7 @@ sort lower(this)
 A common SuperPipe use case is to process sequences of record-oriented data
 (e.g., arising from formats like JSON or Avro) in the form of events
 or structured logs.  In this case, the input values to the operators
-are [records](../formats/zed.md#21-record) and the fields of a record are referenced with the dot operator.
+are [records](../formats/data-model.md#21-record) and the fields of a record are referenced with the dot operator.
 
 For example, if the input above were a sequence of records instead of strings
 and perhaps contained a second field, then we could refer to the field `s`

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -25,7 +25,7 @@ as well as [`jq`](https://stedolan.github.io/jq/).
 
 ## But JSON
 
-While `super` is based on a new type of [data model](../formats/zed.md),
+While `super` is based on a new type of [data model](../formats/data-model.md),
 Zed just so happens to be a superset of JSON.
 
 So if all you ever use `zq` for is manipulating JSON data,
@@ -210,7 +210,7 @@ produces
 
 ## Comprehensive Types
 
-ZSON also has a [comprehensive type system](../formats/zed.md).
+ZSON also has a [comprehensive type system](../formats/data-model.md).
 
 For example, here is ZSON "record" with a taste of different types
 of values as record fields:


### PR DESCRIPTION
## tl;dr

Recent adjustments to the [superdb.org](https://superdb.org/) web site led me to link to the Data Model page, which made me confront that it's ready for the de-Zed-ification I've done here. I did a bit of other clean-up along the way.

## Details

I intentionally avoided ever saying "SuperDB", since even though we only be the full implementation of this stuff, I assume we want things like the Data Model to read as independent from any single implementation.