### PR TITLE
Remove mentions of "SuperPipe" from docs, plus other fixes

### DIFF
--- a/docs/formats/_index.md
+++ b/docs/formats/_index.md
@@ -123,7 +123,7 @@ then such a collection of records looks precisely like a relational table.
 Here, the record type
 of such a collection corresponds to a well-defined schema consisting
 of field names (i.e., column names) where each field has a specific type.
-[Named types](data-model#3-named-type) are also available, so by simply naming a particular record type
+[Named types](data-model.md#3-named-type) are also available, so by simply naming a particular record type
 (i.e., a schema), a relational table can be projected from a pool of data
 with a simple query for that named type.
 

--- a/docs/formats/_index.md
+++ b/docs/formats/_index.md
@@ -101,7 +101,7 @@ or more simply, _"the hybrid pattern"_.
 
 ## 2. A Super-structured Pattern
 
-The super data model removes the tabular and schema concepts from
+The [super data model](data-model.md) removes the tabular and schema concepts from
 the underlying data model altogether and replaces them with a granular and
 modern type system inspired by general-purpose programming languages.
 Instead of defining a single, composite schema to
@@ -111,7 +111,7 @@ express its type in accordance with the type system.
 In this approach, data in SuperDB is neither tabular nor semi-structured but
 instead "super-structured".
 
-In particular, SuperDB's record type looks like a schema but when values are
+In particular, SuperDB's [record type](data-model.md#21-record) looks like a schema but when values are
 serialized, the model is very different.  A sequence of values need not
 comprise a record-type declaration followed by a sequence of
 homogeneously-typed record values, but instead,
@@ -122,8 +122,8 @@ Yet when a sequence of values _in fact conforms to a uniform record type_,
 then such a collection of records looks precisely like a relational table.
 Here, the record type
 of such a collection corresponds to a well-defined schema consisting
-of field names (i.e, column names) where each field has a specific type.
-[Named types](../language/data-types.md#named-types) are also available, so by simply naming a particular record type
+of field names (i.e., column names) where each field has a specific type.
+[Named types](data-model#3-named-type) are also available, so by simply naming a particular record type
 (i.e., a schema), a relational table can be projected from a pool of data
 with a simple query for that named type.
 
@@ -143,7 +143,7 @@ defines its entire structure, i.e., its super-structure.  There is
 no need to traverse each hierarchical value --- as with JSON, BSON, or Ion ---
 to discover each value's structure.
 
-And because SuperDB derives it design from the vast landscape
+And because SuperDB derives its design from the vast landscape
 of existing formats and data models, it was deliberately designed to be
 a superset of --- and thus interoperable with --- a broad range of formats
 including JSON, BSON, Ion, Avro, ORC, Parquet, CSV, JSON Schema, and XML.
@@ -242,9 +242,9 @@ Likewise, you could select a sample value of each shape like this:
     SELECT any(this) AS sample, typeof(this) AS shape GROUP BY shape,sample
   )
 ```
-The SuperPipe language provides shortcuts that express such operations in ways
+The SuperSQL language provides shortcuts that express such operations in ways
 that more directly leverage the nature of super-structured data. For example,
-the above two SuperSQL queries could be written as:
+the above two queries could be written as:
 ```
   count() by shape:=typeof(this)
   any(this) by typeof(this) | cut any

--- a/docs/language/data-types.md
+++ b/docs/language/data-types.md
@@ -3,7 +3,7 @@ weight: 3
 title: Data Types
 ---
 
-The SuperPipe language includes most data types of a typical programming language
+The SuperSQL language includes most data types of a typical programming language
 as defined in the [super data model](../formats/data-model.md).
 
 The syntax of individual literal values generally follows
@@ -21,19 +21,19 @@ constant values like Super JSON and can be composed from [literal expressions](e
 
 ## First-class Types
 
-As in the super data model, the SuperPipe language has first-class types:
+As in the super data model, the SuperSQL language has first-class types:
 any type may be used as a value.
 
 The primitive types are listed in the
 [data model specification](../formats/data-model.md#1-primitive-types)
-and have the same syntax in SuperPipe.  Complex types also follow
+and have the same syntax in SuperSQL.  Complex types also follow
 the Super JSON syntax.  Note that the type of a type value is simply `type`.
 
 As in Super JSON, _when types are used as values_, e.g., in an expression,
 they must be referenced within angle brackets.  That is, the integer type
 `int64` is expressed as a type value using the syntax `<int64>`.
 
-Complex types in the SuperPipe language follow the Super JSON syntax as well.  Here are
+Complex types in the SuperSQL language follow the Super JSON syntax as well.  Here are
 a few examples:
 * a simple record type - `{x:int64,y:int64}`
 * an array of integers - `[int64]`
@@ -108,7 +108,7 @@ type socket = {addr:ip,port:port=uint16}
 defines a named type `socket` that is a record with field `addr` of type `ip`
 and field `port` of type "port", where type "port" is a named type for type `uint16` .
 
-Named types may also be defined by the input data itself, as super data is
+Named types may also be defined by the input data itself, as super-structured data is
 comprehensively self describing.
 When named types are defined in the input data, there is no need to declare their
 type in a query.
@@ -175,13 +175,13 @@ In general, it is bad practice to define multiple versions of a single named typ
 though the SuperDB system and super data model accommodate such dynamic bindings.
 Managing and enforcing the relationship between type names and their type definitions
 on a global basis (e.g., across many different data pools in a data lake) is outside
-the scope of the Zed data model and language.  That said, Zed provides flexible
+the scope of the super data model and SuperSQL language.  That said, SuperDB provides flexible
 building blocks so systems can define their own schema versioning and schema
-management policies on top of these Zed primitives.
+management policies on top of these primitives.
 
 The [super-structured data model](../formats/_index.md#2-a-super-structured-pattern)
 is a superset of relational tables and
-SuperPipe's type system can easily make this connection.
+SuperSQL's type system can easily make this connection.
 As an example, consider this type definition for "employee":
 ```
 type employee = {id:int64,first:string,last:string,job:string,salary:float64}
@@ -193,7 +193,7 @@ FROM employee
 ORDER BY salary
 LIMIT 5
 ```
-In SuperPipe, you would say
+Using pipes in SuperSQL, you could say
 ```
 from anywhere
 | typeof(this)==<employee>
@@ -210,7 +210,7 @@ from anywhere
 | sort salary
 | head 5
 ```
-The power of SuperPipe is that you can interpret data on the fly as belonging to
+The power of SuperSQL is that you can interpret data on the fly as belonging to
 a certain schema, in this case "employee", and those records can be intermixed
 with other relevant data.  There is no need to create a table called "employee"
 and put the data into the table before that data can be queried as an "employee".
@@ -219,7 +219,7 @@ to work.
 
 ## First-class Errors
 
-As with types, errors in SuperPipe are first-class: any value can be transformed
+As with types, errors in SuperSQL are first-class: any value can be transformed
 into an error by wrapping it in an [`error` type](../formats/data-model.md#27-error).
 
 In general, expressions and functions that result in errors simply return
@@ -269,11 +269,11 @@ typeof(1/this)
 ```
 
 First-class errors are particularly useful for creating structured errors.
-When a SuperPipe query encounters a problematic condition,
+When a SuperSQL query encounters a problematic condition,
 instead of silently dropping the problematic error
 and logging an error obscurely into some hard-to-find system log as so many
-ETL pipelines do, the Zed logic can
-preferably wrap the offending value as an error and propagate it to its output.
+ETL pipelines do, the offending value can be wrapped as an error and
+propagated to its output.
 
 For example, suppose a bad value shows up:
 ```
@@ -306,7 +306,7 @@ landing at the final output stage.
 Errors will unfortunately and inevitably occur even in production,
 but having a first-class data type to manage them all while allowing them to
 peacefully coexist with valid production data is a novel and
-useful approach that Zed enables.
+useful approach that SuperSQL enables.
 
 ### Missing and Quiet
 
@@ -338,7 +338,7 @@ To solve this problem, the `MISSING` value was proposed to represent the value t
 results from accessing a field that is not present.  Thus, `x==NULL` and
 `x==MISSING` could disambiguate the two cases above.
 
-SuperPipe, instead, recognizes that the SQL value `MISSING` is a paradox:
+SuperSQL, instead, recognizes that the SQL value `MISSING` is a paradox:
 I'm here but I'm not.
 
 In reality, a `MISSING` value is not a value.  It's an error condition
@@ -347,7 +347,7 @@ that resulted from trying to reference something that didn't exist.
 So why should we pretend that this is a bona fide value?  SQL adopted this
 approach because it lacks first-class errors.
 
-But SuperPipe has first-class errors so
+But SuperSQL has first-class errors so
 a reference to something that does not exist is an error of type
 `error(string)` whose value is `error("missing")`.  For example,
 ```mdtest-spq

--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -65,10 +65,7 @@ The `in` operator has the form
 ```
 and is true if the `<item-expr>` expression results in a value that
 appears somewhere in the `<container-expr>` as an exact match of the item.
-The right-hand side value can be any Zed value and complex values are
-recursively traversed to determine if the item is present anywhere within them.
-
-For example,
+The right-hand side value can be any value. For example,
 ```mdtest-spq
 # spq
 1 in this
@@ -79,6 +76,22 @@ For example,
 # expected output
 {a:[1,2]}
 {d:{e:1}}
+```
+
+Complex values are recursively traversed to determine if the item is present
+anywhere within them:
+```mdtest-spq
+# spq
+{s:"foo"} in this
+# input
+{s:"foo"}
+{s:"foo",t:"bar"}
+{a:{s:"foo"}}
+[1,{s:"foo"},2]
+# expected output
+{s:"foo"}
+{a:{s:"foo"}}
+[1,{s:"foo"},2]
 ```
 
 You can also use this operator with a static array:

--- a/docs/language/functions/cast.md
+++ b/docs/language/functions/cast.md
@@ -22,7 +22,7 @@ In the second form, where the `name` argument is a string, cast creates
 a new [named type](../data-types.md#named-types) where the name for the type is given by `name` and its
 type is given by `typeof(val)`.  This provides a convenient mechanism
 to create new named types from the input data itself without having to
-hard code the type in the SuperPipe query.
+hard code the type in the SuperSQL query.
 
 For complex types, the cast function visits each leaf value in `val` and
 casts that value to the corresponding type in `t`.
@@ -30,7 +30,7 @@ When a complex value has multiple levels of nesting,
 casting is applied recursively down the tree.  For example, cast is recursively
 applied to each element in an array of records and recursively applied to each record.
 
-If `val` is a record (or if any of its nested value is a record):
+If `val` is a record (or if any of its nested values is a record):
 * absent fields are ignored and omitted from the result,
 * extra input fields are passed through unmodified to the result, and
 * fields are matched by name and are order independent and the _input_ order is retained.

--- a/docs/language/functions/grok.md
+++ b/docs/language/functions/grok.md
@@ -36,7 +36,7 @@ that can be referenced in any pattern. The included named patterns can be seen
 
 Although Grok functionality appears in many open source tools, it lacks a
 formal specification. As a result, example parsing configurations found via
-web searches may not all plug seamlessly into SuperPipe's `grok` function without
+web searches may not all plug seamlessly into SuperSQL's `grok` function without
 modification.
 
 [Logstash](https://www.elastic.co/logstash) was the first tool to widely
@@ -49,7 +49,7 @@ the use of the `grok` function, review the tips below.
 
 {{% tip "Note" %}}
 
-As these represent areas of possible future SuperPipe enhancement, links to open
+As these represent areas of possible future SuperSQL enhancement, links to open
 issues are provided. If you find a functional gap significantly impacts your
 ability to use the `grok` function, please add a comment to the relevant
 issue describing your use case.
@@ -61,24 +61,24 @@ issue describing your use case.
    ```
    %{NUMBER:num:int}
    ```
-  to store `num` as an integer type instead of as a
-  string. SuperPipe currently accepts this trailing `:type` syntax but effectively
-  ignores it and stores all parsed values as strings. Downstream use of the
-  [`cast` function](cast.md) can be used instead for data type conversion.
-  ([super/4928](https://github.com/brimdata/super/issues/4928))
-
+   to store `num` as an integer type instead of as a
+   string. SuperSQL currently accepts this trailing `:type` syntax but effectively
+   ignores it and stores all parsed values as strings. Downstream use of the
+   [`cast` function](cast.md) can be used instead for data type conversion.
+   ([super/4928](https://github.com/brimdata/super/issues/4928))
+<br><br>
 2. Some Logstash Grok examples use an optional square bracket syntax for
    storing a parsed value in a nested field, e.g.,
    ```
    %{GREEDYDATA:[nested][field]}
    ```
-   to store a value into `{"nested": {"field": ... }}`. In SuperPipe the more common
+   to store a value into `{"nested": {"field": ... }}`. In SuperSQL the more common
    dot-separated field naming convention `nested.field` can be combined
    with the downstream use of the [`nest_dotted` function](nest_dotted.md) to
    store values in nested fields.
    ([super/4929](https://github.com/brimdata/super/issues/4929))
-
-3. SuperPipe's regular expressions syntax does not currently support the
+<br><br>
+3. SuperSQL's regular expressions syntax does not currently support the
    "named capture" syntax shown in the
    [Logstash docs](https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html#_custom_patterns).
    ([super/4899](https://github.com/brimdata/super/issues/4899))
@@ -96,10 +96,11 @@ issue describing your use case.
    # expected output
    {timestamp:"Jan  1 06:25:43",logsource:"mailserver14",program:"postfix/cleanup",pid:"21403",queue_id:"BEF25A72965",syslog_message:"message-id=<20130101142543.5828399CCAF@mailserver14.example.com>"}
    ```
+<br><br>
 
 4. The Grok implementation for Logstash uses the
    [Oniguruma](https://github.com/kkos/oniguruma) regular expressions library
-   while SuperPipe's `grok` uses Go's [regexp](https://pkg.go.dev/regexp) and
+   while SuperSQL's `grok` uses Go's [regexp](https://pkg.go.dev/regexp) and
    [RE2 syntax](https://github.com/google/re2/wiki/Syntax). These
    implementations share the same basic syntax which should suffice for most
    parsing needs. But per a detailed
@@ -112,10 +113,10 @@ issue describing your use case.
 {{% tip "Note" %}}
 
 If you absolutely require features of Logstash's Grok that are not currently
-present in SuperPipe, you can create a Logstash-based preprocessing
+present in SuperSQL, you can create a Logstash-based preprocessing
 pipeline that uses its
 [Grok filter plugin](https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html)
-and send its output as JSON to SuperPipe. Issue
+and send its output as JSON to SuperSQL. Issue
 [super/3151](https://github.com/brimdata/super/issues/3151) provides some tips for
 getting started. If you pursue this approach, please add a comment to the
 issue describing your use case or come talk to us on
@@ -139,7 +140,7 @@ To aid in this workflow, you may find an
 that these have their own
 [differences and limitations](https://github.com/cjslack/grok-debugger).
 If you devise a working Grok config in such a tool be sure to incrementally
-test it with SuperPipe's `grok`. Be mindful of necessary adjustments such as those
+test it with SuperSQL's `grok`. Be mindful of necessary adjustments such as those
 described [above](#comparison-to-other-implementations) and in the [examples](#examples).
 
 ### Need Help?

--- a/docs/language/operators/load.md
+++ b/docs/language/operators/load.md
@@ -21,7 +21,7 @@ The `load` operator is exclusively for working with pools in a
 The `load` operator populates the specified `<pool>` with the values it
 receives as input. Much like how [`super db load`](../../commands/super-db.md#load)
 is used at the command line to populate a pool with data from files, streams,
-and URIs, the `load` operator is used to save query results from your SuperPipe
+and URIs, the `load` operator is used to save query results from your SuperSQL
 query to a pool in the same SuperDB data lake. `<pool>` is a string indicating the
 [name or ID](../../commands/super-db.md#data-pools) of the destination pool.
 If the optional `@<branch>` string is included then the data will be committed

--- a/docs/language/operators/over.md
+++ b/docs/language/operators/over.md
@@ -12,7 +12,7 @@ The `over` operator traverses complex values to create a new sequence
 of derived values (e.g., the elements of an array) and either
 (in the first form) sends the new values directly to its output or
 (in the second form) sends the values to a scoped computation as indicated
-by `<lateral>`, which may represent any SuperPipe [subquery](../lateral-subqueries.md) operating on the
+by `<lateral>`, which may represent any SuperSQL [subquery](../lateral-subqueries.md) operating on the
 derived sequence of values as [`this`](../pipeline-model.md#the-special-value-this).
 
 Each expression `<expr>` is evaluated in left-to-right order and derived sequences are
@@ -22,8 +22,8 @@ generated from each such result depending on its types:
 entry in the map, and
 * all other values generate a single value equal to itself.
 
-Records can be converted to maps with the [`flatten` function](../functions/flatten.md)
-resulting in a map that can be traversed,
+A record can be converted with the [`flatten` function](../functions/flatten.md) to
+an array that can be traversed,
 e.g., if `this` is a record, it can be traversed with `over flatten(this)`.
 
 The nested subquery depicted as `<lateral>` is called a [lateral subquery](../lateral-subqueries.md).

--- a/docs/language/operators/put.md
+++ b/docs/language/operators/put.md
@@ -10,11 +10,11 @@
 
 The `put` operator modifies its input with
 one or more [field assignments](../pipeline-model.md#field-assignments).
-Each expression is evaluated based on the input record
+Each [expression](../expressions.md) `<expr>` is evaluated based on the input record
 and the result is either assigned to a new field of the input record if it does not
 exist, or the existing field is modified in its original location with the result.
 
-New fields are append in left-to-right order to the right of existing record fields
+New fields are appended in left-to-right order to the right of existing record fields
 while modified fields are mutated in place.
 
 If multiple fields are written in a single `put`, all the new field values are
@@ -29,12 +29,12 @@ Each `<field>` expression must be a field reference expressed as a dotted path o
 constant index operations on `this`, e.g., `a.b`, `this["a"]["b"]`,
 etc.
 
-Each right-hand side `<expr>` can be any SuperPipe expression.
+Each right-hand side `<expr>` can be any SuperSQL expression.
 
 For any input value that is not a record, an error is emitted.
 
 Note that when the field references are all top level,
-`put` is a special case of a `yield` with a
+`put` is a special case of a [`yield`](yield.md) with a
 [record literal](../expressions.md#record-expressions)
 using a spread operator of the form:
 ```

--- a/docs/language/operators/sort.md
+++ b/docs/language/operators/sort.md
@@ -18,7 +18,7 @@ default, the sort order is ascending, from lowest value to highest. If
 `desc` is specified in a sort expression, the sort order for that key is
 descending.
 
-SuperPipe follows the SQL convention that, by default, `null` values appear last
+SuperSQL follows the SQL convention that, by default, `null` values appear last
 in either case of ascending or descending sort.  This can be overridden
 by specifying `-nulls first`.
 
@@ -42,7 +42,7 @@ output is desired.
 If not all data fits in memory, values are spilled to temporary storage
 and sorted with an external merge sort.
 
-SuperPipe's `sort` is [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+SuperSQL's `sort` is [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
 such that values with identical sort keys always have the same relative order
 in the output as they had in the input, such as provided by the `-s` option in
 Unix's "sort" command-line utility.

--- a/docs/language/operators/where.md
+++ b/docs/language/operators/where.md
@@ -8,7 +8,7 @@
 ```
 ### Description
 
-The `where` operator filters its input by applying a Boolean expression `<expr>`
+The `where` operator filters its input by applying a Boolean [expression](../expressions.md) `<expr>`
 to each input value and dropping each value for which the expression evaluates
 to `false` or to an error.
 
@@ -19,8 +19,8 @@ The "where" keyword requires a boolean-valued expression and does not support
 [search expressions](../search-expressions.md).  Use the
 [search operator](search.md) if you want search syntax.
 
-When SuperPipe queries are run interactively, it is highly convenient to be able to omit
-the "where" keyword, but when where filters appear in query source files,
+When SuperSQL queries are run interactively, it is highly convenient to be able to omit
+the "where" keyword, but when `where` filters appear in query source files,
 it is good practice to include the optional keyword.
 
 ### Examples
@@ -63,7 +63,7 @@ where this >= 2 AND this <= 2
 2
 ```
 
-_A filter with array containment logic_
+_A filter with array [containment](../expressions.md#containment) logic_
 ```mdtest-spq
 # spq
 where this in [1,4]

--- a/docs/language/search-expressions.md
+++ b/docs/language/search-expressions.md
@@ -153,7 +153,7 @@ using Boolean logic to form search expressions.
 When processing [Super Binary](../formats/bsup.md) data, the SuperDB runtime performs a multi-threaded
 Boyer-Moore scan over decompressed data buffers before parsing any data.
 This allows large buffers of data to be efficiently discarded and skipped when
-searching for rarely occurring values.  For a [SuperDB data lake](../lake/format.md),
+searching for rarely occurring values.  For a [SuperDB data lake](../commands/super-db.md),
 a planned feature will use [Super Columnar](../formats/csup.md) files to further accelerate searches.
 
 {{% /tip %}}
@@ -230,7 +230,7 @@ where grep("foo", this)
 ```
 
 Note that the "search" keyword may be omitted.
-For example, the simplest SuperPipe query is perhaps a single keyword search, e.g.,
+For example, the simplest SuperSQL query is perhaps a single keyword search, e.g.,
 ```
 ? foo
 ```
@@ -257,7 +257,7 @@ where grep("foo", this)
 
 This equivalency between keyword search terms and grep semantics
 will change in the near future when we add support for full-text search.
-In this case, grep will still support substring match but keyword search
+In this case, `grep` will still support substring match but keyword search
 will match segmented words from string fields.
 
 {{% /tip %}}
@@ -296,7 +296,7 @@ where (123 in this or grep("123", this))
 ```
 
 Complex values are not supported as search terms but may be queried with
-the "in" operator, e.g.,
+the ["in" operator](expressions.md#containment), e.g.,
 ```
 {s:"foo"} in this
 ```

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -4,7 +4,7 @@ title: Join
 heading: Join Overview
 ---
 
-This is a brief primer on the SuperPipe [`join` operator](../language/operators/join.md).
+This is a brief primer on the SuperSQL [`join` operator](../language/operators/join.md).
 
 Currently, `join` is limited in that only equi-join (i.e., a join predicate
 containing `=`) is supported.
@@ -42,7 +42,7 @@ the joined results.
 Because we're performing an inner join (the default), the
 explicit `inner` is not strictly necessary, but including it clarifies our intention.
 
-The SuperPipe query `inner-join.spq`:
+The query `inner-join.spq`:
 ```mdtest-input inner-join.spq
 file fruit.json
 | inner join (
@@ -167,8 +167,8 @@ produces
 
 In the examples above, we used the
 [`file` operator](../language/operators/file.md) to read our respective inputs
-from named file sources.  However, if the inputs are stored in pools in a SuperDB
-data lake, we would instead specify the sources as data pools using the
+from named file sources.  However, if the inputs are stored in pools in a [SuperDB data lake](../commands/super-db.md),
+we would instead specify the sources as data pools using the
 [`from` operator](../language/operators/from.md).
 
 Here we'll load our input data to pools in a temporary data lake, then execute
@@ -208,9 +208,9 @@ produces
 
 In addition to the syntax shown so far, `join` supports an alternate syntax in
 which left and right inputs are specified by the two branches of a preceding
-[`fork` operator](../language/operators/fork.md),
-[`from` operator](../language/operators/from.md), or
-[`switch` operator](../language/operators/switch.md).
+[`fork`](../language/operators/fork.md),
+[`from`](../language/operators/from.md), or
+[`switch`](../language/operators/switch.md) operator.
 
 Here we'll use the alternate syntax to perform the same inner join shown earlier
 in the [Inner Join section](#inner-join).
@@ -240,10 +240,10 @@ produces
 ## Self Joins
 
 In addition to the named files and pools like we've used in the prior examples,
-SuperPipe also works on a single sequence of data that is split and
+SuperSQL also works on a single sequence of data that is split and
 joined to itself.  Here we'll combine our file sources into a stream that we'll
 pipe into `super` via stdin.  Because `join` requires two separate inputs, here
-we'll use the `has()` function inside a `switch` operator to identify the
+we'll use the `has()` function inside a `switch` operation to identify the
 records in the stream that will be treated as the left and right sides.  Then
 we'll use the [alternate syntax for `join`](#alternate-syntax) to read those two
 inputs.


### PR DESCRIPTION
This PR removes from the docs all mentions of the name "SuperPipe" that was briefly used to refer to the query language's use of pipes.

As I gave a thorough read through each affected doc, I made other changes along the way, e.g., fixing typos, adding/changing hyperlinks, de-Zed-ing, and a few material changes I'll point out with in-line comments.