### PR TITLE
Add a deprecation note about "summarize"

### DIFF
--- a/docs/language/operators/aggregate.md
+++ b/docs/language/operators/aggregate.md
@@ -11,6 +11,15 @@
 [aggregate] [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>] ...] [by [<field>][:=<expr>][, [<field>][:=<expr>]] ...]
 [aggregate] by [<field>][:=<expr>][, [<field>][:=<expr>] ...]
 ```
+
+{{% tip "Note" %}}
+
+The operator name `summarize` that was used previously for performing
+aggregations is now is deprecated and will be removed from the language in the
+future.
+
+{{% /tip %}}
+
 ### Description
 
 In the first four forms, the `aggregate` operator consumes all of its input,
@@ -32,7 +41,7 @@ whether to deliver it to that aggregate. (`where` clauses are analogous
 to the [`where` operator](where.md).)
 
 The output field names for each aggregate and each key are optional.  If omitted,
-a field name is inferred from each right-hand side, e.g, the output field for the
+a field name is inferred from each right-hand side, e.g., the output field for the
 [`count` aggregate function](../aggregates/count.md) is simply `count`.
 
 A key may be either an expression or a field.  If the key field is omitted,


### PR DESCRIPTION
To go with the changes in #5722, I figure it's worth putting a brief note in the docs to formally acknowledge that `summarize` is replaced 1-for-1 with `aggregate`. This is probably obvious to users that have been watching the project closely or are likely to read PRs/changelog, but for the more casual user that's looking at a bunch of their old queries that might still say `summarize`, this means when they type that word into the search tool they'll get the specific message that this is all intentional and that it's advised they update their queries.