### PR TITLE
Optimize by inlining record expression spreads

### DIFF
--- a/compiler/ztests/inline-record-expr-spreads.yaml
+++ b/compiler/ztests/inline-record-expr-spreads.yaml
@@ -1,0 +1,9 @@
+script: |
+  super compile -C -O 'yield {...{a}}, {...{...{b}}}'
+
+outputs:
+  - name: stdout
+    data: |
+      null
+      | yield {a:a}, {b:b}
+      | output main

--- a/compiler/ztests/merge-yields.yaml
+++ b/compiler/ztests/merge-yields.yaml
@@ -2,6 +2,8 @@ script: |
   super compile -C -O 'yield {a:1} | yield a, {b:a}'
   echo ===
   super compile -C -O 'yield {...a} | yield {...b.c} | yield d, {e}'
+  echo ===
+  super compile -C -O 'yield {a:{b:1}} | yield {a:{...a,c:2}} | yield {a:{...a,d:3}}'
 
 outputs:
   - name: stdout
@@ -12,4 +14,8 @@ outputs:
       ===
       null
       | yield a.b.c.d, {e:a.b.c.e}
+      | output main
+      ===
+      null
+      | yield {a:{b:1,c:2,d:3}}
       | output main


### PR DESCRIPTION
Optimize queries by inlining spreads of record expressions inside other record expressions so that, e.g., "{...{a}}" becomes "{a}".