### PR TITLE
Fix data race in vector Parquet reader with pruner

### DIFF
--- a/runtime/exec/environment.go
+++ b/runtime/exec/environment.go
@@ -14,7 +14,6 @@ import (
 	"github.com/brimdata/super/order"
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/pkg/storage"
-	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/runtime/vam"
 	"github.com/brimdata/super/vector"
 	"github.com/brimdata/super/zbuf"
@@ -126,7 +125,7 @@ func (c *closePuller) Pull(done bool) (zbuf.Batch, error) {
 	return batch, err
 }
 
-func (e *Environment) VectorOpen(ctx context.Context, zctx *super.Context, path, format string, fields []field.Path, pruner expr.Evaluator) (vector.Puller, error) {
+func (e *Environment) VectorOpen(ctx context.Context, zctx *super.Context, path, format string, fields []field.Path, pruner zbuf.Filter) (vector.Puller, error) {
 	if path == "-" {
 		path = "stdio:stdin"
 	}

--- a/zio/parquetio/vectorreader.go
+++ b/zio/parquetio/vectorreader.go
@@ -19,23 +19,25 @@ import (
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/vector"
+	"github.com/brimdata/super/zbuf"
 	"github.com/brimdata/super/zio/arrowio"
 )
 
 type VectorReader struct {
 	ctx    context.Context
 	zctx   *super.Context
-	pruner expr.Evaluator
+	pruner zbuf.Filter
 
-	fr           *pqarrow.FileReader
-	colIndexes   []int
-	nextRowGroup *atomic.Int64
-	rr           pqarrow.RecordReader
-	schema       *arrow.Schema
-	vb           vectorBuilder
+	fr              *pqarrow.FileReader
+	colIndexes      []int
+	nextRowGroup    *atomic.Int64
+	prunerEvaluator expr.Evaluator
+	rr              pqarrow.RecordReader
+	schema          *arrow.Schema
+	vb              vectorBuilder
 }
 
-func NewVectorReader(ctx context.Context, zctx *super.Context, r io.Reader, fields []field.Path, pruner expr.Evaluator) (*VectorReader, error) {
+func NewVectorReader(ctx context.Context, zctx *super.Context, r io.Reader, fields []field.Path, pruner zbuf.Filter) (*VectorReader, error) {
 	ras, ok := r.(parquet.ReaderAtSeeker)
 	if !ok {
 		return nil, errors.New("reader cannot seek")
@@ -62,29 +64,45 @@ func NewVectorReader(ctx context.Context, zctx *super.Context, r io.Reader, fiel
 	if err != nil {
 		return nil, err
 	}
+	var evaluator expr.Evaluator
+	if pruner != nil {
+		evaluator, err = pruner.AsEvaluator()
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &VectorReader{
-		ctx:          ctx,
-		zctx:         zctx,
-		pruner:       pruner,
-		fr:           fr,
-		colIndexes:   colIndexes,
-		nextRowGroup: &atomic.Int64{},
-		schema:       schema,
-		vb:           vectorBuilder{zctx, map[arrow.DataType]super.Type{}},
+		ctx:             ctx,
+		zctx:            zctx,
+		pruner:          pruner,
+		fr:              fr,
+		colIndexes:      colIndexes,
+		nextRowGroup:    &atomic.Int64{},
+		prunerEvaluator: evaluator,
+		schema:          schema,
+		vb:              vectorBuilder{zctx, map[arrow.DataType]super.Type{}},
 	}, nil
 }
 
-func (p *VectorReader) NewConcurrentPuller() vector.Puller {
-	return &VectorReader{
-		ctx:          p.ctx,
-		zctx:         p.zctx,
-		pruner:       p.pruner,
-		fr:           p.fr,
-		colIndexes:   p.colIndexes,
-		nextRowGroup: p.nextRowGroup,
-		schema:       p.schema,
-		vb:           vectorBuilder{p.zctx, map[arrow.DataType]super.Type{}},
+func (p *VectorReader) NewConcurrentPuller() (vector.Puller, error) {
+	var evaluator expr.Evaluator
+	if p.pruner != nil {
+		var err error
+		evaluator, err = p.pruner.AsEvaluator()
+		if err != nil {
+			return nil, err
+		}
 	}
+	return &VectorReader{
+		ctx:             p.ctx,
+		zctx:            p.zctx,
+		fr:              p.fr,
+		colIndexes:      p.colIndexes,
+		nextRowGroup:    p.nextRowGroup,
+		prunerEvaluator: evaluator,
+		schema:          p.schema,
+		vb:              vectorBuilder{p.zctx, map[arrow.DataType]super.Type{}},
+	}, nil
 }
 func (p *VectorReader) Pull(done bool) (vector.Any, error) {
 	if done {
@@ -100,10 +118,10 @@ func (p *VectorReader) Pull(done bool) (vector.Any, error) {
 			if rowGroup >= pr.NumRowGroups() {
 				return nil, nil
 			}
-			if p.pruner != nil {
+			if p.prunerEvaluator != nil {
 				rgMetadata := pr.MetaData().RowGroup(rowGroup)
 				val := buildPrunerValue(p.zctx, rgMetadata, p.schema, p.colIndexes)
-				if !p.pruner.Eval(nil, val).Ptr().AsBool() {
+				if !p.prunerEvaluator.Eval(nil, val).Ptr().AsBool() {
 					continue
 				}
 			}


### PR DESCRIPTION
In a vector Parquet reader with a pruner, multiple goroutines may use the pruner concurrently, but the pruner is a sam/expr.Evalautor, some implementations of which (notably sam/expr.DotExpr) are unsafe for concurrent use.  Fix this by changing the pruner paramter to a zbuf.Filter for runtime/exec.Environment.VectorOpen, parquetio.NewVectorReader, and vngio.NewVectorReader.

Fixes #5723.