### PR TITLE
Fix SELECT typo

### DIFF
--- a/docs/commands/super.md
+++ b/docs/commands/super.md
@@ -916,7 +916,7 @@ WHERE
 
 In SuperSQL, `grep` allows for a much shorter query.
 ```sql
-SELLECT count()
+SELECT count()
 FROM 'gha.bsup'
 WHERE grep('in case you have any feedback 😊')
 ```


### PR DESCRIPTION
I just spotted this typo in the docs and figured it's worth fixing right away.