### PR TITLE
Fix links that broke due to zui#3182

### DIFF
--- a/docs/formats/_index.md
+++ b/docs/formats/_index.md
@@ -280,7 +280,7 @@ values.
 embodies the super data model for heterogeneous and self-describing schemas.
 * [Super JSON over JSON](zjson.md) defines a format for encapsulating Super JSON
 inside plain JSON for easy decoding by JSON-based clients, e.g.,
-the [JavaScript library used by SuperDB Desktop](https://github.com/brimdata/zui/tree/main/packages/zed-js)
+the [JavaScript library used by SuperDB Desktop](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 and the [SuperDB Python library](../libraries/python.md).
 
 Because all of the formats conform to the same super data model, conversions between

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -64,7 +64,7 @@ sufficient for the [super-structured data model](./_index.md#2-a-super-structure
 That said, JSON can be used as an encoding format for super data with another layer
 of encoding on top of a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Super JSON and, with the help of client
-libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/zed-js),
+libraries like [superdb-types](https://github.com/brimdata/zui/tree/main/packages/superdb-types),
 to manipulate the rich, structured Super JSON types that are implemented on top of
 the basic JavaScript types.
 

--- a/docs/libraries/javascript.md
+++ b/docs/libraries/javascript.md
@@ -3,12 +3,12 @@ weight: 2
 title: JavaScript
 ---
 
-The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
-provides support for the Zed data model from within
-JavaScript as well as methods for communicating with a Zed lake.
+The [superdb-types library](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
+provides support for the super data model from within
+JavaScript as well as methods for communicating with a SuperDB data lake.
 
-Because JavaScript's native type system is limtied, zed-js provides
-implementations for each of Zed's primitive types as well as
+Because JavaScript's native type system is limited, superdb-types provides
+implementations for each of the super data model's primitive types as well as
 technique for interpreting and/or constructing arbitrary complex types.
 
 ## Installation


### PR DESCRIPTION
The changes in https://github.com/brimdata/zui/pull/3182 renamed the "zed-js" JavaScript library to "superdb-types", and that broke some links in the SuperDB docs. This PR fixes those links.
