### PR TITLE
Fix bug merging adjacent yields with non-initial spread

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -500,6 +500,7 @@ func inlineRecordExprSpreads(seq dag.Seq) dag.Seq {
 
 func mergeYieldOps(seq dag.Seq) dag.Seq {
 	return walk(seq, true, func(seq dag.Seq) dag.Seq {
+	Loop:
 		for i := 0; i+1 < len(seq); i++ {
 			y1, ok1 := seq[i].(*dag.Yield)
 			y2, ok2 := seq[i+1].(*dag.Yield)
@@ -512,11 +513,14 @@ func mergeYieldOps(seq dag.Seq) dag.Seq {
 			}
 			y1TopLevelFields := map[string]dag.Expr{}
 			var y1TopLevelSpread dag.Expr
-			for _, e := range re1.Elems {
+			for i, e := range re1.Elems {
 				switch e := e.(type) {
 				case *dag.Field:
 					y1TopLevelFields[e.Name] = e.Value
 				case *dag.Spread:
+					if i > 0 {
+						continue Loop
+					}
 					y1TopLevelSpread = e.Expr
 				default:
 					panic(e)

--- a/compiler/ztests/merge-yields.yaml
+++ b/compiler/ztests/merge-yields.yaml
@@ -4,6 +4,10 @@ script: |
   super compile -C -O 'yield {...a} | yield {...b.c} | yield d, {e}'
   echo ===
   super compile -C -O 'yield {a:{b:1}} | yield {a:{...a,c:2}} | yield {a:{...a,d:3}}'
+  echo ===
+  super compile -C -O '{...a,...b} | yield {c}'
+  echo ===
+  super compile -C -O '{a,...b} | yield {a}'
 
 outputs:
   - name: stdout
@@ -18,4 +22,14 @@ outputs:
       ===
       null
       | yield {a:{b:1,c:2,d:3}}
+      | output main
+      ===
+      null
+      | yield {...a,...b}
+      | yield {c:c}
+      | output main
+      ===
+      null
+      | yield {a:a,...b}
+      | yield {a:a}
       | output main


### PR DESCRIPTION
Adjacent yield operators cannot be merged safely when the first yields a record expression containing a non-initial spread like "{a,...b}".

@mattnibs: This produces correct output for the example you shared.

```console
$ echo '{a:{x:{z:1}},b:{y:{aa:2}}}' | super -c '{...a,...b} | yield {...x}' -
{z:1}
```