### PR TITLE
Implement distinct qualifier for aggregate function calls

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -732,9 +732,10 @@ func (*Delete) OpAST()       {}
 // upon a function of the record, e.g., count() counts up records without
 // looking into them.
 type Agg struct {
-	Kind  string `json:"kind" unpack:""`
-	Name  string `json:"name"`
-	Expr  Expr   `json:"expr"`
-	Where Expr   `json:"where"`
-	Loc   `json:"loc"`
+	Kind     string `json:"kind" unpack:""`
+	Name     string `json:"name"`
+	Distinct bool   `json:"distinct"`
+	Expr     Expr   `json:"expr"`
+	Where    Expr   `json:"where"`
+	Loc      `json:"loc"`
 }

--- a/compiler/dag/expr.go
+++ b/compiler/dag/expr.go
@@ -18,10 +18,11 @@ type (
 
 type (
 	Agg struct {
-		Kind  string `json:"kind" unpack:""`
-		Name  string `json:"name"`
-		Expr  Expr   `json:"expr"`
-		Where Expr   `json:"where"`
+		Kind     string `json:"kind" unpack:""`
+		Name     string `json:"name"`
+		Distinct bool   `json:"distinct"`
+		Expr     Expr   `json:"expr"`
+		Where    Expr   `json:"where"`
 	}
 	ArrayExpr struct {
 		Kind  string       `json:"kind" unpack:""`

--- a/compiler/kernel/aggregate.go
+++ b/compiler/kernel/aggregate.go
@@ -70,5 +70,5 @@ func (b *Builder) compileAgg(agg *dag.Agg) (*expr.Aggregator, error) {
 			return nil, err
 		}
 	}
-	return expr.NewAggregator(name, arg, where)
+	return expr.NewAggregator(name, agg.Distinct, arg, where)
 }

--- a/compiler/kernel/vop.go
+++ b/compiler/kernel/vop.go
@@ -441,5 +441,5 @@ func (b *Builder) compileVamAgg(agg *dag.Agg) (*vamexpr.Aggregator, error) {
 			return nil, err
 		}
 	}
-	return vamexpr.NewAggregator(name, arg, where)
+	return vamexpr.NewAggregator(name, agg.Distinct, arg, where)
 }

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -1934,67 +1934,23 @@ var g = &grammar{
 								},
 								&labeledExpr{
 									pos:   position{line: 228, col: 16, offset: 6008},
-									label: "op",
+									label: "aggDistinct",
 									expr: &ruleRefExpr{
-										pos:  position{line: 228, col: 19, offset: 6011},
-										name: "AggName",
+										pos:  position{line: 228, col: 28, offset: 6020},
+										name: "AggDistinct",
 									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 228, col: 27, offset: 6019},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 228, col: 30, offset: 6022},
-									val:        "(",
-									ignoreCase: false,
-									want:       "\"(\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 228, col: 34, offset: 6026},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 228, col: 37, offset: 6029},
-									label: "expr",
-									expr: &zeroOrOneExpr{
-										pos: position{line: 228, col: 42, offset: 6034},
-										expr: &choiceExpr{
-											pos: position{line: 228, col: 43, offset: 6035},
-											alternatives: []any{
-												&ruleRefExpr{
-													pos:  position{line: 228, col: 43, offset: 6035},
-													name: "OverExpr",
-												},
-												&ruleRefExpr{
-													pos:  position{line: 228, col: 54, offset: 6046},
-													name: "Expr",
-												},
-											},
-										},
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 228, col: 61, offset: 6053},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 228, col: 64, offset: 6056},
-									val:        ")",
-									ignoreCase: false,
-									want:       "\")\"",
 								},
 								&notExpr{
-									pos: position{line: 228, col: 68, offset: 6060},
+									pos: position{line: 228, col: 40, offset: 6032},
 									expr: &seqExpr{
-										pos: position{line: 228, col: 70, offset: 6062},
+										pos: position{line: 228, col: 42, offset: 6034},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 228, col: 70, offset: 6062},
+												pos:  position{line: 228, col: 42, offset: 6034},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 228, col: 73, offset: 6065},
+												pos:        position{line: 228, col: 45, offset: 6037},
 												val:        ".",
 												ignoreCase: false,
 												want:       "\".\"",
@@ -2003,12 +1959,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 228, col: 78, offset: 6070},
+									pos:   position{line: 228, col: 50, offset: 6042},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 228, col: 84, offset: 6076},
+										pos: position{line: 228, col: 56, offset: 6048},
 										expr: &ruleRefExpr{
-											pos:  position{line: 228, col: 84, offset: 6076},
+											pos:  position{line: 228, col: 56, offset: 6048},
 											name: "WhereClause",
 										},
 									},
@@ -2017,13 +1973,110 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 242, col: 5, offset: 6364},
-						run: (*parser).callonAgg25,
+						pos: position{line: 236, col: 5, offset: 6223},
+						run: (*parser).callonAgg15,
+						expr: &seqExpr{
+							pos: position{line: 236, col: 5, offset: 6223},
+							exprs: []any{
+								&notExpr{
+									pos: position{line: 236, col: 5, offset: 6223},
+									expr: &ruleRefExpr{
+										pos:  position{line: 236, col: 6, offset: 6224},
+										name: "FuncGuard",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 236, col: 16, offset: 6234},
+									label: "name",
+									expr: &ruleRefExpr{
+										pos:  position{line: 236, col: 21, offset: 6239},
+										name: "AggName",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 236, col: 29, offset: 6247},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 236, col: 32, offset: 6250},
+									val:        "(",
+									ignoreCase: false,
+									want:       "\"(\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 236, col: 36, offset: 6254},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 236, col: 39, offset: 6257},
+									label: "expr",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 236, col: 44, offset: 6262},
+										expr: &choiceExpr{
+											pos: position{line: 236, col: 45, offset: 6263},
+											alternatives: []any{
+												&ruleRefExpr{
+													pos:  position{line: 236, col: 45, offset: 6263},
+													name: "OverExpr",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 236, col: 56, offset: 6274},
+													name: "Expr",
+												},
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 236, col: 63, offset: 6281},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 236, col: 66, offset: 6284},
+									val:        ")",
+									ignoreCase: false,
+									want:       "\")\"",
+								},
+								&notExpr{
+									pos: position{line: 236, col: 70, offset: 6288},
+									expr: &seqExpr{
+										pos: position{line: 236, col: 72, offset: 6290},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 236, col: 72, offset: 6290},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 236, col: 75, offset: 6293},
+												val:        ".",
+												ignoreCase: false,
+												want:       "\".\"",
+											},
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 236, col: 80, offset: 6298},
+									label: "where",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 236, col: 86, offset: 6304},
+										expr: &ruleRefExpr{
+											pos:  position{line: 236, col: 86, offset: 6304},
+											name: "WhereClause",
+										},
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 250, col: 5, offset: 6594},
+						run: (*parser).callonAgg38,
 						expr: &labeledExpr{
-							pos:   position{line: 242, col: 5, offset: 6364},
+							pos:   position{line: 250, col: 5, offset: 6594},
 							label: "cs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 242, col: 8, offset: 6367},
+								pos:  position{line: 250, col: 8, offset: 6597},
 								name: "CountStar",
 							},
 						},
@@ -2034,21 +2087,100 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
+			name: "AggDistinct",
+			pos:  position{line: 258, col: 1, offset: 6735},
+			expr: &actionExpr{
+				pos: position{line: 259, col: 5, offset: 6751},
+				run: (*parser).callonAggDistinct1,
+				expr: &seqExpr{
+					pos: position{line: 259, col: 5, offset: 6751},
+					exprs: []any{
+						&notExpr{
+							pos: position{line: 259, col: 5, offset: 6751},
+							expr: &ruleRefExpr{
+								pos:  position{line: 259, col: 6, offset: 6752},
+								name: "FuncGuard",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 259, col: 16, offset: 6762},
+							label: "name",
+							expr: &ruleRefExpr{
+								pos:  position{line: 259, col: 21, offset: 6767},
+								name: "AggName",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 259, col: 29, offset: 6775},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 259, col: 32, offset: 6778},
+							val:        "(",
+							ignoreCase: false,
+							want:       "\"(\"",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 259, col: 36, offset: 6782},
+							name: "__",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 259, col: 39, offset: 6785},
+							name: "DISTINCT",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 259, col: 48, offset: 6794},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 259, col: 50, offset: 6796},
+							label: "expr",
+							expr: &choiceExpr{
+								pos: position{line: 259, col: 56, offset: 6802},
+								alternatives: []any{
+									&ruleRefExpr{
+										pos:  position{line: 259, col: 56, offset: 6802},
+										name: "OverExpr",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 259, col: 67, offset: 6813},
+										name: "Expr",
+									},
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 259, col: 73, offset: 6819},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 259, col: 76, offset: 6822},
+							val:        ")",
+							ignoreCase: false,
+							want:       "\")\"",
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
 			name: "AggName",
-			pos:  position{line: 250, col: 1, offset: 6505},
+			pos:  position{line: 269, col: 1, offset: 7007},
 			expr: &choiceExpr{
-				pos: position{line: 251, col: 5, offset: 6517},
+				pos: position{line: 270, col: 5, offset: 7019},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 251, col: 5, offset: 6517},
+						pos:  position{line: 270, col: 5, offset: 7019},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 252, col: 5, offset: 6536},
+						pos:  position{line: 271, col: 5, offset: 7038},
 						name: "AND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 253, col: 5, offset: 6544},
+						pos:  position{line: 272, col: 5, offset: 7046},
 						name: "OR",
 					},
 				},
@@ -2058,30 +2190,30 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 255, col: 1, offset: 6548},
+			pos:  position{line: 274, col: 1, offset: 7050},
 			expr: &actionExpr{
-				pos: position{line: 255, col: 15, offset: 6562},
+				pos: position{line: 274, col: 15, offset: 7064},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 255, col: 15, offset: 6562},
+					pos: position{line: 274, col: 15, offset: 7064},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 255, col: 15, offset: 6562},
+							pos:  position{line: 274, col: 15, offset: 7064},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 255, col: 17, offset: 6564},
+							pos:  position{line: 274, col: 17, offset: 7066},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 255, col: 23, offset: 6570},
+							pos:  position{line: 274, col: 23, offset: 7072},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 255, col: 25, offset: 6572},
+							pos:   position{line: 274, col: 25, offset: 7074},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 255, col: 30, offset: 6577},
+								pos:  position{line: 274, col: 30, offset: 7079},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -2093,45 +2225,45 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 257, col: 1, offset: 6613},
+			pos:  position{line: 276, col: 1, offset: 7115},
 			expr: &actionExpr{
-				pos: position{line: 258, col: 5, offset: 6632},
+				pos: position{line: 277, col: 5, offset: 7134},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 258, col: 5, offset: 6632},
+					pos: position{line: 277, col: 5, offset: 7134},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 258, col: 5, offset: 6632},
+							pos:   position{line: 277, col: 5, offset: 7134},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 258, col: 11, offset: 6638},
+								pos:  position{line: 277, col: 11, offset: 7140},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 258, col: 25, offset: 6652},
+							pos:   position{line: 277, col: 25, offset: 7154},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 258, col: 30, offset: 6657},
+								pos: position{line: 277, col: 30, offset: 7159},
 								expr: &seqExpr{
-									pos: position{line: 258, col: 31, offset: 6658},
+									pos: position{line: 277, col: 31, offset: 7160},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 258, col: 31, offset: 6658},
+											pos:  position{line: 277, col: 31, offset: 7160},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 258, col: 34, offset: 6661},
+											pos:        position{line: 277, col: 34, offset: 7163},
 											val:        ",",
 											ignoreCase: false,
 											want:       "\",\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 258, col: 38, offset: 6665},
+											pos:  position{line: 277, col: 38, offset: 7167},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 258, col: 41, offset: 6668},
+											pos:  position{line: 277, col: 41, offset: 7170},
 											name: "AggAssignment",
 										},
 									},
@@ -2146,43 +2278,43 @@ var g = &grammar{
 		},
 		{
 			name: "CountStar",
-			pos:  position{line: 266, col: 1, offset: 6842},
+			pos:  position{line: 285, col: 1, offset: 7344},
 			expr: &actionExpr{
-				pos: position{line: 266, col: 13, offset: 6854},
+				pos: position{line: 285, col: 13, offset: 7356},
 				run: (*parser).callonCountStar1,
 				expr: &seqExpr{
-					pos: position{line: 266, col: 13, offset: 6854},
+					pos: position{line: 285, col: 13, offset: 7356},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 266, col: 13, offset: 6854},
+							pos:  position{line: 285, col: 13, offset: 7356},
 							name: "COUNT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 266, col: 19, offset: 6860},
+							pos:  position{line: 285, col: 19, offset: 7362},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 266, col: 22, offset: 6863},
+							pos:        position{line: 285, col: 22, offset: 7365},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 266, col: 26, offset: 6867},
+							pos:  position{line: 285, col: 26, offset: 7369},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 266, col: 29, offset: 6870},
+							pos:        position{line: 285, col: 29, offset: 7372},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 266, col: 33, offset: 6874},
+							pos:  position{line: 285, col: 33, offset: 7376},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 266, col: 36, offset: 6877},
+							pos:        position{line: 285, col: 36, offset: 7379},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2195,28 +2327,28 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 276, col: 1, offset: 7071},
+			pos:  position{line: 295, col: 1, offset: 7573},
 			expr: &choiceExpr{
-				pos: position{line: 277, col: 5, offset: 7084},
+				pos: position{line: 296, col: 5, offset: 7586},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 277, col: 5, offset: 7084},
+						pos: position{line: 296, col: 5, offset: 7586},
 						run: (*parser).callonOperator2,
 						expr: &seqExpr{
-							pos: position{line: 277, col: 5, offset: 7084},
+							pos: position{line: 296, col: 5, offset: 7586},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 277, col: 5, offset: 7084},
+									pos:   position{line: 296, col: 5, offset: 7586},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 277, col: 8, offset: 7087},
+										pos:  position{line: 296, col: 8, offset: 7589},
 										name: "SelectOp",
 									},
 								},
 								&andExpr{
-									pos: position{line: 277, col: 17, offset: 7096},
+									pos: position{line: 296, col: 17, offset: 7598},
 									expr: &ruleRefExpr{
-										pos:  position{line: 277, col: 18, offset: 7097},
+										pos:  position{line: 296, col: 18, offset: 7599},
 										name: "EndOfOp",
 									},
 								},
@@ -2224,119 +2356,119 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 278, col: 5, offset: 7128},
+						pos:  position{line: 297, col: 5, offset: 7630},
 						name: "ForkOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 279, col: 5, offset: 7139},
+						pos:  position{line: 298, col: 5, offset: 7641},
 						name: "SwitchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 280, col: 5, offset: 7153},
+						pos:  position{line: 299, col: 5, offset: 7655},
 						name: "FromForkOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 281, col: 5, offset: 7168},
+						pos:  position{line: 300, col: 5, offset: 7670},
 						name: "SearchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 282, col: 5, offset: 7181},
+						pos:  position{line: 301, col: 5, offset: 7683},
 						name: "AssertOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 283, col: 5, offset: 7194},
+						pos:  position{line: 302, col: 5, offset: 7696},
 						name: "SortOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 284, col: 5, offset: 7205},
+						pos:  position{line: 303, col: 5, offset: 7707},
 						name: "TopOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 285, col: 5, offset: 7215},
+						pos:  position{line: 304, col: 5, offset: 7717},
 						name: "CutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 286, col: 5, offset: 7225},
+						pos:  position{line: 305, col: 5, offset: 7727},
 						name: "DistinctOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 5, offset: 7240},
+						pos:  position{line: 306, col: 5, offset: 7742},
 						name: "DropOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 288, col: 5, offset: 7251},
+						pos:  position{line: 307, col: 5, offset: 7753},
 						name: "HeadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 289, col: 5, offset: 7262},
+						pos:  position{line: 308, col: 5, offset: 7764},
 						name: "TailOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 290, col: 5, offset: 7273},
+						pos:  position{line: 309, col: 5, offset: 7775},
 						name: "WhereOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 5, offset: 7285},
+						pos:  position{line: 310, col: 5, offset: 7787},
 						name: "UniqOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 292, col: 5, offset: 7296},
+						pos:  position{line: 311, col: 5, offset: 7798},
 						name: "PutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 5, offset: 7306},
+						pos:  position{line: 312, col: 5, offset: 7808},
 						name: "RenameOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 5, offset: 7319},
+						pos:  position{line: 313, col: 5, offset: 7821},
 						name: "FuseOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 5, offset: 7330},
+						pos:  position{line: 314, col: 5, offset: 7832},
 						name: "ShapeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 296, col: 5, offset: 7342},
+						pos:  position{line: 315, col: 5, offset: 7844},
 						name: "JoinOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 297, col: 5, offset: 7353},
+						pos:  position{line: 316, col: 5, offset: 7855},
 						name: "SampleOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 298, col: 5, offset: 7366},
+						pos:  position{line: 317, col: 5, offset: 7868},
 						name: "FromOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 299, col: 5, offset: 7377},
+						pos:  position{line: 318, col: 5, offset: 7879},
 						name: "PassOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 300, col: 5, offset: 7388},
+						pos:  position{line: 319, col: 5, offset: 7890},
 						name: "ExplodeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 301, col: 5, offset: 7402},
+						pos:  position{line: 320, col: 5, offset: 7904},
 						name: "MergeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 302, col: 5, offset: 7414},
+						pos:  position{line: 321, col: 5, offset: 7916},
 						name: "OverOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 5, offset: 7425},
+						pos:  position{line: 322, col: 5, offset: 7927},
 						name: "YieldOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 304, col: 5, offset: 7437},
+						pos:  position{line: 323, col: 5, offset: 7939},
 						name: "LoadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 305, col: 5, offset: 7448},
+						pos:  position{line: 324, col: 5, offset: 7950},
 						name: "OutputOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 306, col: 5, offset: 7461},
+						pos:  position{line: 325, col: 5, offset: 7963},
 						name: "DebugOp",
 					},
 				},
@@ -2346,132 +2478,132 @@ var g = &grammar{
 		},
 		{
 			name: "PipeKeyword",
-			pos:  position{line: 308, col: 1, offset: 7470},
+			pos:  position{line: 327, col: 1, offset: 7972},
 			expr: &choiceExpr{
-				pos: position{line: 309, col: 5, offset: 7486},
+				pos: position{line: 328, col: 5, offset: 7988},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 5, offset: 7486},
+						pos:  position{line: 328, col: 5, offset: 7988},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 14, offset: 7495},
+						pos:  position{line: 328, col: 14, offset: 7997},
 						name: "FORK",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 21, offset: 7502},
+						pos:  position{line: 328, col: 21, offset: 8004},
 						name: "SWITCH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 30, offset: 7511},
+						pos:  position{line: 328, col: 30, offset: 8013},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 37, offset: 7518},
+						pos:  position{line: 328, col: 37, offset: 8020},
 						name: "SEARCH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 46, offset: 7527},
+						pos:  position{line: 328, col: 46, offset: 8029},
 						name: "ASSERT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 55, offset: 7536},
+						pos:  position{line: 328, col: 55, offset: 8038},
 						name: "SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 62, offset: 7543},
+						pos:  position{line: 328, col: 62, offset: 8045},
 						name: "TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 67, offset: 7548},
+						pos:  position{line: 328, col: 67, offset: 8050},
 						name: "CUT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 73, offset: 7554},
+						pos:  position{line: 328, col: 73, offset: 8056},
 						name: "DROP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 5, offset: 7563},
+						pos:  position{line: 329, col: 5, offset: 8065},
 						name: "HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 12, offset: 7570},
+						pos:  position{line: 329, col: 12, offset: 8072},
 						name: "TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 19, offset: 7577},
+						pos:  position{line: 329, col: 19, offset: 8079},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 27, offset: 7585},
+						pos:  position{line: 329, col: 27, offset: 8087},
 						name: "UNIQ",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 34, offset: 7592},
+						pos:  position{line: 329, col: 34, offset: 8094},
 						name: "PUT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 40, offset: 7598},
+						pos:  position{line: 329, col: 40, offset: 8100},
 						name: "RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 49, offset: 7607},
+						pos:  position{line: 329, col: 49, offset: 8109},
 						name: "FUSE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 56, offset: 7614},
+						pos:  position{line: 329, col: 56, offset: 8116},
 						name: "SHAPE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 64, offset: 7622},
+						pos:  position{line: 329, col: 64, offset: 8124},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 71, offset: 7629},
+						pos:  position{line: 329, col: 71, offset: 8131},
 						name: "SAMPLE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 5, offset: 7640},
+						pos:  position{line: 330, col: 5, offset: 8142},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 12, offset: 7647},
+						pos:  position{line: 330, col: 12, offset: 8149},
 						name: "PASS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 19, offset: 7654},
+						pos:  position{line: 330, col: 19, offset: 8156},
 						name: "EXPLODE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 29, offset: 7664},
+						pos:  position{line: 330, col: 29, offset: 8166},
 						name: "MERGE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 37, offset: 7672},
+						pos:  position{line: 330, col: 37, offset: 8174},
 						name: "OVER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 44, offset: 7679},
+						pos:  position{line: 330, col: 44, offset: 8181},
 						name: "YIELD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 52, offset: 7687},
+						pos:  position{line: 330, col: 52, offset: 8189},
 						name: "LOAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 59, offset: 7694},
+						pos:  position{line: 330, col: 59, offset: 8196},
 						name: "OUTPUT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 68, offset: 7703},
+						pos:  position{line: 330, col: 68, offset: 8205},
 						name: "DEBUG",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 312, col: 5, offset: 7713},
+						pos:  position{line: 331, col: 5, offset: 8215},
 						name: "AGGREGATE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 312, col: 17, offset: 7725},
+						pos:  position{line: 331, col: 17, offset: 8227},
 						name: "SUMMARIZE",
 					},
 				},
@@ -2481,44 +2613,44 @@ var g = &grammar{
 		},
 		{
 			name: "ForkOp",
-			pos:  position{line: 314, col: 2, offset: 7737},
+			pos:  position{line: 333, col: 2, offset: 8239},
 			expr: &actionExpr{
-				pos: position{line: 315, col: 4, offset: 7749},
+				pos: position{line: 334, col: 4, offset: 8251},
 				run: (*parser).callonForkOp1,
 				expr: &seqExpr{
-					pos: position{line: 315, col: 4, offset: 7749},
+					pos: position{line: 334, col: 4, offset: 8251},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 315, col: 4, offset: 7749},
+							pos:  position{line: 334, col: 4, offset: 8251},
 							name: "FORK",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 315, col: 9, offset: 7754},
+							pos:  position{line: 334, col: 9, offset: 8256},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 315, col: 12, offset: 7757},
+							pos:        position{line: 334, col: 12, offset: 8259},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 315, col: 16, offset: 7761},
+							pos:   position{line: 334, col: 16, offset: 8263},
 							label: "paths",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 315, col: 22, offset: 7767},
+								pos: position{line: 334, col: 22, offset: 8269},
 								expr: &ruleRefExpr{
-									pos:  position{line: 315, col: 22, offset: 7767},
+									pos:  position{line: 334, col: 22, offset: 8269},
 									name: "Path",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 315, col: 28, offset: 7773},
+							pos:  position{line: 334, col: 28, offset: 8275},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 315, col: 31, offset: 7776},
+							pos:        position{line: 334, col: 31, offset: 8278},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2531,32 +2663,32 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 327, col: 1, offset: 8025},
+			pos:  position{line: 346, col: 1, offset: 8527},
 			expr: &actionExpr{
-				pos: position{line: 327, col: 8, offset: 8032},
+				pos: position{line: 346, col: 8, offset: 8534},
 				run: (*parser).callonPath1,
 				expr: &seqExpr{
-					pos: position{line: 327, col: 8, offset: 8032},
+					pos: position{line: 346, col: 8, offset: 8534},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 327, col: 8, offset: 8032},
+							pos:  position{line: 346, col: 8, offset: 8534},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 327, col: 11, offset: 8035},
+							pos:        position{line: 346, col: 11, offset: 8537},
 							val:        "=>",
 							ignoreCase: false,
 							want:       "\"=>\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 327, col: 16, offset: 8040},
+							pos:  position{line: 346, col: 16, offset: 8542},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 327, col: 19, offset: 8043},
+							pos:   position{line: 346, col: 19, offset: 8545},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 327, col: 23, offset: 8047},
+								pos:  position{line: 346, col: 23, offset: 8549},
 								name: "Seq",
 							},
 						},
@@ -2568,59 +2700,59 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchOp",
-			pos:  position{line: 329, col: 1, offset: 8072},
+			pos:  position{line: 348, col: 1, offset: 8574},
 			expr: &choiceExpr{
-				pos: position{line: 330, col: 5, offset: 8085},
+				pos: position{line: 349, col: 5, offset: 8587},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 330, col: 5, offset: 8085},
+						pos: position{line: 349, col: 5, offset: 8587},
 						run: (*parser).callonSwitchOp2,
 						expr: &seqExpr{
-							pos: position{line: 330, col: 5, offset: 8085},
+							pos: position{line: 349, col: 5, offset: 8587},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 330, col: 5, offset: 8085},
+									pos:  position{line: 349, col: 5, offset: 8587},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 330, col: 12, offset: 8092},
+									pos:  position{line: 349, col: 12, offset: 8594},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 330, col: 14, offset: 8094},
+									pos:   position{line: 349, col: 14, offset: 8596},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 330, col: 19, offset: 8099},
+										pos:  position{line: 349, col: 19, offset: 8601},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 330, col: 24, offset: 8104},
+									pos:  position{line: 349, col: 24, offset: 8606},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 330, col: 26, offset: 8106},
+									pos:        position{line: 349, col: 26, offset: 8608},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 330, col: 30, offset: 8110},
+									pos:   position{line: 349, col: 30, offset: 8612},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 330, col: 36, offset: 8116},
+										pos: position{line: 349, col: 36, offset: 8618},
 										expr: &ruleRefExpr{
-											pos:  position{line: 330, col: 36, offset: 8116},
+											pos:  position{line: 349, col: 36, offset: 8618},
 											name: "SwitchPath",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 330, col: 48, offset: 8128},
+									pos:  position{line: 349, col: 48, offset: 8630},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 330, col: 51, offset: 8131},
+									pos:        position{line: 349, col: 51, offset: 8633},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -2629,42 +2761,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 338, col: 5, offset: 8311},
+						pos: position{line: 357, col: 5, offset: 8813},
 						run: (*parser).callonSwitchOp15,
 						expr: &seqExpr{
-							pos: position{line: 338, col: 5, offset: 8311},
+							pos: position{line: 357, col: 5, offset: 8813},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 338, col: 5, offset: 8311},
+									pos:  position{line: 357, col: 5, offset: 8813},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 338, col: 12, offset: 8318},
+									pos:  position{line: 357, col: 12, offset: 8820},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 338, col: 15, offset: 8321},
+									pos:        position{line: 357, col: 15, offset: 8823},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 338, col: 19, offset: 8325},
+									pos:   position{line: 357, col: 19, offset: 8827},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 338, col: 25, offset: 8331},
+										pos: position{line: 357, col: 25, offset: 8833},
 										expr: &ruleRefExpr{
-											pos:  position{line: 338, col: 25, offset: 8331},
+											pos:  position{line: 357, col: 25, offset: 8833},
 											name: "SwitchPath",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 338, col: 37, offset: 8343},
+									pos:  position{line: 357, col: 37, offset: 8845},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 338, col: 40, offset: 8346},
+									pos:        position{line: 357, col: 40, offset: 8848},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -2679,30 +2811,30 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchPath",
-			pos:  position{line: 346, col: 1, offset: 8490},
+			pos:  position{line: 365, col: 1, offset: 8992},
 			expr: &actionExpr{
-				pos: position{line: 347, col: 5, offset: 8505},
+				pos: position{line: 366, col: 5, offset: 9007},
 				run: (*parser).callonSwitchPath1,
 				expr: &seqExpr{
-					pos: position{line: 347, col: 5, offset: 8505},
+					pos: position{line: 366, col: 5, offset: 9007},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 347, col: 5, offset: 8505},
+							pos:  position{line: 366, col: 5, offset: 9007},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 347, col: 8, offset: 8508},
+							pos:   position{line: 366, col: 8, offset: 9010},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 347, col: 13, offset: 8513},
+								pos:  position{line: 366, col: 13, offset: 9015},
 								name: "Case",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 347, col: 18, offset: 8518},
+							pos:   position{line: 366, col: 18, offset: 9020},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 347, col: 23, offset: 8523},
+								pos:  position{line: 366, col: 23, offset: 9025},
 								name: "Path",
 							},
 						},
@@ -2714,29 +2846,29 @@ var g = &grammar{
 		},
 		{
 			name: "Case",
-			pos:  position{line: 355, col: 1, offset: 8670},
+			pos:  position{line: 374, col: 1, offset: 9172},
 			expr: &choiceExpr{
-				pos: position{line: 356, col: 5, offset: 8679},
+				pos: position{line: 375, col: 5, offset: 9181},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 356, col: 5, offset: 8679},
+						pos: position{line: 375, col: 5, offset: 9181},
 						run: (*parser).callonCase2,
 						expr: &seqExpr{
-							pos: position{line: 356, col: 5, offset: 8679},
+							pos: position{line: 375, col: 5, offset: 9181},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 356, col: 5, offset: 8679},
+									pos:  position{line: 375, col: 5, offset: 9181},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 356, col: 10, offset: 8684},
+									pos:  position{line: 375, col: 10, offset: 9186},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 356, col: 12, offset: 8686},
+									pos:   position{line: 375, col: 12, offset: 9188},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 356, col: 17, offset: 8691},
+										pos:  position{line: 375, col: 17, offset: 9193},
 										name: "Expr",
 									},
 								},
@@ -2744,10 +2876,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 357, col: 5, offset: 8721},
+						pos: position{line: 376, col: 5, offset: 9223},
 						run: (*parser).callonCase8,
 						expr: &ruleRefExpr{
-							pos:  position{line: 357, col: 5, offset: 8721},
+							pos:  position{line: 376, col: 5, offset: 9223},
 							name: "DEFAULT",
 						},
 					},
@@ -2758,44 +2890,44 @@ var g = &grammar{
 		},
 		{
 			name: "FromForkOp",
-			pos:  position{line: 359, col: 1, offset: 8750},
+			pos:  position{line: 378, col: 1, offset: 9252},
 			expr: &actionExpr{
-				pos: position{line: 360, col: 5, offset: 8765},
+				pos: position{line: 379, col: 5, offset: 9267},
 				run: (*parser).callonFromForkOp1,
 				expr: &seqExpr{
-					pos: position{line: 360, col: 5, offset: 8765},
+					pos: position{line: 379, col: 5, offset: 9267},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 360, col: 5, offset: 8765},
+							pos:  position{line: 379, col: 5, offset: 9267},
 							name: "FROM",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 360, col: 10, offset: 8770},
+							pos:  position{line: 379, col: 10, offset: 9272},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 360, col: 13, offset: 8773},
+							pos:        position{line: 379, col: 13, offset: 9275},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 360, col: 17, offset: 8777},
+							pos:   position{line: 379, col: 17, offset: 9279},
 							label: "trunks",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 360, col: 24, offset: 8784},
+								pos: position{line: 379, col: 24, offset: 9286},
 								expr: &ruleRefExpr{
-									pos:  position{line: 360, col: 24, offset: 8784},
+									pos:  position{line: 379, col: 24, offset: 9286},
 									name: "FromPath",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 360, col: 34, offset: 8794},
+							pos:  position{line: 379, col: 34, offset: 9296},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 360, col: 37, offset: 8797},
+							pos:        position{line: 379, col: 37, offset: 9299},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2808,55 +2940,55 @@ var g = &grammar{
 		},
 		{
 			name: "FromPath",
-			pos:  position{line: 368, col: 1, offset: 8945},
+			pos:  position{line: 387, col: 1, offset: 9447},
 			expr: &actionExpr{
-				pos: position{line: 369, col: 5, offset: 8958},
+				pos: position{line: 388, col: 5, offset: 9460},
 				run: (*parser).callonFromPath1,
 				expr: &seqExpr{
-					pos: position{line: 369, col: 5, offset: 8958},
+					pos: position{line: 388, col: 5, offset: 9460},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 369, col: 5, offset: 8958},
+							pos:  position{line: 388, col: 5, offset: 9460},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 8, offset: 8961},
+							pos:   position{line: 388, col: 8, offset: 9463},
 							label: "source",
 							expr: &ruleRefExpr{
-								pos:  position{line: 369, col: 15, offset: 8968},
+								pos:  position{line: 388, col: 15, offset: 9470},
 								name: "FromSource",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 26, offset: 8979},
+							pos:   position{line: 388, col: 26, offset: 9481},
 							label: "seq",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 369, col: 30, offset: 8983},
+								pos: position{line: 388, col: 30, offset: 9485},
 								expr: &actionExpr{
-									pos: position{line: 369, col: 31, offset: 8984},
+									pos: position{line: 388, col: 31, offset: 9486},
 									run: (*parser).callonFromPath8,
 									expr: &seqExpr{
-										pos: position{line: 369, col: 31, offset: 8984},
+										pos: position{line: 388, col: 31, offset: 9486},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 369, col: 31, offset: 8984},
+												pos:  position{line: 388, col: 31, offset: 9486},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 369, col: 34, offset: 8987},
+												pos:        position{line: 388, col: 34, offset: 9489},
 												val:        "=>",
 												ignoreCase: false,
 												want:       "\"=>\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 369, col: 39, offset: 8992},
+												pos:  position{line: 388, col: 39, offset: 9494},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 369, col: 42, offset: 8995},
+												pos:   position{line: 388, col: 42, offset: 9497},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 369, col: 44, offset: 8997},
+													pos:  position{line: 388, col: 44, offset: 9499},
 													name: "Seq",
 												},
 											},
@@ -2873,29 +3005,29 @@ var g = &grammar{
 		},
 		{
 			name: "FromSource",
-			pos:  position{line: 377, col: 1, offset: 9177},
+			pos:  position{line: 396, col: 1, offset: 9679},
 			expr: &choiceExpr{
-				pos: position{line: 378, col: 5, offset: 9192},
+				pos: position{line: 397, col: 5, offset: 9694},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 378, col: 5, offset: 9192},
+						pos: position{line: 397, col: 5, offset: 9694},
 						run: (*parser).callonFromSource2,
 						expr: &seqExpr{
-							pos: position{line: 378, col: 5, offset: 9192},
+							pos: position{line: 397, col: 5, offset: 9694},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 378, col: 5, offset: 9192},
+									pos:  position{line: 397, col: 5, offset: 9694},
 									name: "FromKeyWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 378, col: 17, offset: 9204},
+									pos:  position{line: 397, col: 17, offset: 9706},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 378, col: 19, offset: 9206},
+									pos:   position{line: 397, col: 19, offset: 9708},
 									label: "elem",
 									expr: &ruleRefExpr{
-										pos:  position{line: 378, col: 24, offset: 9211},
+										pos:  position{line: 397, col: 24, offset: 9713},
 										name: "FromElem",
 									},
 								},
@@ -2903,7 +3035,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 385, col: 5, offset: 9382},
+						pos:  position{line: 404, col: 5, offset: 9884},
 						name: "PassOp",
 					},
 				},
@@ -2913,40 +3045,40 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOp",
-			pos:  position{line: 387, col: 1, offset: 9390},
+			pos:  position{line: 406, col: 1, offset: 9892},
 			expr: &actionExpr{
-				pos: position{line: 388, col: 5, offset: 9403},
+				pos: position{line: 407, col: 5, offset: 9905},
 				run: (*parser).callonSearchOp1,
 				expr: &seqExpr{
-					pos: position{line: 388, col: 5, offset: 9403},
+					pos: position{line: 407, col: 5, offset: 9905},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 388, col: 6, offset: 9404},
+							pos: position{line: 407, col: 6, offset: 9906},
 							alternatives: []any{
 								&seqExpr{
-									pos: position{line: 388, col: 6, offset: 9404},
+									pos: position{line: 407, col: 6, offset: 9906},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 388, col: 6, offset: 9404},
+											pos:  position{line: 407, col: 6, offset: 9906},
 											name: "SEARCH",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 388, col: 13, offset: 9411},
+											pos:  position{line: 407, col: 13, offset: 9913},
 											name: "_",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 388, col: 17, offset: 9415},
+									pos: position{line: 407, col: 17, offset: 9917},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 388, col: 17, offset: 9415},
+											pos:        position{line: 407, col: 17, offset: 9917},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 388, col: 21, offset: 9419},
+											pos:  position{line: 407, col: 21, offset: 9921},
 											name: "__",
 										},
 									},
@@ -2954,10 +3086,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 388, col: 25, offset: 9423},
+							pos:   position{line: 407, col: 25, offset: 9925},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 388, col: 30, offset: 9428},
+								pos:  position{line: 407, col: 30, offset: 9930},
 								name: "SearchBoolean",
 							},
 						},
@@ -2969,32 +3101,32 @@ var g = &grammar{
 		},
 		{
 			name: "AssertOp",
-			pos:  position{line: 392, col: 1, offset: 9528},
+			pos:  position{line: 411, col: 1, offset: 10030},
 			expr: &actionExpr{
-				pos: position{line: 393, col: 5, offset: 9541},
+				pos: position{line: 412, col: 5, offset: 10043},
 				run: (*parser).callonAssertOp1,
 				expr: &seqExpr{
-					pos: position{line: 393, col: 5, offset: 9541},
+					pos: position{line: 412, col: 5, offset: 10043},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 393, col: 5, offset: 9541},
+							pos:  position{line: 412, col: 5, offset: 10043},
 							name: "ASSERT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 393, col: 12, offset: 9548},
+							pos:  position{line: 412, col: 12, offset: 10050},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 393, col: 14, offset: 9550},
+							pos:   position{line: 412, col: 14, offset: 10052},
 							label: "expr",
 							expr: &actionExpr{
-								pos: position{line: 393, col: 20, offset: 9556},
+								pos: position{line: 412, col: 20, offset: 10058},
 								run: (*parser).callonAssertOp6,
 								expr: &labeledExpr{
-									pos:   position{line: 393, col: 20, offset: 9556},
+									pos:   position{line: 412, col: 20, offset: 10058},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 393, col: 22, offset: 9558},
+										pos:  position{line: 412, col: 22, offset: 10060},
 										name: "Expr",
 									},
 								},
@@ -3008,33 +3140,33 @@ var g = &grammar{
 		},
 		{
 			name: "SortOp",
-			pos:  position{line: 402, col: 1, offset: 9788},
+			pos:  position{line: 421, col: 1, offset: 10290},
 			expr: &actionExpr{
-				pos: position{line: 403, col: 5, offset: 9799},
+				pos: position{line: 422, col: 5, offset: 10301},
 				run: (*parser).callonSortOp1,
 				expr: &seqExpr{
-					pos: position{line: 403, col: 5, offset: 9799},
+					pos: position{line: 422, col: 5, offset: 10301},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 403, col: 6, offset: 9800},
+							pos: position{line: 422, col: 6, offset: 10302},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 403, col: 6, offset: 9800},
+									pos:  position{line: 422, col: 6, offset: 10302},
 									name: "SORT",
 								},
 								&seqExpr{
-									pos: position{line: 403, col: 13, offset: 9807},
+									pos: position{line: 422, col: 13, offset: 10309},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 403, col: 13, offset: 9807},
+											pos:  position{line: 422, col: 13, offset: 10309},
 											name: "ORDER",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 403, col: 19, offset: 9813},
+											pos:  position{line: 422, col: 19, offset: 10315},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 403, col: 21, offset: 9815},
+											pos:  position{line: 422, col: 21, offset: 10317},
 											name: "BY",
 										},
 									},
@@ -3042,40 +3174,40 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 403, col: 25, offset: 9819},
+							pos: position{line: 422, col: 25, offset: 10321},
 							expr: &ruleRefExpr{
-								pos:  position{line: 403, col: 26, offset: 9820},
+								pos:  position{line: 422, col: 26, offset: 10322},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 403, col: 31, offset: 9825},
+							pos:   position{line: 422, col: 31, offset: 10327},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 403, col: 36, offset: 9830},
+								pos:  position{line: 422, col: 36, offset: 10332},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 403, col: 45, offset: 9839},
+							pos:   position{line: 422, col: 45, offset: 10341},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 403, col: 51, offset: 9845},
+								pos: position{line: 422, col: 51, offset: 10347},
 								expr: &actionExpr{
-									pos: position{line: 403, col: 52, offset: 9846},
+									pos: position{line: 422, col: 52, offset: 10348},
 									run: (*parser).callonSortOp15,
 									expr: &seqExpr{
-										pos: position{line: 403, col: 52, offset: 9846},
+										pos: position{line: 422, col: 52, offset: 10348},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 403, col: 52, offset: 9846},
+												pos:  position{line: 422, col: 52, offset: 10348},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 403, col: 55, offset: 9849},
+												pos:   position{line: 422, col: 55, offset: 10351},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 403, col: 57, offset: 9851},
+													pos:  position{line: 422, col: 57, offset: 10353},
 													name: "OrderByList",
 												},
 											},
@@ -3092,30 +3224,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 421, col: 1, offset: 10250},
+			pos:  position{line: 440, col: 1, offset: 10752},
 			expr: &actionExpr{
-				pos: position{line: 421, col: 12, offset: 10261},
+				pos: position{line: 440, col: 12, offset: 10763},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 421, col: 12, offset: 10261},
+					pos:   position{line: 440, col: 12, offset: 10763},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 421, col: 17, offset: 10266},
+						pos: position{line: 440, col: 17, offset: 10768},
 						expr: &actionExpr{
-							pos: position{line: 421, col: 18, offset: 10267},
+							pos: position{line: 440, col: 18, offset: 10769},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 421, col: 18, offset: 10267},
+								pos: position{line: 440, col: 18, offset: 10769},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 421, col: 18, offset: 10267},
+										pos:  position{line: 440, col: 18, offset: 10769},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 421, col: 20, offset: 10269},
+										pos:   position{line: 440, col: 20, offset: 10771},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 421, col: 22, offset: 10271},
+											pos:  position{line: 440, col: 22, offset: 10773},
 											name: "SortArg",
 										},
 									},
@@ -3130,53 +3262,53 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 423, col: 1, offset: 10328},
+			pos:  position{line: 442, col: 1, offset: 10830},
 			expr: &choiceExpr{
-				pos: position{line: 424, col: 5, offset: 10340},
+				pos: position{line: 443, col: 5, offset: 10842},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 424, col: 5, offset: 10340},
+						pos: position{line: 443, col: 5, offset: 10842},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 424, col: 5, offset: 10340},
+							pos:        position{line: 443, col: 5, offset: 10842},
 							val:        "-r",
 							ignoreCase: false,
 							want:       "\"-r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 425, col: 5, offset: 10407},
+						pos: position{line: 444, col: 5, offset: 10909},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 425, col: 5, offset: 10407},
+							pos: position{line: 444, col: 5, offset: 10909},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 425, col: 5, offset: 10407},
+									pos:        position{line: 444, col: 5, offset: 10909},
 									val:        "-nulls",
 									ignoreCase: false,
 									want:       "\"-nulls\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 425, col: 14, offset: 10416},
+									pos:  position{line: 444, col: 14, offset: 10918},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 425, col: 16, offset: 10418},
+									pos:   position{line: 444, col: 16, offset: 10920},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 425, col: 23, offset: 10425},
+										pos: position{line: 444, col: 23, offset: 10927},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 425, col: 24, offset: 10426},
+											pos: position{line: 444, col: 24, offset: 10928},
 											alternatives: []any{
 												&litMatcher{
-													pos:        position{line: 425, col: 24, offset: 10426},
+													pos:        position{line: 444, col: 24, offset: 10928},
 													val:        "first",
 													ignoreCase: false,
 													want:       "\"first\"",
 												},
 												&litMatcher{
-													pos:        position{line: 425, col: 34, offset: 10436},
+													pos:        position{line: 444, col: 34, offset: 10938},
 													val:        "last",
 													ignoreCase: false,
 													want:       "\"last\"",
@@ -3195,44 +3327,44 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 429, col: 1, offset: 10555},
+			pos:  position{line: 448, col: 1, offset: 11057},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 10565},
+				pos: position{line: 449, col: 5, offset: 11067},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 430, col: 5, offset: 10565},
+					pos: position{line: 449, col: 5, offset: 11067},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 430, col: 5, offset: 10565},
+							pos:  position{line: 449, col: 5, offset: 11067},
 							name: "TOP",
 						},
 						&andExpr{
-							pos: position{line: 430, col: 9, offset: 10569},
+							pos: position{line: 449, col: 9, offset: 11071},
 							expr: &ruleRefExpr{
-								pos:  position{line: 430, col: 10, offset: 10570},
+								pos:  position{line: 449, col: 10, offset: 11072},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 430, col: 15, offset: 10575},
+							pos:   position{line: 449, col: 15, offset: 11077},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 430, col: 21, offset: 10581},
+								pos: position{line: 449, col: 21, offset: 11083},
 								expr: &actionExpr{
-									pos: position{line: 430, col: 22, offset: 10582},
+									pos: position{line: 449, col: 22, offset: 11084},
 									run: (*parser).callonTopOp8,
 									expr: &seqExpr{
-										pos: position{line: 430, col: 22, offset: 10582},
+										pos: position{line: 449, col: 22, offset: 11084},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 430, col: 22, offset: 10582},
+												pos:  position{line: 449, col: 22, offset: 11084},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 430, col: 24, offset: 10584},
+												pos:   position{line: 449, col: 24, offset: 11086},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 430, col: 26, offset: 10586},
+													pos:  position{line: 449, col: 26, offset: 11088},
 													name: "Expr",
 												},
 											},
@@ -3242,19 +3374,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 430, col: 51, offset: 10611},
+							pos:   position{line: 449, col: 51, offset: 11113},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 430, col: 57, offset: 10617},
+								pos: position{line: 449, col: 57, offset: 11119},
 								expr: &seqExpr{
-									pos: position{line: 430, col: 58, offset: 10618},
+									pos: position{line: 449, col: 58, offset: 11120},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 430, col: 58, offset: 10618},
+											pos:  position{line: 449, col: 58, offset: 11120},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 430, col: 60, offset: 10620},
+											pos:        position{line: 449, col: 60, offset: 11122},
 											val:        "-flush",
 											ignoreCase: false,
 											want:       "\"-flush\"",
@@ -3264,25 +3396,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 430, col: 71, offset: 10631},
+							pos:   position{line: 449, col: 71, offset: 11133},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 430, col: 78, offset: 10638},
+								pos: position{line: 449, col: 78, offset: 11140},
 								expr: &actionExpr{
-									pos: position{line: 430, col: 79, offset: 10639},
+									pos: position{line: 449, col: 79, offset: 11141},
 									run: (*parser).callonTopOp20,
 									expr: &seqExpr{
-										pos: position{line: 430, col: 79, offset: 10639},
+										pos: position{line: 449, col: 79, offset: 11141},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 430, col: 79, offset: 10639},
+												pos:  position{line: 449, col: 79, offset: 11141},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 430, col: 81, offset: 10641},
+												pos:   position{line: 449, col: 81, offset: 11143},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 430, col: 83, offset: 10643},
+													pos:  position{line: 449, col: 83, offset: 11145},
 													name: "Lvals",
 												},
 											},
@@ -3299,26 +3431,26 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 447, col: 1, offset: 10972},
+			pos:  position{line: 466, col: 1, offset: 11474},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 5, offset: 10982},
+				pos: position{line: 467, col: 5, offset: 11484},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 448, col: 5, offset: 10982},
+					pos: position{line: 467, col: 5, offset: 11484},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 448, col: 5, offset: 10982},
+							pos:  position{line: 467, col: 5, offset: 11484},
 							name: "CUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 448, col: 9, offset: 10986},
+							pos:  position{line: 467, col: 9, offset: 11488},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 448, col: 11, offset: 10988},
+							pos:   position{line: 467, col: 11, offset: 11490},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 448, col: 16, offset: 10993},
+								pos:  position{line: 467, col: 16, offset: 11495},
 								name: "FlexAssignments",
 							},
 						},
@@ -3330,26 +3462,26 @@ var g = &grammar{
 		},
 		{
 			name: "DistinctOp",
-			pos:  position{line: 456, col: 1, offset: 11141},
+			pos:  position{line: 475, col: 1, offset: 11643},
 			expr: &actionExpr{
-				pos: position{line: 457, col: 5, offset: 11156},
+				pos: position{line: 476, col: 5, offset: 11658},
 				run: (*parser).callonDistinctOp1,
 				expr: &seqExpr{
-					pos: position{line: 457, col: 5, offset: 11156},
+					pos: position{line: 476, col: 5, offset: 11658},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 457, col: 5, offset: 11156},
+							pos:  position{line: 476, col: 5, offset: 11658},
 							name: "DISTINCT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 457, col: 14, offset: 11165},
+							pos:  position{line: 476, col: 14, offset: 11667},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 457, col: 16, offset: 11167},
+							pos:   position{line: 476, col: 16, offset: 11669},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 457, col: 18, offset: 11169},
+								pos:  position{line: 476, col: 18, offset: 11671},
 								name: "Expr",
 							},
 						},
@@ -3361,26 +3493,26 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 465, col: 1, offset: 11305},
+			pos:  position{line: 484, col: 1, offset: 11807},
 			expr: &actionExpr{
-				pos: position{line: 466, col: 5, offset: 11316},
+				pos: position{line: 485, col: 5, offset: 11818},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 466, col: 5, offset: 11316},
+					pos: position{line: 485, col: 5, offset: 11818},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 466, col: 5, offset: 11316},
+							pos:  position{line: 485, col: 5, offset: 11818},
 							name: "DROP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 466, col: 10, offset: 11321},
+							pos:  position{line: 485, col: 10, offset: 11823},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 466, col: 12, offset: 11323},
+							pos:   position{line: 485, col: 12, offset: 11825},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 466, col: 17, offset: 11328},
+								pos:  position{line: 485, col: 17, offset: 11830},
 								name: "Lvals",
 							},
 						},
@@ -3392,45 +3524,45 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 474, col: 1, offset: 11468},
+			pos:  position{line: 493, col: 1, offset: 11970},
 			expr: &choiceExpr{
-				pos: position{line: 475, col: 5, offset: 11479},
+				pos: position{line: 494, col: 5, offset: 11981},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 475, col: 5, offset: 11479},
+						pos: position{line: 494, col: 5, offset: 11981},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 475, col: 5, offset: 11479},
+							pos: position{line: 494, col: 5, offset: 11981},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 475, col: 6, offset: 11480},
+									pos: position{line: 494, col: 6, offset: 11982},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 475, col: 6, offset: 11480},
+											pos:  position{line: 494, col: 6, offset: 11982},
 											name: "HEAD",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 475, col: 13, offset: 11487},
+											pos:  position{line: 494, col: 13, offset: 11989},
 											name: "LIMIT",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 475, col: 20, offset: 11494},
+									pos:  position{line: 494, col: 20, offset: 11996},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 475, col: 22, offset: 11496},
+									pos: position{line: 494, col: 22, offset: 11998},
 									expr: &ruleRefExpr{
-										pos:  position{line: 475, col: 23, offset: 11497},
+										pos:  position{line: 494, col: 23, offset: 11999},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 475, col: 31, offset: 11505},
+									pos:   position{line: 494, col: 31, offset: 12007},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 475, col: 37, offset: 11511},
+										pos:  position{line: 494, col: 37, offset: 12013},
 										name: "Expr",
 									},
 								},
@@ -3438,26 +3570,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 11641},
+						pos: position{line: 501, col: 5, offset: 12143},
 						run: (*parser).callonHeadOp12,
 						expr: &seqExpr{
-							pos: position{line: 482, col: 5, offset: 11641},
+							pos: position{line: 501, col: 5, offset: 12143},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 482, col: 5, offset: 11641},
+									pos:  position{line: 501, col: 5, offset: 12143},
 									name: "HEAD",
 								},
 								&notExpr{
-									pos: position{line: 482, col: 10, offset: 11646},
+									pos: position{line: 501, col: 10, offset: 12148},
 									expr: &seqExpr{
-										pos: position{line: 482, col: 12, offset: 11648},
+										pos: position{line: 501, col: 12, offset: 12150},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 482, col: 12, offset: 11648},
+												pos:  position{line: 501, col: 12, offset: 12150},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 482, col: 15, offset: 11651},
+												pos:        position{line: 501, col: 15, offset: 12153},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3466,9 +3598,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 482, col: 20, offset: 11656},
+									pos: position{line: 501, col: 20, offset: 12158},
 									expr: &ruleRefExpr{
-										pos:  position{line: 482, col: 21, offset: 11657},
+										pos:  position{line: 501, col: 21, offset: 12159},
 										name: "EOKW",
 									},
 								},
@@ -3482,36 +3614,36 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 489, col: 1, offset: 11751},
+			pos:  position{line: 508, col: 1, offset: 12253},
 			expr: &choiceExpr{
-				pos: position{line: 490, col: 5, offset: 11762},
+				pos: position{line: 509, col: 5, offset: 12264},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 490, col: 5, offset: 11762},
+						pos: position{line: 509, col: 5, offset: 12264},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 490, col: 5, offset: 11762},
+							pos: position{line: 509, col: 5, offset: 12264},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 490, col: 5, offset: 11762},
+									pos:  position{line: 509, col: 5, offset: 12264},
 									name: "TAIL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 490, col: 10, offset: 11767},
+									pos:  position{line: 509, col: 10, offset: 12269},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 490, col: 12, offset: 11769},
+									pos: position{line: 509, col: 12, offset: 12271},
 									expr: &ruleRefExpr{
-										pos:  position{line: 490, col: 13, offset: 11770},
+										pos:  position{line: 509, col: 13, offset: 12272},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 490, col: 21, offset: 11778},
+									pos:   position{line: 509, col: 21, offset: 12280},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 490, col: 27, offset: 11784},
+										pos:  position{line: 509, col: 27, offset: 12286},
 										name: "Expr",
 									},
 								},
@@ -3519,26 +3651,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 497, col: 5, offset: 11914},
+						pos: position{line: 516, col: 5, offset: 12416},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 497, col: 5, offset: 11914},
+							pos: position{line: 516, col: 5, offset: 12416},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 497, col: 5, offset: 11914},
+									pos:  position{line: 516, col: 5, offset: 12416},
 									name: "TAIL",
 								},
 								&notExpr{
-									pos: position{line: 497, col: 10, offset: 11919},
+									pos: position{line: 516, col: 10, offset: 12421},
 									expr: &seqExpr{
-										pos: position{line: 497, col: 12, offset: 11921},
+										pos: position{line: 516, col: 12, offset: 12423},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 497, col: 12, offset: 11921},
+												pos:  position{line: 516, col: 12, offset: 12423},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 497, col: 15, offset: 11924},
+												pos:        position{line: 516, col: 15, offset: 12426},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3547,9 +3679,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 497, col: 20, offset: 11929},
+									pos: position{line: 516, col: 20, offset: 12431},
 									expr: &ruleRefExpr{
-										pos:  position{line: 497, col: 21, offset: 11930},
+										pos:  position{line: 516, col: 21, offset: 12432},
 										name: "EOKW",
 									},
 								},
@@ -3563,26 +3695,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 504, col: 1, offset: 12024},
+			pos:  position{line: 523, col: 1, offset: 12526},
 			expr: &actionExpr{
-				pos: position{line: 505, col: 5, offset: 12036},
+				pos: position{line: 524, col: 5, offset: 12538},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 505, col: 5, offset: 12036},
+					pos: position{line: 524, col: 5, offset: 12538},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 505, col: 5, offset: 12036},
+							pos:  position{line: 524, col: 5, offset: 12538},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 505, col: 11, offset: 12042},
+							pos:  position{line: 524, col: 11, offset: 12544},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 505, col: 13, offset: 12044},
+							pos:   position{line: 524, col: 13, offset: 12546},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 505, col: 18, offset: 12049},
+								pos:  position{line: 524, col: 18, offset: 12551},
 								name: "Expr",
 							},
 						},
@@ -3594,26 +3726,26 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 513, col: 1, offset: 12176},
+			pos:  position{line: 532, col: 1, offset: 12678},
 			expr: &choiceExpr{
-				pos: position{line: 514, col: 5, offset: 12187},
+				pos: position{line: 533, col: 5, offset: 12689},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 12187},
+						pos: position{line: 533, col: 5, offset: 12689},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 514, col: 5, offset: 12187},
+							pos: position{line: 533, col: 5, offset: 12689},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 5, offset: 12187},
+									pos:  position{line: 533, col: 5, offset: 12689},
 									name: "UNIQ",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 10, offset: 12192},
+									pos:  position{line: 533, col: 10, offset: 12694},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 514, col: 12, offset: 12194},
+									pos:        position{line: 533, col: 12, offset: 12696},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3622,26 +3754,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 517, col: 5, offset: 12279},
+						pos: position{line: 536, col: 5, offset: 12781},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 517, col: 5, offset: 12279},
+							pos: position{line: 536, col: 5, offset: 12781},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 517, col: 5, offset: 12279},
+									pos:  position{line: 536, col: 5, offset: 12781},
 									name: "UNIQ",
 								},
 								&notExpr{
-									pos: position{line: 517, col: 10, offset: 12284},
+									pos: position{line: 536, col: 10, offset: 12786},
 									expr: &seqExpr{
-										pos: position{line: 517, col: 12, offset: 12286},
+										pos: position{line: 536, col: 12, offset: 12788},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 517, col: 12, offset: 12286},
+												pos:  position{line: 536, col: 12, offset: 12788},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 517, col: 15, offset: 12289},
+												pos:        position{line: 536, col: 15, offset: 12791},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3650,9 +3782,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 517, col: 20, offset: 12294},
+									pos: position{line: 536, col: 20, offset: 12796},
 									expr: &ruleRefExpr{
-										pos:  position{line: 517, col: 21, offset: 12295},
+										pos:  position{line: 536, col: 21, offset: 12797},
 										name: "EOKW",
 									},
 								},
@@ -3666,26 +3798,26 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 521, col: 1, offset: 12364},
+			pos:  position{line: 540, col: 1, offset: 12866},
 			expr: &actionExpr{
-				pos: position{line: 522, col: 5, offset: 12374},
+				pos: position{line: 541, col: 5, offset: 12876},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 522, col: 5, offset: 12374},
+					pos: position{line: 541, col: 5, offset: 12876},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 522, col: 5, offset: 12374},
+							pos:  position{line: 541, col: 5, offset: 12876},
 							name: "PUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 522, col: 9, offset: 12378},
+							pos:  position{line: 541, col: 9, offset: 12880},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 522, col: 11, offset: 12380},
+							pos:   position{line: 541, col: 11, offset: 12882},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 522, col: 16, offset: 12385},
+								pos:  position{line: 541, col: 16, offset: 12887},
 								name: "Assignments",
 							},
 						},
@@ -3697,59 +3829,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 530, col: 1, offset: 12535},
+			pos:  position{line: 549, col: 1, offset: 13037},
 			expr: &actionExpr{
-				pos: position{line: 531, col: 5, offset: 12548},
+				pos: position{line: 550, col: 5, offset: 13050},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 531, col: 5, offset: 12548},
+					pos: position{line: 550, col: 5, offset: 13050},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 531, col: 5, offset: 12548},
+							pos:  position{line: 550, col: 5, offset: 13050},
 							name: "RENAME",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 531, col: 12, offset: 12555},
+							pos:  position{line: 550, col: 12, offset: 13057},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 531, col: 14, offset: 12557},
+							pos:   position{line: 550, col: 14, offset: 13059},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 531, col: 20, offset: 12563},
+								pos:  position{line: 550, col: 20, offset: 13065},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 531, col: 31, offset: 12574},
+							pos:   position{line: 550, col: 31, offset: 13076},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 531, col: 36, offset: 12579},
+								pos: position{line: 550, col: 36, offset: 13081},
 								expr: &actionExpr{
-									pos: position{line: 531, col: 37, offset: 12580},
+									pos: position{line: 550, col: 37, offset: 13082},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 531, col: 37, offset: 12580},
+										pos: position{line: 550, col: 37, offset: 13082},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 531, col: 37, offset: 12580},
+												pos:  position{line: 550, col: 37, offset: 13082},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 531, col: 40, offset: 12583},
+												pos:        position{line: 550, col: 40, offset: 13085},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 531, col: 44, offset: 12587},
+												pos:  position{line: 550, col: 44, offset: 13089},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 531, col: 47, offset: 12590},
+												pos:   position{line: 550, col: 47, offset: 13092},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 531, col: 50, offset: 12593},
+													pos:  position{line: 550, col: 50, offset: 13095},
 													name: "Assignment",
 												},
 											},
@@ -3766,28 +3898,28 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 544, col: 1, offset: 13058},
+			pos:  position{line: 563, col: 1, offset: 13560},
 			expr: &actionExpr{
-				pos: position{line: 545, col: 5, offset: 13069},
+				pos: position{line: 564, col: 5, offset: 13571},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 545, col: 5, offset: 13069},
+					pos: position{line: 564, col: 5, offset: 13571},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 545, col: 5, offset: 13069},
+							pos:  position{line: 564, col: 5, offset: 13571},
 							name: "FUSE",
 						},
 						&notExpr{
-							pos: position{line: 545, col: 10, offset: 13074},
+							pos: position{line: 564, col: 10, offset: 13576},
 							expr: &seqExpr{
-								pos: position{line: 545, col: 12, offset: 13076},
+								pos: position{line: 564, col: 12, offset: 13578},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 545, col: 12, offset: 13076},
+										pos:  position{line: 564, col: 12, offset: 13578},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 545, col: 15, offset: 13079},
+										pos:        position{line: 564, col: 15, offset: 13581},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3796,9 +3928,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 545, col: 20, offset: 13084},
+							pos: position{line: 564, col: 20, offset: 13586},
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 21, offset: 13085},
+								pos:  position{line: 564, col: 21, offset: 13587},
 								name: "EOKW",
 							},
 						},
@@ -3810,28 +3942,28 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 549, col: 1, offset: 13154},
+			pos:  position{line: 568, col: 1, offset: 13656},
 			expr: &actionExpr{
-				pos: position{line: 550, col: 5, offset: 13166},
+				pos: position{line: 569, col: 5, offset: 13668},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 550, col: 5, offset: 13166},
+					pos: position{line: 569, col: 5, offset: 13668},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 550, col: 5, offset: 13166},
+							pos:  position{line: 569, col: 5, offset: 13668},
 							name: "SHAPE",
 						},
 						&notExpr{
-							pos: position{line: 550, col: 11, offset: 13172},
+							pos: position{line: 569, col: 11, offset: 13674},
 							expr: &seqExpr{
-								pos: position{line: 550, col: 13, offset: 13174},
+								pos: position{line: 569, col: 13, offset: 13676},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 550, col: 13, offset: 13174},
+										pos:  position{line: 569, col: 13, offset: 13676},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 550, col: 16, offset: 13177},
+										pos:        position{line: 569, col: 16, offset: 13679},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3840,9 +3972,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 550, col: 21, offset: 13182},
+							pos: position{line: 569, col: 21, offset: 13684},
 							expr: &ruleRefExpr{
-								pos:  position{line: 550, col: 22, offset: 13183},
+								pos:  position{line: 569, col: 22, offset: 13685},
 								name: "EOKW",
 							},
 						},
@@ -3854,55 +3986,55 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 554, col: 1, offset: 13254},
+			pos:  position{line: 573, col: 1, offset: 13756},
 			expr: &actionExpr{
-				pos: position{line: 555, col: 5, offset: 13265},
+				pos: position{line: 574, col: 5, offset: 13767},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 555, col: 5, offset: 13265},
+					pos: position{line: 574, col: 5, offset: 13767},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 555, col: 5, offset: 13265},
+							pos:   position{line: 574, col: 5, offset: 13767},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 555, col: 11, offset: 13271},
+								pos:  position{line: 574, col: 11, offset: 13773},
 								name: "JoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 555, col: 21, offset: 13281},
+							pos:  position{line: 574, col: 21, offset: 13783},
 							name: "JOIN",
 						},
 						&labeledExpr{
-							pos:   position{line: 555, col: 26, offset: 13286},
+							pos:   position{line: 574, col: 26, offset: 13788},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 555, col: 37, offset: 13297},
+								pos:  position{line: 574, col: 37, offset: 13799},
 								name: "JoinRightInput",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 555, col: 52, offset: 13312},
+							pos:   position{line: 574, col: 52, offset: 13814},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 555, col: 54, offset: 13314},
+								pos:  position{line: 574, col: 54, offset: 13816},
 								name: "JoinExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 555, col: 63, offset: 13323},
+							pos:   position{line: 574, col: 63, offset: 13825},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 555, col: 71, offset: 13331},
+								pos: position{line: 574, col: 71, offset: 13833},
 								expr: &seqExpr{
-									pos: position{line: 555, col: 72, offset: 13332},
+									pos: position{line: 574, col: 72, offset: 13834},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 555, col: 72, offset: 13332},
+											pos:  position{line: 574, col: 72, offset: 13834},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 555, col: 74, offset: 13334},
+											pos:  position{line: 574, col: 74, offset: 13836},
 											name: "FlexAssignments",
 										},
 									},
@@ -3917,83 +4049,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 571, col: 1, offset: 13700},
+			pos:  position{line: 590, col: 1, offset: 14202},
 			expr: &choiceExpr{
-				pos: position{line: 572, col: 5, offset: 13714},
+				pos: position{line: 591, col: 5, offset: 14216},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 572, col: 5, offset: 13714},
+						pos: position{line: 591, col: 5, offset: 14216},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 572, col: 5, offset: 13714},
+							pos: position{line: 591, col: 5, offset: 14216},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 572, col: 5, offset: 13714},
+									pos:  position{line: 591, col: 5, offset: 14216},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 572, col: 10, offset: 13719},
+									pos:  position{line: 591, col: 10, offset: 14221},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 573, col: 5, offset: 13749},
+						pos: position{line: 592, col: 5, offset: 14251},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 573, col: 5, offset: 13749},
+							pos: position{line: 592, col: 5, offset: 14251},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 573, col: 5, offset: 13749},
+									pos:  position{line: 592, col: 5, offset: 14251},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 573, col: 11, offset: 13755},
+									pos:  position{line: 592, col: 11, offset: 14257},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 574, col: 5, offset: 13785},
+						pos: position{line: 593, col: 5, offset: 14287},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 574, col: 5, offset: 13785},
+							pos: position{line: 593, col: 5, offset: 14287},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 574, col: 5, offset: 13785},
+									pos:  position{line: 593, col: 5, offset: 14287},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 574, col: 11, offset: 13791},
+									pos:  position{line: 593, col: 11, offset: 14293},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 575, col: 5, offset: 13820},
+						pos: position{line: 594, col: 5, offset: 14322},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 575, col: 5, offset: 13820},
+							pos: position{line: 594, col: 5, offset: 14322},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 575, col: 5, offset: 13820},
+									pos:  position{line: 594, col: 5, offset: 14322},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 575, col: 11, offset: 13826},
+									pos:  position{line: 594, col: 11, offset: 14328},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 576, col: 5, offset: 13856},
+						pos: position{line: 595, col: 5, offset: 14358},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 576, col: 5, offset: 13856},
+							pos:        position{line: 595, col: 5, offset: 14358},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4006,44 +4138,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 578, col: 1, offset: 13891},
+			pos:  position{line: 597, col: 1, offset: 14393},
 			expr: &choiceExpr{
-				pos: position{line: 579, col: 5, offset: 13910},
+				pos: position{line: 598, col: 5, offset: 14412},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 579, col: 5, offset: 13910},
+						pos: position{line: 598, col: 5, offset: 14412},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 579, col: 5, offset: 13910},
+							pos: position{line: 598, col: 5, offset: 14412},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 579, col: 5, offset: 13910},
+									pos:  position{line: 598, col: 5, offset: 14412},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 579, col: 8, offset: 13913},
+									pos:        position{line: 598, col: 8, offset: 14415},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 579, col: 12, offset: 13917},
+									pos:  position{line: 598, col: 12, offset: 14419},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 579, col: 15, offset: 13920},
+									pos:   position{line: 598, col: 15, offset: 14422},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 579, col: 17, offset: 13922},
+										pos:  position{line: 598, col: 17, offset: 14424},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 579, col: 21, offset: 13926},
+									pos:  position{line: 598, col: 21, offset: 14428},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 579, col: 24, offset: 13929},
+									pos:        position{line: 598, col: 24, offset: 14431},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4052,10 +4184,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 580, col: 5, offset: 13955},
+						pos: position{line: 599, col: 5, offset: 14457},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 580, col: 5, offset: 13955},
+							pos:        position{line: 599, col: 5, offset: 14457},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4068,36 +4200,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 582, col: 1, offset: 13979},
+			pos:  position{line: 601, col: 1, offset: 14481},
 			expr: &choiceExpr{
-				pos: position{line: 583, col: 5, offset: 13991},
+				pos: position{line: 602, col: 5, offset: 14493},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 583, col: 5, offset: 13991},
+						pos:  position{line: 602, col: 5, offset: 14493},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 584, col: 5, offset: 14000},
+						pos: position{line: 603, col: 5, offset: 14502},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 584, col: 5, offset: 14000},
+							pos: position{line: 603, col: 5, offset: 14502},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 584, col: 5, offset: 14000},
+									pos:        position{line: 603, col: 5, offset: 14502},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 584, col: 9, offset: 14004},
+									pos:   position{line: 603, col: 9, offset: 14506},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 584, col: 14, offset: 14009},
+										pos:  position{line: 603, col: 14, offset: 14511},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 584, col: 19, offset: 14014},
+									pos:        position{line: 603, col: 19, offset: 14516},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4112,44 +4244,44 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 586, col: 1, offset: 14040},
+			pos:  position{line: 605, col: 1, offset: 14542},
 			expr: &actionExpr{
-				pos: position{line: 587, col: 5, offset: 14053},
+				pos: position{line: 606, col: 5, offset: 14555},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 587, col: 5, offset: 14053},
+					pos: position{line: 606, col: 5, offset: 14555},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 587, col: 5, offset: 14053},
+							pos:  position{line: 606, col: 5, offset: 14555},
 							name: "SAMPLE",
 						},
 						&andExpr{
-							pos: position{line: 587, col: 12, offset: 14060},
+							pos: position{line: 606, col: 12, offset: 14562},
 							expr: &ruleRefExpr{
-								pos:  position{line: 587, col: 13, offset: 14061},
+								pos:  position{line: 606, col: 13, offset: 14563},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 587, col: 18, offset: 14066},
+							pos:   position{line: 606, col: 18, offset: 14568},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 587, col: 23, offset: 14071},
+								pos: position{line: 606, col: 23, offset: 14573},
 								expr: &actionExpr{
-									pos: position{line: 587, col: 24, offset: 14072},
+									pos: position{line: 606, col: 24, offset: 14574},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 587, col: 24, offset: 14072},
+										pos: position{line: 606, col: 24, offset: 14574},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 587, col: 24, offset: 14072},
+												pos:  position{line: 606, col: 24, offset: 14574},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 587, col: 26, offset: 14074},
+												pos:   position{line: 606, col: 26, offset: 14576},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 587, col: 28, offset: 14076},
+													pos:  position{line: 606, col: 28, offset: 14578},
 													name: "Lval",
 												},
 											},
@@ -4166,15 +4298,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 600, col: 1, offset: 14515},
+			pos:  position{line: 619, col: 1, offset: 15017},
 			expr: &actionExpr{
-				pos: position{line: 601, col: 5, offset: 14532},
+				pos: position{line: 620, col: 5, offset: 15034},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 601, col: 5, offset: 14532},
+					pos:   position{line: 620, col: 5, offset: 15034},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 601, col: 7, offset: 14534},
+						pos:  position{line: 620, col: 7, offset: 15036},
 						name: "Assignments",
 					},
 				},
@@ -4184,69 +4316,69 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 609, col: 1, offset: 14706},
+			pos:  position{line: 628, col: 1, offset: 15208},
 			expr: &actionExpr{
-				pos: position{line: 610, col: 5, offset: 14717},
+				pos: position{line: 629, col: 5, offset: 15219},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 610, col: 5, offset: 14717},
+					pos: position{line: 629, col: 5, offset: 15219},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 610, col: 5, offset: 14717},
+							pos:  position{line: 629, col: 5, offset: 15219},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 610, col: 10, offset: 14722},
+							pos:  position{line: 629, col: 10, offset: 15224},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 12, offset: 14724},
+							pos:   position{line: 629, col: 12, offset: 15226},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 610, col: 17, offset: 14729},
+								pos:  position{line: 629, col: 17, offset: 15231},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 22, offset: 14734},
+							pos:   position{line: 629, col: 22, offset: 15236},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 610, col: 29, offset: 14741},
+								pos: position{line: 629, col: 29, offset: 15243},
 								expr: &ruleRefExpr{
-									pos:  position{line: 610, col: 29, offset: 14741},
+									pos:  position{line: 629, col: 29, offset: 15243},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 41, offset: 14753},
+							pos:   position{line: 629, col: 41, offset: 15255},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 610, col: 48, offset: 14760},
+								pos: position{line: 629, col: 48, offset: 15262},
 								expr: &ruleRefExpr{
-									pos:  position{line: 610, col: 48, offset: 14760},
+									pos:  position{line: 629, col: 48, offset: 15262},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 59, offset: 14771},
+							pos:   position{line: 629, col: 59, offset: 15273},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 610, col: 67, offset: 14779},
+								pos: position{line: 629, col: 67, offset: 15281},
 								expr: &ruleRefExpr{
-									pos:  position{line: 610, col: 67, offset: 14779},
+									pos:  position{line: 629, col: 67, offset: 15281},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 79, offset: 14791},
+							pos:   position{line: 629, col: 79, offset: 15293},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 610, col: 84, offset: 14796},
+								pos: position{line: 629, col: 84, offset: 15298},
 								expr: &ruleRefExpr{
-									pos:  position{line: 610, col: 84, offset: 14796},
+									pos:  position{line: 629, col: 84, offset: 15298},
 									name: "MetaArg",
 								},
 							},
@@ -4259,30 +4391,30 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 622, col: 1, offset: 15078},
+			pos:  position{line: 641, col: 1, offset: 15580},
 			expr: &actionExpr{
-				pos: position{line: 623, col: 5, offset: 15092},
+				pos: position{line: 642, col: 5, offset: 15594},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 623, col: 5, offset: 15092},
+					pos: position{line: 642, col: 5, offset: 15594},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 623, col: 5, offset: 15092},
+							pos:  position{line: 642, col: 5, offset: 15594},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 623, col: 7, offset: 15094},
+							pos:  position{line: 642, col: 7, offset: 15596},
 							name: "AUTHOR",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 623, col: 14, offset: 15101},
+							pos:  position{line: 642, col: 14, offset: 15603},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 623, col: 16, offset: 15103},
+							pos:   position{line: 642, col: 16, offset: 15605},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 623, col: 18, offset: 15105},
+								pos:  position{line: 642, col: 18, offset: 15607},
 								name: "Name",
 							},
 						},
@@ -4294,30 +4426,30 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 625, col: 1, offset: 15129},
+			pos:  position{line: 644, col: 1, offset: 15631},
 			expr: &actionExpr{
-				pos: position{line: 626, col: 5, offset: 15144},
+				pos: position{line: 645, col: 5, offset: 15646},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 626, col: 5, offset: 15144},
+					pos: position{line: 645, col: 5, offset: 15646},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 5, offset: 15144},
+							pos:  position{line: 645, col: 5, offset: 15646},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 7, offset: 15146},
+							pos:  position{line: 645, col: 7, offset: 15648},
 							name: "MESSAGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 15, offset: 15154},
+							pos:  position{line: 645, col: 15, offset: 15656},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 17, offset: 15156},
+							pos:   position{line: 645, col: 17, offset: 15658},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 626, col: 19, offset: 15158},
+								pos:  position{line: 645, col: 19, offset: 15660},
 								name: "Name",
 							},
 						},
@@ -4329,30 +4461,30 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 628, col: 1, offset: 15182},
+			pos:  position{line: 647, col: 1, offset: 15684},
 			expr: &actionExpr{
-				pos: position{line: 629, col: 5, offset: 15194},
+				pos: position{line: 648, col: 5, offset: 15696},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 629, col: 5, offset: 15194},
+					pos: position{line: 648, col: 5, offset: 15696},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 629, col: 5, offset: 15194},
+							pos:  position{line: 648, col: 5, offset: 15696},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 629, col: 7, offset: 15196},
+							pos:  position{line: 648, col: 7, offset: 15698},
 							name: "META",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 629, col: 12, offset: 15201},
+							pos:  position{line: 648, col: 12, offset: 15703},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 14, offset: 15203},
+							pos:   position{line: 648, col: 14, offset: 15705},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 629, col: 16, offset: 15205},
+								pos:  position{line: 648, col: 16, offset: 15707},
 								name: "Name",
 							},
 						},
@@ -4364,24 +4496,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 631, col: 1, offset: 15229},
+			pos:  position{line: 650, col: 1, offset: 15731},
 			expr: &actionExpr{
-				pos: position{line: 632, col: 5, offset: 15244},
+				pos: position{line: 651, col: 5, offset: 15746},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 632, col: 5, offset: 15244},
+					pos: position{line: 651, col: 5, offset: 15746},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 632, col: 5, offset: 15244},
+							pos:        position{line: 651, col: 5, offset: 15746},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 632, col: 9, offset: 15248},
+							pos:   position{line: 651, col: 9, offset: 15750},
 							label: "branch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 632, col: 16, offset: 15255},
+								pos:  position{line: 651, col: 16, offset: 15757},
 								name: "Name",
 							},
 						},
@@ -4393,26 +4525,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 634, col: 1, offset: 15284},
+			pos:  position{line: 653, col: 1, offset: 15786},
 			expr: &actionExpr{
-				pos: position{line: 635, col: 5, offset: 15297},
+				pos: position{line: 654, col: 5, offset: 15799},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 635, col: 5, offset: 15297},
+					pos: position{line: 654, col: 5, offset: 15799},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 635, col: 5, offset: 15297},
+							pos:  position{line: 654, col: 5, offset: 15799},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 635, col: 12, offset: 15304},
+							pos:  position{line: 654, col: 12, offset: 15806},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 635, col: 14, offset: 15306},
+							pos:   position{line: 654, col: 14, offset: 15808},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 19, offset: 15311},
+								pos:  position{line: 654, col: 19, offset: 15813},
 								name: "Identifier",
 							},
 						},
@@ -4424,44 +4556,44 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 643, col: 1, offset: 15445},
+			pos:  position{line: 662, col: 1, offset: 15947},
 			expr: &actionExpr{
-				pos: position{line: 644, col: 5, offset: 15457},
+				pos: position{line: 663, col: 5, offset: 15959},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 644, col: 5, offset: 15457},
+					pos: position{line: 663, col: 5, offset: 15959},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 644, col: 5, offset: 15457},
+							pos:  position{line: 663, col: 5, offset: 15959},
 							name: "DEBUG",
 						},
 						&andExpr{
-							pos: position{line: 644, col: 11, offset: 15463},
+							pos: position{line: 663, col: 11, offset: 15965},
 							expr: &ruleRefExpr{
-								pos:  position{line: 644, col: 12, offset: 15464},
+								pos:  position{line: 663, col: 12, offset: 15966},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 644, col: 17, offset: 15469},
+							pos:   position{line: 663, col: 17, offset: 15971},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 644, col: 22, offset: 15474},
+								pos: position{line: 663, col: 22, offset: 15976},
 								expr: &actionExpr{
-									pos: position{line: 644, col: 23, offset: 15475},
+									pos: position{line: 663, col: 23, offset: 15977},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 644, col: 23, offset: 15475},
+										pos: position{line: 663, col: 23, offset: 15977},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 644, col: 23, offset: 15475},
+												pos:  position{line: 663, col: 23, offset: 15977},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 644, col: 25, offset: 15477},
+												pos:   position{line: 663, col: 25, offset: 15979},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 644, col: 27, offset: 15479},
+													pos:  position{line: 663, col: 27, offset: 15981},
 													name: "Expr",
 												},
 											},
@@ -4478,26 +4610,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 655, col: 1, offset: 15672},
+			pos:  position{line: 674, col: 1, offset: 16174},
 			expr: &actionExpr{
-				pos: position{line: 656, col: 5, offset: 15683},
+				pos: position{line: 675, col: 5, offset: 16185},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 656, col: 5, offset: 15683},
+					pos: position{line: 675, col: 5, offset: 16185},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 656, col: 5, offset: 15683},
+							pos:  position{line: 675, col: 5, offset: 16185},
 							name: "FromKeyWord",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 656, col: 17, offset: 15695},
+							pos:  position{line: 675, col: 17, offset: 16197},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 656, col: 19, offset: 15697},
+							pos:   position{line: 675, col: 19, offset: 16199},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 656, col: 25, offset: 15703},
+								pos:  position{line: 675, col: 25, offset: 16205},
 								name: "FromElems",
 							},
 						},
@@ -4509,16 +4641,16 @@ var g = &grammar{
 		},
 		{
 			name: "FromKeyWord",
-			pos:  position{line: 664, col: 1, offset: 15846},
+			pos:  position{line: 683, col: 1, offset: 16348},
 			expr: &choiceExpr{
-				pos: position{line: 665, col: 5, offset: 15862},
+				pos: position{line: 684, col: 5, offset: 16364},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 665, col: 5, offset: 15862},
+						pos:  position{line: 684, col: 5, offset: 16364},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 666, col: 5, offset: 15871},
+						pos:  position{line: 685, col: 5, offset: 16373},
 						name: "DeprecatedFroms",
 					},
 				},
@@ -4528,24 +4660,24 @@ var g = &grammar{
 		},
 		{
 			name: "DeprecatedFroms",
-			pos:  position{line: 668, col: 1, offset: 15888},
+			pos:  position{line: 687, col: 1, offset: 16390},
 			expr: &choiceExpr{
-				pos: position{line: 668, col: 19, offset: 15906},
+				pos: position{line: 687, col: 19, offset: 16408},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 668, col: 19, offset: 15906},
+						pos:        position{line: 687, col: 19, offset: 16408},
 						val:        "get",
 						ignoreCase: false,
 						want:       "\"get\"",
 					},
 					&litMatcher{
-						pos:        position{line: 668, col: 27, offset: 15914},
+						pos:        position{line: 687, col: 27, offset: 16416},
 						val:        "file",
 						ignoreCase: false,
 						want:       "\"file\"",
 					},
 					&litMatcher{
-						pos:        position{line: 668, col: 36, offset: 15923},
+						pos:        position{line: 687, col: 36, offset: 16425},
 						val:        "pool",
 						ignoreCase: false,
 						want:       "\"pool\"",
@@ -4557,51 +4689,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 670, col: 1, offset: 15931},
+			pos:  position{line: 689, col: 1, offset: 16433},
 			expr: &actionExpr{
-				pos: position{line: 671, col: 5, offset: 15945},
+				pos: position{line: 690, col: 5, offset: 16447},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 671, col: 5, offset: 15945},
+					pos: position{line: 690, col: 5, offset: 16447},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 671, col: 5, offset: 15945},
+							pos:   position{line: 690, col: 5, offset: 16447},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 671, col: 11, offset: 15951},
+								pos:  position{line: 690, col: 11, offset: 16453},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 671, col: 20, offset: 15960},
+							pos:   position{line: 690, col: 20, offset: 16462},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 671, col: 25, offset: 15965},
+								pos: position{line: 690, col: 25, offset: 16467},
 								expr: &actionExpr{
-									pos: position{line: 671, col: 27, offset: 15967},
+									pos: position{line: 690, col: 27, offset: 16469},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 671, col: 27, offset: 15967},
+										pos: position{line: 690, col: 27, offset: 16469},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 671, col: 27, offset: 15967},
+												pos:  position{line: 690, col: 27, offset: 16469},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 671, col: 30, offset: 15970},
+												pos:        position{line: 690, col: 30, offset: 16472},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 671, col: 34, offset: 15974},
+												pos:  position{line: 690, col: 34, offset: 16476},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 671, col: 37, offset: 15977},
+												pos:   position{line: 690, col: 37, offset: 16479},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 671, col: 42, offset: 15982},
+													pos:  position{line: 690, col: 42, offset: 16484},
 													name: "FromElem",
 												},
 											},
@@ -4618,42 +4750,42 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 675, col: 1, offset: 16066},
+			pos:  position{line: 694, col: 1, offset: 16568},
 			expr: &actionExpr{
-				pos: position{line: 676, col: 5, offset: 16079},
+				pos: position{line: 695, col: 5, offset: 16581},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 676, col: 5, offset: 16079},
+					pos: position{line: 695, col: 5, offset: 16581},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 676, col: 5, offset: 16079},
+							pos:   position{line: 695, col: 5, offset: 16581},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 676, col: 12, offset: 16086},
+								pos:  position{line: 695, col: 12, offset: 16588},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 676, col: 23, offset: 16097},
+							pos:   position{line: 695, col: 23, offset: 16599},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 676, col: 28, offset: 16102},
+								pos:  position{line: 695, col: 28, offset: 16604},
 								name: "FromArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 676, col: 37, offset: 16111},
+							pos:   position{line: 695, col: 37, offset: 16613},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 676, col: 39, offset: 16113},
+								pos:  position{line: 695, col: 39, offset: 16615},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 676, col: 53, offset: 16127},
+							pos:   position{line: 695, col: 53, offset: 16629},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 676, col: 59, offset: 16133},
+								pos:  position{line: 695, col: 59, offset: 16635},
 								name: "OptAlias",
 							},
 						},
@@ -4665,46 +4797,46 @@ var g = &grammar{
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 694, col: 1, offset: 16521},
+			pos:  position{line: 713, col: 1, offset: 17023},
 			expr: &choiceExpr{
-				pos: position{line: 695, col: 5, offset: 16536},
+				pos: position{line: 714, col: 5, offset: 17038},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 16536},
+						pos: position{line: 714, col: 5, offset: 17038},
 						run: (*parser).callonFromEntity2,
 						expr: &labeledExpr{
-							pos:   position{line: 695, col: 5, offset: 16536},
+							pos:   position{line: 714, col: 5, offset: 17038},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 695, col: 9, offset: 16540},
+								pos:  position{line: 714, col: 9, offset: 17042},
 								name: "UnquotedURL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 702, col: 5, offset: 16672},
+						pos:  position{line: 721, col: 5, offset: 17174},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 703, col: 5, offset: 16683},
+						pos:  position{line: 722, col: 5, offset: 17185},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 704, col: 5, offset: 16692},
+						pos: position{line: 723, col: 5, offset: 17194},
 						run: (*parser).callonFromEntity7,
 						expr: &seqExpr{
-							pos: position{line: 704, col: 5, offset: 16692},
+							pos: position{line: 723, col: 5, offset: 17194},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 704, col: 5, offset: 16692},
+									pos:        position{line: 723, col: 5, offset: 17194},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 704, col: 9, offset: 16696},
+									pos: position{line: 723, col: 9, offset: 17198},
 									expr: &ruleRefExpr{
-										pos:  position{line: 704, col: 10, offset: 16697},
+										pos:  position{line: 723, col: 10, offset: 17199},
 										name: "ExprGuard",
 									},
 								},
@@ -4712,43 +4844,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 705, col: 5, offset: 16778},
+						pos: position{line: 724, col: 5, offset: 17280},
 						run: (*parser).callonFromEntity12,
 						expr: &seqExpr{
-							pos: position{line: 705, col: 5, offset: 16778},
+							pos: position{line: 724, col: 5, offset: 17280},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 705, col: 5, offset: 16778},
+									pos:  position{line: 724, col: 5, offset: 17280},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 705, col: 10, offset: 16783},
+									pos:  position{line: 724, col: 10, offset: 17285},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 705, col: 13, offset: 16786},
+									pos:        position{line: 724, col: 13, offset: 17288},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 705, col: 17, offset: 16790},
+									pos:  position{line: 724, col: 17, offset: 17292},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 705, col: 20, offset: 16793},
+									pos:   position{line: 724, col: 20, offset: 17295},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 705, col: 22, offset: 16795},
+										pos:  position{line: 724, col: 22, offset: 17297},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 705, col: 27, offset: 16800},
+									pos:  position{line: 724, col: 27, offset: 17302},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 705, col: 30, offset: 16803},
+									pos:        position{line: 724, col: 30, offset: 17305},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4757,35 +4889,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 16939},
+						pos: position{line: 731, col: 5, offset: 17441},
 						run: (*parser).callonFromEntity22,
 						expr: &labeledExpr{
-							pos:   position{line: 712, col: 5, offset: 16939},
+							pos:   position{line: 731, col: 5, offset: 17441},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 712, col: 10, offset: 16944},
+								pos:  position{line: 731, col: 10, offset: 17446},
 								name: "PoolMeta",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 17087},
+						pos: position{line: 738, col: 5, offset: 17589},
 						run: (*parser).callonFromEntity25,
 						expr: &seqExpr{
-							pos: position{line: 719, col: 5, offset: 17087},
+							pos: position{line: 738, col: 5, offset: 17589},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 719, col: 5, offset: 17087},
+									pos:   position{line: 738, col: 5, offset: 17589},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 719, col: 10, offset: 17092},
+										pos:  position{line: 738, col: 10, offset: 17594},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 719, col: 24, offset: 17106},
+									pos: position{line: 738, col: 24, offset: 17608},
 									expr: &ruleRefExpr{
-										pos:  position{line: 719, col: 25, offset: 17107},
+										pos:  position{line: 738, col: 25, offset: 17609},
 										name: "AliasClause",
 									},
 								},
@@ -4793,35 +4925,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 720, col: 5, offset: 17142},
+						pos: position{line: 739, col: 5, offset: 17644},
 						run: (*parser).callonFromEntity31,
 						expr: &seqExpr{
-							pos: position{line: 720, col: 5, offset: 17142},
+							pos: position{line: 739, col: 5, offset: 17644},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 720, col: 5, offset: 17142},
+									pos:        position{line: 739, col: 5, offset: 17644},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 720, col: 9, offset: 17146},
+									pos:  position{line: 739, col: 9, offset: 17648},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 720, col: 12, offset: 17149},
+									pos:   position{line: 739, col: 12, offset: 17651},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 720, col: 17, offset: 17154},
+										pos:  position{line: 739, col: 17, offset: 17656},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 720, col: 31, offset: 17168},
+									pos:  position{line: 739, col: 31, offset: 17670},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 720, col: 34, offset: 17171},
+									pos:        position{line: 739, col: 34, offset: 17673},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4830,35 +4962,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 721, col: 5, offset: 17200},
+						pos: position{line: 740, col: 5, offset: 17702},
 						run: (*parser).callonFromEntity39,
 						expr: &seqExpr{
-							pos: position{line: 721, col: 5, offset: 17200},
+							pos: position{line: 740, col: 5, offset: 17702},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 721, col: 5, offset: 17200},
+									pos:        position{line: 740, col: 5, offset: 17702},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 721, col: 9, offset: 17204},
+									pos:  position{line: 740, col: 9, offset: 17706},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 721, col: 12, offset: 17207},
+									pos:   position{line: 740, col: 12, offset: 17709},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 721, col: 14, offset: 17209},
+										pos:  position{line: 740, col: 14, offset: 17711},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 721, col: 22, offset: 17217},
+									pos:  position{line: 740, col: 22, offset: 17719},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 721, col: 25, offset: 17220},
+									pos:        position{line: 740, col: 25, offset: 17722},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4867,13 +4999,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 724, col: 6, offset: 17257},
+						pos: position{line: 743, col: 6, offset: 17759},
 						run: (*parser).callonFromEntity47,
 						expr: &labeledExpr{
-							pos:   position{line: 724, col: 6, offset: 17257},
+							pos:   position{line: 743, col: 6, offset: 17759},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 724, col: 11, offset: 17262},
+								pos:  position{line: 743, col: 11, offset: 17764},
 								name: "Name",
 							},
 						},
@@ -4885,40 +5017,40 @@ var g = &grammar{
 		},
 		{
 			name: "FromArgs",
-			pos:  position{line: 727, col: 1, offset: 17360},
+			pos:  position{line: 746, col: 1, offset: 17862},
 			expr: &choiceExpr{
-				pos: position{line: 728, col: 5, offset: 17373},
+				pos: position{line: 747, col: 5, offset: 17875},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 728, col: 5, offset: 17373},
+						pos: position{line: 747, col: 5, offset: 17875},
 						run: (*parser).callonFromArgs2,
 						expr: &seqExpr{
-							pos: position{line: 728, col: 5, offset: 17373},
+							pos: position{line: 747, col: 5, offset: 17875},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 728, col: 5, offset: 17373},
+									pos:   position{line: 747, col: 5, offset: 17875},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 728, col: 12, offset: 17380},
+										pos:  position{line: 747, col: 12, offset: 17882},
 										name: "PoolCommit",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 23, offset: 17391},
+									pos:   position{line: 747, col: 23, offset: 17893},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 728, col: 28, offset: 17396},
+										pos: position{line: 747, col: 28, offset: 17898},
 										expr: &ruleRefExpr{
-											pos:  position{line: 728, col: 28, offset: 17396},
+											pos:  position{line: 747, col: 28, offset: 17898},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 38, offset: 17406},
+									pos:   position{line: 747, col: 38, offset: 17908},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 728, col: 42, offset: 17410},
+										pos:  position{line: 747, col: 42, offset: 17912},
 										name: "TapArg",
 									},
 								},
@@ -4926,24 +5058,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 737, col: 5, offset: 17614},
+						pos: position{line: 756, col: 5, offset: 18116},
 						run: (*parser).callonFromArgs11,
 						expr: &seqExpr{
-							pos: position{line: 737, col: 5, offset: 17614},
+							pos: position{line: 756, col: 5, offset: 18116},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 737, col: 5, offset: 17614},
+									pos:   position{line: 756, col: 5, offset: 18116},
 									label: "meta",
 									expr: &ruleRefExpr{
-										pos:  position{line: 737, col: 10, offset: 17619},
+										pos:  position{line: 756, col: 10, offset: 18121},
 										name: "PoolMeta",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 737, col: 19, offset: 17628},
+									pos:   position{line: 756, col: 19, offset: 18130},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 737, col: 23, offset: 17632},
+										pos:  position{line: 756, col: 23, offset: 18134},
 										name: "TapArg",
 									},
 								},
@@ -4951,41 +5083,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 745, col: 5, offset: 17798},
+						pos: position{line: 764, col: 5, offset: 18300},
 						run: (*parser).callonFromArgs17,
 						expr: &seqExpr{
-							pos: position{line: 745, col: 5, offset: 17798},
+							pos: position{line: 764, col: 5, offset: 18300},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 745, col: 5, offset: 17798},
+									pos:   position{line: 764, col: 5, offset: 18300},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 745, col: 12, offset: 17805},
+										pos:  position{line: 764, col: 12, offset: 18307},
 										name: "FormatArg",
 									},
 								},
 								&notExpr{
-									pos: position{line: 745, col: 22, offset: 17815},
+									pos: position{line: 764, col: 22, offset: 18317},
 									expr: &seqExpr{
-										pos: position{line: 745, col: 24, offset: 17817},
+										pos: position{line: 764, col: 24, offset: 18319},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 745, col: 24, offset: 17817},
+												pos:  position{line: 764, col: 24, offset: 18319},
 												name: "_",
 											},
 											&choiceExpr{
-												pos: position{line: 745, col: 27, offset: 17820},
+												pos: position{line: 764, col: 27, offset: 18322},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 745, col: 27, offset: 17820},
+														pos:  position{line: 764, col: 27, offset: 18322},
 														name: "METHOD",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 745, col: 36, offset: 17829},
+														pos:  position{line: 764, col: 36, offset: 18331},
 														name: "HEADERS",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 745, col: 46, offset: 17839},
+														pos:  position{line: 764, col: 46, offset: 18341},
 														name: "BODY",
 													},
 												},
@@ -4997,51 +5129,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 752, col: 5, offset: 17984},
+						pos: position{line: 771, col: 5, offset: 18486},
 						run: (*parser).callonFromArgs28,
 						expr: &seqExpr{
-							pos: position{line: 752, col: 5, offset: 17984},
+							pos: position{line: 771, col: 5, offset: 18486},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 752, col: 5, offset: 17984},
+									pos:   position{line: 771, col: 5, offset: 18486},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 752, col: 12, offset: 17991},
+										pos: position{line: 771, col: 12, offset: 18493},
 										expr: &ruleRefExpr{
-											pos:  position{line: 752, col: 12, offset: 17991},
+											pos:  position{line: 771, col: 12, offset: 18493},
 											name: "FormatArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 752, col: 23, offset: 18002},
+									pos:   position{line: 771, col: 23, offset: 18504},
 									label: "method",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 752, col: 30, offset: 18009},
+										pos: position{line: 771, col: 30, offset: 18511},
 										expr: &ruleRefExpr{
-											pos:  position{line: 752, col: 30, offset: 18009},
+											pos:  position{line: 771, col: 30, offset: 18511},
 											name: "MethodArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 752, col: 41, offset: 18020},
+									pos:   position{line: 771, col: 41, offset: 18522},
 									label: "headers",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 752, col: 49, offset: 18028},
+										pos: position{line: 771, col: 49, offset: 18530},
 										expr: &ruleRefExpr{
-											pos:  position{line: 752, col: 49, offset: 18028},
+											pos:  position{line: 771, col: 49, offset: 18530},
 											name: "HeadersArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 752, col: 61, offset: 18040},
+									pos:   position{line: 771, col: 61, offset: 18542},
 									label: "body",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 752, col: 66, offset: 18045},
+										pos: position{line: 771, col: 66, offset: 18547},
 										expr: &ruleRefExpr{
-											pos:  position{line: 752, col: 66, offset: 18045},
+											pos:  position{line: 771, col: 66, offset: 18547},
 											name: "BodyArg",
 										},
 									},
@@ -5056,30 +5188,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 769, col: 1, offset: 18461},
+			pos:  position{line: 788, col: 1, offset: 18963},
 			expr: &actionExpr{
-				pos: position{line: 769, col: 13, offset: 18473},
+				pos: position{line: 788, col: 13, offset: 18975},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 769, col: 13, offset: 18473},
+					pos: position{line: 788, col: 13, offset: 18975},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 769, col: 13, offset: 18473},
+							pos:  position{line: 788, col: 13, offset: 18975},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 769, col: 15, offset: 18475},
+							pos:  position{line: 788, col: 15, offset: 18977},
 							name: "FORMAT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 769, col: 22, offset: 18482},
+							pos:  position{line: 788, col: 22, offset: 18984},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 769, col: 24, offset: 18484},
+							pos:   position{line: 788, col: 24, offset: 18986},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 769, col: 26, offset: 18486},
+								pos:  position{line: 788, col: 26, offset: 18988},
 								name: "Name",
 							},
 						},
@@ -5091,30 +5223,30 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 771, col: 1, offset: 18510},
+			pos:  position{line: 790, col: 1, offset: 19012},
 			expr: &actionExpr{
-				pos: position{line: 771, col: 13, offset: 18522},
+				pos: position{line: 790, col: 13, offset: 19024},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 771, col: 13, offset: 18522},
+					pos: position{line: 790, col: 13, offset: 19024},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 771, col: 13, offset: 18522},
+							pos:  position{line: 790, col: 13, offset: 19024},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 771, col: 15, offset: 18524},
+							pos:  position{line: 790, col: 15, offset: 19026},
 							name: "METHOD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 771, col: 22, offset: 18531},
+							pos:  position{line: 790, col: 22, offset: 19033},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 771, col: 24, offset: 18533},
+							pos:   position{line: 790, col: 24, offset: 19035},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 771, col: 26, offset: 18535},
+								pos:  position{line: 790, col: 26, offset: 19037},
 								name: "Name",
 							},
 						},
@@ -5126,30 +5258,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 773, col: 1, offset: 18559},
+			pos:  position{line: 792, col: 1, offset: 19061},
 			expr: &actionExpr{
-				pos: position{line: 773, col: 14, offset: 18572},
+				pos: position{line: 792, col: 14, offset: 19074},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 773, col: 14, offset: 18572},
+					pos: position{line: 792, col: 14, offset: 19074},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 773, col: 14, offset: 18572},
+							pos:  position{line: 792, col: 14, offset: 19074},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 773, col: 16, offset: 18574},
+							pos:  position{line: 792, col: 16, offset: 19076},
 							name: "HEADERS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 773, col: 24, offset: 18582},
+							pos:  position{line: 792, col: 24, offset: 19084},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 773, col: 26, offset: 18584},
+							pos:   position{line: 792, col: 26, offset: 19086},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 773, col: 28, offset: 18586},
+								pos:  position{line: 792, col: 28, offset: 19088},
 								name: "Record",
 							},
 						},
@@ -5161,30 +5293,30 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 775, col: 1, offset: 18612},
+			pos:  position{line: 794, col: 1, offset: 19114},
 			expr: &actionExpr{
-				pos: position{line: 775, col: 11, offset: 18622},
+				pos: position{line: 794, col: 11, offset: 19124},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 775, col: 11, offset: 18622},
+					pos: position{line: 794, col: 11, offset: 19124},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 775, col: 11, offset: 18622},
+							pos:  position{line: 794, col: 11, offset: 19124},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 775, col: 13, offset: 18624},
+							pos:  position{line: 794, col: 13, offset: 19126},
 							name: "BODY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 775, col: 18, offset: 18629},
+							pos:  position{line: 794, col: 18, offset: 19131},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 775, col: 20, offset: 18631},
+							pos:   position{line: 794, col: 20, offset: 19133},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 775, col: 22, offset: 18633},
+								pos:  position{line: 794, col: 22, offset: 19135},
 								name: "Name",
 							},
 						},
@@ -5196,24 +5328,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 777, col: 1, offset: 18657},
+			pos:  position{line: 796, col: 1, offset: 19159},
 			expr: &actionExpr{
-				pos: position{line: 777, col: 15, offset: 18671},
+				pos: position{line: 796, col: 15, offset: 19173},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 777, col: 15, offset: 18671},
+					pos: position{line: 796, col: 15, offset: 19173},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 777, col: 16, offset: 18672},
+							pos: position{line: 796, col: 16, offset: 19174},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 777, col: 16, offset: 18672},
+									pos:        position{line: 796, col: 16, offset: 19174},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 777, col: 28, offset: 18684},
+									pos:        position{line: 796, col: 28, offset: 19186},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
@@ -5221,9 +5353,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 777, col: 40, offset: 18696},
+							pos: position{line: 796, col: 40, offset: 19198},
 							expr: &ruleRefExpr{
-								pos:  position{line: 777, col: 40, offset: 18696},
+								pos:  position{line: 796, col: 40, offset: 19198},
 								name: "URLChar",
 							},
 						},
@@ -5235,9 +5367,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 779, col: 1, offset: 18737},
+			pos:  position{line: 798, col: 1, offset: 19239},
 			expr: &charClassMatcher{
-				pos:        position{line: 779, col: 11, offset: 18747},
+				pos:        position{line: 798, col: 11, offset: 19249},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -5249,30 +5381,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 782, col: 1, offset: 18811},
+			pos:  position{line: 801, col: 1, offset: 19313},
 			expr: &actionExpr{
-				pos: position{line: 783, col: 5, offset: 18822},
+				pos: position{line: 802, col: 5, offset: 19324},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 783, col: 5, offset: 18822},
+					pos: position{line: 802, col: 5, offset: 19324},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 783, col: 5, offset: 18822},
+							pos:  position{line: 802, col: 5, offset: 19324},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 783, col: 7, offset: 18824},
+							pos:  position{line: 802, col: 7, offset: 19326},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 783, col: 10, offset: 18827},
+							pos:  position{line: 802, col: 10, offset: 19329},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 783, col: 12, offset: 18829},
+							pos:   position{line: 802, col: 12, offset: 19331},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 783, col: 15, offset: 18832},
+								pos:  position{line: 802, col: 15, offset: 19334},
 								name: "KSUID",
 							},
 						},
@@ -5284,14 +5416,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 786, col: 1, offset: 18898},
+			pos:  position{line: 805, col: 1, offset: 19400},
 			expr: &actionExpr{
-				pos: position{line: 786, col: 9, offset: 18906},
+				pos: position{line: 805, col: 9, offset: 19408},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 786, col: 9, offset: 18906},
+					pos: position{line: 805, col: 9, offset: 19408},
 					expr: &charClassMatcher{
-						pos:        position{line: 786, col: 10, offset: 18907},
+						pos:        position{line: 805, col: 10, offset: 19409},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -5304,24 +5436,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 788, col: 1, offset: 18953},
+			pos:  position{line: 807, col: 1, offset: 19455},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 5, offset: 18968},
+				pos: position{line: 808, col: 5, offset: 19470},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 5, offset: 18968},
+					pos: position{line: 808, col: 5, offset: 19470},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 789, col: 5, offset: 18968},
+							pos:        position{line: 808, col: 5, offset: 19470},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 9, offset: 18972},
+							pos:   position{line: 808, col: 9, offset: 19474},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 11, offset: 18974},
+								pos:  position{line: 808, col: 11, offset: 19476},
 								name: "Name",
 							},
 						},
@@ -5333,24 +5465,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 791, col: 1, offset: 18998},
+			pos:  position{line: 810, col: 1, offset: 19500},
 			expr: &actionExpr{
-				pos: position{line: 792, col: 5, offset: 19011},
+				pos: position{line: 811, col: 5, offset: 19513},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 792, col: 5, offset: 19011},
+					pos: position{line: 811, col: 5, offset: 19513},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 792, col: 5, offset: 19011},
+							pos:        position{line: 811, col: 5, offset: 19513},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 792, col: 9, offset: 19015},
+							pos:   position{line: 811, col: 9, offset: 19517},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 792, col: 11, offset: 19017},
+								pos:  position{line: 811, col: 11, offset: 19519},
 								name: "Name",
 							},
 						},
@@ -5362,32 +5494,32 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 794, col: 1, offset: 19041},
+			pos:  position{line: 813, col: 1, offset: 19543},
 			expr: &choiceExpr{
-				pos: position{line: 795, col: 5, offset: 19052},
+				pos: position{line: 814, col: 5, offset: 19554},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 795, col: 5, offset: 19052},
+						pos: position{line: 814, col: 5, offset: 19554},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 795, col: 5, offset: 19052},
+							pos: position{line: 814, col: 5, offset: 19554},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 795, col: 5, offset: 19052},
+									pos:  position{line: 814, col: 5, offset: 19554},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 795, col: 7, offset: 19054},
+									pos:  position{line: 814, col: 7, offset: 19556},
 									name: "TAP",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 796, col: 5, offset: 19083},
+						pos: position{line: 815, col: 5, offset: 19585},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 796, col: 5, offset: 19083},
+							pos:        position{line: 815, col: 5, offset: 19585},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -5400,28 +5532,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 798, col: 1, offset: 19109},
+			pos:  position{line: 817, col: 1, offset: 19611},
 			expr: &actionExpr{
-				pos: position{line: 799, col: 5, offset: 19120},
+				pos: position{line: 818, col: 5, offset: 19622},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 799, col: 5, offset: 19120},
+					pos: position{line: 818, col: 5, offset: 19622},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 5, offset: 19120},
+							pos:  position{line: 818, col: 5, offset: 19622},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 799, col: 10, offset: 19125},
+							pos: position{line: 818, col: 10, offset: 19627},
 							expr: &seqExpr{
-								pos: position{line: 799, col: 12, offset: 19127},
+								pos: position{line: 818, col: 12, offset: 19629},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 799, col: 12, offset: 19127},
+										pos:  position{line: 818, col: 12, offset: 19629},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 799, col: 15, offset: 19130},
+										pos:        position{line: 818, col: 15, offset: 19632},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5430,9 +5562,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 799, col: 20, offset: 19135},
+							pos: position{line: 818, col: 20, offset: 19637},
 							expr: &ruleRefExpr{
-								pos:  position{line: 799, col: 21, offset: 19136},
+								pos:  position{line: 818, col: 21, offset: 19638},
 								name: "EOKW",
 							},
 						},
@@ -5444,44 +5576,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 805, col: 1, offset: 19327},
+			pos:  position{line: 824, col: 1, offset: 19829},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 5, offset: 19341},
+				pos: position{line: 825, col: 5, offset: 19843},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 806, col: 5, offset: 19341},
+					pos: position{line: 825, col: 5, offset: 19843},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 5, offset: 19341},
+							pos:  position{line: 825, col: 5, offset: 19843},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 13, offset: 19349},
+							pos:  position{line: 825, col: 13, offset: 19851},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 806, col: 15, offset: 19351},
+							pos:   position{line: 825, col: 15, offset: 19853},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 806, col: 20, offset: 19356},
+								pos:  position{line: 825, col: 20, offset: 19858},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 806, col: 26, offset: 19362},
+							pos:   position{line: 825, col: 26, offset: 19864},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 806, col: 30, offset: 19366},
+								pos:  position{line: 825, col: 30, offset: 19868},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 806, col: 38, offset: 19374},
+							pos:   position{line: 825, col: 38, offset: 19876},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 806, col: 41, offset: 19377},
+								pos: position{line: 825, col: 41, offset: 19879},
 								expr: &ruleRefExpr{
-									pos:  position{line: 806, col: 41, offset: 19377},
+									pos:  position{line: 825, col: 41, offset: 19879},
 									name: "AsArg",
 								},
 							},
@@ -5494,26 +5626,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 819, col: 1, offset: 19619},
+			pos:  position{line: 838, col: 1, offset: 20121},
 			expr: &actionExpr{
-				pos: position{line: 820, col: 5, offset: 19631},
+				pos: position{line: 839, col: 5, offset: 20133},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 820, col: 5, offset: 19631},
+					pos: position{line: 839, col: 5, offset: 20133},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 820, col: 5, offset: 19631},
+							pos:  position{line: 839, col: 5, offset: 20133},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 820, col: 11, offset: 19637},
+							pos:  position{line: 839, col: 11, offset: 20139},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 820, col: 13, offset: 19639},
+							pos:   position{line: 839, col: 13, offset: 20141},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 820, col: 18, offset: 19644},
+								pos:  position{line: 839, col: 18, offset: 20146},
 								name: "Expr",
 							},
 						},
@@ -5525,56 +5657,56 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 828, col: 1, offset: 19771},
+			pos:  position{line: 847, col: 1, offset: 20273},
 			expr: &actionExpr{
-				pos: position{line: 829, col: 5, offset: 19782},
+				pos: position{line: 848, col: 5, offset: 20284},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 829, col: 5, offset: 19782},
+					pos: position{line: 848, col: 5, offset: 20284},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 829, col: 6, offset: 19783},
+							pos: position{line: 848, col: 6, offset: 20285},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 829, col: 6, offset: 19783},
+									pos:  position{line: 848, col: 6, offset: 20285},
 									name: "OVER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 829, col: 13, offset: 19790},
+									pos:  position{line: 848, col: 13, offset: 20292},
 									name: "UNNEST",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 829, col: 21, offset: 19798},
+							pos:  position{line: 848, col: 21, offset: 20300},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 829, col: 23, offset: 19800},
+							pos:   position{line: 848, col: 23, offset: 20302},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 829, col: 29, offset: 19806},
+								pos:  position{line: 848, col: 29, offset: 20308},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 829, col: 35, offset: 19812},
+							pos:   position{line: 848, col: 35, offset: 20314},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 829, col: 42, offset: 19819},
+								pos: position{line: 848, col: 42, offset: 20321},
 								expr: &ruleRefExpr{
-									pos:  position{line: 829, col: 42, offset: 19819},
+									pos:  position{line: 848, col: 42, offset: 20321},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 829, col: 50, offset: 19827},
+							pos:   position{line: 848, col: 50, offset: 20329},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 829, col: 55, offset: 19832},
+								pos: position{line: 848, col: 55, offset: 20334},
 								expr: &ruleRefExpr{
-									pos:  position{line: 829, col: 55, offset: 19832},
+									pos:  position{line: 848, col: 55, offset: 20334},
 									name: "Lateral",
 								},
 							},
@@ -5587,54 +5719,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 844, col: 1, offset: 20157},
+			pos:  position{line: 863, col: 1, offset: 20659},
 			expr: &choiceExpr{
-				pos: position{line: 845, col: 5, offset: 20169},
+				pos: position{line: 864, col: 5, offset: 20671},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 845, col: 5, offset: 20169},
+						pos: position{line: 864, col: 5, offset: 20671},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 845, col: 5, offset: 20169},
+							pos: position{line: 864, col: 5, offset: 20671},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 845, col: 5, offset: 20169},
+									pos:  position{line: 864, col: 5, offset: 20671},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 845, col: 8, offset: 20172},
+									pos:        position{line: 864, col: 8, offset: 20674},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 845, col: 13, offset: 20177},
+									pos:  position{line: 864, col: 13, offset: 20679},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 845, col: 16, offset: 20180},
+									pos:        position{line: 864, col: 16, offset: 20682},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 845, col: 20, offset: 20184},
+									pos:  position{line: 864, col: 20, offset: 20686},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 845, col: 23, offset: 20187},
+									pos:   position{line: 864, col: 23, offset: 20689},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 845, col: 29, offset: 20193},
+										pos:  position{line: 864, col: 29, offset: 20695},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 845, col: 35, offset: 20199},
+									pos:  position{line: 864, col: 35, offset: 20701},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 845, col: 38, offset: 20202},
+									pos:        position{line: 864, col: 38, offset: 20704},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5643,49 +5775,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 848, col: 5, offset: 20283},
+						pos: position{line: 867, col: 5, offset: 20785},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 848, col: 5, offset: 20283},
+							pos: position{line: 867, col: 5, offset: 20785},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 5, offset: 20283},
+									pos:  position{line: 867, col: 5, offset: 20785},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 848, col: 8, offset: 20286},
+									pos:        position{line: 867, col: 8, offset: 20788},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 13, offset: 20291},
+									pos:  position{line: 867, col: 13, offset: 20793},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 848, col: 16, offset: 20294},
+									pos:        position{line: 867, col: 16, offset: 20796},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 20, offset: 20298},
+									pos:  position{line: 867, col: 20, offset: 20800},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 848, col: 23, offset: 20301},
+									pos:   position{line: 867, col: 23, offset: 20803},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 848, col: 27, offset: 20305},
+										pos:  position{line: 867, col: 27, offset: 20807},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 848, col: 31, offset: 20309},
+									pos:  position{line: 867, col: 31, offset: 20811},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 848, col: 34, offset: 20312},
+									pos:        position{line: 867, col: 34, offset: 20814},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5700,63 +5832,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 852, col: 1, offset: 20368},
+			pos:  position{line: 871, col: 1, offset: 20870},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 5, offset: 20379},
+				pos: position{line: 872, col: 5, offset: 20881},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 853, col: 5, offset: 20379},
+					pos: position{line: 872, col: 5, offset: 20881},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 853, col: 5, offset: 20379},
+							pos:  position{line: 872, col: 5, offset: 20881},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 853, col: 7, offset: 20381},
+							pos:  position{line: 872, col: 7, offset: 20883},
 							name: "WITH",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 853, col: 12, offset: 20386},
+							pos:  position{line: 872, col: 12, offset: 20888},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 14, offset: 20388},
+							pos:   position{line: 872, col: 14, offset: 20890},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 20, offset: 20394},
+								pos:  position{line: 872, col: 20, offset: 20896},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 37, offset: 20411},
+							pos:   position{line: 872, col: 37, offset: 20913},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 853, col: 42, offset: 20416},
+								pos: position{line: 872, col: 42, offset: 20918},
 								expr: &actionExpr{
-									pos: position{line: 853, col: 43, offset: 20417},
+									pos: position{line: 872, col: 43, offset: 20919},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 853, col: 43, offset: 20417},
+										pos: position{line: 872, col: 43, offset: 20919},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 853, col: 43, offset: 20417},
+												pos:  position{line: 872, col: 43, offset: 20919},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 853, col: 46, offset: 20420},
+												pos:        position{line: 872, col: 46, offset: 20922},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 853, col: 50, offset: 20424},
+												pos:  position{line: 872, col: 50, offset: 20926},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 853, col: 53, offset: 20427},
+												pos:   position{line: 872, col: 53, offset: 20929},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 853, col: 55, offset: 20429},
+													pos:  position{line: 872, col: 55, offset: 20931},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5773,45 +5905,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 857, col: 1, offset: 20514},
+			pos:  position{line: 876, col: 1, offset: 21016},
 			expr: &actionExpr{
-				pos: position{line: 858, col: 5, offset: 20535},
+				pos: position{line: 877, col: 5, offset: 21037},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 858, col: 5, offset: 20535},
+					pos: position{line: 877, col: 5, offset: 21037},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 858, col: 5, offset: 20535},
+							pos:   position{line: 877, col: 5, offset: 21037},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 858, col: 10, offset: 20540},
+								pos:  position{line: 877, col: 10, offset: 21042},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 858, col: 21, offset: 20551},
+							pos:   position{line: 877, col: 21, offset: 21053},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 858, col: 25, offset: 20555},
+								pos: position{line: 877, col: 25, offset: 21057},
 								expr: &seqExpr{
-									pos: position{line: 858, col: 26, offset: 20556},
+									pos: position{line: 877, col: 26, offset: 21058},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 858, col: 26, offset: 20556},
+											pos:  position{line: 877, col: 26, offset: 21058},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 858, col: 29, offset: 20559},
+											pos:        position{line: 877, col: 29, offset: 21061},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 858, col: 33, offset: 20563},
+											pos:  position{line: 877, col: 33, offset: 21065},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 858, col: 36, offset: 20566},
+											pos:  position{line: 877, col: 36, offset: 21068},
 											name: "Expr",
 										},
 									},
@@ -5826,26 +5958,26 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 870, col: 1, offset: 20790},
+			pos:  position{line: 889, col: 1, offset: 21292},
 			expr: &actionExpr{
-				pos: position{line: 871, col: 5, offset: 20802},
+				pos: position{line: 890, col: 5, offset: 21304},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 871, col: 5, offset: 20802},
+					pos: position{line: 890, col: 5, offset: 21304},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 871, col: 5, offset: 20802},
+							pos:  position{line: 890, col: 5, offset: 21304},
 							name: "YIELD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 871, col: 11, offset: 20808},
+							pos:  position{line: 890, col: 11, offset: 21310},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 871, col: 13, offset: 20810},
+							pos:   position{line: 890, col: 13, offset: 21312},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 871, col: 19, offset: 20816},
+								pos:  position{line: 890, col: 19, offset: 21318},
 								name: "Exprs",
 							},
 						},
@@ -5857,30 +5989,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 879, col: 1, offset: 20960},
+			pos:  position{line: 898, col: 1, offset: 21462},
 			expr: &actionExpr{
-				pos: position{line: 880, col: 5, offset: 20972},
+				pos: position{line: 899, col: 5, offset: 21474},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 880, col: 5, offset: 20972},
+					pos: position{line: 899, col: 5, offset: 21474},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 880, col: 5, offset: 20972},
+							pos:  position{line: 899, col: 5, offset: 21474},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 880, col: 7, offset: 20974},
+							pos:  position{line: 899, col: 7, offset: 21476},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 880, col: 10, offset: 20977},
+							pos:  position{line: 899, col: 10, offset: 21479},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 880, col: 12, offset: 20979},
+							pos:   position{line: 899, col: 12, offset: 21481},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 880, col: 16, offset: 20983},
+								pos:  position{line: 899, col: 16, offset: 21485},
 								name: "Type",
 							},
 						},
@@ -5892,30 +6024,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 882, col: 1, offset: 21009},
+			pos:  position{line: 901, col: 1, offset: 21511},
 			expr: &actionExpr{
-				pos: position{line: 883, col: 5, offset: 21019},
+				pos: position{line: 902, col: 5, offset: 21521},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 883, col: 5, offset: 21019},
+					pos: position{line: 902, col: 5, offset: 21521},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 883, col: 5, offset: 21019},
+							pos:  position{line: 902, col: 5, offset: 21521},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 883, col: 7, offset: 21021},
+							pos:  position{line: 902, col: 7, offset: 21523},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 883, col: 10, offset: 21024},
+							pos:  position{line: 902, col: 10, offset: 21526},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 883, col: 12, offset: 21026},
+							pos:   position{line: 902, col: 12, offset: 21528},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 883, col: 16, offset: 21030},
+								pos:  position{line: 902, col: 16, offset: 21532},
 								name: "Lval",
 							},
 						},
@@ -5927,9 +6059,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 887, col: 1, offset: 21081},
+			pos:  position{line: 906, col: 1, offset: 21583},
 			expr: &ruleRefExpr{
-				pos:  position{line: 887, col: 8, offset: 21088},
+				pos:  position{line: 906, col: 8, offset: 21590},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5937,51 +6069,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 889, col: 1, offset: 21099},
+			pos:  position{line: 908, col: 1, offset: 21601},
 			expr: &actionExpr{
-				pos: position{line: 890, col: 5, offset: 21109},
+				pos: position{line: 909, col: 5, offset: 21611},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 890, col: 5, offset: 21109},
+					pos: position{line: 909, col: 5, offset: 21611},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 890, col: 5, offset: 21109},
+							pos:   position{line: 909, col: 5, offset: 21611},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 890, col: 11, offset: 21115},
+								pos:  position{line: 909, col: 11, offset: 21617},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 890, col: 16, offset: 21120},
+							pos:   position{line: 909, col: 16, offset: 21622},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 890, col: 21, offset: 21125},
+								pos: position{line: 909, col: 21, offset: 21627},
 								expr: &actionExpr{
-									pos: position{line: 890, col: 22, offset: 21126},
+									pos: position{line: 909, col: 22, offset: 21628},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 890, col: 22, offset: 21126},
+										pos: position{line: 909, col: 22, offset: 21628},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 890, col: 22, offset: 21126},
+												pos:  position{line: 909, col: 22, offset: 21628},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 890, col: 25, offset: 21129},
+												pos:        position{line: 909, col: 25, offset: 21631},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 890, col: 29, offset: 21133},
+												pos:  position{line: 909, col: 29, offset: 21635},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 890, col: 32, offset: 21136},
+												pos:   position{line: 909, col: 32, offset: 21638},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 890, col: 37, offset: 21141},
+													pos:  position{line: 909, col: 37, offset: 21643},
 													name: "Lval",
 												},
 											},
@@ -5998,51 +6130,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 894, col: 1, offset: 21217},
+			pos:  position{line: 913, col: 1, offset: 21719},
 			expr: &actionExpr{
-				pos: position{line: 895, col: 5, offset: 21233},
+				pos: position{line: 914, col: 5, offset: 21735},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 895, col: 5, offset: 21233},
+					pos: position{line: 914, col: 5, offset: 21735},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 895, col: 5, offset: 21233},
+							pos:   position{line: 914, col: 5, offset: 21735},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 895, col: 11, offset: 21239},
+								pos:  position{line: 914, col: 11, offset: 21741},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 895, col: 22, offset: 21250},
+							pos:   position{line: 914, col: 22, offset: 21752},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 895, col: 27, offset: 21255},
+								pos: position{line: 914, col: 27, offset: 21757},
 								expr: &actionExpr{
-									pos: position{line: 895, col: 28, offset: 21256},
+									pos: position{line: 914, col: 28, offset: 21758},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 895, col: 28, offset: 21256},
+										pos: position{line: 914, col: 28, offset: 21758},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 895, col: 28, offset: 21256},
+												pos:  position{line: 914, col: 28, offset: 21758},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 895, col: 31, offset: 21259},
+												pos:        position{line: 914, col: 31, offset: 21761},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 895, col: 35, offset: 21263},
+												pos:  position{line: 914, col: 35, offset: 21765},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 895, col: 38, offset: 21266},
+												pos:   position{line: 914, col: 38, offset: 21768},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 895, col: 40, offset: 21268},
+													pos:  position{line: 914, col: 40, offset: 21770},
 													name: "Assignment",
 												},
 											},
@@ -6059,40 +6191,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 899, col: 1, offset: 21343},
+			pos:  position{line: 918, col: 1, offset: 21845},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 21358},
+				pos: position{line: 919, col: 5, offset: 21860},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 21358},
+					pos: position{line: 919, col: 5, offset: 21860},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 21358},
+							pos:   position{line: 919, col: 5, offset: 21860},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 9, offset: 21362},
+								pos:  position{line: 919, col: 9, offset: 21864},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 900, col: 14, offset: 21367},
+							pos:  position{line: 919, col: 14, offset: 21869},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 900, col: 17, offset: 21370},
+							pos:        position{line: 919, col: 17, offset: 21872},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 900, col: 22, offset: 21375},
+							pos:  position{line: 919, col: 22, offset: 21877},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 900, col: 25, offset: 21378},
+							pos:   position{line: 919, col: 25, offset: 21880},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 29, offset: 21382},
+								pos:  position{line: 919, col: 29, offset: 21884},
 								name: "Expr",
 							},
 						},
@@ -6104,9 +6236,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 909, col: 1, offset: 21553},
+			pos:  position{line: 928, col: 1, offset: 22055},
 			expr: &ruleRefExpr{
-				pos:  position{line: 909, col: 8, offset: 21560},
+				pos:  position{line: 928, col: 8, offset: 22062},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -6114,63 +6246,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 911, col: 1, offset: 21577},
+			pos:  position{line: 930, col: 1, offset: 22079},
 			expr: &actionExpr{
-				pos: position{line: 912, col: 5, offset: 21597},
+				pos: position{line: 931, col: 5, offset: 22099},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 912, col: 5, offset: 21597},
+					pos: position{line: 931, col: 5, offset: 22099},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 912, col: 5, offset: 21597},
+							pos:   position{line: 931, col: 5, offset: 22099},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 912, col: 10, offset: 21602},
+								pos:  position{line: 931, col: 10, offset: 22104},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 912, col: 24, offset: 21616},
+							pos:   position{line: 931, col: 24, offset: 22118},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 912, col: 28, offset: 21620},
+								pos: position{line: 931, col: 28, offset: 22122},
 								expr: &seqExpr{
-									pos: position{line: 912, col: 29, offset: 21621},
+									pos: position{line: 931, col: 29, offset: 22123},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 912, col: 29, offset: 21621},
+											pos:  position{line: 931, col: 29, offset: 22123},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 912, col: 32, offset: 21624},
+											pos:        position{line: 931, col: 32, offset: 22126},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 912, col: 36, offset: 21628},
+											pos:  position{line: 931, col: 36, offset: 22130},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 912, col: 39, offset: 21631},
+											pos:  position{line: 931, col: 39, offset: 22133},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 912, col: 44, offset: 21636},
+											pos:  position{line: 931, col: 44, offset: 22138},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 912, col: 47, offset: 21639},
+											pos:        position{line: 931, col: 47, offset: 22141},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 912, col: 51, offset: 21643},
+											pos:  position{line: 931, col: 51, offset: 22145},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 912, col: 54, offset: 21646},
+											pos:  position{line: 931, col: 54, offset: 22148},
 											name: "Expr",
 										},
 									},
@@ -6185,53 +6317,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 926, col: 1, offset: 21967},
+			pos:  position{line: 945, col: 1, offset: 22469},
 			expr: &actionExpr{
-				pos: position{line: 927, col: 5, offset: 21985},
+				pos: position{line: 946, col: 5, offset: 22487},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 927, col: 5, offset: 21985},
+					pos: position{line: 946, col: 5, offset: 22487},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 927, col: 5, offset: 21985},
+							pos:   position{line: 946, col: 5, offset: 22487},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 927, col: 11, offset: 21991},
+								pos:  position{line: 946, col: 11, offset: 22493},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 928, col: 5, offset: 22010},
+							pos:   position{line: 947, col: 5, offset: 22512},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 928, col: 10, offset: 22015},
+								pos: position{line: 947, col: 10, offset: 22517},
 								expr: &actionExpr{
-									pos: position{line: 928, col: 11, offset: 22016},
+									pos: position{line: 947, col: 11, offset: 22518},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 928, col: 11, offset: 22016},
+										pos: position{line: 947, col: 11, offset: 22518},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 928, col: 11, offset: 22016},
+												pos:  position{line: 947, col: 11, offset: 22518},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 928, col: 14, offset: 22019},
+												pos:   position{line: 947, col: 14, offset: 22521},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 928, col: 17, offset: 22022},
+													pos:  position{line: 947, col: 17, offset: 22524},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 928, col: 20, offset: 22025},
+												pos:  position{line: 947, col: 20, offset: 22527},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 928, col: 23, offset: 22028},
+												pos:   position{line: 947, col: 23, offset: 22530},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 928, col: 28, offset: 22033},
+													pos:  position{line: 947, col: 28, offset: 22535},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6248,53 +6380,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 932, col: 1, offset: 22147},
+			pos:  position{line: 951, col: 1, offset: 22649},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 5, offset: 22166},
+				pos: position{line: 952, col: 5, offset: 22668},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 933, col: 5, offset: 22166},
+					pos: position{line: 952, col: 5, offset: 22668},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 933, col: 5, offset: 22166},
+							pos:   position{line: 952, col: 5, offset: 22668},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 933, col: 11, offset: 22172},
+								pos:  position{line: 952, col: 11, offset: 22674},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 934, col: 5, offset: 22184},
+							pos:   position{line: 953, col: 5, offset: 22686},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 934, col: 10, offset: 22189},
+								pos: position{line: 953, col: 10, offset: 22691},
 								expr: &actionExpr{
-									pos: position{line: 934, col: 11, offset: 22190},
+									pos: position{line: 953, col: 11, offset: 22692},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 934, col: 11, offset: 22190},
+										pos: position{line: 953, col: 11, offset: 22692},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 934, col: 11, offset: 22190},
+												pos:  position{line: 953, col: 11, offset: 22692},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 934, col: 14, offset: 22193},
+												pos:   position{line: 953, col: 14, offset: 22695},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 934, col: 17, offset: 22196},
+													pos:  position{line: 953, col: 17, offset: 22698},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 934, col: 21, offset: 22200},
+												pos:  position{line: 953, col: 21, offset: 22702},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 934, col: 24, offset: 22203},
+												pos:   position{line: 953, col: 24, offset: 22705},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 934, col: 29, offset: 22208},
+													pos:  position{line: 953, col: 29, offset: 22710},
 													name: "NotExpr",
 												},
 											},
@@ -6311,43 +6443,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 938, col: 1, offset: 22315},
+			pos:  position{line: 957, col: 1, offset: 22817},
 			expr: &choiceExpr{
-				pos: position{line: 939, col: 5, offset: 22327},
+				pos: position{line: 958, col: 5, offset: 22829},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 939, col: 5, offset: 22327},
+						pos: position{line: 958, col: 5, offset: 22829},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 939, col: 5, offset: 22327},
+							pos: position{line: 958, col: 5, offset: 22829},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 939, col: 6, offset: 22328},
+									pos: position{line: 958, col: 6, offset: 22830},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 939, col: 6, offset: 22328},
+											pos: position{line: 958, col: 6, offset: 22830},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 939, col: 6, offset: 22328},
+													pos:  position{line: 958, col: 6, offset: 22830},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 939, col: 10, offset: 22332},
+													pos:  position{line: 958, col: 10, offset: 22834},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 939, col: 14, offset: 22336},
+											pos: position{line: 958, col: 14, offset: 22838},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 939, col: 14, offset: 22336},
+													pos:        position{line: 958, col: 14, offset: 22838},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 939, col: 18, offset: 22340},
+													pos:  position{line: 958, col: 18, offset: 22842},
 													name: "__",
 												},
 											},
@@ -6355,10 +6487,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 939, col: 22, offset: 22344},
+									pos:   position{line: 958, col: 22, offset: 22846},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 939, col: 24, offset: 22346},
+										pos:  position{line: 958, col: 24, offset: 22848},
 										name: "NotExpr",
 									},
 								},
@@ -6366,7 +6498,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 947, col: 5, offset: 22512},
+						pos:  position{line: 966, col: 5, offset: 23014},
 						name: "BetweenExpr",
 					},
 				},
@@ -6376,61 +6508,61 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 949, col: 1, offset: 22527},
+			pos:  position{line: 968, col: 1, offset: 23029},
 			expr: &choiceExpr{
-				pos: position{line: 950, col: 5, offset: 22543},
+				pos: position{line: 969, col: 5, offset: 23045},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 950, col: 5, offset: 22543},
+						pos: position{line: 969, col: 5, offset: 23045},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 950, col: 5, offset: 22543},
+							pos: position{line: 969, col: 5, offset: 23045},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 950, col: 5, offset: 22543},
+									pos:   position{line: 969, col: 5, offset: 23045},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 10, offset: 22548},
+										pos:  position{line: 969, col: 10, offset: 23050},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 25, offset: 22563},
+									pos:  position{line: 969, col: 25, offset: 23065},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 27, offset: 22565},
+									pos:  position{line: 969, col: 27, offset: 23067},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 35, offset: 22573},
+									pos:  position{line: 969, col: 35, offset: 23075},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 950, col: 37, offset: 22575},
+									pos:   position{line: 969, col: 37, offset: 23077},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 43, offset: 22581},
+										pos:  position{line: 969, col: 43, offset: 23083},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 55, offset: 22593},
+									pos:  position{line: 969, col: 55, offset: 23095},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 57, offset: 22595},
+									pos:  position{line: 969, col: 57, offset: 23097},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 61, offset: 22599},
+									pos:  position{line: 969, col: 61, offset: 23101},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 950, col: 63, offset: 22601},
+									pos:   position{line: 969, col: 63, offset: 23103},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 69, offset: 22607},
+										pos:  position{line: 969, col: 69, offset: 23109},
 										name: "BetweenExpr",
 									},
 								},
@@ -6438,7 +6570,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 959, col: 5, offset: 22814},
+						pos:  position{line: 978, col: 5, offset: 23316},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6448,46 +6580,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 961, col: 1, offset: 22830},
+			pos:  position{line: 980, col: 1, offset: 23332},
 			expr: &choiceExpr{
-				pos: position{line: 962, col: 5, offset: 22849},
+				pos: position{line: 981, col: 5, offset: 23351},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 962, col: 5, offset: 22849},
+						pos: position{line: 981, col: 5, offset: 23351},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 962, col: 5, offset: 22849},
+							pos: position{line: 981, col: 5, offset: 23351},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 962, col: 5, offset: 22849},
+									pos:   position{line: 981, col: 5, offset: 23351},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 962, col: 10, offset: 22854},
+										pos:  position{line: 981, col: 10, offset: 23356},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 23, offset: 22867},
+									pos:  position{line: 981, col: 23, offset: 23369},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 25, offset: 22869},
+									pos:  position{line: 981, col: 25, offset: 23371},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 962, col: 28, offset: 22872},
+									pos:   position{line: 981, col: 28, offset: 23374},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 962, col: 32, offset: 22876},
+										pos: position{line: 981, col: 32, offset: 23378},
 										expr: &seqExpr{
-											pos: position{line: 962, col: 33, offset: 22877},
+											pos: position{line: 981, col: 33, offset: 23379},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 962, col: 33, offset: 22877},
+													pos:  position{line: 981, col: 33, offset: 23379},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 962, col: 35, offset: 22879},
+													pos:  position{line: 981, col: 35, offset: 23381},
 													name: "NOT",
 												},
 											},
@@ -6495,82 +6627,82 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 41, offset: 22885},
+									pos:  position{line: 981, col: 41, offset: 23387},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 962, col: 43, offset: 22887},
+									pos:  position{line: 981, col: 43, offset: 23389},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 970, col: 5, offset: 23055},
+						pos: position{line: 989, col: 5, offset: 23557},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 970, col: 5, offset: 23055},
+							pos: position{line: 989, col: 5, offset: 23557},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 970, col: 5, offset: 23055},
+									pos:   position{line: 989, col: 5, offset: 23557},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 9, offset: 23059},
+										pos:  position{line: 989, col: 9, offset: 23561},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 970, col: 22, offset: 23072},
+									pos:   position{line: 989, col: 22, offset: 23574},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 970, col: 31, offset: 23081},
+										pos: position{line: 989, col: 31, offset: 23583},
 										expr: &choiceExpr{
-											pos: position{line: 970, col: 32, offset: 23082},
+											pos: position{line: 989, col: 32, offset: 23584},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 970, col: 32, offset: 23082},
+													pos: position{line: 989, col: 32, offset: 23584},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 970, col: 32, offset: 23082},
+															pos:  position{line: 989, col: 32, offset: 23584},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 970, col: 35, offset: 23085},
+															pos:  position{line: 989, col: 35, offset: 23587},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 970, col: 46, offset: 23096},
+															pos:  position{line: 989, col: 46, offset: 23598},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 970, col: 49, offset: 23099},
+															pos:  position{line: 989, col: 49, offset: 23601},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 970, col: 64, offset: 23114},
+													pos: position{line: 989, col: 64, offset: 23616},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 970, col: 64, offset: 23114},
+															pos:  position{line: 989, col: 64, offset: 23616},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 970, col: 68, offset: 23118},
+															pos: position{line: 989, col: 68, offset: 23620},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 970, col: 68, offset: 23118},
+																pos:        position{line: 989, col: 68, offset: 23620},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 970, col: 104, offset: 23154},
+															pos:  position{line: 989, col: 104, offset: 23656},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 970, col: 107, offset: 23157},
+															pos:  position{line: 989, col: 107, offset: 23659},
 															name: "Regexp",
 														},
 													},
@@ -6589,53 +6721,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 983, col: 1, offset: 23443},
+			pos:  position{line: 1002, col: 1, offset: 23945},
 			expr: &actionExpr{
-				pos: position{line: 984, col: 5, offset: 23460},
+				pos: position{line: 1003, col: 5, offset: 23962},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 984, col: 5, offset: 23460},
+					pos: position{line: 1003, col: 5, offset: 23962},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 984, col: 5, offset: 23460},
+							pos:   position{line: 1003, col: 5, offset: 23962},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 984, col: 11, offset: 23466},
+								pos:  position{line: 1003, col: 11, offset: 23968},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 985, col: 5, offset: 23489},
+							pos:   position{line: 1004, col: 5, offset: 23991},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 985, col: 10, offset: 23494},
+								pos: position{line: 1004, col: 10, offset: 23996},
 								expr: &actionExpr{
-									pos: position{line: 985, col: 11, offset: 23495},
+									pos: position{line: 1004, col: 11, offset: 23997},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 985, col: 11, offset: 23495},
+										pos: position{line: 1004, col: 11, offset: 23997},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 985, col: 11, offset: 23495},
+												pos:  position{line: 1004, col: 11, offset: 23997},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 985, col: 14, offset: 23498},
+												pos:   position{line: 1004, col: 14, offset: 24000},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 985, col: 17, offset: 23501},
+													pos:  position{line: 1004, col: 17, offset: 24003},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 985, col: 34, offset: 23518},
+												pos:  position{line: 1004, col: 34, offset: 24020},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 985, col: 37, offset: 23521},
+												pos:   position{line: 1004, col: 37, offset: 24023},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 985, col: 42, offset: 23526},
+													pos:  position{line: 1004, col: 42, offset: 24028},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6652,21 +6784,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 989, col: 1, offset: 23644},
+			pos:  position{line: 1008, col: 1, offset: 24146},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 20, offset: 23663},
+				pos: position{line: 1008, col: 20, offset: 24165},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 989, col: 21, offset: 23664},
+					pos: position{line: 1008, col: 21, offset: 24166},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 989, col: 21, offset: 23664},
+							pos:        position{line: 1008, col: 21, offset: 24166},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 989, col: 27, offset: 23670},
+							pos:        position{line: 1008, col: 27, offset: 24172},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6679,53 +6811,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 991, col: 1, offset: 23707},
+			pos:  position{line: 1010, col: 1, offset: 24209},
 			expr: &actionExpr{
-				pos: position{line: 992, col: 5, offset: 23730},
+				pos: position{line: 1011, col: 5, offset: 24232},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 992, col: 5, offset: 23730},
+					pos: position{line: 1011, col: 5, offset: 24232},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 992, col: 5, offset: 23730},
+							pos:   position{line: 1011, col: 5, offset: 24232},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 992, col: 11, offset: 23736},
+								pos:  position{line: 1011, col: 11, offset: 24238},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 993, col: 5, offset: 23751},
+							pos:   position{line: 1012, col: 5, offset: 24253},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 993, col: 10, offset: 23756},
+								pos: position{line: 1012, col: 10, offset: 24258},
 								expr: &actionExpr{
-									pos: position{line: 993, col: 11, offset: 23757},
+									pos: position{line: 1012, col: 11, offset: 24259},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 993, col: 11, offset: 23757},
+										pos: position{line: 1012, col: 11, offset: 24259},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 993, col: 11, offset: 23757},
+												pos:  position{line: 1012, col: 11, offset: 24259},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 993, col: 14, offset: 23760},
+												pos:   position{line: 1012, col: 14, offset: 24262},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 993, col: 17, offset: 23763},
+													pos:  position{line: 1012, col: 17, offset: 24265},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 993, col: 40, offset: 23786},
+												pos:  position{line: 1012, col: 40, offset: 24288},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 993, col: 43, offset: 23789},
+												pos:   position{line: 1012, col: 43, offset: 24291},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 993, col: 48, offset: 23794},
+													pos:  position{line: 1012, col: 48, offset: 24296},
 													name: "ConcatExpr",
 												},
 											},
@@ -6742,27 +6874,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 997, col: 1, offset: 23904},
+			pos:  position{line: 1016, col: 1, offset: 24406},
 			expr: &actionExpr{
-				pos: position{line: 997, col: 26, offset: 23929},
+				pos: position{line: 1016, col: 26, offset: 24431},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 997, col: 27, offset: 23930},
+					pos: position{line: 1016, col: 27, offset: 24432},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 997, col: 27, offset: 23930},
+							pos:        position{line: 1016, col: 27, offset: 24432},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 997, col: 33, offset: 23936},
+							pos:        position{line: 1016, col: 33, offset: 24438},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 997, col: 39, offset: 23942},
+							pos:        position{line: 1016, col: 39, offset: 24444},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6775,51 +6907,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 999, col: 1, offset: 23979},
+			pos:  position{line: 1018, col: 1, offset: 24481},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 5, offset: 23995},
+				pos: position{line: 1019, col: 5, offset: 24497},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1000, col: 5, offset: 23995},
+					pos: position{line: 1019, col: 5, offset: 24497},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1000, col: 5, offset: 23995},
+							pos:   position{line: 1019, col: 5, offset: 24497},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 11, offset: 24001},
+								pos:  position{line: 1019, col: 11, offset: 24503},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1001, col: 5, offset: 24022},
+							pos:   position{line: 1020, col: 5, offset: 24524},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1001, col: 10, offset: 24027},
+								pos: position{line: 1020, col: 10, offset: 24529},
 								expr: &actionExpr{
-									pos: position{line: 1001, col: 11, offset: 24028},
+									pos: position{line: 1020, col: 11, offset: 24530},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1001, col: 11, offset: 24028},
+										pos: position{line: 1020, col: 11, offset: 24530},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1001, col: 11, offset: 24028},
+												pos:  position{line: 1020, col: 11, offset: 24530},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1001, col: 14, offset: 24031},
+												pos:        position{line: 1020, col: 14, offset: 24533},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1001, col: 19, offset: 24036},
+												pos:  position{line: 1020, col: 19, offset: 24538},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1001, col: 22, offset: 24039},
+												pos:   position{line: 1020, col: 22, offset: 24541},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1001, col: 27, offset: 24044},
+													pos:  position{line: 1020, col: 27, offset: 24546},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6836,40 +6968,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 1005, col: 1, offset: 24162},
+			pos:  position{line: 1024, col: 1, offset: 24664},
 			expr: &choiceExpr{
-				pos: position{line: 1006, col: 5, offset: 24183},
+				pos: position{line: 1025, col: 5, offset: 24685},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1006, col: 5, offset: 24183},
+						pos: position{line: 1025, col: 5, offset: 24685},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 1006, col: 5, offset: 24183},
+							pos: position{line: 1025, col: 5, offset: 24685},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1006, col: 5, offset: 24183},
+									pos: position{line: 1025, col: 5, offset: 24685},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1006, col: 6, offset: 24184},
+										pos:  position{line: 1025, col: 6, offset: 24686},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1006, col: 14, offset: 24192},
+									pos:   position{line: 1025, col: 14, offset: 24694},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1006, col: 17, offset: 24195},
+										pos:  position{line: 1025, col: 17, offset: 24697},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1006, col: 31, offset: 24209},
+									pos:  position{line: 1025, col: 31, offset: 24711},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1006, col: 34, offset: 24212},
+									pos:   position{line: 1025, col: 34, offset: 24714},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1006, col: 36, offset: 24214},
+										pos:  position{line: 1025, col: 36, offset: 24716},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6877,7 +7009,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1015, col: 5, offset: 24398},
+						pos:  position{line: 1034, col: 5, offset: 24900},
 						name: "DerefExpr",
 					},
 				},
@@ -6887,21 +7019,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 1017, col: 1, offset: 24409},
+			pos:  position{line: 1036, col: 1, offset: 24911},
 			expr: &actionExpr{
-				pos: position{line: 1017, col: 17, offset: 24425},
+				pos: position{line: 1036, col: 17, offset: 24927},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 1017, col: 18, offset: 24426},
+					pos: position{line: 1036, col: 18, offset: 24928},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1017, col: 18, offset: 24426},
+							pos:        position{line: 1036, col: 18, offset: 24928},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1017, col: 24, offset: 24432},
+							pos:        position{line: 1036, col: 24, offset: 24934},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6914,73 +7046,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 1019, col: 1, offset: 24469},
+			pos:  position{line: 1038, col: 1, offset: 24971},
 			expr: &choiceExpr{
-				pos: position{line: 1020, col: 5, offset: 24483},
+				pos: position{line: 1039, col: 5, offset: 24985},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1020, col: 5, offset: 24483},
+						pos: position{line: 1039, col: 5, offset: 24985},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1020, col: 5, offset: 24483},
+							pos: position{line: 1039, col: 5, offset: 24985},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1020, col: 5, offset: 24483},
+									pos:   position{line: 1039, col: 5, offset: 24985},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1020, col: 10, offset: 24488},
+										pos:  position{line: 1039, col: 10, offset: 24990},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 20, offset: 24498},
+									pos:        position{line: 1039, col: 20, offset: 25000},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 24, offset: 24502},
+									pos:  position{line: 1039, col: 24, offset: 25004},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1020, col: 27, offset: 24505},
+									pos:   position{line: 1039, col: 27, offset: 25007},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1020, col: 32, offset: 24510},
+										pos:  position{line: 1039, col: 32, offset: 25012},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 45, offset: 24523},
+									pos:  position{line: 1039, col: 45, offset: 25025},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 48, offset: 24526},
+									pos:        position{line: 1039, col: 48, offset: 25028},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 52, offset: 24530},
+									pos:  position{line: 1039, col: 52, offset: 25032},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1020, col: 55, offset: 24533},
+									pos:   position{line: 1039, col: 55, offset: 25035},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1020, col: 58, offset: 24536},
+										pos: position{line: 1039, col: 58, offset: 25038},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1020, col: 58, offset: 24536},
+											pos:  position{line: 1039, col: 58, offset: 25038},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 72, offset: 24550},
+									pos:  position{line: 1039, col: 72, offset: 25052},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 75, offset: 24553},
+									pos:        position{line: 1039, col: 75, offset: 25055},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6989,49 +7121,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1032, col: 5, offset: 24792},
+						pos: position{line: 1051, col: 5, offset: 25294},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1032, col: 5, offset: 24792},
+							pos: position{line: 1051, col: 5, offset: 25294},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1032, col: 5, offset: 24792},
+									pos:   position{line: 1051, col: 5, offset: 25294},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1032, col: 10, offset: 24797},
+										pos:  position{line: 1051, col: 10, offset: 25299},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1032, col: 20, offset: 24807},
+									pos:        position{line: 1051, col: 20, offset: 25309},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1032, col: 24, offset: 24811},
+									pos:  position{line: 1051, col: 24, offset: 25313},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1032, col: 27, offset: 24814},
+									pos:        position{line: 1051, col: 27, offset: 25316},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1032, col: 31, offset: 24818},
+									pos:  position{line: 1051, col: 31, offset: 25320},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1032, col: 34, offset: 24821},
+									pos:   position{line: 1051, col: 34, offset: 25323},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1032, col: 37, offset: 24824},
+										pos:  position{line: 1051, col: 37, offset: 25326},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1032, col: 50, offset: 24837},
+									pos:        position{line: 1051, col: 50, offset: 25339},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7040,35 +7172,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1040, col: 5, offset: 25001},
+						pos: position{line: 1059, col: 5, offset: 25503},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1040, col: 5, offset: 25001},
+							pos: position{line: 1059, col: 5, offset: 25503},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1040, col: 5, offset: 25001},
+									pos:   position{line: 1059, col: 5, offset: 25503},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1040, col: 10, offset: 25006},
+										pos:  position{line: 1059, col: 10, offset: 25508},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1040, col: 20, offset: 25016},
+									pos:        position{line: 1059, col: 20, offset: 25518},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1040, col: 24, offset: 25020},
+									pos:   position{line: 1059, col: 24, offset: 25522},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1040, col: 30, offset: 25026},
+										pos:  position{line: 1059, col: 30, offset: 25528},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1040, col: 35, offset: 25031},
+									pos:        position{line: 1059, col: 35, offset: 25533},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7077,30 +7209,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1048, col: 5, offset: 25201},
+						pos: position{line: 1067, col: 5, offset: 25703},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1048, col: 5, offset: 25201},
+							pos: position{line: 1067, col: 5, offset: 25703},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1048, col: 5, offset: 25201},
+									pos:   position{line: 1067, col: 5, offset: 25703},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1048, col: 10, offset: 25206},
+										pos:  position{line: 1067, col: 10, offset: 25708},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1048, col: 20, offset: 25216},
+									pos:        position{line: 1067, col: 20, offset: 25718},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1048, col: 24, offset: 25220},
+									pos:   position{line: 1067, col: 24, offset: 25722},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1048, col: 27, offset: 25223},
+										pos:  position{line: 1067, col: 27, offset: 25725},
 										name: "Identifier",
 									},
 								},
@@ -7108,11 +7240,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1057, col: 5, offset: 25413},
+						pos:  position{line: 1076, col: 5, offset: 25915},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1058, col: 5, offset: 25426},
+						pos:  position{line: 1077, col: 5, offset: 25928},
 						name: "Primary",
 					},
 				},
@@ -7122,16 +7254,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 1060, col: 1, offset: 25435},
+			pos:  position{line: 1079, col: 1, offset: 25937},
 			expr: &choiceExpr{
-				pos: position{line: 1061, col: 5, offset: 25448},
+				pos: position{line: 1080, col: 5, offset: 25950},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1061, col: 5, offset: 25448},
+						pos:  position{line: 1080, col: 5, offset: 25950},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1062, col: 5, offset: 25457},
+						pos:  position{line: 1081, col: 5, offset: 25959},
 						name: "Function",
 					},
 				},
@@ -7141,20 +7273,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1064, col: 1, offset: 25467},
+			pos:  position{line: 1083, col: 1, offset: 25969},
 			expr: &seqExpr{
-				pos: position{line: 1064, col: 13, offset: 25479},
+				pos: position{line: 1083, col: 13, offset: 25981},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1064, col: 13, offset: 25479},
+						pos:  position{line: 1083, col: 13, offset: 25981},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1064, col: 22, offset: 25488},
+						pos:  position{line: 1083, col: 22, offset: 25990},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1064, col: 25, offset: 25491},
+						pos:        position{line: 1083, col: 25, offset: 25993},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -7166,16 +7298,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1066, col: 1, offset: 25496},
+			pos:  position{line: 1085, col: 1, offset: 25998},
 			expr: &choiceExpr{
-				pos: position{line: 1067, col: 5, offset: 25509},
+				pos: position{line: 1086, col: 5, offset: 26011},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 5, offset: 25509},
+						pos:  position{line: 1086, col: 5, offset: 26011},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1068, col: 5, offset: 25517},
+						pos:  position{line: 1087, col: 5, offset: 26019},
 						name: "SELECT",
 					},
 				},
@@ -7185,58 +7317,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1070, col: 1, offset: 25525},
+			pos:  position{line: 1089, col: 1, offset: 26027},
 			expr: &actionExpr{
-				pos: position{line: 1071, col: 5, offset: 25534},
+				pos: position{line: 1090, col: 5, offset: 26036},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1071, col: 5, offset: 25534},
+					pos: position{line: 1090, col: 5, offset: 26036},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1071, col: 5, offset: 25534},
+							pos:   position{line: 1090, col: 5, offset: 26036},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1071, col: 9, offset: 25538},
+								pos:  position{line: 1090, col: 9, offset: 26040},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1071, col: 21, offset: 25550},
+							pos:  position{line: 1090, col: 21, offset: 26052},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1071, col: 24, offset: 25553},
+							pos:        position{line: 1090, col: 24, offset: 26055},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1071, col: 28, offset: 25557},
+							pos:  position{line: 1090, col: 28, offset: 26059},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1071, col: 31, offset: 25560},
+							pos:   position{line: 1090, col: 31, offset: 26062},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1071, col: 37, offset: 25566},
+								pos: position{line: 1090, col: 37, offset: 26068},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1071, col: 37, offset: 25566},
+										pos:  position{line: 1090, col: 37, offset: 26068},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1071, col: 48, offset: 25577},
+										pos:  position{line: 1090, col: 48, offset: 26079},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1071, col: 54, offset: 25583},
+							pos:  position{line: 1090, col: 54, offset: 26085},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1071, col: 57, offset: 25586},
+							pos:        position{line: 1090, col: 57, offset: 26088},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7249,85 +7381,85 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1075, col: 1, offset: 25699},
+			pos:  position{line: 1094, col: 1, offset: 26201},
 			expr: &choiceExpr{
-				pos: position{line: 1076, col: 5, offset: 25712},
+				pos: position{line: 1095, col: 5, offset: 26214},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1076, col: 5, offset: 25712},
+						pos:  position{line: 1095, col: 5, offset: 26214},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1078, col: 5, offset: 25799},
+						pos: position{line: 1097, col: 5, offset: 26301},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1078, col: 5, offset: 25799},
+							pos: position{line: 1097, col: 5, offset: 26301},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1078, col: 5, offset: 25799},
+									pos:  position{line: 1097, col: 5, offset: 26301},
 									name: "REGEXP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1078, col: 12, offset: 25806},
+									pos:  position{line: 1097, col: 12, offset: 26308},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1078, col: 15, offset: 25809},
+									pos:        position{line: 1097, col: 15, offset: 26311},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1078, col: 19, offset: 25813},
+									pos:  position{line: 1097, col: 19, offset: 26315},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 22, offset: 25816},
+									pos:   position{line: 1097, col: 22, offset: 26318},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1078, col: 27, offset: 25821},
+										pos:  position{line: 1097, col: 27, offset: 26323},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1078, col: 43, offset: 25837},
+									pos:  position{line: 1097, col: 43, offset: 26339},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1078, col: 46, offset: 25840},
+									pos:        position{line: 1097, col: 46, offset: 26342},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1078, col: 50, offset: 25844},
+									pos:  position{line: 1097, col: 50, offset: 26346},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 53, offset: 25847},
+									pos:   position{line: 1097, col: 53, offset: 26349},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1078, col: 58, offset: 25852},
+										pos:  position{line: 1097, col: 58, offset: 26354},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1078, col: 63, offset: 25857},
+									pos:  position{line: 1097, col: 63, offset: 26359},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1078, col: 66, offset: 25860},
+									pos:        position{line: 1097, col: 66, offset: 26362},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 70, offset: 25864},
+									pos:   position{line: 1097, col: 70, offset: 26366},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1078, col: 76, offset: 25870},
+										pos: position{line: 1097, col: 76, offset: 26372},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1078, col: 76, offset: 25870},
+											pos:  position{line: 1097, col: 76, offset: 26372},
 											name: "WhereClause",
 										},
 									},
@@ -7336,98 +7468,98 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1082, col: 5, offset: 26049},
+						pos: position{line: 1101, col: 5, offset: 26551},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1082, col: 5, offset: 26049},
+							pos: position{line: 1101, col: 5, offset: 26551},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 5, offset: 26049},
+									pos:  position{line: 1101, col: 5, offset: 26551},
 									name: "REGEXP_REPLACE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 20, offset: 26064},
+									pos:  position{line: 1101, col: 20, offset: 26566},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1082, col: 23, offset: 26067},
+									pos:        position{line: 1101, col: 23, offset: 26569},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 27, offset: 26071},
+									pos:  position{line: 1101, col: 27, offset: 26573},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1082, col: 30, offset: 26074},
+									pos:   position{line: 1101, col: 30, offset: 26576},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1082, col: 35, offset: 26079},
+										pos:  position{line: 1101, col: 35, offset: 26581},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 40, offset: 26084},
+									pos:  position{line: 1101, col: 40, offset: 26586},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1082, col: 43, offset: 26087},
+									pos:        position{line: 1101, col: 43, offset: 26589},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 47, offset: 26091},
+									pos:  position{line: 1101, col: 47, offset: 26593},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1082, col: 50, offset: 26094},
+									pos:   position{line: 1101, col: 50, offset: 26596},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1082, col: 55, offset: 26099},
+										pos:  position{line: 1101, col: 55, offset: 26601},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 71, offset: 26115},
+									pos:  position{line: 1101, col: 71, offset: 26617},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1082, col: 74, offset: 26118},
+									pos:        position{line: 1101, col: 74, offset: 26620},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 78, offset: 26122},
+									pos:  position{line: 1101, col: 78, offset: 26624},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1082, col: 81, offset: 26125},
+									pos:   position{line: 1101, col: 81, offset: 26627},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1082, col: 86, offset: 26130},
+										pos:  position{line: 1101, col: 86, offset: 26632},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 91, offset: 26135},
+									pos:  position{line: 1101, col: 91, offset: 26637},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1082, col: 94, offset: 26138},
+									pos:        position{line: 1101, col: 94, offset: 26640},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1082, col: 98, offset: 26142},
+									pos:   position{line: 1101, col: 98, offset: 26644},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1082, col: 104, offset: 26148},
+										pos: position{line: 1101, col: 104, offset: 26650},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1082, col: 104, offset: 26148},
+											pos:  position{line: 1101, col: 104, offset: 26650},
 											name: "WhereClause",
 										},
 									},
@@ -7436,81 +7568,81 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1086, col: 5, offset: 26342},
+						pos: position{line: 1105, col: 5, offset: 26844},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1086, col: 5, offset: 26342},
+							pos: position{line: 1105, col: 5, offset: 26844},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1086, col: 5, offset: 26342},
+									pos: position{line: 1105, col: 5, offset: 26844},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1086, col: 6, offset: 26343},
+										pos:  position{line: 1105, col: 6, offset: 26845},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 16, offset: 26353},
+									pos:  position{line: 1105, col: 16, offset: 26855},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 24, offset: 26361},
+									pos:  position{line: 1105, col: 24, offset: 26863},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1086, col: 27, offset: 26364},
+									pos:        position{line: 1105, col: 27, offset: 26866},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 31, offset: 26368},
+									pos:  position{line: 1105, col: 31, offset: 26870},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1086, col: 34, offset: 26371},
+									pos:   position{line: 1105, col: 34, offset: 26873},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1086, col: 39, offset: 26376},
+										pos:  position{line: 1105, col: 39, offset: 26878},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 44, offset: 26381},
+									pos:  position{line: 1105, col: 44, offset: 26883},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 46, offset: 26383},
+									pos:  position{line: 1105, col: 46, offset: 26885},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 51, offset: 26388},
+									pos:  position{line: 1105, col: 51, offset: 26890},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1086, col: 53, offset: 26390},
+									pos:   position{line: 1105, col: 53, offset: 26892},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1086, col: 55, offset: 26392},
+										pos:  position{line: 1105, col: 55, offset: 26894},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 60, offset: 26397},
+									pos:  position{line: 1105, col: 60, offset: 26899},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1086, col: 63, offset: 26400},
+									pos:        position{line: 1105, col: 63, offset: 26902},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1086, col: 67, offset: 26404},
+									pos:   position{line: 1105, col: 67, offset: 26906},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1086, col: 73, offset: 26410},
+										pos: position{line: 1105, col: 73, offset: 26912},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1086, col: 73, offset: 26410},
+											pos:  position{line: 1105, col: 73, offset: 26912},
 											name: "WhereClause",
 										},
 									},
@@ -7519,70 +7651,70 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1094, col: 5, offset: 26589},
+						pos: position{line: 1113, col: 5, offset: 27091},
 						run: (*parser).callonFunction64,
 						expr: &seqExpr{
-							pos: position{line: 1094, col: 5, offset: 26589},
+							pos: position{line: 1113, col: 5, offset: 27091},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1094, col: 5, offset: 26589},
+									pos: position{line: 1113, col: 5, offset: 27091},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1094, col: 6, offset: 26590},
+										pos:  position{line: 1113, col: 6, offset: 27092},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1094, col: 16, offset: 26600},
+									pos:  position{line: 1113, col: 16, offset: 27102},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1094, col: 21, offset: 26605},
+									pos:  position{line: 1113, col: 21, offset: 27107},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1094, col: 24, offset: 26608},
+									pos:        position{line: 1113, col: 24, offset: 27110},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1094, col: 28, offset: 26612},
+									pos:  position{line: 1113, col: 28, offset: 27114},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1094, col: 31, offset: 26615},
+									pos:   position{line: 1113, col: 31, offset: 27117},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1094, col: 33, offset: 26617},
+										pos:  position{line: 1113, col: 33, offset: 27119},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1094, col: 38, offset: 26622},
+									pos:  position{line: 1113, col: 38, offset: 27124},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1094, col: 40, offset: 26624},
+									pos:  position{line: 1113, col: 40, offset: 27126},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1094, col: 43, offset: 26627},
+									pos:  position{line: 1113, col: 43, offset: 27129},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1094, col: 45, offset: 26629},
+									pos:   position{line: 1113, col: 45, offset: 27131},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1094, col: 49, offset: 26633},
+										pos:  position{line: 1113, col: 49, offset: 27135},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1094, col: 60, offset: 26644},
+									pos:  position{line: 1113, col: 60, offset: 27146},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1094, col: 63, offset: 26647},
+									pos:        position{line: 1113, col: 63, offset: 27149},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7591,65 +7723,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1102, col: 5, offset: 26806},
+						pos: position{line: 1121, col: 5, offset: 27308},
 						run: (*parser).callonFunction81,
 						expr: &seqExpr{
-							pos: position{line: 1102, col: 5, offset: 26806},
+							pos: position{line: 1121, col: 5, offset: 27308},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1102, col: 5, offset: 26806},
+									pos: position{line: 1121, col: 5, offset: 27308},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1102, col: 6, offset: 26807},
+										pos:  position{line: 1121, col: 6, offset: 27309},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 16, offset: 26817},
+									pos:   position{line: 1121, col: 16, offset: 27319},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1102, col: 19, offset: 26820},
+										pos:  position{line: 1121, col: 19, offset: 27322},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 30, offset: 26831},
+									pos:  position{line: 1121, col: 30, offset: 27333},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1102, col: 33, offset: 26834},
+									pos:        position{line: 1121, col: 33, offset: 27336},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 37, offset: 26838},
+									pos:  position{line: 1121, col: 37, offset: 27340},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 40, offset: 26841},
+									pos:   position{line: 1121, col: 40, offset: 27343},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1102, col: 45, offset: 26846},
+										pos:  position{line: 1121, col: 45, offset: 27348},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 58, offset: 26859},
+									pos:  position{line: 1121, col: 58, offset: 27361},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1102, col: 61, offset: 26862},
+									pos:        position{line: 1121, col: 61, offset: 27364},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 65, offset: 26866},
+									pos:   position{line: 1121, col: 65, offset: 27368},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1102, col: 71, offset: 26872},
+										pos: position{line: 1121, col: 71, offset: 27374},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1102, col: 71, offset: 26872},
+											pos:  position{line: 1121, col: 71, offset: 27374},
 											name: "WhereClause",
 										},
 									},
@@ -7658,7 +7790,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1105, col: 5, offset: 26943},
+						pos:  position{line: 1124, col: 5, offset: 27445},
 						name: "CountStar",
 					},
 				},
@@ -7668,15 +7800,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1107, col: 1, offset: 26954},
+			pos:  position{line: 1126, col: 1, offset: 27456},
 			expr: &actionExpr{
-				pos: position{line: 1108, col: 5, offset: 26974},
+				pos: position{line: 1127, col: 5, offset: 27476},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1108, col: 5, offset: 26974},
+					pos:   position{line: 1127, col: 5, offset: 27476},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1108, col: 9, offset: 26978},
+						pos:  position{line: 1127, col: 9, offset: 27480},
 						name: "RegexpPattern",
 					},
 				},
@@ -7686,24 +7818,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1110, col: 1, offset: 27049},
+			pos:  position{line: 1129, col: 1, offset: 27551},
 			expr: &choiceExpr{
-				pos: position{line: 1111, col: 5, offset: 27066},
+				pos: position{line: 1130, col: 5, offset: 27568},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1111, col: 5, offset: 27066},
+						pos: position{line: 1130, col: 5, offset: 27568},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1111, col: 5, offset: 27066},
+							pos:   position{line: 1130, col: 5, offset: 27568},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1111, col: 7, offset: 27068},
+								pos:  position{line: 1130, col: 7, offset: 27570},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1112, col: 5, offset: 27106},
+						pos:  position{line: 1131, col: 5, offset: 27608},
 						name: "OptionalExprs",
 					},
 				},
@@ -7713,96 +7845,96 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1114, col: 1, offset: 27121},
+			pos:  position{line: 1133, col: 1, offset: 27623},
 			expr: &actionExpr{
-				pos: position{line: 1115, col: 5, offset: 27130},
+				pos: position{line: 1134, col: 5, offset: 27632},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1115, col: 5, offset: 27130},
+					pos: position{line: 1134, col: 5, offset: 27632},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1115, col: 5, offset: 27130},
+							pos:  position{line: 1134, col: 5, offset: 27632},
 							name: "GREP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1115, col: 10, offset: 27135},
+							pos:  position{line: 1134, col: 10, offset: 27637},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1115, col: 13, offset: 27138},
+							pos:        position{line: 1134, col: 13, offset: 27640},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1115, col: 17, offset: 27142},
+							pos:  position{line: 1134, col: 17, offset: 27644},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1115, col: 20, offset: 27145},
+							pos:   position{line: 1134, col: 20, offset: 27647},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1115, col: 29, offset: 27154},
+								pos: position{line: 1134, col: 29, offset: 27656},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1115, col: 29, offset: 27154},
+										pos:  position{line: 1134, col: 29, offset: 27656},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1115, col: 38, offset: 27163},
+										pos:  position{line: 1134, col: 38, offset: 27665},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1115, col: 45, offset: 27170},
+										pos:  position{line: 1134, col: 45, offset: 27672},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1115, col: 51, offset: 27176},
+							pos:  position{line: 1134, col: 51, offset: 27678},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1115, col: 54, offset: 27179},
+							pos:   position{line: 1134, col: 54, offset: 27681},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1115, col: 58, offset: 27183},
+								pos: position{line: 1134, col: 58, offset: 27685},
 								expr: &actionExpr{
-									pos: position{line: 1115, col: 59, offset: 27184},
+									pos: position{line: 1134, col: 59, offset: 27686},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1115, col: 59, offset: 27184},
+										pos: position{line: 1134, col: 59, offset: 27686},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1115, col: 59, offset: 27184},
+												pos:        position{line: 1134, col: 59, offset: 27686},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1115, col: 63, offset: 27188},
+												pos:  position{line: 1134, col: 63, offset: 27690},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1115, col: 66, offset: 27191},
+												pos:   position{line: 1134, col: 66, offset: 27693},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1115, col: 69, offset: 27194},
+													pos: position{line: 1134, col: 69, offset: 27696},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1115, col: 69, offset: 27194},
+															pos:  position{line: 1134, col: 69, offset: 27696},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1115, col: 80, offset: 27205},
+															pos:  position{line: 1134, col: 80, offset: 27707},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1115, col: 86, offset: 27211},
+												pos:  position{line: 1134, col: 86, offset: 27713},
 												name: "__",
 											},
 										},
@@ -7811,7 +7943,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1115, col: 109, offset: 27234},
+							pos:        position{line: 1134, col: 109, offset: 27736},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7824,19 +7956,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1127, col: 1, offset: 27447},
+			pos:  position{line: 1146, col: 1, offset: 27949},
 			expr: &choiceExpr{
-				pos: position{line: 1128, col: 5, offset: 27465},
+				pos: position{line: 1147, col: 5, offset: 27967},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1128, col: 5, offset: 27465},
+						pos:  position{line: 1147, col: 5, offset: 27967},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1129, col: 5, offset: 27475},
+						pos: position{line: 1148, col: 5, offset: 27977},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1129, col: 5, offset: 27475},
+							pos:  position{line: 1148, col: 5, offset: 27977},
 							name: "__",
 						},
 					},
@@ -7847,51 +7979,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1131, col: 1, offset: 27503},
+			pos:  position{line: 1150, col: 1, offset: 28005},
 			expr: &actionExpr{
-				pos: position{line: 1132, col: 5, offset: 27513},
+				pos: position{line: 1151, col: 5, offset: 28015},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1132, col: 5, offset: 27513},
+					pos: position{line: 1151, col: 5, offset: 28015},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1132, col: 5, offset: 27513},
+							pos:   position{line: 1151, col: 5, offset: 28015},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1132, col: 11, offset: 27519},
+								pos:  position{line: 1151, col: 11, offset: 28021},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1132, col: 16, offset: 27524},
+							pos:   position{line: 1151, col: 16, offset: 28026},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1132, col: 21, offset: 27529},
+								pos: position{line: 1151, col: 21, offset: 28031},
 								expr: &actionExpr{
-									pos: position{line: 1132, col: 22, offset: 27530},
+									pos: position{line: 1151, col: 22, offset: 28032},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1132, col: 22, offset: 27530},
+										pos: position{line: 1151, col: 22, offset: 28032},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1132, col: 22, offset: 27530},
+												pos:  position{line: 1151, col: 22, offset: 28032},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1132, col: 25, offset: 27533},
+												pos:        position{line: 1151, col: 25, offset: 28035},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1132, col: 29, offset: 27537},
+												pos:  position{line: 1151, col: 29, offset: 28039},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1132, col: 32, offset: 27540},
+												pos:   position{line: 1151, col: 32, offset: 28042},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1132, col: 34, offset: 27542},
+													pos:  position{line: 1151, col: 34, offset: 28044},
 													name: "Expr",
 												},
 											},
@@ -7908,56 +8040,56 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1136, col: 1, offset: 27615},
+			pos:  position{line: 1155, col: 1, offset: 28117},
 			expr: &choiceExpr{
-				pos: position{line: 1137, col: 5, offset: 27627},
+				pos: position{line: 1156, col: 5, offset: 28129},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1137, col: 5, offset: 27627},
+						pos:  position{line: 1156, col: 5, offset: 28129},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1138, col: 5, offset: 27640},
+						pos:  position{line: 1157, col: 5, offset: 28142},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1139, col: 5, offset: 27651},
+						pos:  position{line: 1158, col: 5, offset: 28153},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1140, col: 5, offset: 27661},
+						pos:  position{line: 1159, col: 5, offset: 28163},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1141, col: 5, offset: 27669},
+						pos:  position{line: 1160, col: 5, offset: 28171},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1142, col: 5, offset: 27677},
+						pos:  position{line: 1161, col: 5, offset: 28179},
 						name: "SQLTimeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1143, col: 5, offset: 27694},
+						pos:  position{line: 1162, col: 5, offset: 28196},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1144, col: 5, offset: 27706},
+						pos: position{line: 1163, col: 5, offset: 28208},
 						run: (*parser).callonPrimary9,
 						expr: &seqExpr{
-							pos: position{line: 1144, col: 5, offset: 27706},
+							pos: position{line: 1163, col: 5, offset: 28208},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1144, col: 5, offset: 27706},
+									pos: position{line: 1163, col: 5, offset: 28208},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1144, col: 6, offset: 27707},
+										pos:  position{line: 1163, col: 6, offset: 28209},
 										name: "PipeKeyword",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1144, col: 18, offset: 27719},
+									pos:   position{line: 1163, col: 18, offset: 28221},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1144, col: 21, offset: 27722},
+										pos:  position{line: 1163, col: 21, offset: 28224},
 										name: "Identifier",
 									},
 								},
@@ -7965,39 +8097,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1145, col: 5, offset: 27756},
+						pos:  position{line: 1164, col: 5, offset: 28258},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1146, col: 5, offset: 27766},
+						pos: position{line: 1165, col: 5, offset: 28268},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1146, col: 5, offset: 27766},
+							pos: position{line: 1165, col: 5, offset: 28268},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1146, col: 5, offset: 27766},
+									pos:        position{line: 1165, col: 5, offset: 28268},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1146, col: 9, offset: 27770},
+									pos:  position{line: 1165, col: 9, offset: 28272},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1146, col: 12, offset: 27773},
+									pos:   position{line: 1165, col: 12, offset: 28275},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1146, col: 17, offset: 27778},
+										pos:  position{line: 1165, col: 17, offset: 28280},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1146, col: 26, offset: 27787},
+									pos:  position{line: 1165, col: 26, offset: 28289},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1146, col: 29, offset: 27790},
+									pos:        position{line: 1165, col: 29, offset: 28292},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8006,35 +8138,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1147, col: 5, offset: 27819},
+						pos: position{line: 1166, col: 5, offset: 28321},
 						run: (*parser).callonPrimary24,
 						expr: &seqExpr{
-							pos: position{line: 1147, col: 5, offset: 27819},
+							pos: position{line: 1166, col: 5, offset: 28321},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1147, col: 5, offset: 27819},
+									pos:        position{line: 1166, col: 5, offset: 28321},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 9, offset: 27823},
+									pos:  position{line: 1166, col: 9, offset: 28325},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1147, col: 12, offset: 27826},
+									pos:   position{line: 1166, col: 12, offset: 28328},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1147, col: 17, offset: 27831},
+										pos:  position{line: 1166, col: 17, offset: 28333},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 22, offset: 27836},
+									pos:  position{line: 1166, col: 22, offset: 28338},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1147, col: 25, offset: 27839},
+									pos:        position{line: 1166, col: 25, offset: 28341},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8049,53 +8181,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1149, col: 1, offset: 27865},
+			pos:  position{line: 1168, col: 1, offset: 28367},
 			expr: &choiceExpr{
-				pos: position{line: 1150, col: 5, offset: 27878},
+				pos: position{line: 1169, col: 5, offset: 28380},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1150, col: 5, offset: 27878},
+						pos: position{line: 1169, col: 5, offset: 28380},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1150, col: 5, offset: 27878},
+							pos: position{line: 1169, col: 5, offset: 28380},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1150, col: 5, offset: 27878},
+									pos:  position{line: 1169, col: 5, offset: 28380},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1150, col: 10, offset: 27883},
+									pos:   position{line: 1169, col: 10, offset: 28385},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1150, col: 16, offset: 27889},
+										pos: position{line: 1169, col: 16, offset: 28391},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1150, col: 16, offset: 27889},
+											pos:  position{line: 1169, col: 16, offset: 28391},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1150, col: 22, offset: 27895},
+									pos:   position{line: 1169, col: 22, offset: 28397},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1150, col: 28, offset: 27901},
+										pos: position{line: 1169, col: 28, offset: 28403},
 										expr: &seqExpr{
-											pos: position{line: 1150, col: 29, offset: 27902},
+											pos: position{line: 1169, col: 29, offset: 28404},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1150, col: 29, offset: 27902},
+													pos:  position{line: 1169, col: 29, offset: 28404},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1150, col: 31, offset: 27904},
+													pos:  position{line: 1169, col: 31, offset: 28406},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1150, col: 36, offset: 27909},
+													pos:  position{line: 1169, col: 36, offset: 28411},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1150, col: 38, offset: 27911},
+													pos:  position{line: 1169, col: 38, offset: 28413},
 													name: "Expr",
 												},
 											},
@@ -8103,24 +8235,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1150, col: 45, offset: 27918},
+									pos:  position{line: 1169, col: 45, offset: 28420},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1150, col: 47, offset: 27920},
+									pos:  position{line: 1169, col: 47, offset: 28422},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1150, col: 51, offset: 27924},
+									pos: position{line: 1169, col: 51, offset: 28426},
 									expr: &seqExpr{
-										pos: position{line: 1150, col: 52, offset: 27925},
+										pos: position{line: 1169, col: 52, offset: 28427},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1150, col: 52, offset: 27925},
+												pos:  position{line: 1169, col: 52, offset: 28427},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1150, col: 54, offset: 27927},
+												pos:  position{line: 1169, col: 54, offset: 28429},
 												name: "CASE",
 											},
 										},
@@ -8130,60 +8262,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1174, col: 5, offset: 28576},
+						pos: position{line: 1193, col: 5, offset: 29078},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1174, col: 5, offset: 28576},
+							pos: position{line: 1193, col: 5, offset: 29078},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1174, col: 5, offset: 28576},
+									pos:  position{line: 1193, col: 5, offset: 29078},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1174, col: 10, offset: 28581},
+									pos:  position{line: 1193, col: 10, offset: 29083},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1174, col: 12, offset: 28583},
+									pos:   position{line: 1193, col: 12, offset: 29085},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1174, col: 17, offset: 28588},
+										pos:  position{line: 1193, col: 17, offset: 29090},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1174, col: 22, offset: 28593},
+									pos:   position{line: 1193, col: 22, offset: 29095},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1174, col: 28, offset: 28599},
+										pos: position{line: 1193, col: 28, offset: 29101},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1174, col: 28, offset: 28599},
+											pos:  position{line: 1193, col: 28, offset: 29101},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1174, col: 34, offset: 28605},
+									pos:   position{line: 1193, col: 34, offset: 29107},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1174, col: 40, offset: 28611},
+										pos: position{line: 1193, col: 40, offset: 29113},
 										expr: &seqExpr{
-											pos: position{line: 1174, col: 41, offset: 28612},
+											pos: position{line: 1193, col: 41, offset: 29114},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1174, col: 41, offset: 28612},
+													pos:  position{line: 1193, col: 41, offset: 29114},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1174, col: 43, offset: 28614},
+													pos:  position{line: 1193, col: 43, offset: 29116},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1174, col: 48, offset: 28619},
+													pos:  position{line: 1193, col: 48, offset: 29121},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1174, col: 50, offset: 28621},
+													pos:  position{line: 1193, col: 50, offset: 29123},
 													name: "Expr",
 												},
 											},
@@ -8191,24 +8323,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1174, col: 57, offset: 28628},
+									pos:  position{line: 1193, col: 57, offset: 29130},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1174, col: 59, offset: 28630},
+									pos:  position{line: 1193, col: 59, offset: 29132},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1174, col: 63, offset: 28634},
+									pos: position{line: 1193, col: 63, offset: 29136},
 									expr: &seqExpr{
-										pos: position{line: 1174, col: 64, offset: 28635},
+										pos: position{line: 1193, col: 64, offset: 29137},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1174, col: 64, offset: 28635},
+												pos:  position{line: 1193, col: 64, offset: 29137},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1174, col: 66, offset: 28637},
+												pos:  position{line: 1193, col: 66, offset: 29139},
 												name: "CASE",
 											},
 										},
@@ -8224,50 +8356,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1187, col: 1, offset: 28943},
+			pos:  position{line: 1206, col: 1, offset: 29445},
 			expr: &actionExpr{
-				pos: position{line: 1188, col: 5, offset: 28952},
+				pos: position{line: 1207, col: 5, offset: 29454},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1188, col: 5, offset: 28952},
+					pos: position{line: 1207, col: 5, offset: 29454},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1188, col: 5, offset: 28952},
+							pos:  position{line: 1207, col: 5, offset: 29454},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1188, col: 7, offset: 28954},
+							pos:  position{line: 1207, col: 7, offset: 29456},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1188, col: 12, offset: 28959},
+							pos:  position{line: 1207, col: 12, offset: 29461},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1188, col: 14, offset: 28961},
+							pos:   position{line: 1207, col: 14, offset: 29463},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1188, col: 19, offset: 28966},
+								pos:  position{line: 1207, col: 19, offset: 29468},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1188, col: 24, offset: 28971},
+							pos:  position{line: 1207, col: 24, offset: 29473},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1188, col: 26, offset: 28973},
+							pos:  position{line: 1207, col: 26, offset: 29475},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1188, col: 31, offset: 28978},
+							pos:  position{line: 1207, col: 31, offset: 29480},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1188, col: 33, offset: 28980},
+							pos:   position{line: 1207, col: 33, offset: 29482},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1188, col: 38, offset: 28985},
+								pos:  position{line: 1207, col: 38, offset: 29487},
 								name: "Expr",
 							},
 						},
@@ -8279,57 +8411,57 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1197, col: 1, offset: 29144},
+			pos:  position{line: 1216, col: 1, offset: 29646},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 5, offset: 29157},
+				pos: position{line: 1217, col: 5, offset: 29659},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1198, col: 5, offset: 29157},
+					pos: position{line: 1217, col: 5, offset: 29659},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 5, offset: 29157},
+							pos:  position{line: 1217, col: 5, offset: 29659},
 							name: "OVER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 10, offset: 29162},
+							pos:  position{line: 1217, col: 10, offset: 29664},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1198, col: 12, offset: 29164},
+							pos:   position{line: 1217, col: 12, offset: 29666},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1198, col: 18, offset: 29170},
+								pos:  position{line: 1217, col: 18, offset: 29672},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1198, col: 24, offset: 29176},
+							pos:   position{line: 1217, col: 24, offset: 29678},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1198, col: 31, offset: 29183},
+								pos: position{line: 1217, col: 31, offset: 29685},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1198, col: 31, offset: 29183},
+									pos:  position{line: 1217, col: 31, offset: 29685},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 39, offset: 29191},
+							pos:  position{line: 1217, col: 39, offset: 29693},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 42, offset: 29194},
+							pos:  position{line: 1217, col: 42, offset: 29696},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 47, offset: 29199},
+							pos:  position{line: 1217, col: 47, offset: 29701},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1198, col: 50, offset: 29202},
+							pos:   position{line: 1217, col: 50, offset: 29704},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1198, col: 55, offset: 29207},
+								pos:  position{line: 1217, col: 55, offset: 29709},
 								name: "Seq",
 							},
 						},
@@ -8341,37 +8473,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1208, col: 1, offset: 29438},
+			pos:  position{line: 1227, col: 1, offset: 29940},
 			expr: &actionExpr{
-				pos: position{line: 1209, col: 5, offset: 29449},
+				pos: position{line: 1228, col: 5, offset: 29951},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1209, col: 5, offset: 29449},
+					pos: position{line: 1228, col: 5, offset: 29951},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1209, col: 5, offset: 29449},
+							pos:        position{line: 1228, col: 5, offset: 29951},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1209, col: 9, offset: 29453},
+							pos:  position{line: 1228, col: 9, offset: 29955},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1209, col: 12, offset: 29456},
+							pos:   position{line: 1228, col: 12, offset: 29958},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1209, col: 18, offset: 29462},
+								pos:  position{line: 1228, col: 18, offset: 29964},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1209, col: 30, offset: 29474},
+							pos:  position{line: 1228, col: 30, offset: 29976},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1209, col: 33, offset: 29477},
+							pos:        position{line: 1228, col: 33, offset: 29979},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8384,31 +8516,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1217, col: 1, offset: 29635},
+			pos:  position{line: 1236, col: 1, offset: 30137},
 			expr: &choiceExpr{
-				pos: position{line: 1218, col: 5, offset: 29651},
+				pos: position{line: 1237, col: 5, offset: 30153},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1218, col: 5, offset: 29651},
+						pos: position{line: 1237, col: 5, offset: 30153},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1218, col: 5, offset: 29651},
+							pos: position{line: 1237, col: 5, offset: 30153},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1218, col: 5, offset: 29651},
+									pos:   position{line: 1237, col: 5, offset: 30153},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1218, col: 11, offset: 29657},
+										pos:  position{line: 1237, col: 11, offset: 30159},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1218, col: 22, offset: 29668},
+									pos:   position{line: 1237, col: 22, offset: 30170},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1218, col: 27, offset: 29673},
+										pos: position{line: 1237, col: 27, offset: 30175},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1218, col: 27, offset: 29673},
+											pos:  position{line: 1237, col: 27, offset: 30175},
 											name: "RecordElemTail",
 										},
 									},
@@ -8417,10 +8549,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1221, col: 5, offset: 29736},
+						pos: position{line: 1240, col: 5, offset: 30238},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1221, col: 5, offset: 29736},
+							pos:  position{line: 1240, col: 5, offset: 30238},
 							name: "__",
 						},
 					},
@@ -8431,32 +8563,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1223, col: 1, offset: 29760},
+			pos:  position{line: 1242, col: 1, offset: 30262},
 			expr: &actionExpr{
-				pos: position{line: 1223, col: 18, offset: 29777},
+				pos: position{line: 1242, col: 18, offset: 30279},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1223, col: 18, offset: 29777},
+					pos: position{line: 1242, col: 18, offset: 30279},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1223, col: 18, offset: 29777},
+							pos:  position{line: 1242, col: 18, offset: 30279},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1223, col: 21, offset: 29780},
+							pos:        position{line: 1242, col: 21, offset: 30282},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1223, col: 25, offset: 29784},
+							pos:  position{line: 1242, col: 25, offset: 30286},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1223, col: 28, offset: 29787},
+							pos:   position{line: 1242, col: 28, offset: 30289},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1223, col: 33, offset: 29792},
+								pos:  position{line: 1242, col: 33, offset: 30294},
 								name: "RecordElem",
 							},
 						},
@@ -8468,20 +8600,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1225, col: 1, offset: 29825},
+			pos:  position{line: 1244, col: 1, offset: 30327},
 			expr: &choiceExpr{
-				pos: position{line: 1226, col: 5, offset: 29840},
+				pos: position{line: 1245, col: 5, offset: 30342},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1226, col: 5, offset: 29840},
+						pos:  position{line: 1245, col: 5, offset: 30342},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1227, col: 5, offset: 29851},
+						pos:  position{line: 1246, col: 5, offset: 30353},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1228, col: 5, offset: 29865},
+						pos:  position{line: 1247, col: 5, offset: 30367},
 						name: "Identifier",
 					},
 				},
@@ -8491,28 +8623,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1230, col: 1, offset: 29877},
+			pos:  position{line: 1249, col: 1, offset: 30379},
 			expr: &actionExpr{
-				pos: position{line: 1231, col: 5, offset: 29888},
+				pos: position{line: 1250, col: 5, offset: 30390},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1231, col: 5, offset: 29888},
+					pos: position{line: 1250, col: 5, offset: 30390},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1231, col: 5, offset: 29888},
+							pos:        position{line: 1250, col: 5, offset: 30390},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1231, col: 11, offset: 29894},
+							pos:  position{line: 1250, col: 11, offset: 30396},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1231, col: 14, offset: 29897},
+							pos:   position{line: 1250, col: 14, offset: 30399},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1231, col: 19, offset: 29902},
+								pos:  position{line: 1250, col: 19, offset: 30404},
 								name: "Expr",
 							},
 						},
@@ -8524,40 +8656,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1235, col: 1, offset: 29998},
+			pos:  position{line: 1254, col: 1, offset: 30500},
 			expr: &actionExpr{
-				pos: position{line: 1236, col: 5, offset: 30012},
+				pos: position{line: 1255, col: 5, offset: 30514},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1236, col: 5, offset: 30012},
+					pos: position{line: 1255, col: 5, offset: 30514},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1236, col: 5, offset: 30012},
+							pos:   position{line: 1255, col: 5, offset: 30514},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1236, col: 10, offset: 30017},
+								pos:  position{line: 1255, col: 10, offset: 30519},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1236, col: 15, offset: 30022},
+							pos:  position{line: 1255, col: 15, offset: 30524},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1236, col: 18, offset: 30025},
+							pos:        position{line: 1255, col: 18, offset: 30527},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1236, col: 22, offset: 30029},
+							pos:  position{line: 1255, col: 22, offset: 30531},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1236, col: 25, offset: 30032},
+							pos:   position{line: 1255, col: 25, offset: 30534},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1236, col: 31, offset: 30038},
+								pos:  position{line: 1255, col: 31, offset: 30540},
 								name: "Expr",
 							},
 						},
@@ -8569,37 +8701,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1245, col: 1, offset: 30207},
+			pos:  position{line: 1264, col: 1, offset: 30709},
 			expr: &actionExpr{
-				pos: position{line: 1246, col: 5, offset: 30217},
+				pos: position{line: 1265, col: 5, offset: 30719},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1246, col: 5, offset: 30217},
+					pos: position{line: 1265, col: 5, offset: 30719},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1246, col: 5, offset: 30217},
+							pos:        position{line: 1265, col: 5, offset: 30719},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1246, col: 9, offset: 30221},
+							pos:  position{line: 1265, col: 9, offset: 30723},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1246, col: 12, offset: 30224},
+							pos:   position{line: 1265, col: 12, offset: 30726},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1246, col: 18, offset: 30230},
+								pos:  position{line: 1265, col: 18, offset: 30732},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1246, col: 30, offset: 30242},
+							pos:  position{line: 1265, col: 30, offset: 30744},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1246, col: 33, offset: 30245},
+							pos:        position{line: 1265, col: 33, offset: 30747},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8612,37 +8744,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1254, col: 1, offset: 30401},
+			pos:  position{line: 1273, col: 1, offset: 30903},
 			expr: &actionExpr{
-				pos: position{line: 1255, col: 5, offset: 30409},
+				pos: position{line: 1274, col: 5, offset: 30911},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1255, col: 5, offset: 30409},
+					pos: position{line: 1274, col: 5, offset: 30911},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1255, col: 5, offset: 30409},
+							pos:        position{line: 1274, col: 5, offset: 30911},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1255, col: 10, offset: 30414},
+							pos:  position{line: 1274, col: 10, offset: 30916},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1255, col: 13, offset: 30417},
+							pos:   position{line: 1274, col: 13, offset: 30919},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1255, col: 19, offset: 30423},
+								pos:  position{line: 1274, col: 19, offset: 30925},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1255, col: 31, offset: 30435},
+							pos:  position{line: 1274, col: 31, offset: 30937},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1255, col: 34, offset: 30438},
+							pos:        position{line: 1274, col: 34, offset: 30940},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8655,54 +8787,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1263, col: 1, offset: 30591},
+			pos:  position{line: 1282, col: 1, offset: 31093},
 			expr: &choiceExpr{
-				pos: position{line: 1264, col: 5, offset: 30607},
+				pos: position{line: 1283, col: 5, offset: 31109},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1264, col: 5, offset: 30607},
+						pos: position{line: 1283, col: 5, offset: 31109},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 5, offset: 30607},
+							pos: position{line: 1283, col: 5, offset: 31109},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1264, col: 5, offset: 30607},
+									pos:   position{line: 1283, col: 5, offset: 31109},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1264, col: 11, offset: 30613},
+										pos:  position{line: 1283, col: 11, offset: 31115},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1264, col: 22, offset: 30624},
+									pos:   position{line: 1283, col: 22, offset: 31126},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1264, col: 27, offset: 30629},
+										pos: position{line: 1283, col: 27, offset: 31131},
 										expr: &actionExpr{
-											pos: position{line: 1264, col: 28, offset: 30630},
+											pos: position{line: 1283, col: 28, offset: 31132},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1264, col: 28, offset: 30630},
+												pos: position{line: 1283, col: 28, offset: 31132},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1264, col: 28, offset: 30630},
+														pos:  position{line: 1283, col: 28, offset: 31132},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1264, col: 31, offset: 30633},
+														pos:        position{line: 1283, col: 31, offset: 31135},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1264, col: 35, offset: 30637},
+														pos:  position{line: 1283, col: 35, offset: 31139},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1264, col: 38, offset: 30640},
+														pos:   position{line: 1283, col: 38, offset: 31142},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1264, col: 40, offset: 30642},
+															pos:  position{line: 1283, col: 40, offset: 31144},
 															name: "VectorElem",
 														},
 													},
@@ -8715,10 +8847,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 30724},
+						pos: position{line: 1286, col: 5, offset: 31226},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1267, col: 5, offset: 30724},
+							pos:  position{line: 1286, col: 5, offset: 31226},
 							name: "__",
 						},
 					},
@@ -8729,22 +8861,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1269, col: 1, offset: 30748},
+			pos:  position{line: 1288, col: 1, offset: 31250},
 			expr: &choiceExpr{
-				pos: position{line: 1270, col: 5, offset: 30763},
+				pos: position{line: 1289, col: 5, offset: 31265},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1270, col: 5, offset: 30763},
+						pos:  position{line: 1289, col: 5, offset: 31265},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1271, col: 5, offset: 30774},
+						pos: position{line: 1290, col: 5, offset: 31276},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1271, col: 5, offset: 30774},
+							pos:   position{line: 1290, col: 5, offset: 31276},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1271, col: 7, offset: 30776},
+								pos:  position{line: 1290, col: 7, offset: 31278},
 								name: "Expr",
 							},
 						},
@@ -8756,37 +8888,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1273, col: 1, offset: 30867},
+			pos:  position{line: 1292, col: 1, offset: 31369},
 			expr: &actionExpr{
-				pos: position{line: 1274, col: 5, offset: 30875},
+				pos: position{line: 1293, col: 5, offset: 31377},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1274, col: 5, offset: 30875},
+					pos: position{line: 1293, col: 5, offset: 31377},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1274, col: 5, offset: 30875},
+							pos:        position{line: 1293, col: 5, offset: 31377},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1274, col: 10, offset: 30880},
+							pos:  position{line: 1293, col: 10, offset: 31382},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1274, col: 13, offset: 30883},
+							pos:   position{line: 1293, col: 13, offset: 31385},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1274, col: 19, offset: 30889},
+								pos:  position{line: 1293, col: 19, offset: 31391},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1274, col: 27, offset: 30897},
+							pos:  position{line: 1293, col: 27, offset: 31399},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1274, col: 30, offset: 30900},
+							pos:        position{line: 1293, col: 30, offset: 31402},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8799,31 +8931,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1282, col: 1, offset: 31054},
+			pos:  position{line: 1301, col: 1, offset: 31556},
 			expr: &choiceExpr{
-				pos: position{line: 1283, col: 5, offset: 31066},
+				pos: position{line: 1302, col: 5, offset: 31568},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1283, col: 5, offset: 31066},
+						pos: position{line: 1302, col: 5, offset: 31568},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1283, col: 5, offset: 31066},
+							pos: position{line: 1302, col: 5, offset: 31568},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1283, col: 5, offset: 31066},
+									pos:   position{line: 1302, col: 5, offset: 31568},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1283, col: 11, offset: 31072},
+										pos:  position{line: 1302, col: 11, offset: 31574},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1283, col: 17, offset: 31078},
+									pos:   position{line: 1302, col: 17, offset: 31580},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1283, col: 22, offset: 31083},
+										pos: position{line: 1302, col: 22, offset: 31585},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1283, col: 22, offset: 31083},
+											pos:  position{line: 1302, col: 22, offset: 31585},
 											name: "EntryTail",
 										},
 									},
@@ -8832,10 +8964,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1286, col: 5, offset: 31141},
+						pos: position{line: 1305, col: 5, offset: 31643},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1286, col: 5, offset: 31141},
+							pos:  position{line: 1305, col: 5, offset: 31643},
 							name: "__",
 						},
 					},
@@ -8846,32 +8978,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1289, col: 1, offset: 31166},
+			pos:  position{line: 1308, col: 1, offset: 31668},
 			expr: &actionExpr{
-				pos: position{line: 1289, col: 13, offset: 31178},
+				pos: position{line: 1308, col: 13, offset: 31680},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1289, col: 13, offset: 31178},
+					pos: position{line: 1308, col: 13, offset: 31680},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1289, col: 13, offset: 31178},
+							pos:  position{line: 1308, col: 13, offset: 31680},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1289, col: 16, offset: 31181},
+							pos:        position{line: 1308, col: 16, offset: 31683},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1289, col: 20, offset: 31185},
+							pos:  position{line: 1308, col: 20, offset: 31687},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 23, offset: 31188},
+							pos:   position{line: 1308, col: 23, offset: 31690},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 25, offset: 31190},
+								pos:  position{line: 1308, col: 25, offset: 31692},
 								name: "Entry",
 							},
 						},
@@ -8883,40 +9015,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1291, col: 1, offset: 31215},
+			pos:  position{line: 1310, col: 1, offset: 31717},
 			expr: &actionExpr{
-				pos: position{line: 1292, col: 5, offset: 31225},
+				pos: position{line: 1311, col: 5, offset: 31727},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1292, col: 5, offset: 31225},
+					pos: position{line: 1311, col: 5, offset: 31727},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1292, col: 5, offset: 31225},
+							pos:   position{line: 1311, col: 5, offset: 31727},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1292, col: 9, offset: 31229},
+								pos:  position{line: 1311, col: 9, offset: 31731},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1292, col: 14, offset: 31234},
+							pos:  position{line: 1311, col: 14, offset: 31736},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1292, col: 17, offset: 31237},
+							pos:        position{line: 1311, col: 17, offset: 31739},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1292, col: 21, offset: 31241},
+							pos:  position{line: 1311, col: 21, offset: 31743},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1292, col: 24, offset: 31244},
+							pos:   position{line: 1311, col: 24, offset: 31746},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1292, col: 30, offset: 31250},
+								pos:  position{line: 1311, col: 30, offset: 31752},
 								name: "Expr",
 							},
 						},
@@ -8928,61 +9060,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1296, col: 1, offset: 31353},
+			pos:  position{line: 1315, col: 1, offset: 31855},
 			expr: &actionExpr{
-				pos: position{line: 1297, col: 5, offset: 31363},
+				pos: position{line: 1316, col: 5, offset: 31865},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1297, col: 5, offset: 31363},
+					pos: position{line: 1316, col: 5, offset: 31865},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1297, col: 5, offset: 31363},
+							pos:        position{line: 1316, col: 5, offset: 31865},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1297, col: 9, offset: 31367},
+							pos:  position{line: 1316, col: 9, offset: 31869},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1297, col: 12, offset: 31370},
+							pos:   position{line: 1316, col: 12, offset: 31872},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1297, col: 18, offset: 31376},
+								pos:  position{line: 1316, col: 18, offset: 31878},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1297, col: 23, offset: 31381},
+							pos:   position{line: 1316, col: 23, offset: 31883},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1297, col: 28, offset: 31386},
+								pos: position{line: 1316, col: 28, offset: 31888},
 								expr: &actionExpr{
-									pos: position{line: 1297, col: 29, offset: 31387},
+									pos: position{line: 1316, col: 29, offset: 31889},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1297, col: 29, offset: 31387},
+										pos: position{line: 1316, col: 29, offset: 31889},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1297, col: 29, offset: 31387},
+												pos:  position{line: 1316, col: 29, offset: 31889},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1297, col: 32, offset: 31390},
+												pos:        position{line: 1316, col: 32, offset: 31892},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1297, col: 36, offset: 31394},
+												pos:  position{line: 1316, col: 36, offset: 31896},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1297, col: 39, offset: 31397},
+												pos:   position{line: 1316, col: 39, offset: 31899},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1297, col: 41, offset: 31399},
+													pos:  position{line: 1316, col: 41, offset: 31901},
 													name: "Expr",
 												},
 											},
@@ -8992,11 +9124,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1297, col: 66, offset: 31424},
+							pos:  position{line: 1316, col: 66, offset: 31926},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1297, col: 69, offset: 31427},
+							pos:        position{line: 1316, col: 69, offset: 31929},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -9009,39 +9141,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1305, col: 1, offset: 31586},
+			pos:  position{line: 1324, col: 1, offset: 32088},
 			expr: &actionExpr{
-				pos: position{line: 1306, col: 5, offset: 31603},
+				pos: position{line: 1325, col: 5, offset: 32105},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1306, col: 5, offset: 31603},
+					pos: position{line: 1325, col: 5, offset: 32105},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1306, col: 5, offset: 31603},
+							pos:   position{line: 1325, col: 5, offset: 32105},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1306, col: 10, offset: 31608},
+								pos: position{line: 1325, col: 10, offset: 32110},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1306, col: 10, offset: 31608},
+										pos:  position{line: 1325, col: 10, offset: 32110},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1306, col: 17, offset: 31615},
+										pos:  position{line: 1325, col: 17, offset: 32117},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1306, col: 28, offset: 31626},
+							pos:  position{line: 1325, col: 28, offset: 32128},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1306, col: 30, offset: 31628},
+							pos:   position{line: 1325, col: 30, offset: 32130},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1306, col: 32, offset: 31630},
+								pos:  position{line: 1325, col: 32, offset: 32132},
 								name: "StringLiteral",
 							},
 						},
@@ -9053,56 +9185,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1317, col: 1, offset: 31847},
+			pos:  position{line: 1336, col: 1, offset: 32349},
 			expr: &choiceExpr{
-				pos: position{line: 1318, col: 5, offset: 31859},
+				pos: position{line: 1337, col: 5, offset: 32361},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1318, col: 5, offset: 31859},
+						pos:  position{line: 1337, col: 5, offset: 32361},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1319, col: 5, offset: 31875},
+						pos:  position{line: 1338, col: 5, offset: 32377},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 5, offset: 31893},
+						pos:  position{line: 1339, col: 5, offset: 32395},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1321, col: 5, offset: 31905},
+						pos:  position{line: 1340, col: 5, offset: 32407},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1322, col: 5, offset: 31923},
+						pos:  position{line: 1341, col: 5, offset: 32425},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1323, col: 5, offset: 31942},
+						pos:  position{line: 1342, col: 5, offset: 32444},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1324, col: 5, offset: 31959},
+						pos:  position{line: 1343, col: 5, offset: 32461},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1325, col: 5, offset: 31972},
+						pos:  position{line: 1344, col: 5, offset: 32474},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1326, col: 5, offset: 31981},
+						pos:  position{line: 1345, col: 5, offset: 32483},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1327, col: 5, offset: 31998},
+						pos:  position{line: 1346, col: 5, offset: 32500},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1328, col: 5, offset: 32017},
+						pos:  position{line: 1347, col: 5, offset: 32519},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1329, col: 5, offset: 32036},
+						pos:  position{line: 1348, col: 5, offset: 32538},
 						name: "NullLiteral",
 					},
 				},
@@ -9112,28 +9244,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1331, col: 1, offset: 32049},
+			pos:  position{line: 1350, col: 1, offset: 32551},
 			expr: &choiceExpr{
-				pos: position{line: 1332, col: 5, offset: 32067},
+				pos: position{line: 1351, col: 5, offset: 32569},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1332, col: 5, offset: 32067},
+						pos: position{line: 1351, col: 5, offset: 32569},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1332, col: 5, offset: 32067},
+							pos: position{line: 1351, col: 5, offset: 32569},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1332, col: 5, offset: 32067},
+									pos:   position{line: 1351, col: 5, offset: 32569},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1332, col: 7, offset: 32069},
+										pos:  position{line: 1351, col: 7, offset: 32571},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1332, col: 14, offset: 32076},
+									pos: position{line: 1351, col: 14, offset: 32578},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1332, col: 15, offset: 32077},
+										pos:  position{line: 1351, col: 15, offset: 32579},
 										name: "IdentifierRest",
 									},
 								},
@@ -9141,13 +9273,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1335, col: 5, offset: 32157},
+						pos: position{line: 1354, col: 5, offset: 32659},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1335, col: 5, offset: 32157},
+							pos:   position{line: 1354, col: 5, offset: 32659},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1335, col: 7, offset: 32159},
+								pos:  position{line: 1354, col: 7, offset: 32661},
 								name: "IP4Net",
 							},
 						},
@@ -9159,28 +9291,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1339, col: 1, offset: 32228},
+			pos:  position{line: 1358, col: 1, offset: 32730},
 			expr: &choiceExpr{
-				pos: position{line: 1340, col: 5, offset: 32247},
+				pos: position{line: 1359, col: 5, offset: 32749},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1340, col: 5, offset: 32247},
+						pos: position{line: 1359, col: 5, offset: 32749},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1340, col: 5, offset: 32247},
+							pos: position{line: 1359, col: 5, offset: 32749},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1340, col: 5, offset: 32247},
+									pos:   position{line: 1359, col: 5, offset: 32749},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1340, col: 7, offset: 32249},
+										pos:  position{line: 1359, col: 7, offset: 32751},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1340, col: 11, offset: 32253},
+									pos: position{line: 1359, col: 11, offset: 32755},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1340, col: 12, offset: 32254},
+										pos:  position{line: 1359, col: 12, offset: 32756},
 										name: "IdentifierRest",
 									},
 								},
@@ -9188,13 +9320,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1343, col: 5, offset: 32333},
+						pos: position{line: 1362, col: 5, offset: 32835},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1343, col: 5, offset: 32333},
+							pos:   position{line: 1362, col: 5, offset: 32835},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1343, col: 7, offset: 32335},
+								pos:  position{line: 1362, col: 7, offset: 32837},
 								name: "IP",
 							},
 						},
@@ -9206,15 +9338,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1347, col: 1, offset: 32399},
+			pos:  position{line: 1366, col: 1, offset: 32901},
 			expr: &actionExpr{
-				pos: position{line: 1348, col: 5, offset: 32416},
+				pos: position{line: 1367, col: 5, offset: 32918},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1348, col: 5, offset: 32416},
+					pos:   position{line: 1367, col: 5, offset: 32918},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1348, col: 7, offset: 32418},
+						pos:  position{line: 1367, col: 7, offset: 32920},
 						name: "FloatString",
 					},
 				},
@@ -9224,15 +9356,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1352, col: 1, offset: 32496},
+			pos:  position{line: 1371, col: 1, offset: 32998},
 			expr: &actionExpr{
-				pos: position{line: 1353, col: 5, offset: 32515},
+				pos: position{line: 1372, col: 5, offset: 33017},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1353, col: 5, offset: 32515},
+					pos:   position{line: 1372, col: 5, offset: 33017},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1353, col: 7, offset: 32517},
+						pos:  position{line: 1372, col: 7, offset: 33019},
 						name: "IntString",
 					},
 				},
@@ -9242,23 +9374,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1357, col: 1, offset: 32591},
+			pos:  position{line: 1376, col: 1, offset: 33093},
 			expr: &choiceExpr{
-				pos: position{line: 1358, col: 5, offset: 32610},
+				pos: position{line: 1377, col: 5, offset: 33112},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1358, col: 5, offset: 32610},
+						pos: position{line: 1377, col: 5, offset: 33112},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1358, col: 5, offset: 32610},
+							pos:  position{line: 1377, col: 5, offset: 33112},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1359, col: 5, offset: 32668},
+						pos: position{line: 1378, col: 5, offset: 33170},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1359, col: 5, offset: 32668},
+							pos:  position{line: 1378, col: 5, offset: 33170},
 							name: "FALSE",
 						},
 					},
@@ -9269,12 +9401,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1361, col: 1, offset: 32724},
+			pos:  position{line: 1380, col: 1, offset: 33226},
 			expr: &actionExpr{
-				pos: position{line: 1362, col: 5, offset: 32740},
+				pos: position{line: 1381, col: 5, offset: 33242},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1362, col: 5, offset: 32740},
+					pos:  position{line: 1381, col: 5, offset: 33242},
 					name: "NULL",
 				},
 			},
@@ -9283,23 +9415,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1364, col: 1, offset: 32790},
+			pos:  position{line: 1383, col: 1, offset: 33292},
 			expr: &actionExpr{
-				pos: position{line: 1365, col: 5, offset: 32807},
+				pos: position{line: 1384, col: 5, offset: 33309},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1365, col: 5, offset: 32807},
+					pos: position{line: 1384, col: 5, offset: 33309},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1365, col: 5, offset: 32807},
+							pos:        position{line: 1384, col: 5, offset: 33309},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1365, col: 10, offset: 32812},
+							pos: position{line: 1384, col: 10, offset: 33314},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1365, col: 10, offset: 32812},
+								pos:  position{line: 1384, col: 10, offset: 33314},
 								name: "HexDigit",
 							},
 						},
@@ -9311,29 +9443,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1369, col: 1, offset: 32886},
+			pos:  position{line: 1388, col: 1, offset: 33388},
 			expr: &actionExpr{
-				pos: position{line: 1370, col: 5, offset: 32902},
+				pos: position{line: 1389, col: 5, offset: 33404},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1370, col: 5, offset: 32902},
+					pos: position{line: 1389, col: 5, offset: 33404},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1370, col: 5, offset: 32902},
+							pos:        position{line: 1389, col: 5, offset: 33404},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1370, col: 9, offset: 32906},
+							pos:   position{line: 1389, col: 9, offset: 33408},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1370, col: 13, offset: 32910},
+								pos:  position{line: 1389, col: 13, offset: 33412},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1370, col: 18, offset: 32915},
+							pos:        position{line: 1389, col: 18, offset: 33417},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -9346,16 +9478,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1378, col: 1, offset: 33048},
+			pos:  position{line: 1397, col: 1, offset: 33550},
 			expr: &choiceExpr{
-				pos: position{line: 1379, col: 5, offset: 33057},
+				pos: position{line: 1398, col: 5, offset: 33559},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1379, col: 5, offset: 33057},
+						pos:  position{line: 1398, col: 5, offset: 33559},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1380, col: 5, offset: 33075},
+						pos:  position{line: 1399, col: 5, offset: 33577},
 						name: "ComplexType",
 					},
 				},
@@ -9365,28 +9497,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1382, col: 1, offset: 33088},
+			pos:  position{line: 1401, col: 1, offset: 33590},
 			expr: &choiceExpr{
-				pos: position{line: 1383, col: 5, offset: 33106},
+				pos: position{line: 1402, col: 5, offset: 33608},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1383, col: 5, offset: 33106},
+						pos: position{line: 1402, col: 5, offset: 33608},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1383, col: 5, offset: 33106},
+							pos: position{line: 1402, col: 5, offset: 33608},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1383, col: 5, offset: 33106},
+									pos:   position{line: 1402, col: 5, offset: 33608},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1383, col: 10, offset: 33111},
+										pos:  position{line: 1402, col: 10, offset: 33613},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1383, col: 24, offset: 33125},
+									pos: position{line: 1402, col: 24, offset: 33627},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1383, col: 25, offset: 33126},
+										pos:  position{line: 1402, col: 25, offset: 33628},
 										name: "IdentifierRest",
 									},
 								},
@@ -9394,43 +9526,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1384, col: 5, offset: 33166},
+						pos: position{line: 1403, col: 5, offset: 33668},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1384, col: 5, offset: 33166},
+							pos: position{line: 1403, col: 5, offset: 33668},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1384, col: 5, offset: 33166},
+									pos:  position{line: 1403, col: 5, offset: 33668},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1384, col: 11, offset: 33172},
+									pos:  position{line: 1403, col: 11, offset: 33674},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1384, col: 14, offset: 33175},
+									pos:        position{line: 1403, col: 14, offset: 33677},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1384, col: 18, offset: 33179},
+									pos:  position{line: 1403, col: 18, offset: 33681},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1384, col: 21, offset: 33182},
+									pos:   position{line: 1403, col: 21, offset: 33684},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1384, col: 23, offset: 33184},
+										pos:  position{line: 1403, col: 23, offset: 33686},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1384, col: 28, offset: 33189},
+									pos:  position{line: 1403, col: 28, offset: 33691},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1384, col: 31, offset: 33192},
+									pos:        position{line: 1403, col: 31, offset: 33694},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9439,43 +9571,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1391, col: 5, offset: 33332},
+						pos: position{line: 1410, col: 5, offset: 33834},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1391, col: 5, offset: 33332},
+							pos: position{line: 1410, col: 5, offset: 33834},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1391, col: 5, offset: 33332},
+									pos:   position{line: 1410, col: 5, offset: 33834},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1391, col: 10, offset: 33337},
+										pos:  position{line: 1410, col: 10, offset: 33839},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1391, col: 15, offset: 33342},
+									pos:   position{line: 1410, col: 15, offset: 33844},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1391, col: 19, offset: 33346},
+										pos: position{line: 1410, col: 19, offset: 33848},
 										expr: &seqExpr{
-											pos: position{line: 1391, col: 20, offset: 33347},
+											pos: position{line: 1410, col: 20, offset: 33849},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1391, col: 20, offset: 33347},
+													pos:  position{line: 1410, col: 20, offset: 33849},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1391, col: 23, offset: 33350},
+													pos:        position{line: 1410, col: 23, offset: 33852},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1391, col: 27, offset: 33354},
+													pos:  position{line: 1410, col: 27, offset: 33856},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1391, col: 30, offset: 33357},
+													pos:  position{line: 1410, col: 30, offset: 33859},
 													name: "Type",
 												},
 											},
@@ -9486,31 +9618,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1402, col: 5, offset: 33682},
+						pos: position{line: 1421, col: 5, offset: 34184},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1402, col: 5, offset: 33682},
+							pos: position{line: 1421, col: 5, offset: 34184},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1402, col: 5, offset: 33682},
+									pos:        position{line: 1421, col: 5, offset: 34184},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1402, col: 9, offset: 33686},
+									pos:  position{line: 1421, col: 9, offset: 34188},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1402, col: 12, offset: 33689},
+									pos:   position{line: 1421, col: 12, offset: 34191},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1402, col: 18, offset: 33695},
+										pos:  position{line: 1421, col: 18, offset: 34197},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1402, col: 27, offset: 33704},
+									pos:        position{line: 1421, col: 27, offset: 34206},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9525,28 +9657,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1410, col: 1, offset: 33848},
+			pos:  position{line: 1429, col: 1, offset: 34350},
 			expr: &actionExpr{
-				pos: position{line: 1411, col: 5, offset: 33861},
+				pos: position{line: 1430, col: 5, offset: 34363},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1411, col: 5, offset: 33861},
+					pos: position{line: 1430, col: 5, offset: 34363},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1411, col: 5, offset: 33861},
+							pos:   position{line: 1430, col: 5, offset: 34363},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 11, offset: 33867},
+								pos:  position{line: 1430, col: 11, offset: 34369},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1411, col: 16, offset: 33872},
+							pos:   position{line: 1430, col: 16, offset: 34374},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1411, col: 21, offset: 33877},
+								pos: position{line: 1430, col: 21, offset: 34379},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1411, col: 21, offset: 33877},
+									pos:  position{line: 1430, col: 21, offset: 34379},
 									name: "TypeListTail",
 								},
 							},
@@ -9559,32 +9691,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1415, col: 1, offset: 33935},
+			pos:  position{line: 1434, col: 1, offset: 34437},
 			expr: &actionExpr{
-				pos: position{line: 1415, col: 16, offset: 33950},
+				pos: position{line: 1434, col: 16, offset: 34452},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1415, col: 16, offset: 33950},
+					pos: position{line: 1434, col: 16, offset: 34452},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1415, col: 16, offset: 33950},
+							pos:  position{line: 1434, col: 16, offset: 34452},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1415, col: 19, offset: 33953},
+							pos:        position{line: 1434, col: 19, offset: 34455},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1415, col: 23, offset: 33957},
+							pos:  position{line: 1434, col: 23, offset: 34459},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1415, col: 26, offset: 33960},
+							pos:   position{line: 1434, col: 26, offset: 34462},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1415, col: 30, offset: 33964},
+								pos:  position{line: 1434, col: 30, offset: 34466},
 								name: "Type",
 							},
 						},
@@ -9596,40 +9728,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1417, col: 1, offset: 33990},
+			pos:  position{line: 1436, col: 1, offset: 34492},
 			expr: &choiceExpr{
-				pos: position{line: 1418, col: 5, offset: 34006},
+				pos: position{line: 1437, col: 5, offset: 34508},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1418, col: 5, offset: 34006},
+						pos: position{line: 1437, col: 5, offset: 34508},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1418, col: 5, offset: 34006},
+							pos: position{line: 1437, col: 5, offset: 34508},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1418, col: 5, offset: 34006},
+									pos:        position{line: 1437, col: 5, offset: 34508},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1418, col: 9, offset: 34010},
+									pos:  position{line: 1437, col: 9, offset: 34512},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1418, col: 12, offset: 34013},
+									pos:   position{line: 1437, col: 12, offset: 34515},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1418, col: 19, offset: 34020},
+										pos:  position{line: 1437, col: 19, offset: 34522},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1418, col: 33, offset: 34034},
+									pos:  position{line: 1437, col: 33, offset: 34536},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1418, col: 36, offset: 34037},
+									pos:        position{line: 1437, col: 36, offset: 34539},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9638,35 +9770,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1425, col: 5, offset: 34199},
+						pos: position{line: 1444, col: 5, offset: 34701},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1425, col: 5, offset: 34199},
+							pos: position{line: 1444, col: 5, offset: 34701},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1425, col: 5, offset: 34199},
+									pos:        position{line: 1444, col: 5, offset: 34701},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1425, col: 9, offset: 34203},
+									pos:  position{line: 1444, col: 9, offset: 34705},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1425, col: 12, offset: 34206},
+									pos:   position{line: 1444, col: 12, offset: 34708},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1425, col: 16, offset: 34210},
+										pos:  position{line: 1444, col: 16, offset: 34712},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1425, col: 21, offset: 34215},
+									pos:  position{line: 1444, col: 21, offset: 34717},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1425, col: 24, offset: 34218},
+									pos:        position{line: 1444, col: 24, offset: 34720},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9675,35 +9807,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1432, col: 5, offset: 34360},
+						pos: position{line: 1451, col: 5, offset: 34862},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1432, col: 5, offset: 34360},
+							pos: position{line: 1451, col: 5, offset: 34862},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1432, col: 5, offset: 34360},
+									pos:        position{line: 1451, col: 5, offset: 34862},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1432, col: 10, offset: 34365},
+									pos:  position{line: 1451, col: 10, offset: 34867},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1432, col: 13, offset: 34368},
+									pos:   position{line: 1451, col: 13, offset: 34870},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1432, col: 17, offset: 34372},
+										pos:  position{line: 1451, col: 17, offset: 34874},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1432, col: 22, offset: 34377},
+									pos:  position{line: 1451, col: 22, offset: 34879},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1432, col: 25, offset: 34380},
+									pos:        position{line: 1451, col: 25, offset: 34882},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9712,57 +9844,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1439, col: 5, offset: 34519},
+						pos: position{line: 1458, col: 5, offset: 35021},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1439, col: 5, offset: 34519},
+							pos: position{line: 1458, col: 5, offset: 35021},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1439, col: 5, offset: 34519},
+									pos:        position{line: 1458, col: 5, offset: 35021},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1439, col: 10, offset: 34524},
+									pos:  position{line: 1458, col: 10, offset: 35026},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1439, col: 13, offset: 34527},
+									pos:   position{line: 1458, col: 13, offset: 35029},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1439, col: 21, offset: 34535},
+										pos:  position{line: 1458, col: 21, offset: 35037},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1439, col: 26, offset: 34540},
+									pos:  position{line: 1458, col: 26, offset: 35042},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1439, col: 29, offset: 34543},
+									pos:        position{line: 1458, col: 29, offset: 35045},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1439, col: 33, offset: 34547},
+									pos:  position{line: 1458, col: 33, offset: 35049},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1439, col: 36, offset: 34550},
+									pos:   position{line: 1458, col: 36, offset: 35052},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1439, col: 44, offset: 34558},
+										pos:  position{line: 1458, col: 44, offset: 35060},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1439, col: 49, offset: 34563},
+									pos:  position{line: 1458, col: 49, offset: 35065},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1439, col: 52, offset: 34566},
+									pos:        position{line: 1458, col: 52, offset: 35068},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9777,35 +9909,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1448, col: 1, offset: 34740},
+			pos:  position{line: 1467, col: 1, offset: 35242},
 			expr: &choiceExpr{
-				pos: position{line: 1449, col: 5, offset: 34758},
+				pos: position{line: 1468, col: 5, offset: 35260},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1449, col: 5, offset: 34758},
+						pos: position{line: 1468, col: 5, offset: 35260},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1449, col: 5, offset: 34758},
+							pos: position{line: 1468, col: 5, offset: 35260},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1449, col: 5, offset: 34758},
+									pos:        position{line: 1468, col: 5, offset: 35260},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1449, col: 9, offset: 34762},
+									pos:   position{line: 1468, col: 9, offset: 35264},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1449, col: 11, offset: 34764},
+										pos: position{line: 1468, col: 11, offset: 35266},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1449, col: 11, offset: 34764},
+											pos:  position{line: 1468, col: 11, offset: 35266},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1449, col: 29, offset: 34782},
+									pos:        position{line: 1468, col: 29, offset: 35284},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9814,30 +9946,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1450, col: 5, offset: 34846},
+						pos: position{line: 1469, col: 5, offset: 35348},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1450, col: 5, offset: 34846},
+							pos: position{line: 1469, col: 5, offset: 35348},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1450, col: 5, offset: 34846},
+									pos:        position{line: 1469, col: 5, offset: 35348},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1450, col: 9, offset: 34850},
+									pos:   position{line: 1469, col: 9, offset: 35352},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1450, col: 11, offset: 34852},
+										pos: position{line: 1469, col: 11, offset: 35354},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1450, col: 11, offset: 34852},
+											pos:  position{line: 1469, col: 11, offset: 35354},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1450, col: 29, offset: 34870},
+									pos:        position{line: 1469, col: 29, offset: 35372},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9852,35 +9984,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1452, col: 1, offset: 34931},
+			pos:  position{line: 1471, col: 1, offset: 35433},
 			expr: &choiceExpr{
-				pos: position{line: 1453, col: 5, offset: 34943},
+				pos: position{line: 1472, col: 5, offset: 35445},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1453, col: 5, offset: 34943},
+						pos: position{line: 1472, col: 5, offset: 35445},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1453, col: 5, offset: 34943},
+							pos: position{line: 1472, col: 5, offset: 35445},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1453, col: 5, offset: 34943},
+									pos:        position{line: 1472, col: 5, offset: 35445},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1453, col: 11, offset: 34949},
+									pos:   position{line: 1472, col: 11, offset: 35451},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1453, col: 13, offset: 34951},
+										pos: position{line: 1472, col: 13, offset: 35453},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1453, col: 13, offset: 34951},
+											pos:  position{line: 1472, col: 13, offset: 35453},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1453, col: 38, offset: 34976},
+									pos:        position{line: 1472, col: 38, offset: 35478},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9889,30 +10021,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1460, col: 5, offset: 35122},
+						pos: position{line: 1479, col: 5, offset: 35624},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1460, col: 5, offset: 35122},
+							pos: position{line: 1479, col: 5, offset: 35624},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1460, col: 5, offset: 35122},
+									pos:        position{line: 1479, col: 5, offset: 35624},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1460, col: 10, offset: 35127},
+									pos:   position{line: 1479, col: 10, offset: 35629},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1460, col: 12, offset: 35129},
+										pos: position{line: 1479, col: 12, offset: 35631},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1460, col: 12, offset: 35129},
+											pos:  position{line: 1479, col: 12, offset: 35631},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1460, col: 37, offset: 35154},
+									pos:        position{line: 1479, col: 37, offset: 35656},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9927,24 +10059,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1468, col: 1, offset: 35297},
+			pos:  position{line: 1487, col: 1, offset: 35799},
 			expr: &choiceExpr{
-				pos: position{line: 1469, col: 5, offset: 35325},
+				pos: position{line: 1488, col: 5, offset: 35827},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1469, col: 5, offset: 35325},
+						pos:  position{line: 1488, col: 5, offset: 35827},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1470, col: 5, offset: 35341},
+						pos: position{line: 1489, col: 5, offset: 35843},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1470, col: 5, offset: 35341},
+							pos:   position{line: 1489, col: 5, offset: 35843},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1470, col: 7, offset: 35343},
+								pos: position{line: 1489, col: 7, offset: 35845},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1470, col: 7, offset: 35343},
+									pos:  position{line: 1489, col: 7, offset: 35845},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9957,27 +10089,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1474, col: 1, offset: 35466},
+			pos:  position{line: 1493, col: 1, offset: 35968},
 			expr: &choiceExpr{
-				pos: position{line: 1475, col: 5, offset: 35494},
+				pos: position{line: 1494, col: 5, offset: 35996},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1475, col: 5, offset: 35494},
+						pos: position{line: 1494, col: 5, offset: 35996},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1475, col: 5, offset: 35494},
+							pos: position{line: 1494, col: 5, offset: 35996},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1475, col: 5, offset: 35494},
+									pos:        position{line: 1494, col: 5, offset: 35996},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1475, col: 10, offset: 35499},
+									pos:   position{line: 1494, col: 10, offset: 36001},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1475, col: 12, offset: 35501},
+										pos:        position{line: 1494, col: 12, offset: 36003},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9987,25 +10119,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1476, col: 5, offset: 35527},
+						pos: position{line: 1495, col: 5, offset: 36029},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1476, col: 5, offset: 35527},
+							pos: position{line: 1495, col: 5, offset: 36029},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1476, col: 5, offset: 35527},
+									pos: position{line: 1495, col: 5, offset: 36029},
 									expr: &litMatcher{
-										pos:        position{line: 1476, col: 7, offset: 35529},
+										pos:        position{line: 1495, col: 7, offset: 36031},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1476, col: 12, offset: 35534},
+									pos:   position{line: 1495, col: 12, offset: 36036},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1476, col: 14, offset: 35536},
+										pos:  position{line: 1495, col: 14, offset: 36038},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -10019,24 +10151,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1478, col: 1, offset: 35572},
+			pos:  position{line: 1497, col: 1, offset: 36074},
 			expr: &choiceExpr{
-				pos: position{line: 1479, col: 5, offset: 35600},
+				pos: position{line: 1498, col: 5, offset: 36102},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1479, col: 5, offset: 35600},
+						pos:  position{line: 1498, col: 5, offset: 36102},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1480, col: 5, offset: 35616},
+						pos: position{line: 1499, col: 5, offset: 36118},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1480, col: 5, offset: 35616},
+							pos:   position{line: 1499, col: 5, offset: 36118},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1480, col: 7, offset: 35618},
+								pos: position{line: 1499, col: 7, offset: 36120},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1480, col: 7, offset: 35618},
+									pos:  position{line: 1499, col: 7, offset: 36120},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -10049,27 +10181,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1484, col: 1, offset: 35741},
+			pos:  position{line: 1503, col: 1, offset: 36243},
 			expr: &choiceExpr{
-				pos: position{line: 1485, col: 5, offset: 35769},
+				pos: position{line: 1504, col: 5, offset: 36271},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1485, col: 5, offset: 35769},
+						pos: position{line: 1504, col: 5, offset: 36271},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1485, col: 5, offset: 35769},
+							pos: position{line: 1504, col: 5, offset: 36271},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1485, col: 5, offset: 35769},
+									pos:        position{line: 1504, col: 5, offset: 36271},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1485, col: 10, offset: 35774},
+									pos:   position{line: 1504, col: 10, offset: 36276},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1485, col: 12, offset: 35776},
+										pos:        position{line: 1504, col: 12, offset: 36278},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -10079,25 +10211,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1486, col: 5, offset: 35802},
+						pos: position{line: 1505, col: 5, offset: 36304},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1486, col: 5, offset: 35802},
+							pos: position{line: 1505, col: 5, offset: 36304},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1486, col: 5, offset: 35802},
+									pos: position{line: 1505, col: 5, offset: 36304},
 									expr: &litMatcher{
-										pos:        position{line: 1486, col: 7, offset: 35804},
+										pos:        position{line: 1505, col: 7, offset: 36306},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1486, col: 12, offset: 35809},
+									pos:   position{line: 1505, col: 12, offset: 36311},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1486, col: 14, offset: 35811},
+										pos:  position{line: 1505, col: 14, offset: 36313},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -10111,37 +10243,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1488, col: 1, offset: 35847},
+			pos:  position{line: 1507, col: 1, offset: 36349},
 			expr: &actionExpr{
-				pos: position{line: 1489, col: 5, offset: 35863},
+				pos: position{line: 1508, col: 5, offset: 36365},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1489, col: 5, offset: 35863},
+					pos: position{line: 1508, col: 5, offset: 36365},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1489, col: 5, offset: 35863},
+							pos:        position{line: 1508, col: 5, offset: 36365},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1489, col: 9, offset: 35867},
+							pos:  position{line: 1508, col: 9, offset: 36369},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1489, col: 12, offset: 35870},
+							pos:   position{line: 1508, col: 12, offset: 36372},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1489, col: 14, offset: 35872},
+								pos:  position{line: 1508, col: 14, offset: 36374},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1489, col: 19, offset: 35877},
+							pos:  position{line: 1508, col: 19, offset: 36379},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1489, col: 22, offset: 35880},
+							pos:        position{line: 1508, col: 22, offset: 36382},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -10154,129 +10286,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1497, col: 1, offset: 36015},
+			pos:  position{line: 1516, col: 1, offset: 36517},
 			expr: &actionExpr{
-				pos: position{line: 1498, col: 5, offset: 36033},
+				pos: position{line: 1517, col: 5, offset: 36535},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1498, col: 9, offset: 36037},
+					pos: position{line: 1517, col: 9, offset: 36539},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1498, col: 9, offset: 36037},
+							pos:        position{line: 1517, col: 9, offset: 36539},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1498, col: 19, offset: 36047},
+							pos:        position{line: 1517, col: 19, offset: 36549},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1498, col: 30, offset: 36058},
+							pos:        position{line: 1517, col: 30, offset: 36560},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1498, col: 41, offset: 36069},
+							pos:        position{line: 1517, col: 41, offset: 36571},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1499, col: 9, offset: 36086},
+							pos:        position{line: 1518, col: 9, offset: 36588},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1499, col: 18, offset: 36095},
+							pos:        position{line: 1518, col: 18, offset: 36597},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1499, col: 28, offset: 36105},
+							pos:        position{line: 1518, col: 28, offset: 36607},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1499, col: 38, offset: 36115},
+							pos:        position{line: 1518, col: 38, offset: 36617},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1500, col: 9, offset: 36131},
+							pos:        position{line: 1519, col: 9, offset: 36633},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1500, col: 21, offset: 36143},
+							pos:        position{line: 1519, col: 21, offset: 36645},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1500, col: 33, offset: 36155},
+							pos:        position{line: 1519, col: 33, offset: 36657},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1501, col: 9, offset: 36173},
+							pos:        position{line: 1520, col: 9, offset: 36675},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1501, col: 18, offset: 36182},
+							pos:        position{line: 1520, col: 18, offset: 36684},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1502, col: 9, offset: 36199},
+							pos:        position{line: 1521, col: 9, offset: 36701},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1502, col: 22, offset: 36212},
+							pos:        position{line: 1521, col: 22, offset: 36714},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1503, col: 9, offset: 36227},
+							pos:        position{line: 1522, col: 9, offset: 36729},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1504, col: 9, offset: 36243},
+							pos:        position{line: 1523, col: 9, offset: 36745},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1504, col: 16, offset: 36250},
+							pos:        position{line: 1523, col: 16, offset: 36752},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1505, col: 9, offset: 36264},
+							pos:        position{line: 1524, col: 9, offset: 36766},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1505, col: 18, offset: 36273},
+							pos:        position{line: 1524, col: 18, offset: 36775},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -10289,31 +10421,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1513, col: 1, offset: 36458},
+			pos:  position{line: 1532, col: 1, offset: 36960},
 			expr: &choiceExpr{
-				pos: position{line: 1514, col: 5, offset: 36476},
+				pos: position{line: 1533, col: 5, offset: 36978},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1514, col: 5, offset: 36476},
+						pos: position{line: 1533, col: 5, offset: 36978},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1514, col: 5, offset: 36476},
+							pos: position{line: 1533, col: 5, offset: 36978},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1514, col: 5, offset: 36476},
+									pos:   position{line: 1533, col: 5, offset: 36978},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1514, col: 11, offset: 36482},
+										pos:  position{line: 1533, col: 11, offset: 36984},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1514, col: 21, offset: 36492},
+									pos:   position{line: 1533, col: 21, offset: 36994},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1514, col: 26, offset: 36497},
+										pos: position{line: 1533, col: 26, offset: 36999},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1514, col: 26, offset: 36497},
+											pos:  position{line: 1533, col: 26, offset: 36999},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10322,10 +10454,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1517, col: 5, offset: 36563},
+						pos: position{line: 1536, col: 5, offset: 37065},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1517, col: 5, offset: 36563},
+							pos:        position{line: 1536, col: 5, offset: 37065},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10338,32 +10470,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1519, col: 1, offset: 36587},
+			pos:  position{line: 1538, col: 1, offset: 37089},
 			expr: &actionExpr{
-				pos: position{line: 1519, col: 21, offset: 36607},
+				pos: position{line: 1538, col: 21, offset: 37109},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1519, col: 21, offset: 36607},
+					pos: position{line: 1538, col: 21, offset: 37109},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1519, col: 21, offset: 36607},
+							pos:  position{line: 1538, col: 21, offset: 37109},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1519, col: 24, offset: 36610},
+							pos:        position{line: 1538, col: 24, offset: 37112},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1519, col: 28, offset: 36614},
+							pos:  position{line: 1538, col: 28, offset: 37116},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1519, col: 31, offset: 36617},
+							pos:   position{line: 1538, col: 31, offset: 37119},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1519, col: 35, offset: 36621},
+								pos:  position{line: 1538, col: 35, offset: 37123},
 								name: "TypeField",
 							},
 						},
@@ -10375,40 +10507,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1521, col: 1, offset: 36652},
+			pos:  position{line: 1540, col: 1, offset: 37154},
 			expr: &actionExpr{
-				pos: position{line: 1522, col: 5, offset: 36666},
+				pos: position{line: 1541, col: 5, offset: 37168},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1522, col: 5, offset: 36666},
+					pos: position{line: 1541, col: 5, offset: 37168},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1522, col: 5, offset: 36666},
+							pos:   position{line: 1541, col: 5, offset: 37168},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1522, col: 10, offset: 36671},
+								pos:  position{line: 1541, col: 10, offset: 37173},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1522, col: 15, offset: 36676},
+							pos:  position{line: 1541, col: 15, offset: 37178},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1522, col: 18, offset: 36679},
+							pos:        position{line: 1541, col: 18, offset: 37181},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1522, col: 22, offset: 36683},
+							pos:  position{line: 1541, col: 22, offset: 37185},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1522, col: 25, offset: 36686},
+							pos:   position{line: 1541, col: 25, offset: 37188},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1522, col: 29, offset: 36690},
+								pos:  position{line: 1541, col: 29, offset: 37192},
 								name: "Type",
 							},
 						},
@@ -10420,54 +10552,54 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1530, col: 1, offset: 36839},
+			pos:  position{line: 1549, col: 1, offset: 37341},
 			expr: &choiceExpr{
-				pos: position{line: 1531, col: 5, offset: 36848},
+				pos: position{line: 1550, col: 5, offset: 37350},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1531, col: 5, offset: 36848},
+						pos: position{line: 1550, col: 5, offset: 37350},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1531, col: 5, offset: 36848},
+							pos:   position{line: 1550, col: 5, offset: 37350},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1531, col: 7, offset: 36850},
+								pos:  position{line: 1550, col: 7, offset: 37352},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1532, col: 5, offset: 36939},
+						pos: position{line: 1551, col: 5, offset: 37441},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1532, col: 5, offset: 36939},
+							pos:   position{line: 1551, col: 5, offset: 37441},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1532, col: 7, offset: 36941},
+								pos:  position{line: 1551, col: 7, offset: 37443},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1533, col: 5, offset: 37030},
+						pos: position{line: 1552, col: 5, offset: 37532},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1533, col: 5, offset: 37030},
+							pos:   position{line: 1552, col: 5, offset: 37532},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1533, col: 7, offset: 37032},
+								pos:  position{line: 1552, col: 7, offset: 37534},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1534, col: 5, offset: 37121},
+						pos: position{line: 1553, col: 5, offset: 37623},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1534, col: 5, offset: 37121},
+							pos:   position{line: 1553, col: 5, offset: 37623},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1534, col: 7, offset: 37123},
+								pos:  position{line: 1553, col: 7, offset: 37625},
 								name: "KSUID",
 							},
 						},
@@ -10479,22 +10611,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1536, col: 1, offset: 37209},
+			pos:  position{line: 1555, col: 1, offset: 37711},
 			expr: &actionExpr{
-				pos: position{line: 1537, col: 5, offset: 37223},
+				pos: position{line: 1556, col: 5, offset: 37725},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1537, col: 5, offset: 37223},
+					pos: position{line: 1556, col: 5, offset: 37725},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1537, col: 6, offset: 37224},
+							pos: position{line: 1556, col: 6, offset: 37726},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1537, col: 6, offset: 37224},
+									pos:  position{line: 1556, col: 6, offset: 37726},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1537, col: 24, offset: 37242},
+									pos:        position{line: 1556, col: 24, offset: 37744},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -10502,16 +10634,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1537, col: 29, offset: 37247},
+							pos: position{line: 1556, col: 29, offset: 37749},
 							expr: &choiceExpr{
-								pos: position{line: 1537, col: 30, offset: 37248},
+								pos: position{line: 1556, col: 30, offset: 37750},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1537, col: 30, offset: 37248},
+										pos:  position{line: 1556, col: 30, offset: 37750},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1537, col: 47, offset: 37265},
+										pos:        position{line: 1556, col: 47, offset: 37767},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -10527,15 +10659,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1539, col: 1, offset: 37303},
+			pos:  position{line: 1558, col: 1, offset: 37805},
 			expr: &actionExpr{
-				pos: position{line: 1540, col: 5, offset: 37318},
+				pos: position{line: 1559, col: 5, offset: 37820},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1540, col: 5, offset: 37318},
+					pos:   position{line: 1559, col: 5, offset: 37820},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1540, col: 8, offset: 37321},
+						pos:  position{line: 1559, col: 8, offset: 37823},
 						name: "IdentifierName",
 					},
 				},
@@ -10545,51 +10677,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1548, col: 1, offset: 37454},
+			pos:  position{line: 1567, col: 1, offset: 37956},
 			expr: &actionExpr{
-				pos: position{line: 1549, col: 5, offset: 37470},
+				pos: position{line: 1568, col: 5, offset: 37972},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1549, col: 5, offset: 37470},
+					pos: position{line: 1568, col: 5, offset: 37972},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1549, col: 5, offset: 37470},
+							pos:   position{line: 1568, col: 5, offset: 37972},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1549, col: 11, offset: 37476},
+								pos:  position{line: 1568, col: 11, offset: 37978},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1549, col: 22, offset: 37487},
+							pos:   position{line: 1568, col: 22, offset: 37989},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1549, col: 27, offset: 37492},
+								pos: position{line: 1568, col: 27, offset: 37994},
 								expr: &actionExpr{
-									pos: position{line: 1549, col: 28, offset: 37493},
+									pos: position{line: 1568, col: 28, offset: 37995},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1549, col: 28, offset: 37493},
+										pos: position{line: 1568, col: 28, offset: 37995},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 28, offset: 37493},
+												pos:  position{line: 1568, col: 28, offset: 37995},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1549, col: 31, offset: 37496},
+												pos:        position{line: 1568, col: 31, offset: 37998},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 35, offset: 37500},
+												pos:  position{line: 1568, col: 35, offset: 38002},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1549, col: 38, offset: 37503},
+												pos:   position{line: 1568, col: 38, offset: 38005},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1549, col: 43, offset: 37508},
+													pos:  position{line: 1568, col: 43, offset: 38010},
 													name: "Identifier",
 												},
 											},
@@ -10606,29 +10738,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1553, col: 1, offset: 37586},
+			pos:  position{line: 1572, col: 1, offset: 38088},
 			expr: &choiceExpr{
-				pos: position{line: 1554, col: 5, offset: 37605},
+				pos: position{line: 1573, col: 5, offset: 38107},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1554, col: 5, offset: 37605},
+						pos: position{line: 1573, col: 5, offset: 38107},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1554, col: 5, offset: 37605},
+							pos: position{line: 1573, col: 5, offset: 38107},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1554, col: 5, offset: 37605},
+									pos: position{line: 1573, col: 5, offset: 38107},
 									expr: &seqExpr{
-										pos: position{line: 1554, col: 7, offset: 37607},
+										pos: position{line: 1573, col: 7, offset: 38109},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1554, col: 7, offset: 37607},
+												pos:  position{line: 1573, col: 7, offset: 38109},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1554, col: 15, offset: 37615},
+												pos: position{line: 1573, col: 15, offset: 38117},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1554, col: 16, offset: 37616},
+													pos:  position{line: 1573, col: 16, offset: 38118},
 													name: "IdentifierRest",
 												},
 											},
@@ -10636,13 +10768,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1554, col: 32, offset: 37632},
+									pos:  position{line: 1573, col: 32, offset: 38134},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1554, col: 48, offset: 37648},
+									pos: position{line: 1573, col: 48, offset: 38150},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1554, col: 48, offset: 37648},
+										pos:  position{line: 1573, col: 48, offset: 38150},
 										name: "IdentifierRest",
 									},
 								},
@@ -10650,32 +10782,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1555, col: 5, offset: 37699},
+						pos: position{line: 1574, col: 5, offset: 38201},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1555, col: 5, offset: 37699},
+							pos:        position{line: 1574, col: 5, offset: 38201},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1556, col: 5, offset: 37738},
+						pos: position{line: 1575, col: 5, offset: 38240},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1556, col: 5, offset: 37738},
+							pos: position{line: 1575, col: 5, offset: 38240},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1556, col: 5, offset: 37738},
+									pos:        position{line: 1575, col: 5, offset: 38240},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1556, col: 10, offset: 37743},
+									pos:   position{line: 1575, col: 10, offset: 38245},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1556, col: 13, offset: 37746},
+										pos:  position{line: 1575, col: 13, offset: 38248},
 										name: "IDGuard",
 									},
 								},
@@ -10683,17 +10815,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1558, col: 5, offset: 37837},
+						pos: position{line: 1577, col: 5, offset: 38339},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1558, col: 5, offset: 37837},
+							pos:        position{line: 1577, col: 5, offset: 38339},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1559, col: 5, offset: 37879},
+						pos:  position{line: 1578, col: 5, offset: 38381},
 						name: "BacktickString",
 					},
 				},
@@ -10703,22 +10835,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1561, col: 1, offset: 37896},
+			pos:  position{line: 1580, col: 1, offset: 38398},
 			expr: &choiceExpr{
-				pos: position{line: 1562, col: 5, offset: 37916},
+				pos: position{line: 1581, col: 5, offset: 38418},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1562, col: 5, offset: 37916},
+						pos:  position{line: 1581, col: 5, offset: 38418},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1563, col: 5, offset: 37934},
+						pos:        position{line: 1582, col: 5, offset: 38436},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 5, offset: 37942},
+						pos:        position{line: 1583, col: 5, offset: 38444},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10730,24 +10862,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1566, col: 1, offset: 37947},
+			pos:  position{line: 1585, col: 1, offset: 38449},
 			expr: &choiceExpr{
-				pos: position{line: 1567, col: 5, offset: 37966},
+				pos: position{line: 1586, col: 5, offset: 38468},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1567, col: 5, offset: 37966},
+						pos:  position{line: 1586, col: 5, offset: 38468},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1568, col: 5, offset: 37986},
+						pos:  position{line: 1587, col: 5, offset: 38488},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1569, col: 5, offset: 38011},
+						pos:  position{line: 1588, col: 5, offset: 38513},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1570, col: 5, offset: 38028},
+						pos:  position{line: 1589, col: 5, offset: 38530},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10757,24 +10889,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1572, col: 1, offset: 38057},
+			pos:  position{line: 1591, col: 1, offset: 38559},
 			expr: &choiceExpr{
-				pos: position{line: 1573, col: 5, offset: 38069},
+				pos: position{line: 1592, col: 5, offset: 38571},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1573, col: 5, offset: 38069},
+						pos:  position{line: 1592, col: 5, offset: 38571},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1574, col: 5, offset: 38088},
+						pos:  position{line: 1593, col: 5, offset: 38590},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1575, col: 5, offset: 38104},
+						pos:  position{line: 1594, col: 5, offset: 38606},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1576, col: 5, offset: 38112},
+						pos:  position{line: 1595, col: 5, offset: 38614},
 						name: "Infinity",
 					},
 				},
@@ -10784,25 +10916,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1578, col: 1, offset: 38122},
+			pos:  position{line: 1597, col: 1, offset: 38624},
 			expr: &actionExpr{
-				pos: position{line: 1579, col: 5, offset: 38131},
+				pos: position{line: 1598, col: 5, offset: 38633},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1579, col: 5, offset: 38131},
+					pos: position{line: 1598, col: 5, offset: 38633},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1579, col: 5, offset: 38131},
+							pos:  position{line: 1598, col: 5, offset: 38633},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1579, col: 14, offset: 38140},
+							pos:        position{line: 1598, col: 14, offset: 38642},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1579, col: 18, offset: 38144},
+							pos:  position{line: 1598, col: 18, offset: 38646},
 							name: "FullTime",
 						},
 					},
@@ -10813,32 +10945,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1583, col: 1, offset: 38220},
+			pos:  position{line: 1602, col: 1, offset: 38722},
 			expr: &seqExpr{
-				pos: position{line: 1583, col: 12, offset: 38231},
+				pos: position{line: 1602, col: 12, offset: 38733},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 12, offset: 38231},
+						pos:  position{line: 1602, col: 12, offset: 38733},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1583, col: 15, offset: 38234},
+						pos:        position{line: 1602, col: 15, offset: 38736},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 19, offset: 38238},
+						pos:  position{line: 1602, col: 19, offset: 38740},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1583, col: 22, offset: 38241},
+						pos:        position{line: 1602, col: 22, offset: 38743},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 26, offset: 38245},
+						pos:  position{line: 1602, col: 26, offset: 38747},
 						name: "D2",
 					},
 				},
@@ -10848,33 +10980,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1585, col: 1, offset: 38249},
+			pos:  position{line: 1604, col: 1, offset: 38751},
 			expr: &seqExpr{
-				pos: position{line: 1585, col: 6, offset: 38254},
+				pos: position{line: 1604, col: 6, offset: 38756},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1585, col: 6, offset: 38254},
+						pos:        position{line: 1604, col: 6, offset: 38756},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1585, col: 11, offset: 38259},
+						pos:        position{line: 1604, col: 11, offset: 38761},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1585, col: 16, offset: 38264},
+						pos:        position{line: 1604, col: 16, offset: 38766},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1585, col: 21, offset: 38269},
+						pos:        position{line: 1604, col: 21, offset: 38771},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10887,19 +11019,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1586, col: 1, offset: 38275},
+			pos:  position{line: 1605, col: 1, offset: 38777},
 			expr: &seqExpr{
-				pos: position{line: 1586, col: 6, offset: 38280},
+				pos: position{line: 1605, col: 6, offset: 38782},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1586, col: 6, offset: 38280},
+						pos:        position{line: 1605, col: 6, offset: 38782},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1586, col: 11, offset: 38285},
+						pos:        position{line: 1605, col: 11, offset: 38787},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10912,16 +11044,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1588, col: 1, offset: 38292},
+			pos:  position{line: 1607, col: 1, offset: 38794},
 			expr: &seqExpr{
-				pos: position{line: 1588, col: 12, offset: 38303},
+				pos: position{line: 1607, col: 12, offset: 38805},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1588, col: 12, offset: 38303},
+						pos:  position{line: 1607, col: 12, offset: 38805},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1588, col: 24, offset: 38315},
+						pos:  position{line: 1607, col: 24, offset: 38817},
 						name: "TimeOffset",
 					},
 				},
@@ -10931,49 +11063,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1590, col: 1, offset: 38327},
+			pos:  position{line: 1609, col: 1, offset: 38829},
 			expr: &seqExpr{
-				pos: position{line: 1590, col: 15, offset: 38341},
+				pos: position{line: 1609, col: 15, offset: 38843},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 15, offset: 38341},
+						pos:  position{line: 1609, col: 15, offset: 38843},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1590, col: 18, offset: 38344},
+						pos:        position{line: 1609, col: 18, offset: 38846},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 22, offset: 38348},
+						pos:  position{line: 1609, col: 22, offset: 38850},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1590, col: 25, offset: 38351},
+						pos:        position{line: 1609, col: 25, offset: 38853},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 29, offset: 38355},
+						pos:  position{line: 1609, col: 29, offset: 38857},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1590, col: 32, offset: 38358},
+						pos: position{line: 1609, col: 32, offset: 38860},
 						expr: &seqExpr{
-							pos: position{line: 1590, col: 33, offset: 38359},
+							pos: position{line: 1609, col: 33, offset: 38861},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1590, col: 33, offset: 38359},
+									pos:        position{line: 1609, col: 33, offset: 38861},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1590, col: 37, offset: 38363},
+									pos: position{line: 1609, col: 37, offset: 38865},
 									expr: &charClassMatcher{
-										pos:        position{line: 1590, col: 37, offset: 38363},
+										pos:        position{line: 1609, col: 37, offset: 38865},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10990,30 +11122,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1592, col: 1, offset: 38373},
+			pos:  position{line: 1611, col: 1, offset: 38875},
 			expr: &choiceExpr{
-				pos: position{line: 1593, col: 5, offset: 38388},
+				pos: position{line: 1612, col: 5, offset: 38890},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1593, col: 5, offset: 38388},
+						pos:        position{line: 1612, col: 5, offset: 38890},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1594, col: 5, offset: 38396},
+						pos: position{line: 1613, col: 5, offset: 38898},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1594, col: 6, offset: 38397},
+								pos: position{line: 1613, col: 6, offset: 38899},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1594, col: 6, offset: 38397},
+										pos:        position{line: 1613, col: 6, offset: 38899},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1594, col: 12, offset: 38403},
+										pos:        position{line: 1613, col: 12, offset: 38905},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -11021,34 +11153,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1594, col: 17, offset: 38408},
+								pos:  position{line: 1613, col: 17, offset: 38910},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1594, col: 20, offset: 38411},
+								pos:        position{line: 1613, col: 20, offset: 38913},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1594, col: 24, offset: 38415},
+								pos:  position{line: 1613, col: 24, offset: 38917},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1594, col: 27, offset: 38418},
+								pos: position{line: 1613, col: 27, offset: 38920},
 								expr: &seqExpr{
-									pos: position{line: 1594, col: 28, offset: 38419},
+									pos: position{line: 1613, col: 28, offset: 38921},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1594, col: 28, offset: 38419},
+											pos:        position{line: 1613, col: 28, offset: 38921},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1594, col: 32, offset: 38423},
+											pos: position{line: 1613, col: 32, offset: 38925},
 											expr: &charClassMatcher{
-												pos:        position{line: 1594, col: 32, offset: 38423},
+												pos:        position{line: 1613, col: 32, offset: 38925},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -11067,33 +11199,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1596, col: 1, offset: 38433},
+			pos:  position{line: 1615, col: 1, offset: 38935},
 			expr: &actionExpr{
-				pos: position{line: 1597, col: 5, offset: 38446},
+				pos: position{line: 1616, col: 5, offset: 38948},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1597, col: 5, offset: 38446},
+					pos: position{line: 1616, col: 5, offset: 38948},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1597, col: 5, offset: 38446},
+							pos: position{line: 1616, col: 5, offset: 38948},
 							expr: &litMatcher{
-								pos:        position{line: 1597, col: 5, offset: 38446},
+								pos:        position{line: 1616, col: 5, offset: 38948},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1597, col: 10, offset: 38451},
+							pos: position{line: 1616, col: 10, offset: 38953},
 							expr: &seqExpr{
-								pos: position{line: 1597, col: 11, offset: 38452},
+								pos: position{line: 1616, col: 11, offset: 38954},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1597, col: 11, offset: 38452},
+										pos:  position{line: 1616, col: 11, offset: 38954},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1597, col: 19, offset: 38460},
+										pos:  position{line: 1616, col: 19, offset: 38962},
 										name: "TimeUnit",
 									},
 								},
@@ -11107,27 +11239,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1601, col: 1, offset: 38542},
+			pos:  position{line: 1620, col: 1, offset: 39044},
 			expr: &seqExpr{
-				pos: position{line: 1601, col: 11, offset: 38552},
+				pos: position{line: 1620, col: 11, offset: 39054},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1601, col: 11, offset: 38552},
+						pos:  position{line: 1620, col: 11, offset: 39054},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1601, col: 16, offset: 38557},
+						pos: position{line: 1620, col: 16, offset: 39059},
 						expr: &seqExpr{
-							pos: position{line: 1601, col: 17, offset: 38558},
+							pos: position{line: 1620, col: 17, offset: 39060},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1601, col: 17, offset: 38558},
+									pos:        position{line: 1620, col: 17, offset: 39060},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1601, col: 21, offset: 38562},
+									pos:  position{line: 1620, col: 21, offset: 39064},
 									name: "UInt",
 								},
 							},
@@ -11140,60 +11272,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1603, col: 1, offset: 38570},
+			pos:  position{line: 1622, col: 1, offset: 39072},
 			expr: &choiceExpr{
-				pos: position{line: 1604, col: 5, offset: 38583},
+				pos: position{line: 1623, col: 5, offset: 39085},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1604, col: 5, offset: 38583},
+						pos:        position{line: 1623, col: 5, offset: 39085},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1605, col: 5, offset: 38592},
+						pos:        position{line: 1624, col: 5, offset: 39094},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1606, col: 5, offset: 38601},
+						pos:        position{line: 1625, col: 5, offset: 39103},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1607, col: 5, offset: 38610},
+						pos:        position{line: 1626, col: 5, offset: 39112},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1608, col: 5, offset: 38618},
+						pos:        position{line: 1627, col: 5, offset: 39120},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1609, col: 5, offset: 38626},
+						pos:        position{line: 1628, col: 5, offset: 39128},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1610, col: 5, offset: 38634},
+						pos:        position{line: 1629, col: 5, offset: 39136},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1611, col: 5, offset: 38642},
+						pos:        position{line: 1630, col: 5, offset: 39144},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1612, col: 5, offset: 38650},
+						pos:        position{line: 1631, col: 5, offset: 39152},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -11205,45 +11337,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1614, col: 1, offset: 38655},
+			pos:  position{line: 1633, col: 1, offset: 39157},
 			expr: &actionExpr{
-				pos: position{line: 1615, col: 5, offset: 38662},
+				pos: position{line: 1634, col: 5, offset: 39164},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1615, col: 5, offset: 38662},
+					pos: position{line: 1634, col: 5, offset: 39164},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1615, col: 5, offset: 38662},
+							pos:  position{line: 1634, col: 5, offset: 39164},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1615, col: 10, offset: 38667},
+							pos:        position{line: 1634, col: 10, offset: 39169},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1615, col: 14, offset: 38671},
+							pos:  position{line: 1634, col: 14, offset: 39173},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1615, col: 19, offset: 38676},
+							pos:        position{line: 1634, col: 19, offset: 39178},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1615, col: 23, offset: 38680},
+							pos:  position{line: 1634, col: 23, offset: 39182},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1615, col: 28, offset: 38685},
+							pos:        position{line: 1634, col: 28, offset: 39187},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1615, col: 32, offset: 38689},
+							pos:  position{line: 1634, col: 32, offset: 39191},
 							name: "UInt",
 						},
 					},
@@ -11254,43 +11386,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1617, col: 1, offset: 38726},
+			pos:  position{line: 1636, col: 1, offset: 39228},
 			expr: &actionExpr{
-				pos: position{line: 1618, col: 5, offset: 38734},
+				pos: position{line: 1637, col: 5, offset: 39236},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1618, col: 5, offset: 38734},
+					pos: position{line: 1637, col: 5, offset: 39236},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1618, col: 5, offset: 38734},
+							pos: position{line: 1637, col: 5, offset: 39236},
 							expr: &seqExpr{
-								pos: position{line: 1618, col: 7, offset: 38736},
+								pos: position{line: 1637, col: 7, offset: 39238},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1618, col: 7, offset: 38736},
+										pos:  position{line: 1637, col: 7, offset: 39238},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1618, col: 11, offset: 38740},
+										pos:        position{line: 1637, col: 11, offset: 39242},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1618, col: 15, offset: 38744},
+										pos:  position{line: 1637, col: 15, offset: 39246},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1618, col: 19, offset: 38748},
+										pos: position{line: 1637, col: 19, offset: 39250},
 										expr: &choiceExpr{
-											pos: position{line: 1618, col: 21, offset: 38750},
+											pos: position{line: 1637, col: 21, offset: 39252},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1618, col: 21, offset: 38750},
+													pos:  position{line: 1637, col: 21, offset: 39252},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1618, col: 32, offset: 38761},
+													pos:        position{line: 1637, col: 32, offset: 39263},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11302,10 +11434,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1618, col: 38, offset: 38767},
+							pos:   position{line: 1637, col: 38, offset: 39269},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1618, col: 40, offset: 38769},
+								pos:  position{line: 1637, col: 40, offset: 39271},
 								name: "IP6Variations",
 							},
 						},
@@ -11317,32 +11449,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1622, col: 1, offset: 38933},
+			pos:  position{line: 1641, col: 1, offset: 39435},
 			expr: &choiceExpr{
-				pos: position{line: 1623, col: 5, offset: 38951},
+				pos: position{line: 1642, col: 5, offset: 39453},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1623, col: 5, offset: 38951},
+						pos: position{line: 1642, col: 5, offset: 39453},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1623, col: 5, offset: 38951},
+							pos: position{line: 1642, col: 5, offset: 39453},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1623, col: 5, offset: 38951},
+									pos:   position{line: 1642, col: 5, offset: 39453},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1623, col: 7, offset: 38953},
+										pos: position{line: 1642, col: 7, offset: 39455},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1623, col: 7, offset: 38953},
+											pos:  position{line: 1642, col: 7, offset: 39455},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1623, col: 17, offset: 38963},
+									pos:   position{line: 1642, col: 17, offset: 39465},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1623, col: 19, offset: 38965},
+										pos:  position{line: 1642, col: 19, offset: 39467},
 										name: "IP6Tail",
 									},
 								},
@@ -11350,52 +11482,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1626, col: 5, offset: 39029},
+						pos: position{line: 1645, col: 5, offset: 39531},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1626, col: 5, offset: 39029},
+							pos: position{line: 1645, col: 5, offset: 39531},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1626, col: 5, offset: 39029},
+									pos:   position{line: 1645, col: 5, offset: 39531},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1626, col: 7, offset: 39031},
+										pos:  position{line: 1645, col: 7, offset: 39533},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1626, col: 11, offset: 39035},
+									pos:   position{line: 1645, col: 11, offset: 39537},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1626, col: 13, offset: 39037},
+										pos: position{line: 1645, col: 13, offset: 39539},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1626, col: 13, offset: 39037},
+											pos:  position{line: 1645, col: 13, offset: 39539},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1626, col: 23, offset: 39047},
+									pos:        position{line: 1645, col: 23, offset: 39549},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1626, col: 28, offset: 39052},
+									pos:   position{line: 1645, col: 28, offset: 39554},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1626, col: 30, offset: 39054},
+										pos: position{line: 1645, col: 30, offset: 39556},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1626, col: 30, offset: 39054},
+											pos:  position{line: 1645, col: 30, offset: 39556},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1626, col: 40, offset: 39064},
+									pos:   position{line: 1645, col: 40, offset: 39566},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1626, col: 42, offset: 39066},
+										pos:  position{line: 1645, col: 42, offset: 39568},
 										name: "IP6Tail",
 									},
 								},
@@ -11403,33 +11535,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1629, col: 5, offset: 39165},
+						pos: position{line: 1648, col: 5, offset: 39667},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1629, col: 5, offset: 39165},
+							pos: position{line: 1648, col: 5, offset: 39667},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1629, col: 5, offset: 39165},
+									pos:        position{line: 1648, col: 5, offset: 39667},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1629, col: 10, offset: 39170},
+									pos:   position{line: 1648, col: 10, offset: 39672},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1629, col: 12, offset: 39172},
+										pos: position{line: 1648, col: 12, offset: 39674},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1629, col: 12, offset: 39172},
+											pos:  position{line: 1648, col: 12, offset: 39674},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1629, col: 22, offset: 39182},
+									pos:   position{line: 1648, col: 22, offset: 39684},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1629, col: 24, offset: 39184},
+										pos:  position{line: 1648, col: 24, offset: 39686},
 										name: "IP6Tail",
 									},
 								},
@@ -11437,32 +11569,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1632, col: 5, offset: 39255},
+						pos: position{line: 1651, col: 5, offset: 39757},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1632, col: 5, offset: 39255},
+							pos: position{line: 1651, col: 5, offset: 39757},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1632, col: 5, offset: 39255},
+									pos:   position{line: 1651, col: 5, offset: 39757},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1632, col: 7, offset: 39257},
+										pos:  position{line: 1651, col: 7, offset: 39759},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1632, col: 11, offset: 39261},
+									pos:   position{line: 1651, col: 11, offset: 39763},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1632, col: 13, offset: 39263},
+										pos: position{line: 1651, col: 13, offset: 39765},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1632, col: 13, offset: 39263},
+											pos:  position{line: 1651, col: 13, offset: 39765},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1632, col: 23, offset: 39273},
+									pos:        position{line: 1651, col: 23, offset: 39775},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -11471,10 +11603,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1635, col: 5, offset: 39341},
+						pos: position{line: 1654, col: 5, offset: 39843},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1635, col: 5, offset: 39341},
+							pos:        position{line: 1654, col: 5, offset: 39843},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11487,16 +11619,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1639, col: 1, offset: 39378},
+			pos:  position{line: 1658, col: 1, offset: 39880},
 			expr: &choiceExpr{
-				pos: position{line: 1640, col: 5, offset: 39390},
+				pos: position{line: 1659, col: 5, offset: 39892},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1640, col: 5, offset: 39390},
+						pos:  position{line: 1659, col: 5, offset: 39892},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1641, col: 5, offset: 39397},
+						pos:  position{line: 1660, col: 5, offset: 39899},
 						name: "Hex",
 					},
 				},
@@ -11506,24 +11638,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1643, col: 1, offset: 39402},
+			pos:  position{line: 1662, col: 1, offset: 39904},
 			expr: &actionExpr{
-				pos: position{line: 1643, col: 12, offset: 39413},
+				pos: position{line: 1662, col: 12, offset: 39915},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1643, col: 12, offset: 39413},
+					pos: position{line: 1662, col: 12, offset: 39915},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1643, col: 12, offset: 39413},
+							pos:        position{line: 1662, col: 12, offset: 39915},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1643, col: 16, offset: 39417},
+							pos:   position{line: 1662, col: 16, offset: 39919},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1643, col: 18, offset: 39419},
+								pos:  position{line: 1662, col: 18, offset: 39921},
 								name: "Hex",
 							},
 						},
@@ -11535,23 +11667,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1645, col: 1, offset: 39457},
+			pos:  position{line: 1664, col: 1, offset: 39959},
 			expr: &actionExpr{
-				pos: position{line: 1645, col: 12, offset: 39468},
+				pos: position{line: 1664, col: 12, offset: 39970},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1645, col: 12, offset: 39468},
+					pos: position{line: 1664, col: 12, offset: 39970},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1645, col: 12, offset: 39468},
+							pos:   position{line: 1664, col: 12, offset: 39970},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1645, col: 14, offset: 39470},
+								pos:  position{line: 1664, col: 14, offset: 39972},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1645, col: 18, offset: 39474},
+							pos:        position{line: 1664, col: 18, offset: 39976},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11564,32 +11696,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1647, col: 1, offset: 39512},
+			pos:  position{line: 1666, col: 1, offset: 40014},
 			expr: &actionExpr{
-				pos: position{line: 1648, col: 5, offset: 39523},
+				pos: position{line: 1667, col: 5, offset: 40025},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1648, col: 5, offset: 39523},
+					pos: position{line: 1667, col: 5, offset: 40025},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1648, col: 5, offset: 39523},
+							pos:   position{line: 1667, col: 5, offset: 40025},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1648, col: 7, offset: 39525},
+								pos:  position{line: 1667, col: 7, offset: 40027},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1648, col: 10, offset: 39528},
+							pos:        position{line: 1667, col: 10, offset: 40030},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1648, col: 14, offset: 39532},
+							pos:   position{line: 1667, col: 14, offset: 40034},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1648, col: 16, offset: 39534},
+								pos:  position{line: 1667, col: 16, offset: 40036},
 								name: "UIntString",
 							},
 						},
@@ -11601,32 +11733,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1652, col: 1, offset: 39602},
+			pos:  position{line: 1671, col: 1, offset: 40104},
 			expr: &actionExpr{
-				pos: position{line: 1653, col: 5, offset: 39613},
+				pos: position{line: 1672, col: 5, offset: 40115},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1653, col: 5, offset: 39613},
+					pos: position{line: 1672, col: 5, offset: 40115},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1653, col: 5, offset: 39613},
+							pos:   position{line: 1672, col: 5, offset: 40115},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1653, col: 7, offset: 39615},
+								pos:  position{line: 1672, col: 7, offset: 40117},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1653, col: 11, offset: 39619},
+							pos:        position{line: 1672, col: 11, offset: 40121},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1653, col: 15, offset: 39623},
+							pos:   position{line: 1672, col: 15, offset: 40125},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1653, col: 17, offset: 39625},
+								pos:  position{line: 1672, col: 17, offset: 40127},
 								name: "UIntString",
 							},
 						},
@@ -11638,15 +11770,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1657, col: 1, offset: 39693},
+			pos:  position{line: 1676, col: 1, offset: 40195},
 			expr: &actionExpr{
-				pos: position{line: 1658, col: 4, offset: 39701},
+				pos: position{line: 1677, col: 4, offset: 40203},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1658, col: 4, offset: 39701},
+					pos:   position{line: 1677, col: 4, offset: 40203},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1658, col: 6, offset: 39703},
+						pos:  position{line: 1677, col: 6, offset: 40205},
 						name: "UIntString",
 					},
 				},
@@ -11656,16 +11788,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1660, col: 1, offset: 39743},
+			pos:  position{line: 1679, col: 1, offset: 40245},
 			expr: &choiceExpr{
-				pos: position{line: 1661, col: 5, offset: 39757},
+				pos: position{line: 1680, col: 5, offset: 40259},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1661, col: 5, offset: 39757},
+						pos:  position{line: 1680, col: 5, offset: 40259},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1662, col: 5, offset: 39772},
+						pos:  position{line: 1681, col: 5, offset: 40274},
 						name: "MinusIntString",
 					},
 				},
@@ -11675,14 +11807,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1664, col: 1, offset: 39788},
+			pos:  position{line: 1683, col: 1, offset: 40290},
 			expr: &actionExpr{
-				pos: position{line: 1664, col: 14, offset: 39801},
+				pos: position{line: 1683, col: 14, offset: 40303},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1664, col: 14, offset: 39801},
+					pos: position{line: 1683, col: 14, offset: 40303},
 					expr: &charClassMatcher{
-						pos:        position{line: 1664, col: 14, offset: 39801},
+						pos:        position{line: 1683, col: 14, offset: 40303},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11695,21 +11827,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1666, col: 1, offset: 39840},
+			pos:  position{line: 1685, col: 1, offset: 40342},
 			expr: &actionExpr{
-				pos: position{line: 1667, col: 5, offset: 39859},
+				pos: position{line: 1686, col: 5, offset: 40361},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1667, col: 5, offset: 39859},
+					pos: position{line: 1686, col: 5, offset: 40361},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1667, col: 5, offset: 39859},
+							pos:        position{line: 1686, col: 5, offset: 40361},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 9, offset: 39863},
+							pos:  position{line: 1686, col: 9, offset: 40365},
 							name: "UIntString",
 						},
 					},
@@ -11720,29 +11852,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1669, col: 1, offset: 39906},
+			pos:  position{line: 1688, col: 1, offset: 40408},
 			expr: &choiceExpr{
-				pos: position{line: 1670, col: 5, offset: 39922},
+				pos: position{line: 1689, col: 5, offset: 40424},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1670, col: 5, offset: 39922},
+						pos: position{line: 1689, col: 5, offset: 40424},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1670, col: 5, offset: 39922},
+							pos: position{line: 1689, col: 5, offset: 40424},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1670, col: 5, offset: 39922},
+									pos: position{line: 1689, col: 5, offset: 40424},
 									expr: &litMatcher{
-										pos:        position{line: 1670, col: 5, offset: 39922},
+										pos:        position{line: 1689, col: 5, offset: 40424},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1670, col: 10, offset: 39927},
+									pos: position{line: 1689, col: 10, offset: 40429},
 									expr: &charClassMatcher{
-										pos:        position{line: 1670, col: 10, offset: 39927},
+										pos:        position{line: 1689, col: 10, offset: 40429},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11750,15 +11882,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1670, col: 17, offset: 39934},
+									pos:        position{line: 1689, col: 17, offset: 40436},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1670, col: 21, offset: 39938},
+									pos: position{line: 1689, col: 21, offset: 40440},
 									expr: &charClassMatcher{
-										pos:        position{line: 1670, col: 21, offset: 39938},
+										pos:        position{line: 1689, col: 21, offset: 40440},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11766,9 +11898,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1670, col: 28, offset: 39945},
+									pos: position{line: 1689, col: 28, offset: 40447},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1670, col: 28, offset: 39945},
+										pos:  position{line: 1689, col: 28, offset: 40447},
 										name: "ExponentPart",
 									},
 								},
@@ -11776,30 +11908,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1671, col: 5, offset: 39994},
+						pos: position{line: 1690, col: 5, offset: 40496},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1671, col: 5, offset: 39994},
+							pos: position{line: 1690, col: 5, offset: 40496},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1671, col: 5, offset: 39994},
+									pos: position{line: 1690, col: 5, offset: 40496},
 									expr: &litMatcher{
-										pos:        position{line: 1671, col: 5, offset: 39994},
+										pos:        position{line: 1690, col: 5, offset: 40496},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1671, col: 10, offset: 39999},
+									pos:        position{line: 1690, col: 10, offset: 40501},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1671, col: 14, offset: 40003},
+									pos: position{line: 1690, col: 14, offset: 40505},
 									expr: &charClassMatcher{
-										pos:        position{line: 1671, col: 14, offset: 40003},
+										pos:        position{line: 1690, col: 14, offset: 40505},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11807,9 +11939,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1671, col: 21, offset: 40010},
+									pos: position{line: 1690, col: 21, offset: 40512},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1671, col: 21, offset: 40010},
+										pos:  position{line: 1690, col: 21, offset: 40512},
 										name: "ExponentPart",
 									},
 								},
@@ -11817,17 +11949,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1672, col: 5, offset: 40059},
+						pos: position{line: 1691, col: 5, offset: 40561},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1672, col: 6, offset: 40060},
+							pos: position{line: 1691, col: 6, offset: 40562},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1672, col: 6, offset: 40060},
+									pos:  position{line: 1691, col: 6, offset: 40562},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1672, col: 12, offset: 40066},
+									pos:  position{line: 1691, col: 12, offset: 40568},
 									name: "Infinity",
 								},
 							},
@@ -11840,20 +11972,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1675, col: 1, offset: 40109},
+			pos:  position{line: 1694, col: 1, offset: 40611},
 			expr: &seqExpr{
-				pos: position{line: 1675, col: 16, offset: 40124},
+				pos: position{line: 1694, col: 16, offset: 40626},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1675, col: 16, offset: 40124},
+						pos:        position{line: 1694, col: 16, offset: 40626},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1675, col: 21, offset: 40129},
+						pos: position{line: 1694, col: 21, offset: 40631},
 						expr: &charClassMatcher{
-							pos:        position{line: 1675, col: 21, offset: 40129},
+							pos:        position{line: 1694, col: 21, offset: 40631},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11861,7 +11993,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1675, col: 27, offset: 40135},
+						pos:  position{line: 1694, col: 27, offset: 40637},
 						name: "UIntString",
 					},
 				},
@@ -11871,9 +12003,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1677, col: 1, offset: 40147},
+			pos:  position{line: 1696, col: 1, offset: 40649},
 			expr: &litMatcher{
-				pos:        position{line: 1677, col: 7, offset: 40153},
+				pos:        position{line: 1696, col: 7, offset: 40655},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11883,23 +12015,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1679, col: 1, offset: 40160},
+			pos:  position{line: 1698, col: 1, offset: 40662},
 			expr: &seqExpr{
-				pos: position{line: 1679, col: 12, offset: 40171},
+				pos: position{line: 1698, col: 12, offset: 40673},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1679, col: 12, offset: 40171},
+						pos: position{line: 1698, col: 12, offset: 40673},
 						expr: &choiceExpr{
-							pos: position{line: 1679, col: 13, offset: 40172},
+							pos: position{line: 1698, col: 13, offset: 40674},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1679, col: 13, offset: 40172},
+									pos:        position{line: 1698, col: 13, offset: 40674},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1679, col: 19, offset: 40178},
+									pos:        position{line: 1698, col: 19, offset: 40680},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11908,7 +12040,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1679, col: 25, offset: 40184},
+						pos:        position{line: 1698, col: 25, offset: 40686},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11920,14 +12052,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1681, col: 1, offset: 40191},
+			pos:  position{line: 1700, col: 1, offset: 40693},
 			expr: &actionExpr{
-				pos: position{line: 1681, col: 7, offset: 40197},
+				pos: position{line: 1700, col: 7, offset: 40699},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1681, col: 7, offset: 40197},
+					pos: position{line: 1700, col: 7, offset: 40699},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1681, col: 7, offset: 40197},
+						pos:  position{line: 1700, col: 7, offset: 40699},
 						name: "HexDigit",
 					},
 				},
@@ -11937,9 +12069,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1683, col: 1, offset: 40239},
+			pos:  position{line: 1702, col: 1, offset: 40741},
 			expr: &charClassMatcher{
-				pos:        position{line: 1683, col: 12, offset: 40250},
+				pos:        position{line: 1702, col: 12, offset: 40752},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11950,35 +12082,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1685, col: 1, offset: 40263},
+			pos:  position{line: 1704, col: 1, offset: 40765},
 			expr: &choiceExpr{
-				pos: position{line: 1686, col: 5, offset: 40280},
+				pos: position{line: 1705, col: 5, offset: 40782},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1686, col: 5, offset: 40280},
+						pos: position{line: 1705, col: 5, offset: 40782},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1686, col: 5, offset: 40280},
+							pos: position{line: 1705, col: 5, offset: 40782},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1686, col: 5, offset: 40280},
+									pos:        position{line: 1705, col: 5, offset: 40782},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1686, col: 9, offset: 40284},
+									pos:   position{line: 1705, col: 9, offset: 40786},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1686, col: 11, offset: 40286},
+										pos: position{line: 1705, col: 11, offset: 40788},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1686, col: 11, offset: 40286},
+											pos:  position{line: 1705, col: 11, offset: 40788},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1686, col: 29, offset: 40304},
+									pos:        position{line: 1705, col: 29, offset: 40806},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11987,30 +12119,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1687, col: 5, offset: 40341},
+						pos: position{line: 1706, col: 5, offset: 40843},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1687, col: 5, offset: 40341},
+							pos: position{line: 1706, col: 5, offset: 40843},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1687, col: 5, offset: 40341},
+									pos:        position{line: 1706, col: 5, offset: 40843},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1687, col: 9, offset: 40345},
+									pos:   position{line: 1706, col: 9, offset: 40847},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1687, col: 11, offset: 40347},
+										pos: position{line: 1706, col: 11, offset: 40849},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1687, col: 11, offset: 40347},
+											pos:  position{line: 1706, col: 11, offset: 40849},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1687, col: 29, offset: 40365},
+									pos:        position{line: 1706, col: 29, offset: 40867},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -12025,57 +12157,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1689, col: 1, offset: 40399},
+			pos:  position{line: 1708, col: 1, offset: 40901},
 			expr: &choiceExpr{
-				pos: position{line: 1690, col: 5, offset: 40420},
+				pos: position{line: 1709, col: 5, offset: 40922},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1690, col: 5, offset: 40420},
+						pos: position{line: 1709, col: 5, offset: 40922},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1690, col: 5, offset: 40420},
+							pos: position{line: 1709, col: 5, offset: 40922},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1690, col: 5, offset: 40420},
+									pos: position{line: 1709, col: 5, offset: 40922},
 									expr: &choiceExpr{
-										pos: position{line: 1690, col: 7, offset: 40422},
+										pos: position{line: 1709, col: 7, offset: 40924},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1690, col: 7, offset: 40422},
+												pos:        position{line: 1709, col: 7, offset: 40924},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1690, col: 13, offset: 40428},
+												pos:  position{line: 1709, col: 13, offset: 40930},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1690, col: 26, offset: 40441,
+									line: 1709, col: 26, offset: 40943,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1691, col: 5, offset: 40478},
+						pos: position{line: 1710, col: 5, offset: 40980},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1691, col: 5, offset: 40478},
+							pos: position{line: 1710, col: 5, offset: 40980},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1691, col: 5, offset: 40478},
+									pos:        position{line: 1710, col: 5, offset: 40980},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1691, col: 10, offset: 40483},
+									pos:   position{line: 1710, col: 10, offset: 40985},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1691, col: 12, offset: 40485},
+										pos:  position{line: 1710, col: 12, offset: 40987},
 										name: "EscapeSequence",
 									},
 								},
@@ -12089,32 +12221,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1693, col: 1, offset: 40519},
+			pos:  position{line: 1712, col: 1, offset: 41021},
 			expr: &actionExpr{
-				pos: position{line: 1694, col: 5, offset: 40538},
+				pos: position{line: 1713, col: 5, offset: 41040},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1694, col: 5, offset: 40538},
+					pos: position{line: 1713, col: 5, offset: 41040},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1694, col: 5, offset: 40538},
+							pos:        position{line: 1713, col: 5, offset: 41040},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1694, col: 9, offset: 40542},
+							pos:   position{line: 1713, col: 9, offset: 41044},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1694, col: 11, offset: 40544},
+								pos: position{line: 1713, col: 11, offset: 41046},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1694, col: 11, offset: 40544},
+									pos:  position{line: 1713, col: 11, offset: 41046},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1694, col: 25, offset: 40558},
+							pos:        position{line: 1713, col: 25, offset: 41060},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -12127,57 +12259,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1696, col: 1, offset: 40592},
+			pos:  position{line: 1715, col: 1, offset: 41094},
 			expr: &choiceExpr{
-				pos: position{line: 1697, col: 5, offset: 40609},
+				pos: position{line: 1716, col: 5, offset: 41111},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1697, col: 5, offset: 40609},
+						pos: position{line: 1716, col: 5, offset: 41111},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1697, col: 5, offset: 40609},
+							pos: position{line: 1716, col: 5, offset: 41111},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1697, col: 5, offset: 40609},
+									pos: position{line: 1716, col: 5, offset: 41111},
 									expr: &choiceExpr{
-										pos: position{line: 1697, col: 7, offset: 40611},
+										pos: position{line: 1716, col: 7, offset: 41113},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1697, col: 7, offset: 40611},
+												pos:        position{line: 1716, col: 7, offset: 41113},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1697, col: 13, offset: 40617},
+												pos:  position{line: 1716, col: 13, offset: 41119},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1697, col: 26, offset: 40630,
+									line: 1716, col: 26, offset: 41132,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1698, col: 5, offset: 40667},
+						pos: position{line: 1717, col: 5, offset: 41169},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1698, col: 5, offset: 40667},
+							pos: position{line: 1717, col: 5, offset: 41169},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1698, col: 5, offset: 40667},
+									pos:        position{line: 1717, col: 5, offset: 41169},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1698, col: 10, offset: 40672},
+									pos:   position{line: 1717, col: 10, offset: 41174},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1698, col: 12, offset: 40674},
+										pos:  position{line: 1717, col: 12, offset: 41176},
 										name: "EscapeSequence",
 									},
 								},
@@ -12191,28 +12323,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1700, col: 1, offset: 40708},
+			pos:  position{line: 1719, col: 1, offset: 41210},
 			expr: &actionExpr{
-				pos: position{line: 1701, col: 5, offset: 40720},
+				pos: position{line: 1720, col: 5, offset: 41222},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1701, col: 5, offset: 40720},
+					pos: position{line: 1720, col: 5, offset: 41222},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1701, col: 5, offset: 40720},
+							pos:   position{line: 1720, col: 5, offset: 41222},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1701, col: 10, offset: 40725},
+								pos:  position{line: 1720, col: 10, offset: 41227},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1701, col: 23, offset: 40738},
+							pos:   position{line: 1720, col: 23, offset: 41240},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1701, col: 28, offset: 40743},
+								pos: position{line: 1720, col: 28, offset: 41245},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1701, col: 28, offset: 40743},
+									pos:  position{line: 1720, col: 28, offset: 41245},
 									name: "KeyWordRest",
 								},
 							},
@@ -12225,16 +12357,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1703, col: 1, offset: 40805},
+			pos:  position{line: 1722, col: 1, offset: 41307},
 			expr: &choiceExpr{
-				pos: position{line: 1704, col: 5, offset: 40822},
+				pos: position{line: 1723, col: 5, offset: 41324},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1704, col: 5, offset: 40822},
+						pos:  position{line: 1723, col: 5, offset: 41324},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1705, col: 5, offset: 40839},
+						pos:  position{line: 1724, col: 5, offset: 41341},
 						name: "KeyWordEsc",
 					},
 				},
@@ -12244,16 +12376,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1707, col: 1, offset: 40851},
+			pos:  position{line: 1726, col: 1, offset: 41353},
 			expr: &choiceExpr{
-				pos: position{line: 1708, col: 5, offset: 40867},
+				pos: position{line: 1727, col: 5, offset: 41369},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1708, col: 5, offset: 40867},
+						pos:  position{line: 1727, col: 5, offset: 41369},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1709, col: 5, offset: 40884},
+						pos:        position{line: 1728, col: 5, offset: 41386},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12266,19 +12398,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1711, col: 1, offset: 40891},
+			pos:  position{line: 1730, col: 1, offset: 41393},
 			expr: &actionExpr{
-				pos: position{line: 1711, col: 16, offset: 40906},
+				pos: position{line: 1730, col: 16, offset: 41408},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1711, col: 17, offset: 40907},
+					pos: position{line: 1730, col: 17, offset: 41409},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1711, col: 17, offset: 40907},
+							pos:  position{line: 1730, col: 17, offset: 41409},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1711, col: 33, offset: 40923},
+							pos:        position{line: 1730, col: 33, offset: 41425},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12292,31 +12424,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1713, col: 1, offset: 40967},
+			pos:  position{line: 1732, col: 1, offset: 41469},
 			expr: &actionExpr{
-				pos: position{line: 1713, col: 14, offset: 40980},
+				pos: position{line: 1732, col: 14, offset: 41482},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1713, col: 14, offset: 40980},
+					pos: position{line: 1732, col: 14, offset: 41482},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1713, col: 14, offset: 40980},
+							pos:        position{line: 1732, col: 14, offset: 41482},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1713, col: 19, offset: 40985},
+							pos:   position{line: 1732, col: 19, offset: 41487},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1713, col: 22, offset: 40988},
+								pos: position{line: 1732, col: 22, offset: 41490},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1713, col: 22, offset: 40988},
+										pos:  position{line: 1732, col: 22, offset: 41490},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1713, col: 38, offset: 41004},
+										pos:  position{line: 1732, col: 38, offset: 41506},
 										name: "EscapeSequence",
 									},
 								},
@@ -12330,42 +12462,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1715, col: 1, offset: 41039},
+			pos:  position{line: 1734, col: 1, offset: 41541},
 			expr: &actionExpr{
-				pos: position{line: 1716, col: 5, offset: 41055},
+				pos: position{line: 1735, col: 5, offset: 41557},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1716, col: 5, offset: 41055},
+					pos: position{line: 1735, col: 5, offset: 41557},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1716, col: 5, offset: 41055},
+							pos: position{line: 1735, col: 5, offset: 41557},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1716, col: 6, offset: 41056},
+								pos:  position{line: 1735, col: 6, offset: 41558},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1716, col: 22, offset: 41072},
+							pos: position{line: 1735, col: 22, offset: 41574},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1716, col: 23, offset: 41073},
+								pos:  position{line: 1735, col: 23, offset: 41575},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1716, col: 35, offset: 41085},
+							pos:   position{line: 1735, col: 35, offset: 41587},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1716, col: 40, offset: 41090},
+								pos:  position{line: 1735, col: 40, offset: 41592},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1716, col: 50, offset: 41100},
+							pos:   position{line: 1735, col: 50, offset: 41602},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1716, col: 55, offset: 41105},
+								pos: position{line: 1735, col: 55, offset: 41607},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1716, col: 55, offset: 41105},
+									pos:  position{line: 1735, col: 55, offset: 41607},
 									name: "GlobRest",
 								},
 							},
@@ -12378,28 +12510,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1720, col: 1, offset: 41174},
+			pos:  position{line: 1739, col: 1, offset: 41676},
 			expr: &choiceExpr{
-				pos: position{line: 1720, col: 19, offset: 41192},
+				pos: position{line: 1739, col: 19, offset: 41694},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1720, col: 19, offset: 41192},
+						pos:  position{line: 1739, col: 19, offset: 41694},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1720, col: 34, offset: 41207},
+						pos: position{line: 1739, col: 34, offset: 41709},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1720, col: 34, offset: 41207},
+								pos: position{line: 1739, col: 34, offset: 41709},
 								expr: &litMatcher{
-									pos:        position{line: 1720, col: 34, offset: 41207},
+									pos:        position{line: 1739, col: 34, offset: 41709},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1720, col: 39, offset: 41212},
+								pos:  position{line: 1739, col: 39, offset: 41714},
 								name: "KeyWordRest",
 							},
 						},
@@ -12411,19 +12543,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1721, col: 1, offset: 41224},
+			pos:  position{line: 1740, col: 1, offset: 41726},
 			expr: &seqExpr{
-				pos: position{line: 1721, col: 15, offset: 41238},
+				pos: position{line: 1740, col: 15, offset: 41740},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1721, col: 15, offset: 41238},
+						pos: position{line: 1740, col: 15, offset: 41740},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1721, col: 15, offset: 41238},
+							pos:  position{line: 1740, col: 15, offset: 41740},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1721, col: 28, offset: 41251},
+						pos:        position{line: 1740, col: 28, offset: 41753},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12435,23 +12567,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1723, col: 1, offset: 41256},
+			pos:  position{line: 1742, col: 1, offset: 41758},
 			expr: &choiceExpr{
-				pos: position{line: 1724, col: 5, offset: 41270},
+				pos: position{line: 1743, col: 5, offset: 41772},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1724, col: 5, offset: 41270},
+						pos:  position{line: 1743, col: 5, offset: 41772},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1725, col: 5, offset: 41287},
+						pos:  position{line: 1744, col: 5, offset: 41789},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1726, col: 5, offset: 41299},
+						pos: position{line: 1745, col: 5, offset: 41801},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1726, col: 5, offset: 41299},
+							pos:        position{line: 1745, col: 5, offset: 41801},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12464,16 +12596,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1728, col: 1, offset: 41324},
+			pos:  position{line: 1747, col: 1, offset: 41826},
 			expr: &choiceExpr{
-				pos: position{line: 1729, col: 5, offset: 41337},
+				pos: position{line: 1748, col: 5, offset: 41839},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1729, col: 5, offset: 41337},
+						pos:  position{line: 1748, col: 5, offset: 41839},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1730, col: 5, offset: 41351},
+						pos:        position{line: 1749, col: 5, offset: 41853},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12486,31 +12618,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1732, col: 1, offset: 41358},
+			pos:  position{line: 1751, col: 1, offset: 41860},
 			expr: &actionExpr{
-				pos: position{line: 1732, col: 11, offset: 41368},
+				pos: position{line: 1751, col: 11, offset: 41870},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1732, col: 11, offset: 41368},
+					pos: position{line: 1751, col: 11, offset: 41870},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1732, col: 11, offset: 41368},
+							pos:        position{line: 1751, col: 11, offset: 41870},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1732, col: 16, offset: 41373},
+							pos:   position{line: 1751, col: 16, offset: 41875},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1732, col: 19, offset: 41376},
+								pos: position{line: 1751, col: 19, offset: 41878},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1732, col: 19, offset: 41376},
+										pos:  position{line: 1751, col: 19, offset: 41878},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1732, col: 32, offset: 41389},
+										pos:  position{line: 1751, col: 32, offset: 41891},
 										name: "EscapeSequence",
 									},
 								},
@@ -12524,32 +12656,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1734, col: 1, offset: 41424},
+			pos:  position{line: 1753, col: 1, offset: 41926},
 			expr: &choiceExpr{
-				pos: position{line: 1735, col: 5, offset: 41439},
+				pos: position{line: 1754, col: 5, offset: 41941},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1735, col: 5, offset: 41439},
+						pos: position{line: 1754, col: 5, offset: 41941},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1735, col: 5, offset: 41439},
+							pos:        position{line: 1754, col: 5, offset: 41941},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1736, col: 5, offset: 41467},
+						pos: position{line: 1755, col: 5, offset: 41969},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1736, col: 5, offset: 41467},
+							pos:        position{line: 1755, col: 5, offset: 41969},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1737, col: 5, offset: 41497},
+						pos:        position{line: 1756, col: 5, offset: 41999},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12562,57 +12694,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1739, col: 1, offset: 41503},
+			pos:  position{line: 1758, col: 1, offset: 42005},
 			expr: &choiceExpr{
-				pos: position{line: 1740, col: 5, offset: 41524},
+				pos: position{line: 1759, col: 5, offset: 42026},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1740, col: 5, offset: 41524},
+						pos: position{line: 1759, col: 5, offset: 42026},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1740, col: 5, offset: 41524},
+							pos: position{line: 1759, col: 5, offset: 42026},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1740, col: 5, offset: 41524},
+									pos: position{line: 1759, col: 5, offset: 42026},
 									expr: &choiceExpr{
-										pos: position{line: 1740, col: 7, offset: 41526},
+										pos: position{line: 1759, col: 7, offset: 42028},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1740, col: 7, offset: 41526},
+												pos:        position{line: 1759, col: 7, offset: 42028},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1740, col: 13, offset: 41532},
+												pos:  position{line: 1759, col: 13, offset: 42034},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1740, col: 26, offset: 41545,
+									line: 1759, col: 26, offset: 42047,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1741, col: 5, offset: 41582},
+						pos: position{line: 1760, col: 5, offset: 42084},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1741, col: 5, offset: 41582},
+							pos: position{line: 1760, col: 5, offset: 42084},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1741, col: 5, offset: 41582},
+									pos:        position{line: 1760, col: 5, offset: 42084},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1741, col: 10, offset: 41587},
+									pos:   position{line: 1760, col: 10, offset: 42089},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1741, col: 12, offset: 41589},
+										pos:  position{line: 1760, col: 12, offset: 42091},
 										name: "EscapeSequence",
 									},
 								},
@@ -12626,16 +12758,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1743, col: 1, offset: 41623},
+			pos:  position{line: 1762, col: 1, offset: 42125},
 			expr: &choiceExpr{
-				pos: position{line: 1744, col: 5, offset: 41642},
+				pos: position{line: 1763, col: 5, offset: 42144},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 5, offset: 41642},
+						pos:  position{line: 1763, col: 5, offset: 42144},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1745, col: 5, offset: 41663},
+						pos:  position{line: 1764, col: 5, offset: 42165},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12645,87 +12777,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1747, col: 1, offset: 41678},
+			pos:  position{line: 1766, col: 1, offset: 42180},
 			expr: &choiceExpr{
-				pos: position{line: 1748, col: 5, offset: 41699},
+				pos: position{line: 1767, col: 5, offset: 42201},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1748, col: 5, offset: 41699},
+						pos:        position{line: 1767, col: 5, offset: 42201},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1749, col: 5, offset: 41707},
+						pos: position{line: 1768, col: 5, offset: 42209},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1749, col: 5, offset: 41707},
+							pos:        position{line: 1768, col: 5, offset: 42209},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1750, col: 5, offset: 41747},
+						pos:        position{line: 1769, col: 5, offset: 42249},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1751, col: 5, offset: 41756},
+						pos: position{line: 1770, col: 5, offset: 42258},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1751, col: 5, offset: 41756},
+							pos:        position{line: 1770, col: 5, offset: 42258},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1752, col: 5, offset: 41785},
+						pos: position{line: 1771, col: 5, offset: 42287},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1752, col: 5, offset: 41785},
+							pos:        position{line: 1771, col: 5, offset: 42287},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1753, col: 5, offset: 41814},
+						pos: position{line: 1772, col: 5, offset: 42316},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1753, col: 5, offset: 41814},
+							pos:        position{line: 1772, col: 5, offset: 42316},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1754, col: 5, offset: 41843},
+						pos: position{line: 1773, col: 5, offset: 42345},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1754, col: 5, offset: 41843},
+							pos:        position{line: 1773, col: 5, offset: 42345},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1755, col: 5, offset: 41872},
+						pos: position{line: 1774, col: 5, offset: 42374},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1755, col: 5, offset: 41872},
+							pos:        position{line: 1774, col: 5, offset: 42374},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1756, col: 5, offset: 41901},
+						pos: position{line: 1775, col: 5, offset: 42403},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1756, col: 5, offset: 41901},
+							pos:        position{line: 1775, col: 5, offset: 42403},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12738,32 +12870,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1758, col: 1, offset: 41927},
+			pos:  position{line: 1777, col: 1, offset: 42429},
 			expr: &choiceExpr{
-				pos: position{line: 1759, col: 5, offset: 41945},
+				pos: position{line: 1778, col: 5, offset: 42447},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1759, col: 5, offset: 41945},
+						pos: position{line: 1778, col: 5, offset: 42447},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1759, col: 5, offset: 41945},
+							pos:        position{line: 1778, col: 5, offset: 42447},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1760, col: 5, offset: 41973},
+						pos: position{line: 1779, col: 5, offset: 42475},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1760, col: 5, offset: 41973},
+							pos:        position{line: 1779, col: 5, offset: 42475},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1761, col: 5, offset: 42001},
+						pos:        position{line: 1780, col: 5, offset: 42503},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12776,42 +12908,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1763, col: 1, offset: 42007},
+			pos:  position{line: 1782, col: 1, offset: 42509},
 			expr: &choiceExpr{
-				pos: position{line: 1764, col: 5, offset: 42025},
+				pos: position{line: 1783, col: 5, offset: 42527},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1764, col: 5, offset: 42025},
+						pos: position{line: 1783, col: 5, offset: 42527},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1764, col: 5, offset: 42025},
+							pos: position{line: 1783, col: 5, offset: 42527},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1764, col: 5, offset: 42025},
+									pos:        position{line: 1783, col: 5, offset: 42527},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1764, col: 9, offset: 42029},
+									pos:   position{line: 1783, col: 9, offset: 42531},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1764, col: 16, offset: 42036},
+										pos: position{line: 1783, col: 16, offset: 42538},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1764, col: 16, offset: 42036},
+												pos:  position{line: 1783, col: 16, offset: 42538},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1764, col: 25, offset: 42045},
+												pos:  position{line: 1783, col: 25, offset: 42547},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1764, col: 34, offset: 42054},
+												pos:  position{line: 1783, col: 34, offset: 42556},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1764, col: 43, offset: 42063},
+												pos:  position{line: 1783, col: 43, offset: 42565},
 												name: "HexDigit",
 											},
 										},
@@ -12821,65 +12953,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1767, col: 5, offset: 42126},
+						pos: position{line: 1786, col: 5, offset: 42628},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1767, col: 5, offset: 42126},
+							pos: position{line: 1786, col: 5, offset: 42628},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1767, col: 5, offset: 42126},
+									pos:        position{line: 1786, col: 5, offset: 42628},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1767, col: 9, offset: 42130},
+									pos:        position{line: 1786, col: 9, offset: 42632},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1767, col: 13, offset: 42134},
+									pos:   position{line: 1786, col: 13, offset: 42636},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1767, col: 20, offset: 42141},
+										pos: position{line: 1786, col: 20, offset: 42643},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1767, col: 20, offset: 42141},
+												pos:  position{line: 1786, col: 20, offset: 42643},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1767, col: 29, offset: 42150},
+												pos: position{line: 1786, col: 29, offset: 42652},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1767, col: 29, offset: 42150},
+													pos:  position{line: 1786, col: 29, offset: 42652},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1767, col: 39, offset: 42160},
+												pos: position{line: 1786, col: 39, offset: 42662},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1767, col: 39, offset: 42160},
+													pos:  position{line: 1786, col: 39, offset: 42662},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1767, col: 49, offset: 42170},
+												pos: position{line: 1786, col: 49, offset: 42672},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1767, col: 49, offset: 42170},
+													pos:  position{line: 1786, col: 49, offset: 42672},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1767, col: 59, offset: 42180},
+												pos: position{line: 1786, col: 59, offset: 42682},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1767, col: 59, offset: 42180},
+													pos:  position{line: 1786, col: 59, offset: 42682},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1767, col: 69, offset: 42190},
+												pos: position{line: 1786, col: 69, offset: 42692},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1767, col: 69, offset: 42190},
+													pos:  position{line: 1786, col: 69, offset: 42692},
 													name: "HexDigit",
 												},
 											},
@@ -12887,7 +13019,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1767, col: 80, offset: 42201},
+									pos:        position{line: 1786, col: 80, offset: 42703},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12902,37 +13034,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1771, col: 1, offset: 42255},
+			pos:  position{line: 1790, col: 1, offset: 42757},
 			expr: &actionExpr{
-				pos: position{line: 1772, col: 5, offset: 42273},
+				pos: position{line: 1791, col: 5, offset: 42775},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1772, col: 5, offset: 42273},
+					pos: position{line: 1791, col: 5, offset: 42775},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1772, col: 5, offset: 42273},
+							pos:        position{line: 1791, col: 5, offset: 42775},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1772, col: 9, offset: 42277},
+							pos:   position{line: 1791, col: 9, offset: 42779},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1772, col: 14, offset: 42282},
+								pos:  position{line: 1791, col: 14, offset: 42784},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1772, col: 25, offset: 42293},
+							pos:        position{line: 1791, col: 25, offset: 42795},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1772, col: 29, offset: 42297},
+							pos: position{line: 1791, col: 29, offset: 42799},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1772, col: 30, offset: 42298},
+								pos:  position{line: 1791, col: 30, offset: 42800},
 								name: "KeyWordStart",
 							},
 						},
@@ -12944,33 +13076,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1774, col: 1, offset: 42333},
+			pos:  position{line: 1793, col: 1, offset: 42835},
 			expr: &actionExpr{
-				pos: position{line: 1775, col: 5, offset: 42348},
+				pos: position{line: 1794, col: 5, offset: 42850},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1775, col: 5, offset: 42348},
+					pos: position{line: 1794, col: 5, offset: 42850},
 					expr: &choiceExpr{
-						pos: position{line: 1775, col: 6, offset: 42349},
+						pos: position{line: 1794, col: 6, offset: 42851},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1775, col: 6, offset: 42349},
+								pos:        position{line: 1794, col: 6, offset: 42851},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1775, col: 15, offset: 42358},
+								pos: position{line: 1794, col: 15, offset: 42860},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1775, col: 15, offset: 42358},
+										pos:        position{line: 1794, col: 15, offset: 42860},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1775, col: 20, offset: 42363,
+										line: 1794, col: 20, offset: 42865,
 									},
 								},
 							},
@@ -12983,9 +13115,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1777, col: 1, offset: 42399},
+			pos:  position{line: 1796, col: 1, offset: 42901},
 			expr: &charClassMatcher{
-				pos:        position{line: 1778, col: 5, offset: 42415},
+				pos:        position{line: 1797, col: 5, offset: 42917},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12997,11 +13129,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1780, col: 1, offset: 42430},
+			pos:  position{line: 1799, col: 1, offset: 42932},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1780, col: 5, offset: 42434},
+				pos: position{line: 1799, col: 5, offset: 42936},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1780, col: 5, offset: 42434},
+					pos:  position{line: 1799, col: 5, offset: 42936},
 					name: "AnySpace",
 				},
 			},
@@ -13010,11 +13142,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1782, col: 1, offset: 42445},
+			pos:  position{line: 1801, col: 1, offset: 42947},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1782, col: 6, offset: 42450},
+				pos: position{line: 1801, col: 6, offset: 42952},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1782, col: 6, offset: 42450},
+					pos:  position{line: 1801, col: 6, offset: 42952},
 					name: "AnySpace",
 				},
 			},
@@ -13023,20 +13155,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1784, col: 1, offset: 42461},
+			pos:  position{line: 1803, col: 1, offset: 42963},
 			expr: &choiceExpr{
-				pos: position{line: 1785, col: 5, offset: 42474},
+				pos: position{line: 1804, col: 5, offset: 42976},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1785, col: 5, offset: 42474},
+						pos:  position{line: 1804, col: 5, offset: 42976},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1786, col: 5, offset: 42489},
+						pos:  position{line: 1805, col: 5, offset: 42991},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1787, col: 5, offset: 42508},
+						pos:  position{line: 1806, col: 5, offset: 43010},
 						name: "Comment",
 					},
 				},
@@ -13046,32 +13178,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1789, col: 1, offset: 42517},
+			pos:  position{line: 1808, col: 1, offset: 43019},
 			expr: &choiceExpr{
-				pos: position{line: 1790, col: 5, offset: 42535},
+				pos: position{line: 1809, col: 5, offset: 43037},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1790, col: 5, offset: 42535},
+						pos:  position{line: 1809, col: 5, offset: 43037},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1791, col: 5, offset: 42542},
+						pos:  position{line: 1810, col: 5, offset: 43044},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1792, col: 5, offset: 42549},
+						pos:  position{line: 1811, col: 5, offset: 43051},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1793, col: 5, offset: 42556},
+						pos:  position{line: 1812, col: 5, offset: 43058},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1794, col: 5, offset: 42563},
+						pos:  position{line: 1813, col: 5, offset: 43065},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1795, col: 5, offset: 42570},
+						pos:  position{line: 1814, col: 5, offset: 43072},
 						name: "Nl",
 					},
 				},
@@ -13081,16 +13213,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1797, col: 1, offset: 42574},
+			pos:  position{line: 1816, col: 1, offset: 43076},
 			expr: &choiceExpr{
-				pos: position{line: 1798, col: 5, offset: 42599},
+				pos: position{line: 1817, col: 5, offset: 43101},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1798, col: 5, offset: 42599},
+						pos:  position{line: 1817, col: 5, offset: 43101},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1799, col: 5, offset: 42606},
+						pos:  position{line: 1818, col: 5, offset: 43108},
 						name: "Mc",
 					},
 				},
@@ -13100,9 +13232,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1801, col: 1, offset: 42610},
+			pos:  position{line: 1820, col: 1, offset: 43112},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1802, col: 5, offset: 42627},
+				pos:  position{line: 1821, col: 5, offset: 43129},
 				name: "Nd",
 			},
 			leader:        false,
@@ -13110,9 +13242,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1804, col: 1, offset: 42631},
+			pos:  position{line: 1823, col: 1, offset: 43133},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1805, col: 5, offset: 42663},
+				pos:  position{line: 1824, col: 5, offset: 43165},
 				name: "Pc",
 			},
 			leader:        false,
@@ -13120,9 +13252,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1811, col: 1, offset: 42844},
+			pos:  position{line: 1830, col: 1, offset: 43346},
 			expr: &charClassMatcher{
-				pos:        position{line: 1811, col: 6, offset: 42849},
+				pos:        position{line: 1830, col: 6, offset: 43351},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -13134,9 +13266,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1814, col: 1, offset: 47001},
+			pos:  position{line: 1833, col: 1, offset: 47503},
 			expr: &charClassMatcher{
-				pos:        position{line: 1814, col: 6, offset: 47006},
+				pos:        position{line: 1833, col: 6, offset: 47508},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -13148,9 +13280,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1817, col: 1, offset: 47491},
+			pos:  position{line: 1836, col: 1, offset: 47993},
 			expr: &charClassMatcher{
-				pos:        position{line: 1817, col: 6, offset: 47496},
+				pos:        position{line: 1836, col: 6, offset: 47998},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -13162,9 +13294,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1820, col: 1, offset: 50943},
+			pos:  position{line: 1839, col: 1, offset: 51445},
 			expr: &charClassMatcher{
-				pos:        position{line: 1820, col: 6, offset: 50948},
+				pos:        position{line: 1839, col: 6, offset: 51450},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -13176,9 +13308,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1823, col: 1, offset: 51054},
+			pos:  position{line: 1842, col: 1, offset: 51556},
 			expr: &charClassMatcher{
-				pos:        position{line: 1823, col: 6, offset: 51059},
+				pos:        position{line: 1842, col: 6, offset: 51561},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -13190,9 +13322,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1826, col: 1, offset: 55060},
+			pos:  position{line: 1845, col: 1, offset: 55562},
 			expr: &charClassMatcher{
-				pos:        position{line: 1826, col: 6, offset: 55065},
+				pos:        position{line: 1845, col: 6, offset: 55567},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -13204,9 +13336,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1829, col: 1, offset: 56253},
+			pos:  position{line: 1848, col: 1, offset: 56755},
 			expr: &charClassMatcher{
-				pos:        position{line: 1829, col: 6, offset: 56258},
+				pos:        position{line: 1848, col: 6, offset: 56760},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -13218,9 +13350,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1832, col: 1, offset: 58438},
+			pos:  position{line: 1851, col: 1, offset: 58940},
 			expr: &charClassMatcher{
-				pos:        position{line: 1832, col: 6, offset: 58443},
+				pos:        position{line: 1851, col: 6, offset: 58945},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -13231,9 +13363,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1835, col: 1, offset: 58946},
+			pos:  position{line: 1854, col: 1, offset: 59448},
 			expr: &charClassMatcher{
-				pos:        position{line: 1835, col: 6, offset: 58951},
+				pos:        position{line: 1854, col: 6, offset: 59453},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -13245,9 +13377,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1838, col: 1, offset: 59065},
+			pos:  position{line: 1857, col: 1, offset: 59567},
 			expr: &charClassMatcher{
-				pos:        position{line: 1838, col: 6, offset: 59070},
+				pos:        position{line: 1857, col: 6, offset: 59572},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -13259,9 +13391,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1841, col: 1, offset: 59151},
+			pos:  position{line: 1860, col: 1, offset: 59653},
 			expr: &charClassMatcher{
-				pos:        position{line: 1841, col: 6, offset: 59156},
+				pos:        position{line: 1860, col: 6, offset: 59658},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13273,9 +13405,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1843, col: 1, offset: 59209},
+			pos:  position{line: 1862, col: 1, offset: 59711},
 			expr: &anyMatcher{
-				line: 1844, col: 5, offset: 59229,
+				line: 1863, col: 5, offset: 59731,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13283,48 +13415,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1846, col: 1, offset: 59232},
+			pos:         position{line: 1865, col: 1, offset: 59734},
 			expr: &choiceExpr{
-				pos: position{line: 1847, col: 5, offset: 59260},
+				pos: position{line: 1866, col: 5, offset: 59762},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1847, col: 5, offset: 59260},
+						pos:        position{line: 1866, col: 5, offset: 59762},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1848, col: 5, offset: 59269},
+						pos:        position{line: 1867, col: 5, offset: 59771},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1849, col: 5, offset: 59278},
+						pos:        position{line: 1868, col: 5, offset: 59780},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1850, col: 5, offset: 59287},
+						pos:        position{line: 1869, col: 5, offset: 59789},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1851, col: 5, offset: 59295},
+						pos:        position{line: 1870, col: 5, offset: 59797},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1852, col: 5, offset: 59308},
+						pos:        position{line: 1871, col: 5, offset: 59810},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1853, col: 5, offset: 59321},
+						pos:  position{line: 1872, col: 5, offset: 59823},
 						name: "Zs",
 					},
 				},
@@ -13334,9 +13466,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1855, col: 1, offset: 59325},
+			pos:  position{line: 1874, col: 1, offset: 59827},
 			expr: &charClassMatcher{
-				pos:        position{line: 1856, col: 5, offset: 59344},
+				pos:        position{line: 1875, col: 5, offset: 59846},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13348,9 +13480,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1862, col: 1, offset: 59674},
+			pos:         position{line: 1881, col: 1, offset: 60176},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1865, col: 5, offset: 59745},
+				pos:  position{line: 1884, col: 5, offset: 60247},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -13358,39 +13490,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1867, col: 1, offset: 59764},
+			pos:  position{line: 1886, col: 1, offset: 60266},
 			expr: &seqExpr{
-				pos: position{line: 1868, col: 5, offset: 59785},
+				pos: position{line: 1887, col: 5, offset: 60287},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1868, col: 5, offset: 59785},
+						pos:        position{line: 1887, col: 5, offset: 60287},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1868, col: 10, offset: 59790},
+						pos: position{line: 1887, col: 10, offset: 60292},
 						expr: &seqExpr{
-							pos: position{line: 1868, col: 11, offset: 59791},
+							pos: position{line: 1887, col: 11, offset: 60293},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1868, col: 11, offset: 59791},
+									pos: position{line: 1887, col: 11, offset: 60293},
 									expr: &litMatcher{
-										pos:        position{line: 1868, col: 12, offset: 59792},
+										pos:        position{line: 1887, col: 12, offset: 60294},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1868, col: 17, offset: 59797},
+									pos:  position{line: 1887, col: 17, offset: 60299},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1868, col: 35, offset: 59815},
+						pos:        position{line: 1887, col: 35, offset: 60317},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13402,33 +13534,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1870, col: 1, offset: 59821},
+			pos:  position{line: 1889, col: 1, offset: 60323},
 			expr: &choiceExpr{
-				pos: position{line: 1871, col: 5, offset: 59843},
+				pos: position{line: 1890, col: 5, offset: 60345},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1871, col: 5, offset: 59843},
+						pos: position{line: 1890, col: 5, offset: 60345},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1871, col: 5, offset: 59843},
+								pos:        position{line: 1890, col: 5, offset: 60345},
 								val:        "//",
 								ignoreCase: false,
 								want:       "\"//\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1871, col: 10, offset: 59848},
+								pos: position{line: 1890, col: 10, offset: 60350},
 								expr: &seqExpr{
-									pos: position{line: 1871, col: 11, offset: 59849},
+									pos: position{line: 1890, col: 11, offset: 60351},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1871, col: 11, offset: 59849},
+											pos: position{line: 1890, col: 11, offset: 60351},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1871, col: 12, offset: 59850},
+												pos:  position{line: 1890, col: 12, offset: 60352},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1871, col: 27, offset: 59865},
+											pos:  position{line: 1890, col: 27, offset: 60367},
 											name: "SourceCharacter",
 										},
 									},
@@ -13437,28 +13569,28 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1872, col: 5, offset: 59887},
+						pos: position{line: 1891, col: 5, offset: 60389},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1872, col: 5, offset: 59887},
+								pos:        position{line: 1891, col: 5, offset: 60389},
 								val:        "--",
 								ignoreCase: false,
 								want:       "\"--\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1872, col: 10, offset: 59892},
+								pos: position{line: 1891, col: 10, offset: 60394},
 								expr: &seqExpr{
-									pos: position{line: 1872, col: 11, offset: 59893},
+									pos: position{line: 1891, col: 11, offset: 60395},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1872, col: 11, offset: 59893},
+											pos: position{line: 1891, col: 11, offset: 60395},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1872, col: 12, offset: 59894},
+												pos:  position{line: 1891, col: 12, offset: 60396},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1872, col: 27, offset: 59909},
+											pos:  position{line: 1891, col: 27, offset: 60411},
 											name: "SourceCharacter",
 										},
 									},
@@ -13473,19 +13605,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1874, col: 1, offset: 59928},
+			pos:  position{line: 1893, col: 1, offset: 60430},
 			expr: &seqExpr{
-				pos: position{line: 1874, col: 7, offset: 59934},
+				pos: position{line: 1893, col: 7, offset: 60436},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1874, col: 7, offset: 59934},
+						pos: position{line: 1893, col: 7, offset: 60436},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1874, col: 7, offset: 59934},
+							pos:  position{line: 1893, col: 7, offset: 60436},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1874, col: 19, offset: 59946},
+						pos:  position{line: 1893, col: 19, offset: 60448},
 						name: "LineTerminator",
 					},
 				},
@@ -13495,16 +13627,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1876, col: 1, offset: 59962},
+			pos:  position{line: 1895, col: 1, offset: 60464},
 			expr: &choiceExpr{
-				pos: position{line: 1876, col: 7, offset: 59968},
+				pos: position{line: 1895, col: 7, offset: 60470},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1876, col: 7, offset: 59968},
+						pos:  position{line: 1895, col: 7, offset: 60470},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1876, col: 11, offset: 59972},
+						pos:  position{line: 1895, col: 11, offset: 60474},
 						name: "EOF",
 					},
 				},
@@ -13514,11 +13646,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1878, col: 1, offset: 59977},
+			pos:  position{line: 1897, col: 1, offset: 60479},
 			expr: &notExpr{
-				pos: position{line: 1878, col: 7, offset: 59983},
+				pos: position{line: 1897, col: 7, offset: 60485},
 				expr: &anyMatcher{
-					line: 1878, col: 8, offset: 59984,
+					line: 1897, col: 8, offset: 60486,
 				},
 			},
 			leader:        false,
@@ -13526,11 +13658,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1880, col: 1, offset: 59987},
+			pos:  position{line: 1899, col: 1, offset: 60489},
 			expr: &notExpr{
-				pos: position{line: 1880, col: 8, offset: 59994},
+				pos: position{line: 1899, col: 8, offset: 60496},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1880, col: 9, offset: 59995},
+					pos:  position{line: 1899, col: 9, offset: 60497},
 					name: "KeyWordChars",
 				},
 			},
@@ -13539,15 +13671,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1884, col: 1, offset: 60031},
+			pos:  position{line: 1903, col: 1, offset: 60533},
 			expr: &actionExpr{
-				pos: position{line: 1885, col: 5, offset: 60044},
+				pos: position{line: 1904, col: 5, offset: 60546},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1885, col: 5, offset: 60044},
+					pos:   position{line: 1904, col: 5, offset: 60546},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1885, col: 7, offset: 60046},
+						pos:  position{line: 1904, col: 7, offset: 60548},
 						name: "Seq",
 					},
 				},
@@ -13557,27 +13689,27 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1893, col: 1, offset: 60192},
+			pos:  position{line: 1912, col: 1, offset: 60694},
 			expr: &actionExpr{
-				pos: position{line: 1893, col: 12, offset: 60203},
+				pos: position{line: 1912, col: 12, offset: 60705},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1893, col: 12, offset: 60203},
+					pos: position{line: 1912, col: 12, offset: 60705},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1893, col: 12, offset: 60203},
+							pos: position{line: 1912, col: 12, offset: 60705},
 							expr: &litMatcher{
-								pos:        position{line: 1893, col: 13, offset: 60204},
+								pos:        position{line: 1912, col: 13, offset: 60706},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1893, col: 17, offset: 60208},
+							pos:   position{line: 1912, col: 17, offset: 60710},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1893, col: 20, offset: 60211},
+								pos:  position{line: 1912, col: 20, offset: 60713},
 								name: "SelectExpr",
 							},
 						},
@@ -13589,65 +13721,65 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1895, col: 1, offset: 60241},
+			pos:  position{line: 1914, col: 1, offset: 60743},
 			expr: &actionExpr{
-				pos: position{line: 1896, col: 5, offset: 60257},
+				pos: position{line: 1915, col: 5, offset: 60759},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1896, col: 5, offset: 60257},
+					pos: position{line: 1915, col: 5, offset: 60759},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1896, col: 5, offset: 60257},
+							pos:   position{line: 1915, col: 5, offset: 60759},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1896, col: 10, offset: 60262},
+								pos:  position{line: 1915, col: 10, offset: 60764},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1897, col: 5, offset: 60280},
+							pos:   position{line: 1916, col: 5, offset: 60782},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1898, col: 9, offset: 60295},
+								pos: position{line: 1917, col: 9, offset: 60797},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1898, col: 9, offset: 60295},
+										pos:  position{line: 1917, col: 9, offset: 60797},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1899, col: 9, offset: 60316},
+										pos:  position{line: 1918, col: 9, offset: 60818},
 										name: "Select",
 									},
 									&actionExpr{
-										pos: position{line: 1900, col: 9, offset: 60331},
+										pos: position{line: 1919, col: 9, offset: 60833},
 										run: (*parser).callonSelectExpr9,
 										expr: &seqExpr{
-											pos: position{line: 1900, col: 9, offset: 60331},
+											pos: position{line: 1919, col: 9, offset: 60833},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1900, col: 9, offset: 60331},
+													pos:        position{line: 1919, col: 9, offset: 60833},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1900, col: 13, offset: 60335},
+													pos:  position{line: 1919, col: 13, offset: 60837},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1900, col: 16, offset: 60338},
+													pos:   position{line: 1919, col: 16, offset: 60840},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1900, col: 18, offset: 60340},
+														pos:  position{line: 1919, col: 18, offset: 60842},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1900, col: 26, offset: 60348},
+													pos:  position{line: 1919, col: 26, offset: 60850},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1900, col: 28, offset: 60350},
+													pos:        position{line: 1919, col: 28, offset: 60852},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13659,97 +13791,97 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1902, col: 5, offset: 60387},
+							pos:   position{line: 1921, col: 5, offset: 60889},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1902, col: 13, offset: 60395},
+								pos:  position{line: 1921, col: 13, offset: 60897},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1903, col: 5, offset: 60416},
+							pos:   position{line: 1922, col: 5, offset: 60918},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1903, col: 11, offset: 60422},
+								pos:  position{line: 1922, col: 11, offset: 60924},
 								name: "OptLimitClause",
 							},
 						},
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1923, col: 1, offset: 60808},
+			pos:  position{line: 1942, col: 1, offset: 61310},
 			expr: &actionExpr{
-				pos: position{line: 1924, col: 5, offset: 60820},
+				pos: position{line: 1943, col: 5, offset: 61322},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1924, col: 5, offset: 60820},
+					pos: position{line: 1943, col: 5, offset: 61322},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1924, col: 5, offset: 60820},
+							pos:  position{line: 1943, col: 5, offset: 61322},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1925, col: 5, offset: 60832},
+							pos:   position{line: 1944, col: 5, offset: 61334},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1925, col: 14, offset: 60841},
+								pos:  position{line: 1944, col: 14, offset: 61343},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1926, col: 5, offset: 60857},
+							pos:   position{line: 1945, col: 5, offset: 61359},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1926, col: 11, offset: 60863},
+								pos:  position{line: 1945, col: 11, offset: 61365},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1929, col: 5, offset: 61003},
+							pos:  position{line: 1948, col: 5, offset: 61505},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1929, col: 7, offset: 61005},
+							pos:   position{line: 1948, col: 7, offset: 61507},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1929, col: 17, offset: 61015},
+								pos:  position{line: 1948, col: 17, offset: 61517},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1930, col: 5, offset: 61029},
+							pos:   position{line: 1949, col: 5, offset: 61531},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1930, col: 10, offset: 61034},
+								pos:  position{line: 1949, col: 10, offset: 61536},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1931, col: 5, offset: 61052},
+							pos:   position{line: 1950, col: 5, offset: 61554},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1931, col: 11, offset: 61058},
+								pos:  position{line: 1950, col: 11, offset: 61560},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1932, col: 5, offset: 61077},
+							pos:   position{line: 1951, col: 5, offset: 61579},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1932, col: 11, offset: 61083},
+								pos:  position{line: 1951, col: 11, offset: 61585},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1933, col: 5, offset: 61102},
+							pos:   position{line: 1952, col: 5, offset: 61604},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1933, col: 12, offset: 61109},
+								pos:  position{line: 1952, col: 12, offset: 61611},
 								name: "OptHavingClause",
 							},
 						},
@@ -13761,49 +13893,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 1959, col: 1, offset: 61715},
+			pos:  position{line: 1978, col: 1, offset: 62217},
 			expr: &choiceExpr{
-				pos: position{line: 1960, col: 5, offset: 61731},
+				pos: position{line: 1979, col: 5, offset: 62233},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1960, col: 5, offset: 61731},
+						pos: position{line: 1979, col: 5, offset: 62233},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 1960, col: 5, offset: 61731},
+							pos: position{line: 1979, col: 5, offset: 62233},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1960, col: 5, offset: 61731},
+									pos:  position{line: 1979, col: 5, offset: 62233},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1960, col: 7, offset: 61733},
+									pos:  position{line: 1979, col: 7, offset: 62235},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1961, col: 5, offset: 61770},
+						pos: position{line: 1980, col: 5, offset: 62272},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 1961, col: 5, offset: 61770},
+							pos: position{line: 1980, col: 5, offset: 62272},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1961, col: 5, offset: 61770},
+									pos:  position{line: 1980, col: 5, offset: 62272},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1961, col: 7, offset: 61772},
+									pos:  position{line: 1980, col: 7, offset: 62274},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1962, col: 5, offset: 61808},
+						pos: position{line: 1981, col: 5, offset: 62310},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 1962, col: 5, offset: 61808},
+							pos:        position{line: 1981, col: 5, offset: 62310},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13816,57 +13948,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 1964, col: 1, offset: 61847},
+			pos:  position{line: 1983, col: 1, offset: 62349},
 			expr: &choiceExpr{
-				pos: position{line: 1965, col: 5, offset: 61866},
+				pos: position{line: 1984, col: 5, offset: 62368},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1965, col: 5, offset: 61866},
+						pos: position{line: 1984, col: 5, offset: 62368},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 1965, col: 5, offset: 61866},
+							pos: position{line: 1984, col: 5, offset: 62368},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1965, col: 5, offset: 61866},
+									pos:  position{line: 1984, col: 5, offset: 62368},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1965, col: 7, offset: 61868},
+									pos:  position{line: 1984, col: 7, offset: 62370},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1965, col: 10, offset: 61871},
+									pos:  position{line: 1984, col: 10, offset: 62373},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1965, col: 12, offset: 61873},
+									pos:  position{line: 1984, col: 12, offset: 62375},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1966, col: 5, offset: 61905},
+						pos: position{line: 1985, col: 5, offset: 62407},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 1966, col: 5, offset: 61905},
+							pos: position{line: 1985, col: 5, offset: 62407},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1966, col: 5, offset: 61905},
+									pos:  position{line: 1985, col: 5, offset: 62407},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1966, col: 7, offset: 61907},
+									pos:  position{line: 1985, col: 7, offset: 62409},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1967, col: 5, offset: 61978},
+						pos: position{line: 1986, col: 5, offset: 62480},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 1967, col: 5, offset: 61978},
+							pos:        position{line: 1986, col: 5, offset: 62480},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13879,19 +14011,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 1969, col: 1, offset: 62021},
+			pos:  position{line: 1988, col: 1, offset: 62523},
 			expr: &choiceExpr{
-				pos: position{line: 1970, col: 5, offset: 62040},
+				pos: position{line: 1989, col: 5, offset: 62542},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1970, col: 5, offset: 62040},
+						pos:  position{line: 1989, col: 5, offset: 62542},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 1971, col: 5, offset: 62056},
+						pos: position{line: 1990, col: 5, offset: 62558},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 1971, col: 5, offset: 62056},
+							pos:        position{line: 1990, col: 5, offset: 62558},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13904,38 +14036,38 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 1973, col: 1, offset: 62089},
+			pos:  position{line: 1992, col: 1, offset: 62591},
 			expr: &actionExpr{
-				pos: position{line: 1974, col: 5, offset: 62105},
+				pos: position{line: 1993, col: 5, offset: 62607},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 1974, col: 5, offset: 62105},
+					pos: position{line: 1993, col: 5, offset: 62607},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1974, col: 5, offset: 62105},
+							pos:  position{line: 1993, col: 5, offset: 62607},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1974, col: 7, offset: 62107},
+							pos:  position{line: 1993, col: 7, offset: 62609},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 1974, col: 12, offset: 62112},
+							pos:   position{line: 1993, col: 12, offset: 62614},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1974, col: 14, offset: 62114},
+								pos:  position{line: 1993, col: 14, offset: 62616},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1974, col: 27, offset: 62127},
+							pos:  position{line: 1993, col: 27, offset: 62629},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1974, col: 29, offset: 62129},
+							pos:   position{line: 1993, col: 29, offset: 62631},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1974, col: 34, offset: 62134},
+								pos:  position{line: 1993, col: 34, offset: 62636},
 								name: "CteList",
 							},
 						},
@@ -13947,32 +14079,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 1983, col: 1, offset: 62319},
+			pos:  position{line: 2002, col: 1, offset: 62821},
 			expr: &choiceExpr{
-				pos: position{line: 1984, col: 5, offset: 62337},
+				pos: position{line: 2003, col: 5, offset: 62839},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1984, col: 5, offset: 62337},
+						pos: position{line: 2003, col: 5, offset: 62839},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 1984, col: 5, offset: 62337},
+							pos: position{line: 2003, col: 5, offset: 62839},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1984, col: 5, offset: 62337},
+									pos:  position{line: 2003, col: 5, offset: 62839},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1984, col: 7, offset: 62339},
+									pos:  position{line: 2003, col: 7, offset: 62841},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1985, col: 5, offset: 62375},
+						pos: position{line: 2004, col: 5, offset: 62877},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 1985, col: 5, offset: 62375},
+							pos:        position{line: 2004, col: 5, offset: 62877},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13985,51 +14117,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 1987, col: 1, offset: 62414},
+			pos:  position{line: 2006, col: 1, offset: 62916},
 			expr: &actionExpr{
-				pos: position{line: 1987, col: 11, offset: 62424},
+				pos: position{line: 2006, col: 11, offset: 62926},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 1987, col: 11, offset: 62424},
+					pos: position{line: 2006, col: 11, offset: 62926},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1987, col: 11, offset: 62424},
+							pos:   position{line: 2006, col: 11, offset: 62926},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 17, offset: 62430},
+								pos:  position{line: 2006, col: 17, offset: 62932},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1987, col: 21, offset: 62434},
+							pos:   position{line: 2006, col: 21, offset: 62936},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1987, col: 26, offset: 62439},
+								pos: position{line: 2006, col: 26, offset: 62941},
 								expr: &actionExpr{
-									pos: position{line: 1987, col: 28, offset: 62441},
+									pos: position{line: 2006, col: 28, offset: 62943},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 1987, col: 28, offset: 62441},
+										pos: position{line: 2006, col: 28, offset: 62943},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1987, col: 28, offset: 62441},
+												pos:  position{line: 2006, col: 28, offset: 62943},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1987, col: 31, offset: 62444},
+												pos:        position{line: 2006, col: 31, offset: 62946},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1987, col: 35, offset: 62448},
+												pos:  position{line: 2006, col: 35, offset: 62950},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1987, col: 38, offset: 62451},
+												pos:   position{line: 2006, col: 38, offset: 62953},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1987, col: 42, offset: 62455},
+													pos:  position{line: 2006, col: 42, offset: 62957},
 													name: "Cte",
 												},
 											},
@@ -14046,65 +14178,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 1991, col: 1, offset: 62524},
+			pos:  position{line: 2010, col: 1, offset: 63026},
 			expr: &actionExpr{
-				pos: position{line: 1992, col: 5, offset: 62532},
+				pos: position{line: 2011, col: 5, offset: 63034},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 1992, col: 5, offset: 62532},
+					pos: position{line: 2011, col: 5, offset: 63034},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1992, col: 5, offset: 62532},
+							pos:   position{line: 2011, col: 5, offset: 63034},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1992, col: 10, offset: 62537},
+								pos:  position{line: 2011, col: 10, offset: 63039},
 								name: "AliasName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1992, col: 20, offset: 62547},
+							pos:  position{line: 2011, col: 20, offset: 63049},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1992, col: 22, offset: 62549},
+							pos:  position{line: 2011, col: 22, offset: 63051},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 1992, col: 25, offset: 62552},
+							pos:   position{line: 2011, col: 25, offset: 63054},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1992, col: 27, offset: 62554},
+								pos:  position{line: 2011, col: 27, offset: 63056},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1992, col: 43, offset: 62570},
+							pos:  position{line: 2011, col: 43, offset: 63072},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1992, col: 46, offset: 62573},
+							pos:        position{line: 2011, col: 46, offset: 63075},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1992, col: 50, offset: 62577},
+							pos:  position{line: 2011, col: 50, offset: 63079},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1992, col: 53, offset: 62580},
+							pos:   position{line: 2011, col: 53, offset: 63082},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1992, col: 55, offset: 62582},
+								pos:  position{line: 2011, col: 55, offset: 63084},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1992, col: 63, offset: 62590},
+							pos:  position{line: 2011, col: 63, offset: 63092},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1992, col: 66, offset: 62593},
+							pos:        position{line: 2011, col: 66, offset: 63095},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14117,9 +14249,9 @@ var g = &grammar{
 		},
 		{
 			name: "AliasName",
-			pos:  position{line: 2001, col: 1, offset: 62768},
+			pos:  position{line: 2020, col: 1, offset: 63270},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2001, col: 13, offset: 62780},
+				pos:  position{line: 2020, col: 13, offset: 63282},
 				name: "Identifier",
 			},
 			leader:        false,
@@ -14127,65 +14259,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2003, col: 1, offset: 62792},
+			pos:  position{line: 2022, col: 1, offset: 63294},
 			expr: &choiceExpr{
-				pos: position{line: 2004, col: 5, offset: 62813},
+				pos: position{line: 2023, col: 5, offset: 63315},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2004, col: 5, offset: 62813},
+						pos: position{line: 2023, col: 5, offset: 63315},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2004, col: 5, offset: 62813},
+							pos: position{line: 2023, col: 5, offset: 63315},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2004, col: 5, offset: 62813},
+									pos:  position{line: 2023, col: 5, offset: 63315},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2004, col: 7, offset: 62815},
+									pos:  position{line: 2023, col: 7, offset: 63317},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2004, col: 20, offset: 62828},
+									pos:  position{line: 2023, col: 20, offset: 63330},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2005, col: 5, offset: 62867},
+						pos: position{line: 2024, col: 5, offset: 63369},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2005, col: 5, offset: 62867},
+							pos: position{line: 2024, col: 5, offset: 63369},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2005, col: 5, offset: 62867},
+									pos:  position{line: 2024, col: 5, offset: 63369},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2005, col: 7, offset: 62869},
+									pos:  position{line: 2024, col: 7, offset: 63371},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2005, col: 11, offset: 62873},
+									pos:  position{line: 2024, col: 11, offset: 63375},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2005, col: 13, offset: 62875},
+									pos:  position{line: 2024, col: 13, offset: 63377},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2005, col: 26, offset: 62888},
+									pos:  position{line: 2024, col: 26, offset: 63390},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2006, col: 5, offset: 62919},
+						pos: position{line: 2025, col: 5, offset: 63421},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2006, col: 5, offset: 62919},
+							pos:        position{line: 2025, col: 5, offset: 63421},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14198,25 +14330,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2008, col: 1, offset: 62974},
+			pos:  position{line: 2027, col: 1, offset: 63476},
 			expr: &choiceExpr{
-				pos: position{line: 2009, col: 5, offset: 62991},
+				pos: position{line: 2028, col: 5, offset: 63493},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2009, col: 5, offset: 62991},
+						pos: position{line: 2028, col: 5, offset: 63493},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2009, col: 5, offset: 62991},
+								pos:  position{line: 2028, col: 5, offset: 63493},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2009, col: 7, offset: 62993},
+								pos:  position{line: 2028, col: 7, offset: 63495},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2010, col: 5, offset: 63002},
+						pos:        position{line: 2029, col: 5, offset: 63504},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14228,25 +14360,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2012, col: 1, offset: 63006},
+			pos:  position{line: 2031, col: 1, offset: 63508},
 			expr: &choiceExpr{
-				pos: position{line: 2013, col: 5, offset: 63024},
+				pos: position{line: 2032, col: 5, offset: 63526},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2013, col: 5, offset: 63024},
+						pos: position{line: 2032, col: 5, offset: 63526},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2013, col: 5, offset: 63024},
+							pos: position{line: 2032, col: 5, offset: 63526},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2013, col: 5, offset: 63024},
+									pos:  position{line: 2032, col: 5, offset: 63526},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2013, col: 7, offset: 63026},
+									pos:   position{line: 2032, col: 7, offset: 63528},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2013, col: 12, offset: 63031},
+										pos:  position{line: 2032, col: 12, offset: 63533},
 										name: "FromOp",
 									},
 								},
@@ -14254,10 +14386,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2016, col: 5, offset: 63073},
+						pos: position{line: 2035, col: 5, offset: 63575},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2016, col: 5, offset: 63073},
+							pos:        position{line: 2035, col: 5, offset: 63575},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14270,27 +14402,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2018, col: 1, offset: 63114},
+			pos:  position{line: 2037, col: 1, offset: 63616},
 			expr: &choiceExpr{
-				pos: position{line: 2019, col: 5, offset: 63133},
+				pos: position{line: 2038, col: 5, offset: 63635},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2019, col: 5, offset: 63133},
+						pos: position{line: 2038, col: 5, offset: 63635},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2019, col: 5, offset: 63133},
+							pos:   position{line: 2038, col: 5, offset: 63635},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2019, col: 11, offset: 63139},
+								pos:  position{line: 2038, col: 11, offset: 63641},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2020, col: 5, offset: 63181},
+						pos: position{line: 2039, col: 5, offset: 63683},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2020, col: 5, offset: 63181},
+							pos:        position{line: 2039, col: 5, offset: 63683},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14303,25 +14435,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2022, col: 1, offset: 63226},
+			pos:  position{line: 2041, col: 1, offset: 63728},
 			expr: &choiceExpr{
-				pos: position{line: 2023, col: 5, offset: 63245},
+				pos: position{line: 2042, col: 5, offset: 63747},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2023, col: 5, offset: 63245},
+						pos: position{line: 2042, col: 5, offset: 63747},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2023, col: 5, offset: 63245},
+							pos: position{line: 2042, col: 5, offset: 63747},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 5, offset: 63245},
+									pos:  position{line: 2042, col: 5, offset: 63747},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2023, col: 7, offset: 63247},
+									pos:   position{line: 2042, col: 7, offset: 63749},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2023, col: 13, offset: 63253},
+										pos:  position{line: 2042, col: 13, offset: 63755},
 										name: "GroupClause",
 									},
 								},
@@ -14329,10 +14461,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2024, col: 5, offset: 63291},
+						pos: position{line: 2043, col: 5, offset: 63793},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2024, col: 5, offset: 63291},
+							pos:        position{line: 2043, col: 5, offset: 63793},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14345,34 +14477,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2026, col: 1, offset: 63332},
+			pos:  position{line: 2045, col: 1, offset: 63834},
 			expr: &actionExpr{
-				pos: position{line: 2027, col: 5, offset: 63348},
+				pos: position{line: 2046, col: 5, offset: 63850},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2027, col: 5, offset: 63348},
+					pos: position{line: 2046, col: 5, offset: 63850},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2027, col: 5, offset: 63348},
+							pos:  position{line: 2046, col: 5, offset: 63850},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2027, col: 11, offset: 63354},
+							pos:  position{line: 2046, col: 11, offset: 63856},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2027, col: 13, offset: 63356},
+							pos:  position{line: 2046, col: 13, offset: 63858},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2027, col: 16, offset: 63359},
+							pos:  position{line: 2046, col: 16, offset: 63861},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2027, col: 18, offset: 63361},
+							pos:   position{line: 2046, col: 18, offset: 63863},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2027, col: 23, offset: 63366},
+								pos:  position{line: 2046, col: 23, offset: 63868},
 								name: "GroupByList",
 							},
 						},
@@ -14384,51 +14516,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2029, col: 1, offset: 63400},
+			pos:  position{line: 2048, col: 1, offset: 63902},
 			expr: &actionExpr{
-				pos: position{line: 2030, col: 5, offset: 63417},
+				pos: position{line: 2049, col: 5, offset: 63919},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2030, col: 5, offset: 63417},
+					pos: position{line: 2049, col: 5, offset: 63919},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2030, col: 5, offset: 63417},
+							pos:   position{line: 2049, col: 5, offset: 63919},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2030, col: 11, offset: 63423},
+								pos:  position{line: 2049, col: 11, offset: 63925},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2030, col: 23, offset: 63435},
+							pos:   position{line: 2049, col: 23, offset: 63937},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2030, col: 28, offset: 63440},
+								pos: position{line: 2049, col: 28, offset: 63942},
 								expr: &actionExpr{
-									pos: position{line: 2030, col: 30, offset: 63442},
+									pos: position{line: 2049, col: 30, offset: 63944},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2030, col: 30, offset: 63442},
+										pos: position{line: 2049, col: 30, offset: 63944},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2030, col: 30, offset: 63442},
+												pos:  position{line: 2049, col: 30, offset: 63944},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2030, col: 33, offset: 63445},
+												pos:        position{line: 2049, col: 33, offset: 63947},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2030, col: 37, offset: 63449},
+												pos:  position{line: 2049, col: 37, offset: 63951},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2030, col: 40, offset: 63452},
+												pos:   position{line: 2049, col: 40, offset: 63954},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2030, col: 42, offset: 63454},
+													pos:  position{line: 2049, col: 42, offset: 63956},
 													name: "GroupByItem",
 												},
 											},
@@ -14445,9 +14577,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2034, col: 1, offset: 63535},
+			pos:  position{line: 2053, col: 1, offset: 64037},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2034, col: 15, offset: 63549},
+				pos:  position{line: 2053, col: 15, offset: 64051},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14455,25 +14587,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2036, col: 1, offset: 63555},
+			pos:  position{line: 2055, col: 1, offset: 64057},
 			expr: &choiceExpr{
-				pos: position{line: 2037, col: 5, offset: 63575},
+				pos: position{line: 2056, col: 5, offset: 64077},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2037, col: 5, offset: 63575},
+						pos: position{line: 2056, col: 5, offset: 64077},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2037, col: 5, offset: 63575},
+							pos: position{line: 2056, col: 5, offset: 64077},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2037, col: 5, offset: 63575},
+									pos:  position{line: 2056, col: 5, offset: 64077},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2037, col: 7, offset: 63577},
+									pos:   position{line: 2056, col: 7, offset: 64079},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2037, col: 9, offset: 63579},
+										pos:  position{line: 2056, col: 9, offset: 64081},
 										name: "HavingClause",
 									},
 								},
@@ -14481,10 +14613,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2038, col: 5, offset: 63614},
+						pos: position{line: 2057, col: 5, offset: 64116},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2038, col: 5, offset: 63614},
+							pos:        position{line: 2057, col: 5, offset: 64116},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14497,26 +14629,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2040, col: 1, offset: 63638},
+			pos:  position{line: 2059, col: 1, offset: 64140},
 			expr: &actionExpr{
-				pos: position{line: 2041, col: 5, offset: 63655},
+				pos: position{line: 2060, col: 5, offset: 64157},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2041, col: 5, offset: 63655},
+					pos: position{line: 2060, col: 5, offset: 64157},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2041, col: 5, offset: 63655},
+							pos:  position{line: 2060, col: 5, offset: 64157},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2041, col: 12, offset: 63662},
+							pos:  position{line: 2060, col: 12, offset: 64164},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2041, col: 14, offset: 63664},
+							pos:   position{line: 2060, col: 14, offset: 64166},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2041, col: 16, offset: 63666},
+								pos:  position{line: 2060, col: 16, offset: 64168},
 								name: "Expr",
 							},
 						},
@@ -14528,16 +14660,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2043, col: 1, offset: 63690},
+			pos:  position{line: 2062, col: 1, offset: 64192},
 			expr: &choiceExpr{
-				pos: position{line: 2044, col: 5, offset: 63708},
+				pos: position{line: 2063, col: 5, offset: 64210},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2044, col: 5, offset: 63708},
+						pos:  position{line: 2063, col: 5, offset: 64210},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2045, col: 5, offset: 63722},
+						pos:  position{line: 2064, col: 5, offset: 64224},
 						name: "ConditionJoin",
 					},
 				},
@@ -14547,30 +14679,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2047, col: 1, offset: 63737},
+			pos:  position{line: 2066, col: 1, offset: 64239},
 			expr: &actionExpr{
-				pos: position{line: 2048, col: 5, offset: 63751},
+				pos: position{line: 2067, col: 5, offset: 64253},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2048, col: 5, offset: 63751},
+					pos: position{line: 2067, col: 5, offset: 64253},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2048, col: 5, offset: 63751},
+							pos:   position{line: 2067, col: 5, offset: 64253},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2048, col: 10, offset: 63756},
+								pos:  position{line: 2067, col: 10, offset: 64258},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2048, col: 19, offset: 63765},
+							pos:  position{line: 2067, col: 19, offset: 64267},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2048, col: 31, offset: 63777},
+							pos:   position{line: 2067, col: 31, offset: 64279},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2048, col: 37, offset: 63783},
+								pos:  position{line: 2067, col: 37, offset: 64285},
 								name: "FromElem",
 							},
 						},
@@ -14582,50 +14714,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2057, col: 1, offset: 63985},
+			pos:  position{line: 2076, col: 1, offset: 64487},
 			expr: &choiceExpr{
-				pos: position{line: 2058, col: 5, offset: 64002},
+				pos: position{line: 2077, col: 5, offset: 64504},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2058, col: 5, offset: 64002},
+						pos: position{line: 2077, col: 5, offset: 64504},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2058, col: 5, offset: 64002},
+								pos:  position{line: 2077, col: 5, offset: 64504},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2058, col: 8, offset: 64005},
+								pos:        position{line: 2077, col: 8, offset: 64507},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2058, col: 12, offset: 64009},
+								pos:  position{line: 2077, col: 12, offset: 64511},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2059, col: 5, offset: 64017},
+						pos: position{line: 2078, col: 5, offset: 64519},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2059, col: 5, offset: 64017},
+								pos:  position{line: 2078, col: 5, offset: 64519},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2059, col: 7, offset: 64019},
+								pos:  position{line: 2078, col: 7, offset: 64521},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2059, col: 13, offset: 64025},
+								pos:  position{line: 2078, col: 13, offset: 64527},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2059, col: 15, offset: 64027},
+								pos:  position{line: 2078, col: 15, offset: 64529},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2059, col: 20, offset: 64032},
+								pos:  position{line: 2078, col: 20, offset: 64534},
 								name: "_",
 							},
 						},
@@ -14637,46 +14769,46 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2061, col: 1, offset: 64036},
+			pos:  position{line: 2080, col: 1, offset: 64538},
 			expr: &actionExpr{
-				pos: position{line: 2062, col: 5, offset: 64054},
+				pos: position{line: 2081, col: 5, offset: 64556},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2062, col: 5, offset: 64054},
+					pos: position{line: 2081, col: 5, offset: 64556},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2062, col: 5, offset: 64054},
+							pos:   position{line: 2081, col: 5, offset: 64556},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2062, col: 10, offset: 64059},
+								pos:  position{line: 2081, col: 10, offset: 64561},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2062, col: 19, offset: 64068},
+							pos:   position{line: 2081, col: 19, offset: 64570},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2062, col: 25, offset: 64074},
+								pos:  position{line: 2081, col: 25, offset: 64576},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2062, col: 38, offset: 64087},
+							pos:  position{line: 2081, col: 38, offset: 64589},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2062, col: 40, offset: 64089},
+							pos:   position{line: 2081, col: 40, offset: 64591},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2062, col: 46, offset: 64095},
+								pos:  position{line: 2081, col: 46, offset: 64597},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2062, col: 55, offset: 64104},
+							pos:   position{line: 2081, col: 55, offset: 64606},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2062, col: 57, offset: 64106},
+								pos:  position{line: 2081, col: 57, offset: 64608},
 								name: "JoinExpr",
 							},
 						},
@@ -14688,161 +14820,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2073, col: 1, offset: 64375},
+			pos:  position{line: 2092, col: 1, offset: 64877},
 			expr: &choiceExpr{
-				pos: position{line: 2074, col: 5, offset: 64393},
+				pos: position{line: 2093, col: 5, offset: 64895},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2074, col: 5, offset: 64393},
+						pos: position{line: 2093, col: 5, offset: 64895},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2074, col: 5, offset: 64393},
+							pos: position{line: 2093, col: 5, offset: 64895},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2074, col: 5, offset: 64393},
+									pos: position{line: 2093, col: 5, offset: 64895},
 									expr: &seqExpr{
-										pos: position{line: 2074, col: 6, offset: 64394},
+										pos: position{line: 2093, col: 6, offset: 64896},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2074, col: 6, offset: 64394},
+												pos:  position{line: 2093, col: 6, offset: 64896},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2074, col: 8, offset: 64396},
+												pos:  position{line: 2093, col: 8, offset: 64898},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2074, col: 16, offset: 64404},
+									pos:  position{line: 2093, col: 16, offset: 64906},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2074, col: 18, offset: 64406},
+									pos:  position{line: 2093, col: 18, offset: 64908},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2075, col: 5, offset: 64451},
+						pos: position{line: 2094, col: 5, offset: 64953},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2075, col: 5, offset: 64451},
+							pos: position{line: 2094, col: 5, offset: 64953},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2075, col: 5, offset: 64451},
+									pos:  position{line: 2094, col: 5, offset: 64953},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2075, col: 7, offset: 64453},
+									pos:  position{line: 2094, col: 7, offset: 64955},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2075, col: 12, offset: 64458},
+									pos: position{line: 2094, col: 12, offset: 64960},
 									expr: &seqExpr{
-										pos: position{line: 2075, col: 13, offset: 64459},
+										pos: position{line: 2094, col: 13, offset: 64961},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2075, col: 13, offset: 64459},
+												pos:  position{line: 2094, col: 13, offset: 64961},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2075, col: 15, offset: 64461},
+												pos:  position{line: 2094, col: 15, offset: 64963},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2075, col: 23, offset: 64469},
+									pos:  position{line: 2094, col: 23, offset: 64971},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2075, col: 25, offset: 64471},
+									pos:  position{line: 2094, col: 25, offset: 64973},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2076, col: 5, offset: 64505},
+						pos: position{line: 2095, col: 5, offset: 65007},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2076, col: 5, offset: 64505},
+							pos: position{line: 2095, col: 5, offset: 65007},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2076, col: 5, offset: 64505},
+									pos:  position{line: 2095, col: 5, offset: 65007},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2076, col: 7, offset: 64507},
+									pos:  position{line: 2095, col: 7, offset: 65009},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2076, col: 12, offset: 64512},
+									pos: position{line: 2095, col: 12, offset: 65014},
 									expr: &seqExpr{
-										pos: position{line: 2076, col: 13, offset: 64513},
+										pos: position{line: 2095, col: 13, offset: 65015},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2076, col: 13, offset: 64513},
+												pos:  position{line: 2095, col: 13, offset: 65015},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2076, col: 15, offset: 64515},
+												pos:  position{line: 2095, col: 15, offset: 65017},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2076, col: 23, offset: 64523},
+									pos:  position{line: 2095, col: 23, offset: 65025},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2076, col: 25, offset: 64525},
+									pos:  position{line: 2095, col: 25, offset: 65027},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2077, col: 5, offset: 64559},
+						pos: position{line: 2096, col: 5, offset: 65061},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2077, col: 5, offset: 64559},
+							pos: position{line: 2096, col: 5, offset: 65061},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2077, col: 5, offset: 64559},
+									pos:  position{line: 2096, col: 5, offset: 65061},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2077, col: 7, offset: 64561},
+									pos:  position{line: 2096, col: 7, offset: 65063},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2077, col: 13, offset: 64567},
+									pos: position{line: 2096, col: 13, offset: 65069},
 									expr: &seqExpr{
-										pos: position{line: 2077, col: 14, offset: 64568},
+										pos: position{line: 2096, col: 14, offset: 65070},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2077, col: 14, offset: 64568},
+												pos:  position{line: 2096, col: 14, offset: 65070},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2077, col: 16, offset: 64570},
+												pos:  position{line: 2096, col: 16, offset: 65072},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2077, col: 24, offset: 64578},
+									pos:  position{line: 2096, col: 24, offset: 65080},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2077, col: 26, offset: 64580},
+									pos:  position{line: 2096, col: 26, offset: 65082},
 									name: "JOIN",
 								},
 							},
@@ -14855,33 +14987,33 @@ var g = &grammar{
 		},
 		{
 			name: "JoinExpr",
-			pos:  position{line: 2079, col: 1, offset: 64612},
+			pos:  position{line: 2098, col: 1, offset: 65114},
 			expr: &choiceExpr{
-				pos: position{line: 2080, col: 5, offset: 64626},
+				pos: position{line: 2099, col: 5, offset: 65128},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2080, col: 5, offset: 64626},
+						pos: position{line: 2099, col: 5, offset: 65128},
 						run: (*parser).callonJoinExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2080, col: 5, offset: 64626},
+							pos: position{line: 2099, col: 5, offset: 65128},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2080, col: 5, offset: 64626},
+									pos:  position{line: 2099, col: 5, offset: 65128},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2080, col: 7, offset: 64628},
+									pos:  position{line: 2099, col: 7, offset: 65130},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2080, col: 10, offset: 64631},
+									pos:  position{line: 2099, col: 10, offset: 65133},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2080, col: 12, offset: 64633},
+									pos:   position{line: 2099, col: 12, offset: 65135},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2080, col: 14, offset: 64635},
+										pos:  position{line: 2099, col: 14, offset: 65137},
 										name: "Expr",
 									},
 								},
@@ -14889,47 +15021,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2087, col: 5, offset: 64790},
+						pos: position{line: 2106, col: 5, offset: 65292},
 						run: (*parser).callonJoinExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2087, col: 5, offset: 64790},
+							pos: position{line: 2106, col: 5, offset: 65292},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2087, col: 5, offset: 64790},
+									pos:  position{line: 2106, col: 5, offset: 65292},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2087, col: 7, offset: 64792},
+									pos:  position{line: 2106, col: 7, offset: 65294},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2087, col: 13, offset: 64798},
+									pos:  position{line: 2106, col: 13, offset: 65300},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2087, col: 16, offset: 64801},
+									pos:        position{line: 2106, col: 16, offset: 65303},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2087, col: 20, offset: 64805},
+									pos:  position{line: 2106, col: 20, offset: 65307},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2087, col: 23, offset: 64808},
+									pos:   position{line: 2106, col: 23, offset: 65310},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2087, col: 30, offset: 64815},
+										pos:  position{line: 2106, col: 30, offset: 65317},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2087, col: 36, offset: 64821},
+									pos:  position{line: 2106, col: 36, offset: 65323},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2087, col: 39, offset: 64824},
+									pos:        position{line: 2106, col: 39, offset: 65326},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14944,40 +15076,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2095, col: 1, offset: 64994},
+			pos:  position{line: 2114, col: 1, offset: 65496},
 			expr: &choiceExpr{
-				pos: position{line: 2096, col: 5, offset: 65013},
+				pos: position{line: 2115, col: 5, offset: 65515},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2096, col: 5, offset: 65013},
+						pos: position{line: 2115, col: 5, offset: 65515},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2096, col: 5, offset: 65013},
+							pos: position{line: 2115, col: 5, offset: 65515},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2096, col: 5, offset: 65013},
+									pos:  position{line: 2115, col: 5, offset: 65515},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2096, col: 7, offset: 65015},
+									pos:  position{line: 2115, col: 7, offset: 65517},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2096, col: 12, offset: 65020},
+									pos:  position{line: 2115, col: 12, offset: 65522},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2096, col: 14, offset: 65022},
+									pos:  position{line: 2115, col: 14, offset: 65524},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2102, col: 5, offset: 65151},
+						pos: position{line: 2121, col: 5, offset: 65653},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2102, col: 5, offset: 65151},
+							pos:        position{line: 2121, col: 5, offset: 65653},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14990,25 +15122,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2104, col: 1, offset: 65200},
+			pos:  position{line: 2123, col: 1, offset: 65702},
 			expr: &choiceExpr{
-				pos: position{line: 2105, col: 5, offset: 65213},
+				pos: position{line: 2124, col: 5, offset: 65715},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2105, col: 5, offset: 65213},
+						pos: position{line: 2124, col: 5, offset: 65715},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2105, col: 5, offset: 65213},
+							pos: position{line: 2124, col: 5, offset: 65715},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 5, offset: 65213},
+									pos:  position{line: 2124, col: 5, offset: 65715},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2105, col: 7, offset: 65215},
+									pos:   position{line: 2124, col: 7, offset: 65717},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2105, col: 9, offset: 65217},
+										pos:  position{line: 2124, col: 9, offset: 65719},
 										name: "AliasClause",
 									},
 								},
@@ -15016,10 +15148,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2106, col: 5, offset: 65251},
+						pos: position{line: 2125, col: 5, offset: 65753},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2106, col: 5, offset: 65251},
+							pos:        position{line: 2125, col: 5, offset: 65753},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15032,50 +15164,50 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2108, col: 1, offset: 65288},
+			pos:  position{line: 2127, col: 1, offset: 65790},
 			expr: &actionExpr{
-				pos: position{line: 2109, col: 5, offset: 65305},
+				pos: position{line: 2128, col: 5, offset: 65807},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2109, col: 5, offset: 65305},
+					pos: position{line: 2128, col: 5, offset: 65807},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2109, col: 5, offset: 65305},
+							pos: position{line: 2128, col: 5, offset: 65807},
 							expr: &seqExpr{
-								pos: position{line: 2109, col: 6, offset: 65306},
+								pos: position{line: 2128, col: 6, offset: 65808},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2109, col: 6, offset: 65306},
+										pos:  position{line: 2128, col: 6, offset: 65808},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2109, col: 9, offset: 65309},
+										pos:  position{line: 2128, col: 9, offset: 65811},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2109, col: 13, offset: 65313},
+							pos: position{line: 2128, col: 13, offset: 65815},
 							expr: &choiceExpr{
-								pos: position{line: 2109, col: 15, offset: 65315},
+								pos: position{line: 2128, col: 15, offset: 65817},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2109, col: 15, offset: 65315},
+										pos:  position{line: 2128, col: 15, offset: 65817},
 										name: "SQLGuard",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2109, col: 26, offset: 65326},
+										pos:  position{line: 2128, col: 26, offset: 65828},
 										name: "DeprecatedFroms",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2109, col: 43, offset: 65343},
+							pos:   position{line: 2128, col: 43, offset: 65845},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2109, col: 48, offset: 65348},
+								pos:  position{line: 2128, col: 48, offset: 65850},
 								name: "IdentifierName",
 							},
 						},
@@ -15087,51 +15219,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2113, col: 1, offset: 65481},
+			pos:  position{line: 2132, col: 1, offset: 65983},
 			expr: &actionExpr{
-				pos: position{line: 2114, col: 5, offset: 65495},
+				pos: position{line: 2133, col: 5, offset: 65997},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2114, col: 5, offset: 65495},
+					pos: position{line: 2133, col: 5, offset: 65997},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2114, col: 5, offset: 65495},
+							pos:   position{line: 2133, col: 5, offset: 65997},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2114, col: 11, offset: 65501},
+								pos:  position{line: 2133, col: 11, offset: 66003},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2114, col: 22, offset: 65512},
+							pos:   position{line: 2133, col: 22, offset: 66014},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2114, col: 27, offset: 65517},
+								pos: position{line: 2133, col: 27, offset: 66019},
 								expr: &actionExpr{
-									pos: position{line: 2114, col: 29, offset: 65519},
+									pos: position{line: 2133, col: 29, offset: 66021},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2114, col: 29, offset: 65519},
+										pos: position{line: 2133, col: 29, offset: 66021},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2114, col: 29, offset: 65519},
+												pos:  position{line: 2133, col: 29, offset: 66021},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2114, col: 32, offset: 65522},
+												pos:        position{line: 2133, col: 32, offset: 66024},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2114, col: 36, offset: 65526},
+												pos:  position{line: 2133, col: 36, offset: 66028},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2114, col: 39, offset: 65529},
+												pos:   position{line: 2133, col: 39, offset: 66031},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2114, col: 41, offset: 65531},
+													pos:  position{line: 2133, col: 41, offset: 66033},
 													name: "SelectElem",
 												},
 											},
@@ -15148,29 +15280,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2123, col: 1, offset: 65757},
+			pos:  position{line: 2142, col: 1, offset: 66259},
 			expr: &choiceExpr{
-				pos: position{line: 2124, col: 5, offset: 65773},
+				pos: position{line: 2143, col: 5, offset: 66275},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2124, col: 5, offset: 65773},
+						pos: position{line: 2143, col: 5, offset: 66275},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2124, col: 5, offset: 65773},
+							pos: position{line: 2143, col: 5, offset: 66275},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2124, col: 5, offset: 65773},
-									label: "e",
-									expr: &ruleRefExpr{
-										pos:  position{line: 2124, col: 7, offset: 65775},
-										name: "Expr",
+									pos:   position{line: 2143, col: 5, offset: 66275},
+									label: "expr",
+									expr: &choiceExpr{
+										pos: position{line: 2143, col: 11, offset: 66281},
+										alternatives: []any{
+											&ruleRefExpr{
+												pos:  position{line: 2143, col: 11, offset: 66281},
+												name: "AggDistinct",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 2143, col: 25, offset: 66295},
+												name: "Expr",
+											},
+										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2124, col: 12, offset: 65780},
+									pos:   position{line: 2143, col: 31, offset: 66301},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2124, col: 15, offset: 65783},
+										pos:  position{line: 2143, col: 34, offset: 66304},
 										name: "OptAsClause",
 									},
 								},
@@ -15178,10 +15319,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2135, col: 5, offset: 65999},
-						run: (*parser).callonSelectElem8,
+						pos: position{line: 2154, col: 5, offset: 66523},
+						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2135, col: 5, offset: 65999},
+							pos:        position{line: 2154, col: 5, offset: 66523},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15194,33 +15335,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2140, col: 1, offset: 66101},
+			pos:  position{line: 2159, col: 1, offset: 66625},
 			expr: &choiceExpr{
-				pos: position{line: 2141, col: 5, offset: 66118},
+				pos: position{line: 2160, col: 5, offset: 66642},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2141, col: 5, offset: 66118},
+						pos: position{line: 2160, col: 5, offset: 66642},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2141, col: 5, offset: 66118},
+							pos: position{line: 2160, col: 5, offset: 66642},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2141, col: 5, offset: 66118},
+									pos:  position{line: 2160, col: 5, offset: 66642},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2141, col: 7, offset: 66120},
+									pos:  position{line: 2160, col: 7, offset: 66644},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2141, col: 10, offset: 66123},
+									pos:  position{line: 2160, col: 10, offset: 66647},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2141, col: 12, offset: 66125},
+									pos:   position{line: 2160, col: 12, offset: 66649},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2141, col: 15, offset: 66128},
+										pos:  position{line: 2160, col: 15, offset: 66652},
 										name: "Identifier",
 									},
 								},
@@ -15228,27 +15369,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2142, col: 5, offset: 66162},
+						pos: position{line: 2161, col: 5, offset: 66686},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2142, col: 5, offset: 66162},
+							pos: position{line: 2161, col: 5, offset: 66686},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2142, col: 5, offset: 66162},
+									pos:  position{line: 2161, col: 5, offset: 66686},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2142, col: 7, offset: 66164},
+									pos: position{line: 2161, col: 7, offset: 66688},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2142, col: 8, offset: 66165},
+										pos:  position{line: 2161, col: 8, offset: 66689},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2142, col: 17, offset: 66174},
+									pos:   position{line: 2161, col: 17, offset: 66698},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2142, col: 20, offset: 66177},
+										pos:  position{line: 2161, col: 20, offset: 66701},
 										name: "Identifier",
 									},
 								},
@@ -15256,10 +15397,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2143, col: 5, offset: 66211},
+						pos: position{line: 2162, col: 5, offset: 66735},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2143, col: 5, offset: 66211},
+							pos:        position{line: 2162, col: 5, offset: 66735},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15272,41 +15413,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2145, col: 1, offset: 66236},
+			pos:  position{line: 2164, col: 1, offset: 66760},
 			expr: &choiceExpr{
-				pos: position{line: 2146, col: 5, offset: 66258},
+				pos: position{line: 2165, col: 5, offset: 66782},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2146, col: 5, offset: 66258},
+						pos: position{line: 2165, col: 5, offset: 66782},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2146, col: 5, offset: 66258},
+							pos: position{line: 2165, col: 5, offset: 66782},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2146, col: 5, offset: 66258},
+									pos:  position{line: 2165, col: 5, offset: 66782},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2146, col: 7, offset: 66260},
+									pos:  position{line: 2165, col: 7, offset: 66784},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2146, col: 13, offset: 66266},
+									pos:  position{line: 2165, col: 13, offset: 66790},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2146, col: 15, offset: 66268},
+									pos:  position{line: 2165, col: 15, offset: 66792},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2146, col: 18, offset: 66271},
+									pos:  position{line: 2165, col: 18, offset: 66795},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2146, col: 20, offset: 66273},
+									pos:   position{line: 2165, col: 20, offset: 66797},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2146, col: 25, offset: 66278},
+										pos:  position{line: 2165, col: 25, offset: 66802},
 										name: "OrderByList",
 									},
 								},
@@ -15314,10 +15455,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2153, col: 5, offset: 66437},
+						pos: position{line: 2172, col: 5, offset: 66961},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2153, col: 5, offset: 66437},
+							pos:        position{line: 2172, col: 5, offset: 66961},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15330,51 +15471,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2155, col: 1, offset: 66470},
+			pos:  position{line: 2174, col: 1, offset: 66994},
 			expr: &actionExpr{
-				pos: position{line: 2156, col: 5, offset: 66487},
+				pos: position{line: 2175, col: 5, offset: 67011},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2156, col: 5, offset: 66487},
+					pos: position{line: 2175, col: 5, offset: 67011},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2156, col: 5, offset: 66487},
+							pos:   position{line: 2175, col: 5, offset: 67011},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 11, offset: 66493},
+								pos:  position{line: 2175, col: 11, offset: 67017},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2156, col: 23, offset: 66505},
+							pos:   position{line: 2175, col: 23, offset: 67029},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2156, col: 28, offset: 66510},
+								pos: position{line: 2175, col: 28, offset: 67034},
 								expr: &actionExpr{
-									pos: position{line: 2156, col: 30, offset: 66512},
+									pos: position{line: 2175, col: 30, offset: 67036},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2156, col: 30, offset: 66512},
+										pos: position{line: 2175, col: 30, offset: 67036},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2156, col: 30, offset: 66512},
+												pos:  position{line: 2175, col: 30, offset: 67036},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2156, col: 33, offset: 66515},
+												pos:        position{line: 2175, col: 33, offset: 67039},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2156, col: 37, offset: 66519},
+												pos:  position{line: 2175, col: 37, offset: 67043},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2156, col: 40, offset: 66522},
+												pos:   position{line: 2175, col: 40, offset: 67046},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2156, col: 42, offset: 66524},
+													pos:  position{line: 2175, col: 42, offset: 67048},
 													name: "OrderByItem",
 												},
 											},
@@ -15391,34 +15532,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2160, col: 1, offset: 66625},
+			pos:  position{line: 2179, col: 1, offset: 67149},
 			expr: &actionExpr{
-				pos: position{line: 2161, col: 5, offset: 66641},
+				pos: position{line: 2180, col: 5, offset: 67165},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2161, col: 5, offset: 66641},
+					pos: position{line: 2180, col: 5, offset: 67165},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2161, col: 5, offset: 66641},
+							pos:   position{line: 2180, col: 5, offset: 67165},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2161, col: 7, offset: 66643},
+								pos:  position{line: 2180, col: 7, offset: 67167},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2161, col: 12, offset: 66648},
+							pos:   position{line: 2180, col: 12, offset: 67172},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2161, col: 18, offset: 66654},
+								pos:  position{line: 2180, col: 18, offset: 67178},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2161, col: 29, offset: 66665},
+							pos:   position{line: 2180, col: 29, offset: 67189},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2161, col: 35, offset: 66671},
+								pos:  position{line: 2180, col: 35, offset: 67195},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15430,49 +15571,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2172, col: 1, offset: 66921},
+			pos:  position{line: 2191, col: 1, offset: 67445},
 			expr: &choiceExpr{
-				pos: position{line: 2173, col: 5, offset: 66936},
+				pos: position{line: 2192, col: 5, offset: 67460},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2173, col: 5, offset: 66936},
+						pos: position{line: 2192, col: 5, offset: 67460},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2173, col: 5, offset: 66936},
+							pos: position{line: 2192, col: 5, offset: 67460},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 5, offset: 66936},
+									pos:  position{line: 2192, col: 5, offset: 67460},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 7, offset: 66938},
+									pos:  position{line: 2192, col: 7, offset: 67462},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2174, col: 5, offset: 67010},
+						pos: position{line: 2193, col: 5, offset: 67534},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2174, col: 5, offset: 67010},
+							pos: position{line: 2193, col: 5, offset: 67534},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 5, offset: 67010},
+									pos:  position{line: 2193, col: 5, offset: 67534},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 7, offset: 67012},
+									pos:  position{line: 2193, col: 7, offset: 67536},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2175, col: 5, offset: 67084},
+						pos: position{line: 2194, col: 5, offset: 67608},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2175, col: 5, offset: 67084},
+							pos:        position{line: 2194, col: 5, offset: 67608},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15485,65 +15626,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2177, col: 1, offset: 67116},
+			pos:  position{line: 2196, col: 1, offset: 67640},
 			expr: &choiceExpr{
-				pos: position{line: 2178, col: 5, offset: 67134},
+				pos: position{line: 2197, col: 5, offset: 67658},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2178, col: 5, offset: 67134},
+						pos: position{line: 2197, col: 5, offset: 67658},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2178, col: 5, offset: 67134},
+							pos: position{line: 2197, col: 5, offset: 67658},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 5, offset: 67134},
+									pos:  position{line: 2197, col: 5, offset: 67658},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 7, offset: 67136},
+									pos:  position{line: 2197, col: 7, offset: 67660},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 13, offset: 67142},
+									pos:  position{line: 2197, col: 13, offset: 67666},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 15, offset: 67144},
+									pos:  position{line: 2197, col: 15, offset: 67668},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2179, col: 5, offset: 67220},
+						pos: position{line: 2198, col: 5, offset: 67744},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2179, col: 5, offset: 67220},
+							pos: position{line: 2198, col: 5, offset: 67744},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 5, offset: 67220},
+									pos:  position{line: 2198, col: 5, offset: 67744},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 7, offset: 67222},
+									pos:  position{line: 2198, col: 7, offset: 67746},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 13, offset: 67228},
+									pos:  position{line: 2198, col: 13, offset: 67752},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 15, offset: 67230},
+									pos:  position{line: 2198, col: 15, offset: 67754},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2180, col: 5, offset: 67305},
+						pos: position{line: 2199, col: 5, offset: 67829},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2180, col: 5, offset: 67305},
+							pos:        position{line: 2199, col: 5, offset: 67829},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15556,29 +15697,29 @@ var g = &grammar{
 		},
 		{
 			name: "SelectLimit",
-			pos:  position{line: 2182, col: 1, offset: 67350},
+			pos:  position{line: 2201, col: 1, offset: 67874},
 			expr: &choiceExpr{
-				pos: position{line: 2183, col: 5, offset: 67366},
+				pos: position{line: 2202, col: 5, offset: 67890},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2183, col: 5, offset: 67366},
+						pos: position{line: 2202, col: 5, offset: 67890},
 						run: (*parser).callonSelectLimit2,
 						expr: &seqExpr{
-							pos: position{line: 2183, col: 5, offset: 67366},
+							pos: position{line: 2202, col: 5, offset: 67890},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2183, col: 5, offset: 67366},
+									pos:   position{line: 2202, col: 5, offset: 67890},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2183, col: 7, offset: 67368},
+										pos:  position{line: 2202, col: 7, offset: 67892},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2183, col: 19, offset: 67380},
+									pos:   position{line: 2202, col: 19, offset: 67904},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2183, col: 21, offset: 67382},
+										pos:  position{line: 2202, col: 21, offset: 67906},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15586,24 +15727,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2190, col: 5, offset: 67528},
+						pos: position{line: 2209, col: 5, offset: 68052},
 						run: (*parser).callonSelectLimit8,
 						expr: &seqExpr{
-							pos: position{line: 2190, col: 5, offset: 67528},
+							pos: position{line: 2209, col: 5, offset: 68052},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2190, col: 5, offset: 67528},
+									pos:   position{line: 2209, col: 5, offset: 68052},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2190, col: 7, offset: 67530},
+										pos:  position{line: 2209, col: 7, offset: 68054},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2190, col: 20, offset: 67543},
+									pos:   position{line: 2209, col: 20, offset: 68067},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2190, col: 22, offset: 67545},
+										pos:  position{line: 2209, col: 22, offset: 68069},
 										name: "OptLimitClause",
 									},
 								},
@@ -15617,25 +15758,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2203, col: 1, offset: 67817},
+			pos:  position{line: 2222, col: 1, offset: 68341},
 			expr: &choiceExpr{
-				pos: position{line: 2204, col: 5, offset: 67837},
+				pos: position{line: 2223, col: 5, offset: 68361},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2204, col: 5, offset: 67837},
+						pos: position{line: 2223, col: 5, offset: 68361},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2204, col: 5, offset: 67837},
+							pos: position{line: 2223, col: 5, offset: 68361},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2204, col: 5, offset: 67837},
+									pos:  position{line: 2223, col: 5, offset: 68361},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2204, col: 7, offset: 67839},
+									pos:   position{line: 2223, col: 7, offset: 68363},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2204, col: 9, offset: 67841},
+										pos:  position{line: 2223, col: 9, offset: 68365},
 										name: "LimitClause",
 									},
 								},
@@ -15643,10 +15784,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2205, col: 5, offset: 67875},
+						pos: position{line: 2224, col: 5, offset: 68399},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2205, col: 5, offset: 67875},
+							pos:        position{line: 2224, col: 5, offset: 68399},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15659,50 +15800,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2207, col: 1, offset: 67912},
+			pos:  position{line: 2226, col: 1, offset: 68436},
 			expr: &choiceExpr{
-				pos: position{line: 2208, col: 5, offset: 67929},
+				pos: position{line: 2227, col: 5, offset: 68453},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2208, col: 5, offset: 67929},
+						pos: position{line: 2227, col: 5, offset: 68453},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2208, col: 5, offset: 67929},
+							pos: position{line: 2227, col: 5, offset: 68453},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2208, col: 5, offset: 67929},
+									pos:  position{line: 2227, col: 5, offset: 68453},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2208, col: 11, offset: 67935},
+									pos:  position{line: 2227, col: 11, offset: 68459},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2208, col: 13, offset: 67937},
+									pos:  position{line: 2227, col: 13, offset: 68461},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2209, col: 5, offset: 67999},
+						pos: position{line: 2228, col: 5, offset: 68523},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2209, col: 5, offset: 67999},
+							pos: position{line: 2228, col: 5, offset: 68523},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2209, col: 5, offset: 67999},
+									pos:  position{line: 2228, col: 5, offset: 68523},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2209, col: 11, offset: 68005},
+									pos:  position{line: 2228, col: 11, offset: 68529},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2209, col: 13, offset: 68007},
+									pos:   position{line: 2228, col: 13, offset: 68531},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2209, col: 15, offset: 68009},
+										pos:  position{line: 2228, col: 15, offset: 68533},
 										name: "Expr",
 									},
 								},
@@ -15716,25 +15857,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2217, col: 1, offset: 68134},
+			pos:  position{line: 2236, col: 1, offset: 68658},
 			expr: &choiceExpr{
-				pos: position{line: 2218, col: 5, offset: 68155},
+				pos: position{line: 2237, col: 5, offset: 68679},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2218, col: 5, offset: 68155},
+						pos: position{line: 2237, col: 5, offset: 68679},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2218, col: 5, offset: 68155},
+							pos: position{line: 2237, col: 5, offset: 68679},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2218, col: 5, offset: 68155},
+									pos:  position{line: 2237, col: 5, offset: 68679},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2218, col: 7, offset: 68157},
+									pos:   position{line: 2237, col: 7, offset: 68681},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2218, col: 9, offset: 68159},
+										pos:  position{line: 2237, col: 9, offset: 68683},
 										name: "OffsetClause",
 									},
 								},
@@ -15742,10 +15883,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2219, col: 5, offset: 68195},
+						pos: position{line: 2238, col: 5, offset: 68719},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2219, col: 5, offset: 68195},
+							pos:        position{line: 2238, col: 5, offset: 68719},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15758,26 +15899,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2221, col: 1, offset: 68220},
+			pos:  position{line: 2240, col: 1, offset: 68744},
 			expr: &actionExpr{
-				pos: position{line: 2222, col: 5, offset: 68238},
+				pos: position{line: 2241, col: 5, offset: 68762},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2222, col: 5, offset: 68238},
+					pos: position{line: 2241, col: 5, offset: 68762},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2222, col: 5, offset: 68238},
+							pos:  position{line: 2241, col: 5, offset: 68762},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2222, col: 12, offset: 68245},
+							pos:  position{line: 2241, col: 12, offset: 68769},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2222, col: 14, offset: 68247},
+							pos:   position{line: 2241, col: 14, offset: 68771},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2222, col: 16, offset: 68249},
+								pos:  position{line: 2241, col: 16, offset: 68773},
 								name: "Expr",
 							},
 						},
@@ -15789,103 +15930,103 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2224, col: 1, offset: 68274},
+			pos:  position{line: 2243, col: 1, offset: 68798},
 			expr: &actionExpr{
-				pos: position{line: 2225, col: 5, offset: 68291},
+				pos: position{line: 2244, col: 5, offset: 68815},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2225, col: 5, offset: 68291},
+					pos: position{line: 2244, col: 5, offset: 68815},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2225, col: 5, offset: 68291},
+							pos:   position{line: 2244, col: 5, offset: 68815},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2225, col: 10, offset: 68296},
+								pos:  position{line: 2244, col: 10, offset: 68820},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2225, col: 21, offset: 68307},
+							pos:   position{line: 2244, col: 21, offset: 68831},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2225, col: 30, offset: 68316},
+								pos:  position{line: 2244, col: 30, offset: 68840},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2225, col: 36, offset: 68322},
+							pos:  position{line: 2244, col: 36, offset: 68846},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2225, col: 38, offset: 68324},
+							pos:   position{line: 2244, col: 38, offset: 68848},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2225, col: 44, offset: 68330},
+								pos:  position{line: 2244, col: 44, offset: 68854},
 								name: "SelectExpr",
 							},
 						},
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2235, col: 1, offset: 68551},
+			pos:  position{line: 2254, col: 1, offset: 69075},
 			expr: &choiceExpr{
-				pos: position{line: 2236, col: 5, offset: 68562},
+				pos: position{line: 2255, col: 5, offset: 69086},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2236, col: 5, offset: 68562},
+						pos: position{line: 2255, col: 5, offset: 69086},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2236, col: 5, offset: 68562},
+							pos: position{line: 2255, col: 5, offset: 69086},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2236, col: 5, offset: 68562},
+									pos:  position{line: 2255, col: 5, offset: 69086},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2236, col: 7, offset: 68564},
+									pos:  position{line: 2255, col: 7, offset: 69088},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2236, col: 13, offset: 68570},
+									pos:  position{line: 2255, col: 13, offset: 69094},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2236, col: 15, offset: 68572},
+									pos:  position{line: 2255, col: 15, offset: 69096},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2237, col: 5, offset: 68608},
+						pos: position{line: 2256, col: 5, offset: 69132},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2237, col: 5, offset: 68608},
+							pos: position{line: 2256, col: 5, offset: 69132},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2237, col: 5, offset: 68608},
+									pos:  position{line: 2256, col: 5, offset: 69132},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2237, col: 7, offset: 68610},
+									pos:  position{line: 2256, col: 7, offset: 69134},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2237, col: 13, offset: 68616},
+									pos: position{line: 2256, col: 13, offset: 69140},
 									expr: &seqExpr{
-										pos: position{line: 2237, col: 14, offset: 68617},
+										pos: position{line: 2256, col: 14, offset: 69141},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2237, col: 14, offset: 68617},
+												pos:  position{line: 2256, col: 14, offset: 69141},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2237, col: 16, offset: 68619},
+												pos:  position{line: 2256, col: 16, offset: 69143},
 												name: "DISTINCT",
 											},
 										},
@@ -15901,80 +16042,80 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2240, col: 1, offset: 68671},
+			pos:  position{line: 2259, col: 1, offset: 69195},
 			expr: &choiceExpr{
-				pos: position{line: 2241, col: 5, offset: 68686},
+				pos: position{line: 2260, col: 5, offset: 69210},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2241, col: 5, offset: 68686},
+						pos:  position{line: 2260, col: 5, offset: 69210},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2241, col: 12, offset: 68693},
+						pos:  position{line: 2260, col: 12, offset: 69217},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2241, col: 20, offset: 68701},
+						pos:  position{line: 2260, col: 20, offset: 69225},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2241, col: 29, offset: 68710},
+						pos:  position{line: 2260, col: 29, offset: 69234},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2241, col: 38, offset: 68719},
+						pos:  position{line: 2260, col: 38, offset: 69243},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2242, col: 5, offset: 68733},
+						pos:  position{line: 2261, col: 5, offset: 69257},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2242, col: 13, offset: 68741},
+						pos:  position{line: 2261, col: 13, offset: 69265},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2242, col: 20, offset: 68748},
+						pos:  position{line: 2261, col: 20, offset: 69272},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2242, col: 28, offset: 68756},
+						pos:  position{line: 2261, col: 28, offset: 69280},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2242, col: 36, offset: 68764},
+						pos:  position{line: 2261, col: 36, offset: 69288},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2242, col: 44, offset: 68772},
+						pos:  position{line: 2261, col: 44, offset: 69296},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2243, col: 5, offset: 68781},
+						pos:  position{line: 2262, col: 5, offset: 69305},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2244, col: 5, offset: 68791},
+						pos:  position{line: 2263, col: 5, offset: 69315},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2245, col: 5, offset: 68801},
+						pos:  position{line: 2264, col: 5, offset: 69325},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2246, col: 5, offset: 68811},
+						pos:  position{line: 2265, col: 5, offset: 69335},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2247, col: 5, offset: 68822},
+						pos:  position{line: 2266, col: 5, offset: 69346},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2248, col: 5, offset: 68831},
+						pos:  position{line: 2267, col: 5, offset: 69355},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2249, col: 5, offset: 68841},
+						pos:  position{line: 2268, col: 5, offset: 69365},
 						name: "ON",
 					},
 				},
@@ -15984,20 +16125,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2251, col: 1, offset: 68845},
+			pos:  position{line: 2270, col: 1, offset: 69369},
 			expr: &seqExpr{
-				pos: position{line: 2251, col: 14, offset: 68858},
+				pos: position{line: 2270, col: 14, offset: 69382},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2251, col: 14, offset: 68858},
+						pos:        position{line: 2270, col: 14, offset: 69382},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2251, col: 33, offset: 68877},
+						pos: position{line: 2270, col: 33, offset: 69401},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2251, col: 34, offset: 68878},
+							pos:  position{line: 2270, col: 34, offset: 69402},
 							name: "IdentifierRest",
 						},
 					},
@@ -16008,20 +16149,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2252, col: 1, offset: 68893},
+			pos:  position{line: 2271, col: 1, offset: 69417},
 			expr: &seqExpr{
-				pos: position{line: 2252, col: 14, offset: 68906},
+				pos: position{line: 2271, col: 14, offset: 69430},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2252, col: 14, offset: 68906},
+						pos:        position{line: 2271, col: 14, offset: 69430},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2252, col: 33, offset: 68925},
+						pos: position{line: 2271, col: 33, offset: 69449},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2252, col: 34, offset: 68926},
+							pos:  position{line: 2271, col: 34, offset: 69450},
 							name: "IdentifierRest",
 						},
 					},
@@ -16032,23 +16173,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2253, col: 1, offset: 68941},
+			pos:  position{line: 2272, col: 1, offset: 69465},
 			expr: &actionExpr{
-				pos: position{line: 2253, col: 14, offset: 68954},
+				pos: position{line: 2272, col: 14, offset: 69478},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2253, col: 14, offset: 68954},
+					pos: position{line: 2272, col: 14, offset: 69478},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2253, col: 14, offset: 68954},
+							pos:        position{line: 2272, col: 14, offset: 69478},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2253, col: 33, offset: 68973},
+							pos: position{line: 2272, col: 33, offset: 69497},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2253, col: 34, offset: 68974},
+								pos:  position{line: 2272, col: 34, offset: 69498},
 								name: "IdentifierRest",
 							},
 						},
@@ -16060,20 +16201,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2254, col: 1, offset: 69011},
+			pos:  position{line: 2273, col: 1, offset: 69535},
 			expr: &seqExpr{
-				pos: position{line: 2254, col: 14, offset: 69024},
+				pos: position{line: 2273, col: 14, offset: 69548},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2254, col: 14, offset: 69024},
+						pos:        position{line: 2273, col: 14, offset: 69548},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2254, col: 33, offset: 69043},
+						pos: position{line: 2273, col: 33, offset: 69567},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2254, col: 34, offset: 69044},
+							pos:  position{line: 2273, col: 34, offset: 69568},
 							name: "IdentifierRest",
 						},
 					},
@@ -16084,20 +16225,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2255, col: 1, offset: 69059},
+			pos:  position{line: 2274, col: 1, offset: 69583},
 			expr: &seqExpr{
-				pos: position{line: 2255, col: 14, offset: 69072},
+				pos: position{line: 2274, col: 14, offset: 69596},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2255, col: 14, offset: 69072},
+						pos:        position{line: 2274, col: 14, offset: 69596},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2255, col: 33, offset: 69091},
+						pos: position{line: 2274, col: 33, offset: 69615},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2255, col: 34, offset: 69092},
+							pos:  position{line: 2274, col: 34, offset: 69616},
 							name: "IdentifierRest",
 						},
 					},
@@ -16108,23 +16249,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2256, col: 1, offset: 69107},
+			pos:  position{line: 2275, col: 1, offset: 69631},
 			expr: &actionExpr{
-				pos: position{line: 2256, col: 14, offset: 69120},
+				pos: position{line: 2275, col: 14, offset: 69644},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2256, col: 14, offset: 69120},
+					pos: position{line: 2275, col: 14, offset: 69644},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2256, col: 14, offset: 69120},
+							pos:        position{line: 2275, col: 14, offset: 69644},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2256, col: 33, offset: 69139},
+							pos: position{line: 2275, col: 33, offset: 69663},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2256, col: 34, offset: 69140},
+								pos:  position{line: 2275, col: 34, offset: 69664},
 								name: "IdentifierRest",
 							},
 						},
@@ -16136,20 +16277,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2257, col: 1, offset: 69177},
+			pos:  position{line: 2276, col: 1, offset: 69701},
 			expr: &seqExpr{
-				pos: position{line: 2257, col: 14, offset: 69190},
+				pos: position{line: 2276, col: 14, offset: 69714},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2257, col: 14, offset: 69190},
+						pos:        position{line: 2276, col: 14, offset: 69714},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2257, col: 33, offset: 69209},
+						pos: position{line: 2276, col: 33, offset: 69733},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2257, col: 34, offset: 69210},
+							pos:  position{line: 2276, col: 34, offset: 69734},
 							name: "IdentifierRest",
 						},
 					},
@@ -16160,20 +16301,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2258, col: 1, offset: 69225},
+			pos:  position{line: 2277, col: 1, offset: 69749},
 			expr: &seqExpr{
-				pos: position{line: 2258, col: 14, offset: 69238},
+				pos: position{line: 2277, col: 14, offset: 69762},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2258, col: 14, offset: 69238},
+						pos:        position{line: 2277, col: 14, offset: 69762},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2258, col: 33, offset: 69257},
+						pos: position{line: 2277, col: 33, offset: 69781},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2258, col: 34, offset: 69258},
+							pos:  position{line: 2277, col: 34, offset: 69782},
 							name: "IdentifierRest",
 						},
 					},
@@ -16184,20 +16325,20 @@ var g = &grammar{
 		},
 		{
 			name: "AUTHOR",
-			pos:  position{line: 2259, col: 1, offset: 69273},
+			pos:  position{line: 2278, col: 1, offset: 69797},
 			expr: &seqExpr{
-				pos: position{line: 2259, col: 14, offset: 69286},
+				pos: position{line: 2278, col: 14, offset: 69810},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2259, col: 14, offset: 69286},
+						pos:        position{line: 2278, col: 14, offset: 69810},
 						val:        "author",
 						ignoreCase: true,
 						want:       "\"AUTHOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2259, col: 33, offset: 69305},
+						pos: position{line: 2278, col: 33, offset: 69829},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2259, col: 34, offset: 69306},
+							pos:  position{line: 2278, col: 34, offset: 69830},
 							name: "IdentifierRest",
 						},
 					},
@@ -16208,20 +16349,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2260, col: 1, offset: 69321},
+			pos:  position{line: 2279, col: 1, offset: 69845},
 			expr: &seqExpr{
-				pos: position{line: 2260, col: 14, offset: 69334},
+				pos: position{line: 2279, col: 14, offset: 69858},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2260, col: 14, offset: 69334},
+						pos:        position{line: 2279, col: 14, offset: 69858},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2260, col: 33, offset: 69353},
+						pos: position{line: 2279, col: 33, offset: 69877},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2260, col: 34, offset: 69354},
+							pos:  position{line: 2279, col: 34, offset: 69878},
 							name: "IdentifierRest",
 						},
 					},
@@ -16232,20 +16373,20 @@ var g = &grammar{
 		},
 		{
 			name: "BODY",
-			pos:  position{line: 2261, col: 1, offset: 69369},
+			pos:  position{line: 2280, col: 1, offset: 69893},
 			expr: &seqExpr{
-				pos: position{line: 2261, col: 14, offset: 69382},
+				pos: position{line: 2280, col: 14, offset: 69906},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2261, col: 14, offset: 69382},
+						pos:        position{line: 2280, col: 14, offset: 69906},
 						val:        "body",
 						ignoreCase: true,
 						want:       "\"BODY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2261, col: 33, offset: 69401},
+						pos: position{line: 2280, col: 33, offset: 69925},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2261, col: 34, offset: 69402},
+							pos:  position{line: 2280, col: 34, offset: 69926},
 							name: "IdentifierRest",
 						},
 					},
@@ -16256,20 +16397,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2262, col: 1, offset: 69417},
+			pos:  position{line: 2281, col: 1, offset: 69941},
 			expr: &seqExpr{
-				pos: position{line: 2262, col: 14, offset: 69430},
+				pos: position{line: 2281, col: 14, offset: 69954},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2262, col: 14, offset: 69430},
+						pos:        position{line: 2281, col: 14, offset: 69954},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2262, col: 33, offset: 69449},
+						pos: position{line: 2281, col: 33, offset: 69973},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2262, col: 34, offset: 69450},
+							pos:  position{line: 2281, col: 34, offset: 69974},
 							name: "IdentifierRest",
 						},
 					},
@@ -16280,20 +16421,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2263, col: 1, offset: 69465},
+			pos:  position{line: 2282, col: 1, offset: 69989},
 			expr: &seqExpr{
-				pos: position{line: 2263, col: 14, offset: 69478},
+				pos: position{line: 2282, col: 14, offset: 70002},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2263, col: 14, offset: 69478},
+						pos:        position{line: 2282, col: 14, offset: 70002},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2263, col: 33, offset: 69497},
+						pos: position{line: 2282, col: 33, offset: 70021},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2263, col: 34, offset: 69498},
+							pos:  position{line: 2282, col: 34, offset: 70022},
 							name: "IdentifierRest",
 						},
 					},
@@ -16304,20 +16445,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2264, col: 1, offset: 69513},
+			pos:  position{line: 2283, col: 1, offset: 70037},
 			expr: &seqExpr{
-				pos: position{line: 2264, col: 14, offset: 69526},
+				pos: position{line: 2283, col: 14, offset: 70050},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2264, col: 14, offset: 69526},
+						pos:        position{line: 2283, col: 14, offset: 70050},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2264, col: 33, offset: 69545},
+						pos: position{line: 2283, col: 33, offset: 70069},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2264, col: 34, offset: 69546},
+							pos:  position{line: 2283, col: 34, offset: 70070},
 							name: "IdentifierRest",
 						},
 					},
@@ -16328,20 +16469,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2265, col: 1, offset: 69561},
+			pos:  position{line: 2284, col: 1, offset: 70085},
 			expr: &seqExpr{
-				pos: position{line: 2265, col: 14, offset: 69574},
+				pos: position{line: 2284, col: 14, offset: 70098},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2265, col: 14, offset: 69574},
+						pos:        position{line: 2284, col: 14, offset: 70098},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2265, col: 33, offset: 69593},
+						pos: position{line: 2284, col: 33, offset: 70117},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2265, col: 34, offset: 69594},
+							pos:  position{line: 2284, col: 34, offset: 70118},
 							name: "IdentifierRest",
 						},
 					},
@@ -16352,20 +16493,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2266, col: 1, offset: 69609},
+			pos:  position{line: 2285, col: 1, offset: 70133},
 			expr: &seqExpr{
-				pos: position{line: 2266, col: 14, offset: 69622},
+				pos: position{line: 2285, col: 14, offset: 70146},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2266, col: 14, offset: 69622},
+						pos:        position{line: 2285, col: 14, offset: 70146},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2266, col: 33, offset: 69641},
+						pos: position{line: 2285, col: 33, offset: 70165},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2266, col: 34, offset: 69642},
+							pos:  position{line: 2285, col: 34, offset: 70166},
 							name: "IdentifierRest",
 						},
 					},
@@ -16376,20 +16517,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2267, col: 1, offset: 69657},
+			pos:  position{line: 2286, col: 1, offset: 70181},
 			expr: &seqExpr{
-				pos: position{line: 2267, col: 14, offset: 69670},
+				pos: position{line: 2286, col: 14, offset: 70194},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2267, col: 14, offset: 69670},
+						pos:        position{line: 2286, col: 14, offset: 70194},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2267, col: 33, offset: 69689},
+						pos: position{line: 2286, col: 33, offset: 70213},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2267, col: 34, offset: 69690},
+							pos:  position{line: 2286, col: 34, offset: 70214},
 							name: "IdentifierRest",
 						},
 					},
@@ -16400,20 +16541,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2268, col: 1, offset: 69705},
+			pos:  position{line: 2287, col: 1, offset: 70229},
 			expr: &seqExpr{
-				pos: position{line: 2268, col: 14, offset: 69718},
+				pos: position{line: 2287, col: 14, offset: 70242},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2268, col: 14, offset: 69718},
+						pos:        position{line: 2287, col: 14, offset: 70242},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2268, col: 33, offset: 69737},
+						pos: position{line: 2287, col: 33, offset: 70261},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2268, col: 34, offset: 69738},
+							pos:  position{line: 2287, col: 34, offset: 70262},
 							name: "IdentifierRest",
 						},
 					},
@@ -16424,23 +16565,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2269, col: 1, offset: 69753},
+			pos:  position{line: 2288, col: 1, offset: 70277},
 			expr: &actionExpr{
-				pos: position{line: 2269, col: 14, offset: 69766},
+				pos: position{line: 2288, col: 14, offset: 70290},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2269, col: 14, offset: 69766},
+					pos: position{line: 2288, col: 14, offset: 70290},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2269, col: 14, offset: 69766},
+							pos:        position{line: 2288, col: 14, offset: 70290},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2269, col: 33, offset: 69785},
+							pos: position{line: 2288, col: 33, offset: 70309},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2269, col: 34, offset: 69786},
+								pos:  position{line: 2288, col: 34, offset: 70310},
 								name: "IdentifierRest",
 							},
 						},
@@ -16452,20 +16593,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2270, col: 1, offset: 69824},
+			pos:  position{line: 2289, col: 1, offset: 70348},
 			expr: &seqExpr{
-				pos: position{line: 2270, col: 14, offset: 69837},
+				pos: position{line: 2289, col: 14, offset: 70361},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2270, col: 14, offset: 69837},
+						pos:        position{line: 2289, col: 14, offset: 70361},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2270, col: 33, offset: 69856},
+						pos: position{line: 2289, col: 33, offset: 70380},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2270, col: 34, offset: 69857},
+							pos:  position{line: 2289, col: 34, offset: 70381},
 							name: "IdentifierRest",
 						},
 					},
@@ -16476,20 +16617,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2271, col: 1, offset: 69872},
+			pos:  position{line: 2290, col: 1, offset: 70396},
 			expr: &seqExpr{
-				pos: position{line: 2271, col: 14, offset: 69885},
+				pos: position{line: 2290, col: 14, offset: 70409},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2271, col: 14, offset: 69885},
+						pos:        position{line: 2290, col: 14, offset: 70409},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2271, col: 33, offset: 69904},
+						pos: position{line: 2290, col: 33, offset: 70428},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2271, col: 34, offset: 69905},
+							pos:  position{line: 2290, col: 34, offset: 70429},
 							name: "IdentifierRest",
 						},
 					},
@@ -16500,23 +16641,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2272, col: 1, offset: 69920},
+			pos:  position{line: 2291, col: 1, offset: 70444},
 			expr: &actionExpr{
-				pos: position{line: 2272, col: 14, offset: 69933},
+				pos: position{line: 2291, col: 14, offset: 70457},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2272, col: 14, offset: 69933},
+					pos: position{line: 2291, col: 14, offset: 70457},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2272, col: 14, offset: 69933},
+							pos:        position{line: 2291, col: 14, offset: 70457},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2272, col: 33, offset: 69952},
+							pos: position{line: 2291, col: 33, offset: 70476},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2272, col: 34, offset: 69953},
+								pos:  position{line: 2291, col: 34, offset: 70477},
 								name: "IdentifierRest",
 							},
 						},
@@ -16528,20 +16669,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2273, col: 1, offset: 69991},
+			pos:  position{line: 2292, col: 1, offset: 70515},
 			expr: &seqExpr{
-				pos: position{line: 2273, col: 14, offset: 70004},
+				pos: position{line: 2292, col: 14, offset: 70528},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2273, col: 14, offset: 70004},
+						pos:        position{line: 2292, col: 14, offset: 70528},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2273, col: 33, offset: 70023},
+						pos: position{line: 2292, col: 33, offset: 70547},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2273, col: 34, offset: 70024},
+							pos:  position{line: 2292, col: 34, offset: 70548},
 							name: "IdentifierRest",
 						},
 					},
@@ -16552,20 +16693,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2274, col: 1, offset: 70039},
+			pos:  position{line: 2293, col: 1, offset: 70563},
 			expr: &seqExpr{
-				pos: position{line: 2274, col: 14, offset: 70052},
+				pos: position{line: 2293, col: 14, offset: 70576},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2274, col: 14, offset: 70052},
+						pos:        position{line: 2293, col: 14, offset: 70576},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2274, col: 33, offset: 70071},
+						pos: position{line: 2293, col: 33, offset: 70595},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2274, col: 34, offset: 70072},
+							pos:  position{line: 2293, col: 34, offset: 70596},
 							name: "IdentifierRest",
 						},
 					},
@@ -16576,20 +16717,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2275, col: 1, offset: 70088},
+			pos:  position{line: 2294, col: 1, offset: 70612},
 			expr: &seqExpr{
-				pos: position{line: 2275, col: 14, offset: 70101},
+				pos: position{line: 2294, col: 14, offset: 70625},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2275, col: 14, offset: 70101},
+						pos:        position{line: 2294, col: 14, offset: 70625},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2275, col: 33, offset: 70120},
+						pos: position{line: 2294, col: 33, offset: 70644},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2275, col: 34, offset: 70121},
+							pos:  position{line: 2294, col: 34, offset: 70645},
 							name: "IdentifierRest",
 						},
 					},
@@ -16600,20 +16741,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2276, col: 1, offset: 70136},
+			pos:  position{line: 2295, col: 1, offset: 70660},
 			expr: &seqExpr{
-				pos: position{line: 2276, col: 14, offset: 70149},
+				pos: position{line: 2295, col: 14, offset: 70673},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2276, col: 14, offset: 70149},
+						pos:        position{line: 2295, col: 14, offset: 70673},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2276, col: 33, offset: 70168},
+						pos: position{line: 2295, col: 33, offset: 70692},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2276, col: 34, offset: 70169},
+							pos:  position{line: 2295, col: 34, offset: 70693},
 							name: "IdentifierRest",
 						},
 					},
@@ -16624,20 +16765,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2277, col: 1, offset: 70184},
+			pos:  position{line: 2296, col: 1, offset: 70708},
 			expr: &seqExpr{
-				pos: position{line: 2277, col: 14, offset: 70197},
+				pos: position{line: 2296, col: 14, offset: 70721},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2277, col: 14, offset: 70197},
+						pos:        position{line: 2296, col: 14, offset: 70721},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2277, col: 33, offset: 70216},
+						pos: position{line: 2296, col: 33, offset: 70740},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2277, col: 34, offset: 70217},
+							pos:  position{line: 2296, col: 34, offset: 70741},
 							name: "IdentifierRest",
 						},
 					},
@@ -16648,20 +16789,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2278, col: 1, offset: 70232},
+			pos:  position{line: 2297, col: 1, offset: 70756},
 			expr: &seqExpr{
-				pos: position{line: 2278, col: 14, offset: 70245},
+				pos: position{line: 2297, col: 14, offset: 70769},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2278, col: 14, offset: 70245},
+						pos:        position{line: 2297, col: 14, offset: 70769},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2278, col: 33, offset: 70264},
+						pos: position{line: 2297, col: 33, offset: 70788},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2278, col: 34, offset: 70265},
+							pos:  position{line: 2297, col: 34, offset: 70789},
 							name: "IdentifierRest",
 						},
 					},
@@ -16672,20 +16813,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2279, col: 1, offset: 70280},
+			pos:  position{line: 2298, col: 1, offset: 70804},
 			expr: &seqExpr{
-				pos: position{line: 2279, col: 14, offset: 70293},
+				pos: position{line: 2298, col: 14, offset: 70817},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2279, col: 14, offset: 70293},
+						pos:        position{line: 2298, col: 14, offset: 70817},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2279, col: 33, offset: 70312},
+						pos: position{line: 2298, col: 33, offset: 70836},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2279, col: 34, offset: 70313},
+							pos:  position{line: 2298, col: 34, offset: 70837},
 							name: "IdentifierRest",
 						},
 					},
@@ -16696,20 +16837,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2280, col: 1, offset: 70328},
+			pos:  position{line: 2299, col: 1, offset: 70852},
 			expr: &seqExpr{
-				pos: position{line: 2280, col: 14, offset: 70341},
+				pos: position{line: 2299, col: 14, offset: 70865},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2280, col: 14, offset: 70341},
+						pos:        position{line: 2299, col: 14, offset: 70865},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2280, col: 33, offset: 70360},
+						pos: position{line: 2299, col: 33, offset: 70884},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2280, col: 34, offset: 70361},
+							pos:  position{line: 2299, col: 34, offset: 70885},
 							name: "IdentifierRest",
 						},
 					},
@@ -16720,20 +16861,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2281, col: 1, offset: 70376},
+			pos:  position{line: 2300, col: 1, offset: 70900},
 			expr: &seqExpr{
-				pos: position{line: 2281, col: 14, offset: 70389},
+				pos: position{line: 2300, col: 14, offset: 70913},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2281, col: 14, offset: 70389},
+						pos:        position{line: 2300, col: 14, offset: 70913},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2281, col: 33, offset: 70408},
+						pos: position{line: 2300, col: 33, offset: 70932},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2281, col: 34, offset: 70409},
+							pos:  position{line: 2300, col: 34, offset: 70933},
 							name: "IdentifierRest",
 						},
 					},
@@ -16744,20 +16885,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2282, col: 1, offset: 70424},
+			pos:  position{line: 2301, col: 1, offset: 70948},
 			expr: &seqExpr{
-				pos: position{line: 2282, col: 14, offset: 70437},
+				pos: position{line: 2301, col: 14, offset: 70961},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2282, col: 14, offset: 70437},
+						pos:        position{line: 2301, col: 14, offset: 70961},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2282, col: 33, offset: 70456},
+						pos: position{line: 2301, col: 33, offset: 70980},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2282, col: 34, offset: 70457},
+							pos:  position{line: 2301, col: 34, offset: 70981},
 							name: "IdentifierRest",
 						},
 					},
@@ -16768,20 +16909,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2283, col: 1, offset: 70472},
+			pos:  position{line: 2302, col: 1, offset: 70996},
 			expr: &seqExpr{
-				pos: position{line: 2283, col: 14, offset: 70485},
+				pos: position{line: 2302, col: 14, offset: 71009},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2283, col: 14, offset: 70485},
+						pos:        position{line: 2302, col: 14, offset: 71009},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2283, col: 33, offset: 70504},
+						pos: position{line: 2302, col: 33, offset: 71028},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2283, col: 34, offset: 70505},
+							pos:  position{line: 2302, col: 34, offset: 71029},
 							name: "IdentifierRest",
 						},
 					},
@@ -16792,20 +16933,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORMAT",
-			pos:  position{line: 2284, col: 1, offset: 70520},
+			pos:  position{line: 2303, col: 1, offset: 71044},
 			expr: &seqExpr{
-				pos: position{line: 2284, col: 14, offset: 70533},
+				pos: position{line: 2303, col: 14, offset: 71057},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2284, col: 14, offset: 70533},
+						pos:        position{line: 2303, col: 14, offset: 71057},
 						val:        "format",
 						ignoreCase: true,
 						want:       "\"FORMAT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2284, col: 33, offset: 70552},
+						pos: position{line: 2303, col: 33, offset: 71076},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2284, col: 34, offset: 70553},
+							pos:  position{line: 2303, col: 34, offset: 71077},
 							name: "IdentifierRest",
 						},
 					},
@@ -16816,20 +16957,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2285, col: 1, offset: 70568},
+			pos:  position{line: 2304, col: 1, offset: 71092},
 			expr: &seqExpr{
-				pos: position{line: 2285, col: 14, offset: 70581},
+				pos: position{line: 2304, col: 14, offset: 71105},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2285, col: 14, offset: 70581},
+						pos:        position{line: 2304, col: 14, offset: 71105},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2285, col: 33, offset: 70600},
+						pos: position{line: 2304, col: 33, offset: 71124},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2285, col: 34, offset: 70601},
+							pos:  position{line: 2304, col: 34, offset: 71125},
 							name: "IdentifierRest",
 						},
 					},
@@ -16840,20 +16981,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2286, col: 1, offset: 70616},
+			pos:  position{line: 2305, col: 1, offset: 71140},
 			expr: &seqExpr{
-				pos: position{line: 2286, col: 14, offset: 70629},
+				pos: position{line: 2305, col: 14, offset: 71153},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2286, col: 14, offset: 70629},
+						pos:        position{line: 2305, col: 14, offset: 71153},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2286, col: 33, offset: 70648},
+						pos: position{line: 2305, col: 33, offset: 71172},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2286, col: 34, offset: 70649},
+							pos:  position{line: 2305, col: 34, offset: 71173},
 							name: "IdentifierRest",
 						},
 					},
@@ -16864,20 +17005,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2287, col: 1, offset: 70664},
+			pos:  position{line: 2306, col: 1, offset: 71188},
 			expr: &seqExpr{
-				pos: position{line: 2287, col: 14, offset: 70677},
+				pos: position{line: 2306, col: 14, offset: 71201},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2287, col: 14, offset: 70677},
+						pos:        position{line: 2306, col: 14, offset: 71201},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2287, col: 33, offset: 70696},
+						pos: position{line: 2306, col: 33, offset: 71220},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2287, col: 34, offset: 70697},
+							pos:  position{line: 2306, col: 34, offset: 71221},
 							name: "IdentifierRest",
 						},
 					},
@@ -16888,20 +17029,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2288, col: 1, offset: 70712},
+			pos:  position{line: 2307, col: 1, offset: 71236},
 			expr: &seqExpr{
-				pos: position{line: 2288, col: 14, offset: 70725},
+				pos: position{line: 2307, col: 14, offset: 71249},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2288, col: 14, offset: 70725},
+						pos:        position{line: 2307, col: 14, offset: 71249},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2288, col: 33, offset: 70744},
+						pos: position{line: 2307, col: 33, offset: 71268},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2288, col: 34, offset: 70745},
+							pos:  position{line: 2307, col: 34, offset: 71269},
 							name: "IdentifierRest",
 						},
 					},
@@ -16912,20 +17053,20 @@ var g = &grammar{
 		},
 		{
 			name: "GREP",
-			pos:  position{line: 2289, col: 1, offset: 70760},
+			pos:  position{line: 2308, col: 1, offset: 71284},
 			expr: &seqExpr{
-				pos: position{line: 2289, col: 14, offset: 70773},
+				pos: position{line: 2308, col: 14, offset: 71297},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2289, col: 14, offset: 70773},
+						pos:        position{line: 2308, col: 14, offset: 71297},
 						val:        "grep",
 						ignoreCase: true,
 						want:       "\"GREP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2289, col: 33, offset: 70792},
+						pos: position{line: 2308, col: 33, offset: 71316},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2289, col: 34, offset: 70793},
+							pos:  position{line: 2308, col: 34, offset: 71317},
 							name: "IdentifierRest",
 						},
 					},
@@ -16936,20 +17077,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2290, col: 1, offset: 70808},
+			pos:  position{line: 2309, col: 1, offset: 71332},
 			expr: &seqExpr{
-				pos: position{line: 2290, col: 14, offset: 70821},
+				pos: position{line: 2309, col: 14, offset: 71345},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2290, col: 14, offset: 70821},
+						pos:        position{line: 2309, col: 14, offset: 71345},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2290, col: 33, offset: 70840},
+						pos: position{line: 2309, col: 33, offset: 71364},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2290, col: 34, offset: 70841},
+							pos:  position{line: 2309, col: 34, offset: 71365},
 							name: "IdentifierRest",
 						},
 					},
@@ -16960,20 +17101,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2291, col: 1, offset: 70856},
+			pos:  position{line: 2310, col: 1, offset: 71380},
 			expr: &seqExpr{
-				pos: position{line: 2291, col: 14, offset: 70869},
+				pos: position{line: 2310, col: 14, offset: 71393},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2291, col: 14, offset: 70869},
+						pos:        position{line: 2310, col: 14, offset: 71393},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2291, col: 33, offset: 70888},
+						pos: position{line: 2310, col: 33, offset: 71412},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2291, col: 34, offset: 70889},
+							pos:  position{line: 2310, col: 34, offset: 71413},
 							name: "IdentifierRest",
 						},
 					},
@@ -16984,20 +17125,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2292, col: 1, offset: 70904},
+			pos:  position{line: 2311, col: 1, offset: 71428},
 			expr: &seqExpr{
-				pos: position{line: 2292, col: 14, offset: 70917},
+				pos: position{line: 2311, col: 14, offset: 71441},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2292, col: 14, offset: 70917},
+						pos:        position{line: 2311, col: 14, offset: 71441},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2292, col: 33, offset: 70936},
+						pos: position{line: 2311, col: 33, offset: 71460},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2292, col: 34, offset: 70937},
+							pos:  position{line: 2311, col: 34, offset: 71461},
 							name: "IdentifierRest",
 						},
 					},
@@ -17008,20 +17149,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEADERS",
-			pos:  position{line: 2293, col: 1, offset: 70953},
+			pos:  position{line: 2312, col: 1, offset: 71477},
 			expr: &seqExpr{
-				pos: position{line: 2293, col: 14, offset: 70966},
+				pos: position{line: 2312, col: 14, offset: 71490},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2293, col: 14, offset: 70966},
+						pos:        position{line: 2312, col: 14, offset: 71490},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"HEADERS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2293, col: 33, offset: 70985},
+						pos: position{line: 2312, col: 33, offset: 71509},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2293, col: 34, offset: 70986},
+							pos:  position{line: 2312, col: 34, offset: 71510},
 							name: "IdentifierRest",
 						},
 					},
@@ -17032,20 +17173,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2294, col: 1, offset: 71001},
+			pos:  position{line: 2313, col: 1, offset: 71525},
 			expr: &seqExpr{
-				pos: position{line: 2294, col: 14, offset: 71014},
+				pos: position{line: 2313, col: 14, offset: 71538},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2294, col: 14, offset: 71014},
+						pos:        position{line: 2313, col: 14, offset: 71538},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2294, col: 33, offset: 71033},
+						pos: position{line: 2313, col: 33, offset: 71557},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2294, col: 34, offset: 71034},
+							pos:  position{line: 2313, col: 34, offset: 71558},
 							name: "IdentifierRest",
 						},
 					},
@@ -17056,20 +17197,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2295, col: 1, offset: 71049},
+			pos:  position{line: 2314, col: 1, offset: 71573},
 			expr: &seqExpr{
-				pos: position{line: 2295, col: 14, offset: 71062},
+				pos: position{line: 2314, col: 14, offset: 71586},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2295, col: 14, offset: 71062},
+						pos:        position{line: 2314, col: 14, offset: 71586},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2295, col: 33, offset: 71081},
+						pos: position{line: 2314, col: 33, offset: 71605},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2295, col: 34, offset: 71082},
+							pos:  position{line: 2314, col: 34, offset: 71606},
 							name: "IdentifierRest",
 						},
 					},
@@ -17080,20 +17221,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2296, col: 1, offset: 71097},
+			pos:  position{line: 2315, col: 1, offset: 71621},
 			expr: &seqExpr{
-				pos: position{line: 2296, col: 14, offset: 71110},
+				pos: position{line: 2315, col: 14, offset: 71634},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2296, col: 14, offset: 71110},
+						pos:        position{line: 2315, col: 14, offset: 71634},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2296, col: 33, offset: 71129},
+						pos: position{line: 2315, col: 33, offset: 71653},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2296, col: 34, offset: 71130},
+							pos:  position{line: 2315, col: 34, offset: 71654},
 							name: "IdentifierRest",
 						},
 					},
@@ -17104,20 +17245,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2297, col: 1, offset: 71145},
+			pos:  position{line: 2316, col: 1, offset: 71669},
 			expr: &seqExpr{
-				pos: position{line: 2297, col: 14, offset: 71158},
+				pos: position{line: 2316, col: 14, offset: 71682},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2297, col: 14, offset: 71158},
+						pos:        position{line: 2316, col: 14, offset: 71682},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2297, col: 33, offset: 71177},
+						pos: position{line: 2316, col: 33, offset: 71701},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2297, col: 34, offset: 71178},
+							pos:  position{line: 2316, col: 34, offset: 71702},
 							name: "IdentifierRest",
 						},
 					},
@@ -17128,20 +17269,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2298, col: 1, offset: 71193},
+			pos:  position{line: 2317, col: 1, offset: 71717},
 			expr: &seqExpr{
-				pos: position{line: 2298, col: 14, offset: 71206},
+				pos: position{line: 2317, col: 14, offset: 71730},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2298, col: 14, offset: 71206},
+						pos:        position{line: 2317, col: 14, offset: 71730},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2298, col: 33, offset: 71225},
+						pos: position{line: 2317, col: 33, offset: 71749},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2298, col: 34, offset: 71226},
+							pos:  position{line: 2317, col: 34, offset: 71750},
 							name: "IdentifierRest",
 						},
 					},
@@ -17152,20 +17293,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2299, col: 1, offset: 71241},
+			pos:  position{line: 2318, col: 1, offset: 71765},
 			expr: &seqExpr{
-				pos: position{line: 2299, col: 14, offset: 71254},
+				pos: position{line: 2318, col: 14, offset: 71778},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2299, col: 14, offset: 71254},
+						pos:        position{line: 2318, col: 14, offset: 71778},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2299, col: 33, offset: 71273},
+						pos: position{line: 2318, col: 33, offset: 71797},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2299, col: 34, offset: 71274},
+							pos:  position{line: 2318, col: 34, offset: 71798},
 							name: "IdentifierRest",
 						},
 					},
@@ -17176,20 +17317,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2300, col: 1, offset: 71289},
+			pos:  position{line: 2319, col: 1, offset: 71813},
 			expr: &seqExpr{
-				pos: position{line: 2300, col: 14, offset: 71302},
+				pos: position{line: 2319, col: 14, offset: 71826},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2300, col: 14, offset: 71302},
+						pos:        position{line: 2319, col: 14, offset: 71826},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2300, col: 32, offset: 71320},
+						pos: position{line: 2319, col: 32, offset: 71844},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2300, col: 33, offset: 71321},
+							pos:  position{line: 2319, col: 33, offset: 71845},
 							name: "IdentifierRest",
 						},
 					},
@@ -17200,20 +17341,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2301, col: 1, offset: 71336},
+			pos:  position{line: 2320, col: 1, offset: 71860},
 			expr: &seqExpr{
-				pos: position{line: 2301, col: 14, offset: 71349},
+				pos: position{line: 2320, col: 14, offset: 71873},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2301, col: 14, offset: 71349},
+						pos:        position{line: 2320, col: 14, offset: 71873},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2301, col: 33, offset: 71368},
+						pos: position{line: 2320, col: 33, offset: 71892},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2301, col: 34, offset: 71369},
+							pos:  position{line: 2320, col: 34, offset: 71893},
 							name: "IdentifierRest",
 						},
 					},
@@ -17224,20 +17365,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2302, col: 1, offset: 71384},
+			pos:  position{line: 2321, col: 1, offset: 71908},
 			expr: &seqExpr{
-				pos: position{line: 2302, col: 14, offset: 71397},
+				pos: position{line: 2321, col: 14, offset: 71921},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2302, col: 14, offset: 71397},
+						pos:        position{line: 2321, col: 14, offset: 71921},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2302, col: 33, offset: 71416},
+						pos: position{line: 2321, col: 33, offset: 71940},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2302, col: 34, offset: 71417},
+							pos:  position{line: 2321, col: 34, offset: 71941},
 							name: "IdentifierRest",
 						},
 					},
@@ -17248,20 +17389,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2303, col: 1, offset: 71432},
+			pos:  position{line: 2322, col: 1, offset: 71956},
 			expr: &seqExpr{
-				pos: position{line: 2303, col: 16, offset: 71447},
+				pos: position{line: 2322, col: 16, offset: 71971},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2303, col: 16, offset: 71447},
+						pos:        position{line: 2322, col: 16, offset: 71971},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2303, col: 33, offset: 71464},
+						pos: position{line: 2322, col: 33, offset: 71988},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2303, col: 34, offset: 71465},
+							pos:  position{line: 2322, col: 34, offset: 71989},
 							name: "IdentifierRest",
 						},
 					},
@@ -17272,20 +17413,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2304, col: 1, offset: 71480},
+			pos:  position{line: 2323, col: 1, offset: 72004},
 			expr: &seqExpr{
-				pos: position{line: 2304, col: 14, offset: 71493},
+				pos: position{line: 2323, col: 14, offset: 72017},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2304, col: 14, offset: 71493},
+						pos:        position{line: 2323, col: 14, offset: 72017},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2304, col: 33, offset: 71512},
+						pos: position{line: 2323, col: 33, offset: 72036},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2304, col: 34, offset: 71513},
+							pos:  position{line: 2323, col: 34, offset: 72037},
 							name: "IdentifierRest",
 						},
 					},
@@ -17296,20 +17437,20 @@ var g = &grammar{
 		},
 		{
 			name: "MESSAGE",
-			pos:  position{line: 2305, col: 1, offset: 71528},
+			pos:  position{line: 2324, col: 1, offset: 72052},
 			expr: &seqExpr{
-				pos: position{line: 2305, col: 14, offset: 71541},
+				pos: position{line: 2324, col: 14, offset: 72065},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2305, col: 14, offset: 71541},
+						pos:        position{line: 2324, col: 14, offset: 72065},
 						val:        "message",
 						ignoreCase: true,
 						want:       "\"MESSAGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2305, col: 33, offset: 71560},
+						pos: position{line: 2324, col: 33, offset: 72084},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2305, col: 34, offset: 71561},
+							pos:  position{line: 2324, col: 34, offset: 72085},
 							name: "IdentifierRest",
 						},
 					},
@@ -17320,20 +17461,20 @@ var g = &grammar{
 		},
 		{
 			name: "META",
-			pos:  position{line: 2306, col: 1, offset: 71576},
+			pos:  position{line: 2325, col: 1, offset: 72100},
 			expr: &seqExpr{
-				pos: position{line: 2306, col: 14, offset: 71589},
+				pos: position{line: 2325, col: 14, offset: 72113},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2306, col: 14, offset: 71589},
+						pos:        position{line: 2325, col: 14, offset: 72113},
 						val:        "meta",
 						ignoreCase: true,
 						want:       "\"META\"i",
 					},
 					&notExpr{
-						pos: position{line: 2306, col: 33, offset: 71608},
+						pos: position{line: 2325, col: 33, offset: 72132},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2306, col: 34, offset: 71609},
+							pos:  position{line: 2325, col: 34, offset: 72133},
 							name: "IdentifierRest",
 						},
 					},
@@ -17344,20 +17485,20 @@ var g = &grammar{
 		},
 		{
 			name: "METHOD",
-			pos:  position{line: 2307, col: 1, offset: 71624},
+			pos:  position{line: 2326, col: 1, offset: 72148},
 			expr: &seqExpr{
-				pos: position{line: 2307, col: 14, offset: 71637},
+				pos: position{line: 2326, col: 14, offset: 72161},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2307, col: 14, offset: 71637},
+						pos:        position{line: 2326, col: 14, offset: 72161},
 						val:        "method",
 						ignoreCase: true,
 						want:       "\"METHOD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2307, col: 33, offset: 71656},
+						pos: position{line: 2326, col: 33, offset: 72180},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2307, col: 34, offset: 71657},
+							pos:  position{line: 2326, col: 34, offset: 72181},
 							name: "IdentifierRest",
 						},
 					},
@@ -17368,20 +17509,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2308, col: 1, offset: 71672},
+			pos:  position{line: 2327, col: 1, offset: 72196},
 			expr: &seqExpr{
-				pos: position{line: 2308, col: 14, offset: 71685},
+				pos: position{line: 2327, col: 14, offset: 72209},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2308, col: 14, offset: 71685},
+						pos:        position{line: 2327, col: 14, offset: 72209},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2308, col: 33, offset: 71704},
+						pos: position{line: 2327, col: 33, offset: 72228},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2308, col: 34, offset: 71705},
+							pos:  position{line: 2327, col: 34, offset: 72229},
 							name: "IdentifierRest",
 						},
 					},
@@ -17392,20 +17533,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2309, col: 1, offset: 71720},
+			pos:  position{line: 2328, col: 1, offset: 72244},
 			expr: &seqExpr{
-				pos: position{line: 2309, col: 14, offset: 71733},
+				pos: position{line: 2328, col: 14, offset: 72257},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2309, col: 14, offset: 71733},
+						pos:        position{line: 2328, col: 14, offset: 72257},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2309, col: 33, offset: 71752},
+						pos: position{line: 2328, col: 33, offset: 72276},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2309, col: 34, offset: 71753},
+							pos:  position{line: 2328, col: 34, offset: 72277},
 							name: "IdentifierRest",
 						},
 					},
@@ -17416,20 +17557,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2310, col: 1, offset: 71768},
+			pos:  position{line: 2329, col: 1, offset: 72292},
 			expr: &seqExpr{
-				pos: position{line: 2310, col: 14, offset: 71781},
+				pos: position{line: 2329, col: 14, offset: 72305},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2310, col: 14, offset: 71781},
+						pos:        position{line: 2329, col: 14, offset: 72305},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2310, col: 33, offset: 71800},
+						pos: position{line: 2329, col: 33, offset: 72324},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2310, col: 34, offset: 71801},
+							pos:  position{line: 2329, col: 34, offset: 72325},
 							name: "IdentifierRest",
 						},
 					},
@@ -17440,20 +17581,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2311, col: 1, offset: 71816},
+			pos:  position{line: 2330, col: 1, offset: 72340},
 			expr: &seqExpr{
-				pos: position{line: 2311, col: 14, offset: 71829},
+				pos: position{line: 2330, col: 14, offset: 72353},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2311, col: 14, offset: 71829},
+						pos:        position{line: 2330, col: 14, offset: 72353},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2311, col: 33, offset: 71848},
+						pos: position{line: 2330, col: 33, offset: 72372},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2311, col: 34, offset: 71849},
+							pos:  position{line: 2330, col: 34, offset: 72373},
 							name: "IdentifierRest",
 						},
 					},
@@ -17464,20 +17605,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2312, col: 1, offset: 71864},
+			pos:  position{line: 2331, col: 1, offset: 72388},
 			expr: &seqExpr{
-				pos: position{line: 2312, col: 14, offset: 71877},
+				pos: position{line: 2331, col: 14, offset: 72401},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2312, col: 14, offset: 71877},
+						pos:        position{line: 2331, col: 14, offset: 72401},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2312, col: 33, offset: 71896},
+						pos: position{line: 2331, col: 33, offset: 72420},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2312, col: 34, offset: 71897},
+							pos:  position{line: 2331, col: 34, offset: 72421},
 							name: "IdentifierRest",
 						},
 					},
@@ -17488,20 +17629,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2313, col: 1, offset: 71912},
+			pos:  position{line: 2332, col: 1, offset: 72436},
 			expr: &seqExpr{
-				pos: position{line: 2313, col: 14, offset: 71925},
+				pos: position{line: 2332, col: 14, offset: 72449},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2313, col: 14, offset: 71925},
+						pos:        position{line: 2332, col: 14, offset: 72449},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2313, col: 33, offset: 71944},
+						pos: position{line: 2332, col: 33, offset: 72468},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2313, col: 34, offset: 71945},
+							pos:  position{line: 2332, col: 34, offset: 72469},
 							name: "IdentifierRest",
 						},
 					},
@@ -17512,23 +17653,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2314, col: 1, offset: 71960},
+			pos:  position{line: 2333, col: 1, offset: 72484},
 			expr: &actionExpr{
-				pos: position{line: 2314, col: 14, offset: 71973},
+				pos: position{line: 2333, col: 14, offset: 72497},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2314, col: 14, offset: 71973},
+					pos: position{line: 2333, col: 14, offset: 72497},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2314, col: 14, offset: 71973},
+							pos:        position{line: 2333, col: 14, offset: 72497},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2314, col: 33, offset: 71992},
+							pos: position{line: 2333, col: 33, offset: 72516},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2314, col: 34, offset: 71993},
+								pos:  position{line: 2333, col: 34, offset: 72517},
 								name: "IdentifierRest",
 							},
 						},
@@ -17540,20 +17681,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2315, col: 1, offset: 72029},
+			pos:  position{line: 2334, col: 1, offset: 72553},
 			expr: &seqExpr{
-				pos: position{line: 2315, col: 14, offset: 72042},
+				pos: position{line: 2334, col: 14, offset: 72566},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2315, col: 14, offset: 72042},
+						pos:        position{line: 2334, col: 14, offset: 72566},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2315, col: 33, offset: 72061},
+						pos: position{line: 2334, col: 33, offset: 72585},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2315, col: 34, offset: 72062},
+							pos:  position{line: 2334, col: 34, offset: 72586},
 							name: "IdentifierRest",
 						},
 					},
@@ -17564,20 +17705,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2316, col: 1, offset: 72077},
+			pos:  position{line: 2335, col: 1, offset: 72601},
 			expr: &seqExpr{
-				pos: position{line: 2316, col: 14, offset: 72090},
+				pos: position{line: 2335, col: 14, offset: 72614},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2316, col: 14, offset: 72090},
+						pos:        position{line: 2335, col: 14, offset: 72614},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2316, col: 33, offset: 72109},
+						pos: position{line: 2335, col: 33, offset: 72633},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2316, col: 34, offset: 72110},
+							pos:  position{line: 2335, col: 34, offset: 72634},
 							name: "IdentifierRest",
 						},
 					},
@@ -17588,20 +17729,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2317, col: 1, offset: 72125},
+			pos:  position{line: 2336, col: 1, offset: 72649},
 			expr: &seqExpr{
-				pos: position{line: 2317, col: 14, offset: 72138},
+				pos: position{line: 2336, col: 14, offset: 72662},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2317, col: 14, offset: 72138},
+						pos:        position{line: 2336, col: 14, offset: 72662},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2317, col: 33, offset: 72157},
+						pos: position{line: 2336, col: 33, offset: 72681},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2317, col: 34, offset: 72158},
+							pos:  position{line: 2336, col: 34, offset: 72682},
 							name: "IdentifierRest",
 						},
 					},
@@ -17612,20 +17753,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2318, col: 1, offset: 72173},
+			pos:  position{line: 2337, col: 1, offset: 72697},
 			expr: &seqExpr{
-				pos: position{line: 2318, col: 14, offset: 72186},
+				pos: position{line: 2337, col: 14, offset: 72710},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2318, col: 14, offset: 72186},
+						pos:        position{line: 2337, col: 14, offset: 72710},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2318, col: 33, offset: 72205},
+						pos: position{line: 2337, col: 33, offset: 72729},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2318, col: 34, offset: 72206},
+							pos:  position{line: 2337, col: 34, offset: 72730},
 							name: "IdentifierRest",
 						},
 					},
@@ -17636,20 +17777,20 @@ var g = &grammar{
 		},
 		{
 			name: "OVER",
-			pos:  position{line: 2319, col: 1, offset: 72221},
+			pos:  position{line: 2338, col: 1, offset: 72745},
 			expr: &seqExpr{
-				pos: position{line: 2319, col: 14, offset: 72234},
+				pos: position{line: 2338, col: 14, offset: 72758},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2319, col: 14, offset: 72234},
+						pos:        position{line: 2338, col: 14, offset: 72758},
 						val:        "over",
 						ignoreCase: true,
 						want:       "\"OVER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2319, col: 33, offset: 72253},
+						pos: position{line: 2338, col: 33, offset: 72777},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2319, col: 34, offset: 72254},
+							pos:  position{line: 2338, col: 34, offset: 72778},
 							name: "IdentifierRest",
 						},
 					},
@@ -17660,20 +17801,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2320, col: 1, offset: 72269},
+			pos:  position{line: 2339, col: 1, offset: 72793},
 			expr: &seqExpr{
-				pos: position{line: 2320, col: 14, offset: 72282},
+				pos: position{line: 2339, col: 14, offset: 72806},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2320, col: 14, offset: 72282},
+						pos:        position{line: 2339, col: 14, offset: 72806},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2320, col: 33, offset: 72301},
+						pos: position{line: 2339, col: 33, offset: 72825},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2320, col: 34, offset: 72302},
+							pos:  position{line: 2339, col: 34, offset: 72826},
 							name: "IdentifierRest",
 						},
 					},
@@ -17684,20 +17825,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2321, col: 1, offset: 72317},
+			pos:  position{line: 2340, col: 1, offset: 72841},
 			expr: &seqExpr{
-				pos: position{line: 2321, col: 14, offset: 72330},
+				pos: position{line: 2340, col: 14, offset: 72854},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2321, col: 14, offset: 72330},
+						pos:        position{line: 2340, col: 14, offset: 72854},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2321, col: 33, offset: 72349},
+						pos: position{line: 2340, col: 33, offset: 72873},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2321, col: 34, offset: 72350},
+							pos:  position{line: 2340, col: 34, offset: 72874},
 							name: "IdentifierRest",
 						},
 					},
@@ -17708,20 +17849,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2322, col: 1, offset: 72365},
+			pos:  position{line: 2341, col: 1, offset: 72889},
 			expr: &seqExpr{
-				pos: position{line: 2322, col: 14, offset: 72378},
+				pos: position{line: 2341, col: 14, offset: 72902},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2322, col: 14, offset: 72378},
+						pos:        position{line: 2341, col: 14, offset: 72902},
 						val:        "RECURSIVE",
 						ignoreCase: false,
 						want:       "\"RECURSIVE\"",
 					},
 					&notExpr{
-						pos: position{line: 2322, col: 33, offset: 72397},
+						pos: position{line: 2341, col: 33, offset: 72921},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2322, col: 34, offset: 72398},
+							pos:  position{line: 2341, col: 34, offset: 72922},
 							name: "IdentifierRest",
 						},
 					},
@@ -17732,20 +17873,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP",
-			pos:  position{line: 2323, col: 1, offset: 72413},
+			pos:  position{line: 2342, col: 1, offset: 72937},
 			expr: &seqExpr{
-				pos: position{line: 2323, col: 14, offset: 72426},
+				pos: position{line: 2342, col: 14, offset: 72950},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2323, col: 14, offset: 72426},
+						pos:        position{line: 2342, col: 14, offset: 72950},
 						val:        "regexp",
 						ignoreCase: true,
 						want:       "\"REGEXP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2323, col: 33, offset: 72445},
+						pos: position{line: 2342, col: 33, offset: 72969},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2323, col: 34, offset: 72446},
+							pos:  position{line: 2342, col: 34, offset: 72970},
 							name: "IdentifierRest",
 						},
 					},
@@ -17756,20 +17897,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP_REPLACE",
-			pos:  position{line: 2324, col: 1, offset: 72461},
+			pos:  position{line: 2343, col: 1, offset: 72985},
 			expr: &seqExpr{
-				pos: position{line: 2324, col: 18, offset: 72478},
+				pos: position{line: 2343, col: 18, offset: 73002},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2324, col: 18, offset: 72478},
+						pos:        position{line: 2343, col: 18, offset: 73002},
 						val:        "regexp_replace",
 						ignoreCase: true,
 						want:       "\"REGEXP_REPLACE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2324, col: 36, offset: 72496},
+						pos: position{line: 2343, col: 36, offset: 73020},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2324, col: 37, offset: 72497},
+							pos:  position{line: 2343, col: 37, offset: 73021},
 							name: "IdentifierRest",
 						},
 					},
@@ -17780,20 +17921,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2325, col: 1, offset: 72512},
+			pos:  position{line: 2344, col: 1, offset: 73036},
 			expr: &seqExpr{
-				pos: position{line: 2325, col: 14, offset: 72525},
+				pos: position{line: 2344, col: 14, offset: 73049},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2325, col: 14, offset: 72525},
+						pos:        position{line: 2344, col: 14, offset: 73049},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2325, col: 33, offset: 72544},
+						pos: position{line: 2344, col: 33, offset: 73068},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2325, col: 34, offset: 72545},
+							pos:  position{line: 2344, col: 34, offset: 73069},
 							name: "IdentifierRest",
 						},
 					},
@@ -17804,20 +17945,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2326, col: 1, offset: 72560},
+			pos:  position{line: 2345, col: 1, offset: 73084},
 			expr: &seqExpr{
-				pos: position{line: 2326, col: 14, offset: 72573},
+				pos: position{line: 2345, col: 14, offset: 73097},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2326, col: 14, offset: 72573},
+						pos:        position{line: 2345, col: 14, offset: 73097},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2326, col: 33, offset: 72592},
+						pos: position{line: 2345, col: 33, offset: 73116},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2326, col: 34, offset: 72593},
+							pos:  position{line: 2345, col: 34, offset: 73117},
 							name: "IdentifierRest",
 						},
 					},
@@ -17828,20 +17969,20 @@ var g = &grammar{
 		},
 		{
 			name: "SAMPLE",
-			pos:  position{line: 2327, col: 1, offset: 72608},
+			pos:  position{line: 2346, col: 1, offset: 73132},
 			expr: &seqExpr{
-				pos: position{line: 2327, col: 14, offset: 72621},
+				pos: position{line: 2346, col: 14, offset: 73145},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2327, col: 14, offset: 72621},
+						pos:        position{line: 2346, col: 14, offset: 73145},
 						val:        "sample",
 						ignoreCase: true,
 						want:       "\"SAMPLE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2327, col: 33, offset: 72640},
+						pos: position{line: 2346, col: 33, offset: 73164},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2327, col: 34, offset: 72641},
+							pos:  position{line: 2346, col: 34, offset: 73165},
 							name: "IdentifierRest",
 						},
 					},
@@ -17852,20 +17993,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2328, col: 1, offset: 72656},
+			pos:  position{line: 2347, col: 1, offset: 73180},
 			expr: &seqExpr{
-				pos: position{line: 2328, col: 14, offset: 72669},
+				pos: position{line: 2347, col: 14, offset: 73193},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2328, col: 14, offset: 72669},
+						pos:        position{line: 2347, col: 14, offset: 73193},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2328, col: 33, offset: 72688},
+						pos: position{line: 2347, col: 33, offset: 73212},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2328, col: 34, offset: 72689},
+							pos:  position{line: 2347, col: 34, offset: 73213},
 							name: "IdentifierRest",
 						},
 					},
@@ -17876,20 +18017,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2329, col: 1, offset: 72704},
+			pos:  position{line: 2348, col: 1, offset: 73228},
 			expr: &seqExpr{
-				pos: position{line: 2329, col: 14, offset: 72717},
+				pos: position{line: 2348, col: 14, offset: 73241},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2329, col: 14, offset: 72717},
+						pos:        position{line: 2348, col: 14, offset: 73241},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2329, col: 33, offset: 72736},
+						pos: position{line: 2348, col: 33, offset: 73260},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2329, col: 34, offset: 72737},
+							pos:  position{line: 2348, col: 34, offset: 73261},
 							name: "IdentifierRest",
 						},
 					},
@@ -17900,20 +18041,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2330, col: 1, offset: 72752},
+			pos:  position{line: 2349, col: 1, offset: 73276},
 			expr: &seqExpr{
-				pos: position{line: 2330, col: 14, offset: 72765},
+				pos: position{line: 2349, col: 14, offset: 73289},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2330, col: 14, offset: 72765},
+						pos:        position{line: 2349, col: 14, offset: 73289},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2330, col: 33, offset: 72784},
+						pos: position{line: 2349, col: 33, offset: 73308},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2330, col: 34, offset: 72785},
+							pos:  position{line: 2349, col: 34, offset: 73309},
 							name: "IdentifierRest",
 						},
 					},
@@ -17924,20 +18065,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2331, col: 1, offset: 72800},
+			pos:  position{line: 2350, col: 1, offset: 73324},
 			expr: &seqExpr{
-				pos: position{line: 2331, col: 14, offset: 72813},
+				pos: position{line: 2350, col: 14, offset: 73337},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2331, col: 14, offset: 72813},
+						pos:        position{line: 2350, col: 14, offset: 73337},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2331, col: 33, offset: 72832},
+						pos: position{line: 2350, col: 33, offset: 73356},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2331, col: 34, offset: 72833},
+							pos:  position{line: 2350, col: 34, offset: 73357},
 							name: "IdentifierRest",
 						},
 					},
@@ -17948,20 +18089,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2332, col: 1, offset: 72848},
+			pos:  position{line: 2351, col: 1, offset: 73372},
 			expr: &seqExpr{
-				pos: position{line: 2332, col: 14, offset: 72861},
+				pos: position{line: 2351, col: 14, offset: 73385},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2332, col: 14, offset: 72861},
+						pos:        position{line: 2351, col: 14, offset: 73385},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2332, col: 33, offset: 72880},
+						pos: position{line: 2351, col: 33, offset: 73404},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2332, col: 34, offset: 72881},
+							pos:  position{line: 2351, col: 34, offset: 73405},
 							name: "IdentifierRest",
 						},
 					},
@@ -17972,20 +18113,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2333, col: 1, offset: 72896},
+			pos:  position{line: 2352, col: 1, offset: 73420},
 			expr: &seqExpr{
-				pos: position{line: 2333, col: 14, offset: 72909},
+				pos: position{line: 2352, col: 14, offset: 73433},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2333, col: 14, offset: 72909},
+						pos:        position{line: 2352, col: 14, offset: 73433},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2333, col: 33, offset: 72928},
+						pos: position{line: 2352, col: 33, offset: 73452},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2333, col: 34, offset: 72929},
+							pos:  position{line: 2352, col: 34, offset: 73453},
 							name: "IdentifierRest",
 						},
 					},
@@ -17996,20 +18137,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2334, col: 1, offset: 72944},
+			pos:  position{line: 2353, col: 1, offset: 73468},
 			expr: &seqExpr{
-				pos: position{line: 2334, col: 14, offset: 72957},
+				pos: position{line: 2353, col: 14, offset: 73481},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2334, col: 14, offset: 72957},
+						pos:        position{line: 2353, col: 14, offset: 73481},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2334, col: 33, offset: 72976},
+						pos: position{line: 2353, col: 33, offset: 73500},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2334, col: 34, offset: 72977},
+							pos:  position{line: 2353, col: 34, offset: 73501},
 							name: "IdentifierRest",
 						},
 					},
@@ -18020,20 +18161,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAP",
-			pos:  position{line: 2335, col: 1, offset: 72993},
+			pos:  position{line: 2354, col: 1, offset: 73517},
 			expr: &seqExpr{
-				pos: position{line: 2335, col: 14, offset: 73006},
+				pos: position{line: 2354, col: 14, offset: 73530},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2335, col: 14, offset: 73006},
+						pos:        position{line: 2354, col: 14, offset: 73530},
 						val:        "tap",
 						ignoreCase: true,
 						want:       "\"TAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2335, col: 33, offset: 73025},
+						pos: position{line: 2354, col: 33, offset: 73549},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2335, col: 34, offset: 73026},
+							pos:  position{line: 2354, col: 34, offset: 73550},
 							name: "IdentifierRest",
 						},
 					},
@@ -18044,20 +18185,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2336, col: 1, offset: 73041},
+			pos:  position{line: 2355, col: 1, offset: 73565},
 			expr: &seqExpr{
-				pos: position{line: 2336, col: 14, offset: 73054},
+				pos: position{line: 2355, col: 14, offset: 73578},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2336, col: 14, offset: 73054},
+						pos:        position{line: 2355, col: 14, offset: 73578},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2336, col: 33, offset: 73073},
+						pos: position{line: 2355, col: 33, offset: 73597},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2336, col: 34, offset: 73074},
+							pos:  position{line: 2355, col: 34, offset: 73598},
 							name: "IdentifierRest",
 						},
 					},
@@ -18068,23 +18209,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2337, col: 1, offset: 73089},
+			pos:  position{line: 2356, col: 1, offset: 73613},
 			expr: &actionExpr{
-				pos: position{line: 2337, col: 14, offset: 73102},
+				pos: position{line: 2356, col: 14, offset: 73626},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2337, col: 14, offset: 73102},
+					pos: position{line: 2356, col: 14, offset: 73626},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2337, col: 14, offset: 73102},
+							pos:        position{line: 2356, col: 14, offset: 73626},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2337, col: 33, offset: 73121},
+							pos: position{line: 2356, col: 33, offset: 73645},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2337, col: 34, offset: 73122},
+								pos:  position{line: 2356, col: 34, offset: 73646},
 								name: "IdentifierRest",
 							},
 						},
@@ -18096,20 +18237,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2338, col: 1, offset: 73165},
+			pos:  position{line: 2357, col: 1, offset: 73689},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 73178},
+				pos: position{line: 2357, col: 14, offset: 73702},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 73178},
+						pos:        position{line: 2357, col: 14, offset: 73702},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 73197},
+						pos: position{line: 2357, col: 33, offset: 73721},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 73198},
+							pos:  position{line: 2357, col: 34, offset: 73722},
 							name: "IdentifierRest",
 						},
 					},
@@ -18120,20 +18261,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2339, col: 1, offset: 73213},
+			pos:  position{line: 2358, col: 1, offset: 73737},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 73226},
+				pos: position{line: 2358, col: 14, offset: 73750},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 73226},
+						pos:        position{line: 2358, col: 14, offset: 73750},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 73245},
+						pos: position{line: 2358, col: 33, offset: 73769},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 73246},
+							pos:  position{line: 2358, col: 34, offset: 73770},
 							name: "IdentifierRest",
 						},
 					},
@@ -18144,20 +18285,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2340, col: 1, offset: 73261},
+			pos:  position{line: 2359, col: 1, offset: 73785},
 			expr: &seqExpr{
-				pos: position{line: 2340, col: 14, offset: 73274},
+				pos: position{line: 2359, col: 14, offset: 73798},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2340, col: 14, offset: 73274},
+						pos:        position{line: 2359, col: 14, offset: 73798},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2340, col: 33, offset: 73293},
+						pos: position{line: 2359, col: 33, offset: 73817},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2340, col: 34, offset: 73294},
+							pos:  position{line: 2359, col: 34, offset: 73818},
 							name: "IdentifierRest",
 						},
 					},
@@ -18168,20 +18309,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2341, col: 1, offset: 73309},
+			pos:  position{line: 2360, col: 1, offset: 73833},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 73322},
+				pos: position{line: 2360, col: 14, offset: 73846},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 73322},
+						pos:        position{line: 2360, col: 14, offset: 73846},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 73341},
+						pos: position{line: 2360, col: 33, offset: 73865},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 73342},
+							pos:  position{line: 2360, col: 34, offset: 73866},
 							name: "IdentifierRest",
 						},
 					},
@@ -18192,20 +18333,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2342, col: 1, offset: 73357},
+			pos:  position{line: 2361, col: 1, offset: 73881},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 73370},
+				pos: position{line: 2361, col: 14, offset: 73894},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 73370},
+						pos:        position{line: 2361, col: 14, offset: 73894},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 73389},
+						pos: position{line: 2361, col: 33, offset: 73913},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 73390},
+							pos:  position{line: 2361, col: 34, offset: 73914},
 							name: "IdentifierRest",
 						},
 					},
@@ -18216,20 +18357,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2343, col: 1, offset: 73406},
+			pos:  position{line: 2362, col: 1, offset: 73930},
 			expr: &seqExpr{
-				pos: position{line: 2343, col: 14, offset: 73419},
+				pos: position{line: 2362, col: 14, offset: 73943},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2343, col: 14, offset: 73419},
+						pos:        position{line: 2362, col: 14, offset: 73943},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2343, col: 33, offset: 73438},
+						pos: position{line: 2362, col: 33, offset: 73962},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2343, col: 34, offset: 73439},
+							pos:  position{line: 2362, col: 34, offset: 73963},
 							name: "IdentifierRest",
 						},
 					},
@@ -18240,20 +18381,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2344, col: 1, offset: 73454},
+			pos:  position{line: 2363, col: 1, offset: 73978},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 73467},
+				pos: position{line: 2363, col: 14, offset: 73991},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 73467},
+						pos:        position{line: 2363, col: 14, offset: 73991},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 73486},
+						pos: position{line: 2363, col: 33, offset: 74010},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 73487},
+							pos:  position{line: 2363, col: 34, offset: 74011},
 							name: "IdentifierRest",
 						},
 					},
@@ -18264,20 +18405,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2345, col: 1, offset: 73502},
+			pos:  position{line: 2364, col: 1, offset: 74026},
 			expr: &seqExpr{
-				pos: position{line: 2345, col: 14, offset: 73515},
+				pos: position{line: 2364, col: 14, offset: 74039},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2345, col: 14, offset: 73515},
+						pos:        position{line: 2364, col: 14, offset: 74039},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2345, col: 33, offset: 73534},
+						pos: position{line: 2364, col: 33, offset: 74058},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2345, col: 34, offset: 73535},
+							pos:  position{line: 2364, col: 34, offset: 74059},
 							name: "IdentifierRest",
 						},
 					},
@@ -18288,20 +18429,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2346, col: 1, offset: 73550},
+			pos:  position{line: 2365, col: 1, offset: 74074},
 			expr: &seqExpr{
-				pos: position{line: 2346, col: 14, offset: 73563},
+				pos: position{line: 2365, col: 14, offset: 74087},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2346, col: 14, offset: 73563},
+						pos:        position{line: 2365, col: 14, offset: 74087},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2346, col: 33, offset: 73582},
+						pos: position{line: 2365, col: 33, offset: 74106},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2346, col: 34, offset: 73583},
+							pos:  position{line: 2365, col: 34, offset: 74107},
 							name: "IdentifierRest",
 						},
 					},
@@ -18312,20 +18453,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2347, col: 1, offset: 73598},
+			pos:  position{line: 2366, col: 1, offset: 74122},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 73611},
+				pos: position{line: 2366, col: 14, offset: 74135},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 73611},
+						pos:        position{line: 2366, col: 14, offset: 74135},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 73630},
+						pos: position{line: 2366, col: 33, offset: 74154},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 73631},
+							pos:  position{line: 2366, col: 34, offset: 74155},
 							name: "IdentifierRest",
 						},
 					},
@@ -18336,20 +18477,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2348, col: 1, offset: 73646},
+			pos:  position{line: 2367, col: 1, offset: 74170},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 73659},
+				pos: position{line: 2367, col: 14, offset: 74183},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 73659},
+						pos:        position{line: 2367, col: 14, offset: 74183},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 73678},
+						pos: position{line: 2367, col: 33, offset: 74202},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 73679},
+							pos:  position{line: 2367, col: 34, offset: 74203},
 							name: "IdentifierRest",
 						},
 					},
@@ -18360,20 +18501,20 @@ var g = &grammar{
 		},
 		{
 			name: "YIELD",
-			pos:  position{line: 2349, col: 1, offset: 73694},
+			pos:  position{line: 2368, col: 1, offset: 74218},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 73707},
+				pos: position{line: 2368, col: 14, offset: 74231},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 73707},
+						pos:        position{line: 2368, col: 14, offset: 74231},
 						val:        "yield",
 						ignoreCase: true,
 						want:       "\"YIELD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 73726},
+						pos: position{line: 2368, col: 33, offset: 74250},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 73727},
+							pos:  position{line: 2368, col: 34, offset: 74251},
 							name: "IdentifierRest",
 						},
 					},
@@ -18863,10 +19004,26 @@ func (p *parser) callonAggAssignment11() (any, error) {
 	return p.cur.onAggAssignment11(stack["agg"])
 }
 
-func (c *current) onAgg2(op, expr, where any) (any, error) {
+func (c *current) onAgg2(aggDistinct, where any) (any, error) {
+	agg := aggDistinct.(*ast.Agg)
+	agg.Loc = loc(c)
+	if where != nil {
+		agg.Where = where.(ast.Expr)
+	}
+	return agg, nil
+
+}
+
+func (p *parser) callonAgg2() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onAgg2(stack["aggDistinct"], stack["where"])
+}
+
+func (c *current) onAgg15(name, expr, where any) (any, error) {
 	agg := &ast.Agg{
 		Kind: "Agg",
-		Name: op.(string),
+		Name: name.(string),
 		Loc:  loc(c),
 	}
 	if expr != nil {
@@ -18879,13 +19036,13 @@ func (c *current) onAgg2(op, expr, where any) (any, error) {
 
 }
 
-func (p *parser) callonAgg2() (any, error) {
+func (p *parser) callonAgg15() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAgg2(stack["op"], stack["expr"], stack["where"])
+	return p.cur.onAgg15(stack["name"], stack["expr"], stack["where"])
 }
 
-func (c *current) onAgg25(cs any) (any, error) {
+func (c *current) onAgg38(cs any) (any, error) {
 	return &ast.Agg{
 		Kind: "Agg",
 		Name: "count",
@@ -18894,10 +19051,27 @@ func (c *current) onAgg25(cs any) (any, error) {
 
 }
 
-func (p *parser) callonAgg25() (any, error) {
+func (p *parser) callonAgg38() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAgg25(stack["cs"])
+	return p.cur.onAgg38(stack["cs"])
+}
+
+func (c *current) onAggDistinct1(name, expr any) (any, error) {
+	return &ast.Agg{
+		Kind:     "Agg",
+		Name:     name.(string),
+		Distinct: true,
+		Expr:     expr.(ast.Expr),
+		Loc:      loc(c),
+	}, nil
+
+}
+
+func (p *parser) callonAggDistinct1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onAggDistinct1(stack["name"], stack["expr"])
 }
 
 func (c *current) onWhereClause1(expr any) (any, error) {
@@ -22771,10 +22945,10 @@ func (p *parser) callonSelection1() (any, error) {
 	return p.cur.onSelection1(stack["first"], stack["rest"])
 }
 
-func (c *current) onSelectElem2(e, as any) (any, error) {
+func (c *current) onSelectElem2(expr, as any) (any, error) {
 	elem := ast.AsExpr{
 		Kind: "AsExpr",
-		Expr: e.(ast.Expr),
+		Expr: expr.(ast.Expr),
 		Loc:  loc(c),
 	}
 	if as != nil {
@@ -22787,19 +22961,19 @@ func (c *current) onSelectElem2(e, as any) (any, error) {
 func (p *parser) callonSelectElem2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSelectElem2(stack["e"], stack["as"])
+	return p.cur.onSelectElem2(stack["expr"], stack["as"])
 }
 
-func (c *current) onSelectElem8() (any, error) {
+func (c *current) onSelectElem10() (any, error) {
 	// empty assignment is star (for now)
 	return ast.AsExpr{Kind: "AsExpr"}, nil
 
 }
 
-func (p *parser) callonSelectElem8() (any, error) {
+func (p *parser) callonSelectElem10() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSelectElem8()
+	return p.cur.onSelectElem10()
 }
 
 func (c *current) onOptAsClause2(id any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -225,10 +225,18 @@ AggAssignment
     }
 
 Agg
-  = !FuncGuard op:AggName __ "(" __ expr:(OverExpr / Expr)? __ ")" !(__ ".") where:WhereClause? {
+  = !FuncGuard aggDistinct:AggDistinct !(__ ".") where:WhereClause? {
+      agg := aggDistinct.(*ast.Agg)
+      agg.Loc = loc(c)
+      if where != nil {
+        agg.Where = where.(ast.Expr)
+      }
+      return agg, nil
+    }
+  / !FuncGuard name:AggName __ "(" __ expr:(OverExpr / Expr)? __ ")" !(__ ".") where:WhereClause? {
       agg := &ast.Agg{
           Kind: "Agg",
-          Name: op.(string),
+          Name: name.(string),
           Loc: loc(c),
       }
       if expr != nil {
@@ -244,6 +252,17 @@ Agg
           Kind: "Agg",
           Name: "count",
           Loc: cs.(*ast.Call).Loc,
+      }, nil
+    }
+
+AggDistinct
+  = !FuncGuard name:AggName __ "(" __ DISTINCT _ expr:(OverExpr / Expr) __ ")" {
+      return &ast.Agg{
+          Kind: "Agg",
+          Name: name.(string),
+          Distinct: true,
+          Expr: expr.(ast.Expr),
+          Loc: loc(c),
       }, nil
     }
 
@@ -2121,10 +2140,10 @@ Selection
 
 //XXX need to add *, id.*, except, replace
 SelectElem 
-  = e:Expr as:OptAsClause {
+  = expr:(AggDistinct / Expr) as:OptAsClause {
       elem := ast.AsExpr{
         Kind: "AsExpr",
-        Expr: e.(ast.Expr),
+        Expr: expr.(ast.Expr),
         Loc: loc(c),
       }
       if as != nil {

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -240,10 +240,11 @@ func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 		}
 		where := a.semExprNullable(e.Where)
 		return &dag.Agg{
-			Kind:  "Agg",
-			Name:  nameLower,
-			Expr:  expr,
-			Where: where,
+			Kind:     "Agg",
+			Name:     nameLower,
+			Distinct: e.Distinct,
+			Expr:     expr,
+			Where:    where,
 		}
 	case *ast.RecordExpr:
 		fields := map[string]struct{}{}
@@ -777,7 +778,7 @@ func (a *analyzer) semField(f ast.Expr) dag.Expr {
 func (a *analyzer) maybeConvertAgg(call *ast.Call) dag.Expr {
 	name := call.Name.Name
 	nameLower := strings.ToLower(name)
-	if _, err := agg.NewPattern(nameLower, true); err != nil {
+	if _, err := agg.NewPattern(nameLower, false, true); err != nil {
 		return nil
 	}
 	var e dag.Expr

--- a/compiler/ztests/sql/agg-distinct.yaml
+++ b/compiler/ztests/sql/agg-distinct.yaml
@@ -1,0 +1,29 @@
+zed: |
+  select
+      key,
+      and(distinct b),
+      any(distinct n),
+      avg(distinct n),
+      collect(distinct key),
+      count(distinct n),
+      dcount(distinct n),
+      max(distinct n),
+      min(distinct n),
+      or(distinct b),
+      sum(distinct n),
+      union(distinct n)
+  group by key
+  order by key
+
+vector: true
+
+input: |
+  {key:"a",n:1,b:true}
+  {key:"a",n:2,b:false}
+  {key:"b",n:1,b:true}
+  {key:"b",n:0,b:true}
+  {key:"a",n:1,b:false}
+
+output: |
+  {key:"a",and:false,any:1,avg:1.5,collect:["a"],count:2(uint64),dcount:2(uint64),max:2,min:1,or:true,sum:3,union:|[1,2]|}
+  {key:"b",and:true,any:1,avg:0.5,collect:["b"],count:2(uint64),dcount:2(uint64),max:1,min:0,or:true,sum:1,union:|[0,1]|}

--- a/compiler/ztests/sql/agg-distinct.yaml
+++ b/compiler/ztests/sql/agg-distinct.yaml
@@ -7,6 +7,7 @@ zed: |
       collect(distinct key),
       count(distinct n),
       dcount(distinct n),
+      // fuse() is not yet supported by vector runtime.
       max(distinct n),
       min(distinct n),
       or(distinct b),

--- a/runtime/sam/expr/agg.go
+++ b/runtime/sam/expr/agg.go
@@ -11,8 +11,8 @@ type Aggregator struct {
 	where   Evaluator
 }
 
-func NewAggregator(op string, expr Evaluator, where Evaluator) (*Aggregator, error) {
-	pattern, err := agg.NewPattern(op, expr != nil)
+func NewAggregator(op string, distinct bool, expr Evaluator, where Evaluator) (*Aggregator, error) {
+	pattern, err := agg.NewPattern(op, distinct, expr != nil)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/sam/expr/agg/agg.go
+++ b/runtime/sam/expr/agg/agg.go
@@ -23,7 +23,7 @@ type Function interface {
 	ResultAsPartial(*super.Context) super.Value
 }
 
-func NewPattern(op string, hasarg bool) (Pattern, error) {
+func NewPattern(op string, distinct, hasarg bool) (Pattern, error) {
 	needarg := true
 	var pattern Pattern
 	switch op {
@@ -86,6 +86,13 @@ func NewPattern(op string, hasarg bool) (Pattern, error) {
 	}
 	if needarg && !hasarg {
 		return nil, fmt.Errorf("%s: argument required", op)
+	}
+	if distinct {
+		switch op {
+		case "avg", "collect", "count", "sum":
+			// Distinct affects only these functions.
+			return func() Function { return newDistinct(pattern()) }, nil
+		}
 	}
 	return pattern, nil
 }

--- a/runtime/sam/expr/agg/distinct.go
+++ b/runtime/sam/expr/agg/distinct.go
@@ -8,7 +8,7 @@ import (
 )
 
 type distinct struct {
-	Function
+	fun      Function
 	buf      []byte
 	seen     map[string]struct{}
 	size     int
@@ -16,7 +16,7 @@ type distinct struct {
 }
 
 func newDistinct(f Function) Function {
-	return &distinct{Function: f, seen: map[string]struct{}{}}
+	return &distinct{fun: f, seen: map[string]struct{}{}}
 }
 
 func (d *distinct) Consume(val super.Value) {
@@ -60,10 +60,10 @@ func (d *distinct) Result(zctx *super.Context) super.Value {
 		if err != nil {
 			panic(err)
 		}
-		d.Function.Consume(super.NewValue(typ, bytes))
+		d.fun.Consume(super.NewValue(typ, bytes))
 		delete(d.seen, key)
 	}
-	return d.Function.Result(zctx)
+	return d.fun.Result(zctx)
 }
 
 func (d *distinct) ResultAsPartial(zctx *super.Context) super.Value {

--- a/runtime/sam/expr/agg/distinct.go
+++ b/runtime/sam/expr/agg/distinct.go
@@ -1,0 +1,76 @@
+package agg
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/brimdata/super"
+)
+
+type distinct struct {
+	Function
+	buf      []byte
+	seen     map[string]struct{}
+	size     int
+	partials [][]byte
+}
+
+func newDistinct(f Function) Function {
+	return &distinct{Function: f, seen: map[string]struct{}{}}
+}
+
+func (d *distinct) Consume(val super.Value) {
+	d.buf = binary.AppendVarint(d.buf[:0], int64(val.Type().ID()))
+	d.buf = append(d.buf, val.Bytes()...)
+	if _, ok := d.seen[string(d.buf)]; ok {
+		return
+	}
+	d.seen[string(d.buf)] = struct{}{}
+	d.size += 1 + len(d.buf)
+}
+
+func (d *distinct) ConsumeAsPartial(val super.Value) {
+	if val.Type() != super.TypeBytes {
+		panic("distinct: invalid partial")
+	}
+	d.partials = append(d.partials, val.Bytes())
+}
+
+func (d *distinct) Result(zctx *super.Context) super.Value {
+	for i, partial := range d.partials {
+		for len(partial) > 0 {
+			length, n := binary.Uvarint(partial)
+			if n <= 0 {
+				panic(fmt.Sprintf("bad varint: %d", n))
+			}
+			partial = partial[n:]
+			d.seen[string(partial[:length])] = struct{}{}
+			partial = partial[length:]
+		}
+		d.partials[i] = nil
+	}
+	for key := range d.seen {
+		bytes := []byte(key)
+		id, n := binary.Varint(bytes)
+		if n <= 0 {
+			panic(fmt.Sprintf("bad varint: %d", n))
+		}
+		bytes = bytes[n:]
+		typ, err := zctx.LookupType(int(id))
+		if err != nil {
+			panic(err)
+		}
+		d.Function.Consume(super.NewValue(typ, bytes))
+		delete(d.seen, key)
+	}
+	return d.Function.Result(zctx)
+}
+
+func (d *distinct) ResultAsPartial(zctx *super.Context) super.Value {
+	buf := make([]byte, 0, d.size)
+	for key := range d.seen {
+		buf = binary.AppendUvarint(buf, uint64(len(key)))
+		buf = append(buf, key...)
+	}
+	return super.NewBytes(buf)
+}

--- a/runtime/sam/expr/agg/ztests/distinct-partials.yaml
+++ b/runtime/sam/expr/agg/ztests/distinct-partials.yaml
@@ -1,0 +1,21 @@
+# This test exercises the partials paths in the reduducers by doing an aggregate
+# with a single-row limit.  We also make sure the partials consumer can handle
+# an empty input by inncluding a record for key "a" with no value field.
+zed: |
+  aggregate
+    avg(distinct n),
+    collect(distinct key),
+    count(distinct n),
+    sum(distinct n) by key
+  | sort key
+
+input: |
+  {key:"a",n:1}
+  {key:"a",n:2}
+  {key:"b",n:1}
+  {key:"b",n:0}
+  {key:"a",n:1}
+
+output: |
+  {key:"a",avg:1.5,collect:["a"],count:2(uint64),sum:3}
+  {key:"b",avg:0.5,collect:["b"],count:2(uint64),sum:1}

--- a/runtime/vam/expr/agg/agg.go
+++ b/runtime/vam/expr/agg/agg.go
@@ -16,7 +16,7 @@ type Func interface {
 
 type Pattern func() Func
 
-func NewPattern(op string, hasarg bool) (Pattern, error) {
+func NewPattern(op string, distinct, hasarg bool) (Pattern, error) {
 	needarg := true
 	var pattern Pattern
 	switch op {
@@ -74,6 +74,13 @@ func NewPattern(op string, hasarg bool) (Pattern, error) {
 	}
 	if needarg && !hasarg {
 		return nil, fmt.Errorf("%s: argument required", op)
+	}
+	if distinct {
+		switch op {
+		case "avg", "collect", "count", "sum":
+			// Distinct affects only these functions.
+			return func() Func { return newDistinct(pattern()) }, nil
+		}
 	}
 	return pattern, nil
 }

--- a/runtime/vam/expr/agg/agg.go
+++ b/runtime/vam/expr/agg/agg.go
@@ -79,7 +79,9 @@ func NewPattern(op string, distinct, hasarg bool) (Pattern, error) {
 		switch op {
 		case "avg", "collect", "count", "sum":
 			// Distinct affects only these functions.
-			return func() Func { return newDistinct(pattern()) }, nil
+			return func() Func {
+				return newDistinct(pattern())
+			}, nil
 		}
 	}
 	return pattern, nil

--- a/runtime/vam/expr/agg/distinct.go
+++ b/runtime/vam/expr/agg/distinct.go
@@ -1,0 +1,95 @@
+package agg
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/vector"
+	"github.com/brimdata/super/zcode"
+)
+
+type distinct struct {
+	Func
+	buf      []byte
+	seen     map[string]struct{}
+	size     int
+	partials [][]byte
+}
+
+func newDistinct(f Func) Func {
+	return &distinct{Func: f, seen: map[string]struct{}{}}
+}
+
+func (d *distinct) Consume(vec vector.Any) {
+	id := vec.Type().ID()
+	var b zcode.Builder
+	for i := range vec.Len() {
+		b.Truncate()
+		vec.Serialize(&b, i)
+		d.buf = binary.AppendVarint(d.buf[:0], int64(id))
+		d.buf = append(d.buf, b.Bytes().Body()...)
+		if _, ok := d.seen[string(d.buf)]; ok {
+			continue
+		}
+		d.seen[string(d.buf)] = struct{}{}
+		d.size += 1 + len(d.buf)
+	}
+}
+
+func (d *distinct) ConsumeAsPartial(vec vector.Any) {
+	if vec.Type() != super.TypeBytes || vec.Len() != 1 {
+		panic("distinct: invalid partial")
+	}
+	d.partials = append(d.partials, vec.(*vector.Bytes).Value(0))
+}
+
+func (d *distinct) Result(zctx *super.Context) super.Value {
+	for i, partial := range d.partials {
+		for len(partial) > 0 {
+			length, n := binary.Uvarint(partial)
+			if n <= 0 {
+				panic(fmt.Sprintf("bad varint: %d", n))
+			}
+			partial = partial[n:]
+			d.seen[string(partial[:length])] = struct{}{}
+			partial = partial[length:]
+		}
+		d.partials[i] = nil
+	}
+	b := vector.NewDynamicBuilder()
+	var count int
+	for key := range d.seen {
+		bytes := []byte(key)
+		id, n := binary.Varint(bytes)
+		if n <= 0 {
+			panic(fmt.Sprintf("bad varint: %d", n))
+		}
+		bytes = bytes[n:]
+		typ, err := zctx.LookupType(int(id))
+		if err != nil {
+			panic(err)
+		}
+		b.Write(super.NewValue(typ, bytes))
+		count++
+		if count == 1024 {
+			d.Func.Consume(b.Build())
+			b = vector.NewDynamicBuilder()
+			count = 0
+		}
+		delete(d.seen, key)
+	}
+	if count > 0 {
+		d.Func.Consume(b.Build())
+	}
+	return d.Func.Result(zctx)
+}
+
+func (d *distinct) ResultAsPartial(*super.Context) super.Value {
+	buf := make([]byte, 0, d.size)
+	for key := range d.seen {
+		buf = binary.AppendUvarint(buf, uint64(len(key)))
+		buf = append(buf, key...)
+	}
+	return super.NewBytes(buf)
+}

--- a/runtime/vam/expr/aggregator.go
+++ b/runtime/vam/expr/aggregator.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Aggregator struct {
-	Pattern agg.Pattern
-	Name    string
-	Expr    Evaluator
-	Where   Evaluator
+	Pattern  agg.Pattern
+	Name     string
+	Distinct bool
+	Expr     Evaluator
+	Where    Evaluator
 }
 
 func NewAggregator(name string, distinct bool, expr Evaluator, where Evaluator) (*Aggregator, error) {
@@ -24,10 +25,11 @@ func NewAggregator(name string, distinct bool, expr Evaluator, where Evaluator) 
 		expr = NewLiteral(super.True)
 	}
 	return &Aggregator{
-		Pattern: pattern,
-		Name:    name,
-		Expr:    expr,
-		Where:   where,
+		Pattern:  pattern,
+		Name:     name,
+		Distinct: distinct,
+		Expr:     expr,
+		Where:    where,
 	}, nil
 }
 

--- a/runtime/vam/expr/aggregator.go
+++ b/runtime/vam/expr/aggregator.go
@@ -13,8 +13,8 @@ type Aggregator struct {
 	Where   Evaluator
 }
 
-func NewAggregator(name string, expr Evaluator, where Evaluator) (*Aggregator, error) {
-	pattern, err := agg.NewPattern(name, expr != nil)
+func NewAggregator(name string, distinct bool, expr Evaluator, where Evaluator) (*Aggregator, error) {
+	pattern, err := agg.NewPattern(name, distinct, expr != nil)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/vam/op/aggregate/aggregate.go
+++ b/runtime/vam/op/aggregate/aggregate.go
@@ -119,8 +119,8 @@ func (a *Aggregate) newAggTable(keyTypes []super.Type) aggTable {
 }
 
 func (a *Aggregate) isCountByString(keyTypes []super.Type) bool {
-	return len(a.aggs) == 1 && len(keyTypes) == 1 && a.aggs[0].Name == "count" &&
-		keyTypes[0].ID() == super.IDString
+	return len(a.aggs) == 1 && a.aggs[0].Name == "count" && !a.aggs[0].Distinct &&
+		len(keyTypes) == 1 && keyTypes[0].ID() == super.IDString
 }
 
 func (a *Aggregate) next() vector.Any {

--- a/runtime/vam/op/ztests/agg-count-by-string.yaml
+++ b/runtime/vam/op/ztests/agg-count-by-string.yaml
@@ -10,6 +10,7 @@ script: |
   export SUPER_VAM=1
   super -z -c 'from t.csup | count() by x'
   super -z -c 'from t.csup | count() by y | sort y'
+  super -z -c 'from t.csup | count(distinct x) by y | sort y'
   super -z -c 'from t.csup | count() by z | z == "257"'
   super -z -c 'from t.csup | count() where y=="1" by z | z == "257"'
 
@@ -19,5 +20,7 @@ outputs:
       {x:"0",count:514(uint64)}
       {y:"1",count:257(uint64)}
       {y:"2",count:257(uint64)}
+      {y:"1",count:1(uint64)}
+      {y:"2",count:1(uint64)}
       {z:"257",count:2(uint64)}
       {z:"257",count:1(uint64)}

--- a/runtime/ztests/op/aggregate/distinct.yaml
+++ b/runtime/ztests/op/aggregate/distinct.yaml
@@ -6,6 +6,7 @@ zed: |
     collect(distinct key),
     count(distinct n),
     dcount(distinct n),
+    // fuse() is not yet supported by vector runtime.
     max(distinct n),
     min(distinct n),
     or(distinct b),

--- a/runtime/ztests/op/aggregate/distinct.yaml
+++ b/runtime/ztests/op/aggregate/distinct.yaml
@@ -1,16 +1,16 @@
 zed: |
   aggregate
-      and(distinct b),
-      any(distinct n),
-      avg(distinct n),
-      collect(distinct key),
-      count(distinct n),
-      dcount(distinct n),
-      max(distinct n),
-      min(distinct n),
-      or(distinct b),
-      sum(distinct n),
-      union(distinct n) by key
+    and(distinct b),
+    any(distinct n),
+    avg(distinct n),
+    collect(distinct key),
+    count(distinct n),
+    dcount(distinct n),
+    max(distinct n),
+    min(distinct n),
+    or(distinct b),
+    sum(distinct n),
+    union(distinct n) by key
   | sort key
 
 vector: true

--- a/runtime/ztests/op/aggregate/distinct.yaml
+++ b/runtime/ztests/op/aggregate/distinct.yaml
@@ -1,0 +1,27 @@
+zed: |
+  aggregate
+      and(distinct b),
+      any(distinct n),
+      avg(distinct n),
+      collect(distinct key),
+      count(distinct n),
+      dcount(distinct n),
+      max(distinct n),
+      min(distinct n),
+      or(distinct b),
+      sum(distinct n),
+      union(distinct n) by key
+  | sort key
+
+vector: true
+
+input: |
+  {key:"a",n:1,b:true}
+  {key:"a",n:2,b:false}
+  {key:"b",n:1,b:true}
+  {key:"b",n:0,b:true}
+  {key:"a",n:1,b:false}
+
+output: |
+  {key:"a",and:false,any:1,avg:1.5,collect:["a"],count:2(uint64),dcount:2(uint64),max:2,min:1,or:true,sum:3,union:|[1,2]|}
+  {key:"b",and:true,any:1,avg:0.5,collect:["b"],count:2(uint64),dcount:2(uint64),max:1,min:0,or:true,sum:1,union:|[0,1]|}

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -92,7 +92,11 @@ func (c *canon) expr(e ast.Expr, parent string) {
 	case nil:
 		c.write("null")
 	case *ast.Agg:
-		c.write("%s(", e.Name)
+		var distinct string
+		if e.Distinct {
+			distinct = "distinct "
+		}
+		c.write("%s(%s", e.Name, distinct)
 		if e.Expr != nil {
 			c.expr(e.Expr, "")
 		}
@@ -765,7 +769,7 @@ func isAggFunc(e ast.Expr) *ast.Aggregate {
 	if !ok {
 		return nil
 	}
-	if _, err := agg.NewPattern(call.Name.Name, true); err != nil {
+	if _, err := agg.NewPattern(call.Name.Name, false, true); err != nil {
 		return nil
 	}
 	return &ast.Aggregate{

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -73,7 +73,11 @@ func (c *canonDAG) expr(e dag.Expr, parent string) {
 	case nil:
 		c.write("null")
 	case *dag.Agg:
-		c.write("%s(", e.Name)
+		var distinct string
+		if e.Distinct {
+			distinct = "distinct "
+		}
+		c.write("%s(%s", e.Name, distinct)
 		if e.Expr != nil {
 			c.expr(e.Expr, "")
 		}


### PR DESCRIPTION
This enables "count(distinct a)" etc.

Fixes #5708.

I didn't see a straightforward way to add this to the documentation so I didn't do so.