### PR TITLE
Ignore specifications.freedesktop.org in link checker for now

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -3,3 +3,5 @@ dirs:
 useGitIgnore: true
 excludedDirs:
   - node_modules
+ignorePatterns:
+  - pattern: '^https://specifications.freedesktop.org.*$'


### PR DESCRIPTION
A hyperlink in the [`super db` command doc](https://superdb.org/docs/commands/super-db/#locating-the-lake) to explain `XDG_DATA_HOME` has been seeing an HTTP 503 in our link checker for a couple days because the freedesktop.org people are apparently doing an overhaul of their site and have set expectations it'll be busted for a couple weeks. Since the XDG topic is pretty niche I don't see another great location to permanently link to instead, and rather than dropping the link entirely here I'm just adding an exception so we won't have to see the link checker failure. I'll reverse this when their site is working properly again.