### PR TITLE
vam: Fix filters on true bool values marked null

### DIFF
--- a/runtime/vam/expr/conditional.go
+++ b/runtime/vam/expr/conditional.go
@@ -102,23 +102,18 @@ func boolMaskRidx(ridx []uint32, bools, errs *roaring.Bitmap, vec vector.Any) {
 			}
 		}
 	case *vector.Bool:
+		trues := vec
+		if vec.Nulls != nil {
+			// if null and true set to false
+			trues = vector.And(trues, vector.Not(vec.Nulls))
+		}
 		if ridx != nil {
-			trues := vec
-			if vec.Nulls != nil {
-				// if null and true set to false
-				trues = vector.And(trues, vector.Not(vec.Nulls))
-			}
 			for i, idx := range ridx {
 				if trues.Value(uint32(i)) {
 					bools.Add(idx)
 				}
 			}
 		} else {
-			trues := vec
-			if vec.Nulls != nil {
-				// if null and true set to false
-				trues = vector.And(trues, vector.Not(vec.Nulls))
-			}
 			bools.Or(roaring.FromDense(trues.Bits, true))
 		}
 	case *vector.Error:


### PR DESCRIPTION
This commit fixes an issue with filters in the vector runtime where boolean vectors where null values that were also set to true were not getting filtered as they should.

Closes #5679