### PR TITLE
Recognize dag.RecordExpr in compiler/optimizer.addPathToExpr

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -146,10 +146,10 @@ func walkEntries(seq dag.Seq, post func(dag.Seq) (dag.Seq, error)) (dag.Seq, err
 // source's pushdown predicate.  This should be called before ParallelizeScan().
 // TBD: we need to do pushdown for search/cut to optimize columnar extraction.
 func (o *Optimizer) Optimize(seq dag.Seq) (dag.Seq, error) {
+	seq = liftFilterOps(seq)
 	seq = mergeFilters(seq)
 	seq = mergeYieldOps(seq)
 	seq = inlineRecordExprSpreads(seq)
-	seq = liftFilterOps(seq)
 	seq = removePassOps(seq)
 	o.optimizeParallels(seq)
 	seq = mergeFilters(seq)

--- a/compiler/ztests/lift-filters.yaml
+++ b/compiler/ztests/lift-filters.yaml
@@ -1,0 +1,24 @@
+script: |
+  super compile -C -O 'yield {a:b} | where a==1'
+  echo ===
+  super compile -C -O 'yield {...a} | where b==1'
+  echo ===
+  super compile -C -O 'yield {a:{b:c}} | where a.b==1'
+
+outputs:
+  - name: stdout
+    data: |
+      null
+      | where b==1
+      | yield {a:b}
+      | output main
+      ===
+      null
+      | where a.b==1
+      | yield {...a}
+      | output main
+      ===
+      null
+      | where {b:c}[b]==1
+      | yield {a:{b:c}}
+      | output main

--- a/compiler/ztests/lift-filters.yaml
+++ b/compiler/ztests/lift-filters.yaml
@@ -19,6 +19,6 @@ outputs:
       | output main
       ===
       null
-      | where {b:c}[b]==1
+      | where c==1
       | yield {a:{b:c}}
       | output main


### PR DESCRIPTION
addPathToExpr can produce expressions like "{a:b}[a]".  Recognize dag.RecordExpr in it so it produces the simpler expression "a" instead.