### PR TITLE
Merge adjacent yield operators containing bare this

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -541,7 +541,7 @@ func mergeYieldOps(seq dag.Seq) dag.Seq {
 		for i := 0; i+1 < len(seq); i++ {
 			y1, ok1 := seq[i].(*dag.Yield)
 			y2, ok2 := seq[i+1].(*dag.Yield)
-			if !ok1 || !ok2 || len(y1.Exprs) != 1 || hasThisWithEmptyPath(y2) {
+			if !ok1 || !ok2 || len(y1.Exprs) != 1 {
 				continue
 			}
 			re1, ok := y1.Exprs[0].(*dag.RecordExpr)
@@ -556,6 +556,9 @@ func mergeYieldOps(seq dag.Seq) dag.Seq {
 				this2, ok := e2.(*dag.This)
 				if !ok {
 					return e2
+				}
+				if len(this2.Path) == 0 {
+					return re1
 				}
 				e1, ok := y1TopLevelFields[this2.Path[0]]
 				if !ok {

--- a/compiler/ztests/merge-yields.yaml
+++ b/compiler/ztests/merge-yields.yaml
@@ -1,5 +1,5 @@
 script: |
-  super compile -C -O 'yield {a:1} | yield a, {b:a}'
+  super compile -C -O 'yield {a:1} | yield a, {b:a}, {c:this}'
   echo ===
   super compile -C -O 'yield {...a} | yield {...b.c} | yield d, {e}'
   echo ===
@@ -13,7 +13,7 @@ outputs:
   - name: stdout
     data: |
       null
-      | yield 1, {b:1}
+      | yield 1, {b:1}, {c:{a:1}}
       | output main
       ===
       null


### PR DESCRIPTION
The optimization that merges adjacent yield operators does not alter "yield {a} | yield {b:this}" because the second yield operator contains a bare reference to "this".  Remove that restriction so it will merge the operators to become "yield {b:{a}}".