### PR TITLE
Exclude unused bits in vector.Bool.TrueCount

### DIFF
--- a/vector/bool.go
+++ b/vector/bool.go
@@ -74,6 +74,11 @@ func (b *Bool) TrueCount() uint32 {
 	for _, bs := range b.Bits {
 		n += uint32(bits.OnesCount64(bs))
 	}
+	if numTailBits := b.Len() % 64; numTailBits > 0 {
+		mask := ^uint64(0) << numTailBits
+		unusedBits := b.Bits[len(b.Bits)-1] & mask
+		n -= uint32(bits.OnesCount64(unusedBits))
+	}
 	return n
 }
 

--- a/vector/bool_test.go
+++ b/vector/bool_test.go
@@ -1,0 +1,18 @@
+package vector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoolTrueCount(t *testing.T) {
+	assert.EqualValues(t, 0, (*Bool)(nil).TrueCount())
+	bits := []uint64{0xff}
+	assert.EqualValues(t, 1, NewBool(bits, 1, nil).TrueCount())
+	assert.EqualValues(t, 8, NewBool(bits, 64, nil).TrueCount())
+	bits = []uint64{0xff, 0xff << 56}
+	assert.EqualValues(t, 8, NewBool(bits, 65, nil).TrueCount())
+	assert.EqualValues(t, 15, NewBool(bits, 127, nil).TrueCount())
+	assert.EqualValues(t, 16, NewBool(bits, 128, nil).TrueCount())
+}


### PR DESCRIPTION
TrueCount counts any ones in the unused bits of Bool.Bits' final word. Exclude those.

This accounts for part of the discrepancy in #5530.