### PR TITLE
Update slice expressions

### DIFF
--- a/compiler/parser/ztests/in.yaml
+++ b/compiler/parser/ztests/in.yaml
@@ -1,5 +1,5 @@
 spq: |
-  yield { x: 2 in a, y: b In a[1:], z: '1' IN <[string]>(a)}
+  yield { x: 2 in a, y: b In a[2:], z: '1' IN <[string]>(a)}
 
 input: |
   {a:[1],b:2}

--- a/docs/language/functions/upper.md
+++ b/docs/language/functions/upper.md
@@ -29,7 +29,7 @@ yield upper(this)
 ```mdtest-spq
 # spq
 func capitalize(str): (
-  upper(str[0:1]) + str[1:]
+  upper(str[1:2]) + str[2:]
 )
 yield capitalize(this)
 # input

--- a/runtime/sam/expr/slice.go
+++ b/runtime/sam/expr/slice.go
@@ -62,9 +62,7 @@ func (s *Slice) Eval(ectx Context, this super.Value) super.Value {
 		}
 		to = length
 	}
-	if from > to || to > length || from < 0 {
-		return s.zctx.NewErrorf("slice out of bounds")
-	}
+	from, to = fixSliceBounds(from, to, length)
 	bytes := elem.Bytes()
 	switch super.TypeUnder(elem.Type()).(type) {
 	case *super.TypeOfBytes:
@@ -98,10 +96,20 @@ func sliceIndex(ectx Context, this super.Value, slot Evaluator, length int) (int
 		return 0, ErrSliceIndex
 	}
 	index := int(v)
+	if index > 0 {
+		index--
+	}
 	if index < 0 {
 		index += length
 	}
 	return index, nil
+}
+
+func fixSliceBounds(start, end, size int) (int, int) {
+	if start > end || end < 0 {
+		return 0, 0
+	}
+	return max(start, 0), min(end, size)
 }
 
 // UTF8PrefixLen returns the length in bytes of the first runeCount runes in b.

--- a/runtime/sam/expr/slice.go
+++ b/runtime/sam/expr/slice.go
@@ -62,7 +62,7 @@ func (s *Slice) Eval(ectx Context, this super.Value) super.Value {
 		}
 		to = length
 	}
-	from, to = fixSliceBounds(from, to, length)
+	from, to = FixSliceBounds(from, to, length)
 	bytes := elem.Bytes()
 	switch super.TypeUnder(elem.Type()).(type) {
 	case *super.TypeOfBytes:
@@ -105,7 +105,7 @@ func sliceIndex(ectx Context, this super.Value, slot Evaluator, length int) (int
 	return index, nil
 }
 
-func fixSliceBounds(start, end, size int) (int, int) {
+func FixSliceBounds(start, end, size int) (int, int) {
 	if start > end || end < 0 {
 		return 0, 0
 	}

--- a/runtime/vam/expr/slice.go
+++ b/runtime/vam/expr/slice.go
@@ -89,21 +89,23 @@ func (s *sliceExpr) evalArrayOrSlice(vec, fromVec, toVec vector.Any) vector.Any 
 			continue
 		}
 		off := offsets[idx]
-		size := int64(offsets[idx+1] - off)
-		start, end := int64(0), size
+		size := int(offsets[idx+1] - off)
+		start, end := 0, size
 		if fromVec != nil {
 			if slowPath {
-				from, _ = vector.IntValue(fromVec, i)
+				v, _ := vector.IntValue(fromVec, i)
+				from = int(v)
 			}
 			start = sliceIndex(from, size)
 		}
 		if toVec != nil {
 			if slowPath {
-				to, _ = vector.IntValue(toVec, i)
+				v, _ := vector.IntValue(toVec, i)
+				to = int(v)
 			}
 			end = sliceIndex(to, size)
 		}
-		start, end = fixSliceBounds(start, end, size)
+		start, end = expr.FixSliceBounds(start, end, size)
 		newOffsets = append(newOffsets, newOffsets[len(newOffsets)-1]+uint32(end-start))
 		for k := start; k < end; k++ {
 			innerIndex = append(innerIndex, off+uint32(k))
@@ -146,16 +148,16 @@ func (s *sliceExpr) evalStringOrBytes(vec, fromVec, toVec vector.Any) vector.Any
 			continue
 		}
 		size := lengthOfBytesOrString(id, slice)
-		start, end := int64(0), size
+		start, end := 0, size
 		if fromVec != nil {
 			from, _ := vector.IntValue(fromVec, i)
-			start = sliceIndex(from, size)
+			start = sliceIndex(int(from), size)
 		}
 		if toVec != nil {
 			to, _ := vector.IntValue(toVec, i)
-			end = sliceIndex(to, size)
+			end = sliceIndex(int(to), size)
 		}
-		start, end = fixSliceBounds(start, end, size)
+		start, end = expr.FixSliceBounds(start, end, size)
 		slice = sliceBytesOrString(slice, id, start, end)
 		newBytes = append(newBytes, slice...)
 		newOffsets = append(newOffsets, newOffsets[len(newOffsets)-1]+uint32(len(slice)))
@@ -168,20 +170,20 @@ func (s *sliceExpr) evalStringOrBytes(vec, fromVec, toVec vector.Any) vector.Any
 	return out
 }
 
-func (s *sliceExpr) evalStringOrBytesFast(vec vector.Any, from, to int64) (vector.Any, bool) {
+func (s *sliceExpr) evalStringOrBytesFast(vec vector.Any, from, to int) (vector.Any, bool) {
 	switch vec := vec.(type) {
 	case *vector.Const:
 		slice := vec.Value().Bytes()
 		id := vec.Type().ID()
 		size := lengthOfBytesOrString(id, slice)
-		start, end := int64(0), size
+		start, end := 0, size
 		if s.fromEval != nil {
 			start = sliceIndex(from, size)
 		}
 		if s.toEval != nil {
 			end = sliceIndex(to, size)
 		}
-		start, end = fixSliceBounds(start, end, size)
+		start, end = expr.FixSliceBounds(start, end, size)
 		slice = sliceBytesOrString(slice, id, start, end)
 		return vector.NewConst(super.NewValue(vec.Type(), slice), vec.Len(), vec.Nulls), true
 	case *vector.View:
@@ -204,14 +206,14 @@ func (s *sliceExpr) evalStringOrBytesFast(vec vector.Any, from, to int64) (vecto
 		for i := range vec.Len() {
 			slice := bytes[offsets[i]:offsets[i+1]]
 			size := lengthOfBytesOrString(id, slice)
-			start, end := int64(0), size
+			start, end := 0, size
 			if s.fromEval != nil {
 				start = sliceIndex(from, size)
 			}
 			if s.toEval != nil {
 				end = sliceIndex(to, size)
 			}
-			start, end = fixSliceBounds(start, end, size)
+			start, end = expr.FixSliceBounds(start, end, size)
 			slice = sliceBytesOrString(slice, id, start, end)
 			newBytes = append(newBytes, slice...)
 			newOffsets = append(newOffsets, newOffsets[len(newOffsets)-1]+uint32(len(slice)))
@@ -260,31 +262,24 @@ func (s *sliceExpr) bytesAt(val vector.Any, slot uint32) ([]byte, bool) {
 	panic(val)
 }
 
-func lengthOfBytesOrString(id int, slice []byte) int64 {
+func lengthOfBytesOrString(id int, slice []byte) int {
 	if id == super.IDString {
-		return int64(utf8.RuneCount(slice))
+		return utf8.RuneCount(slice)
 	}
-	return int64(len(slice))
+	return len(slice)
 }
 
-func fixSliceBounds(start, end, size int64) (int64, int64) {
-	if start > end || end < 0 {
-		return 0, 0
-	}
-	return max(start, 0), min(end, size)
-}
-
-func sliceIsConstIndex(vec vector.Any) (int64, bool) {
+func sliceIsConstIndex(vec vector.Any) (int, bool) {
 	if vec == nil {
 		return 0, true
 	}
 	if c, ok := vec.(*vector.Const); ok && c.Nulls == nil {
-		return c.Value().Int(), true
+		return int(c.Value().Int()), true
 	}
 	return 0, false
 }
 
-func sliceIndex(idx, size int64) int64 {
+func sliceIndex(idx, size int) int {
 	if idx > 0 {
 		idx--
 	}
@@ -294,10 +289,10 @@ func sliceIndex(idx, size int64) int64 {
 	return idx
 }
 
-func sliceBytesOrString(slice []byte, id int, start, end int64) []byte {
+func sliceBytesOrString(slice []byte, id int, start, end int) []byte {
 	if id == super.IDString {
-		slice = slice[expr.UTF8PrefixLen(slice, int(start)):]
-		return slice[:expr.UTF8PrefixLen(slice, int(end-start))]
+		slice = slice[expr.UTF8PrefixLen(slice, start):]
+		return slice[:expr.UTF8PrefixLen(slice, end-start)]
 	} else {
 		return slice[start:end]
 	}

--- a/runtime/vcache/loader.go
+++ b/runtime/vcache/loader.go
@@ -263,7 +263,7 @@ func (l *loader) loadVals(typ super.Type, s *primitive, nulls *vector.Bool) (vec
 		}
 		return b, nil
 	case *super.TypeOfBytes:
-		var bytes []byte
+		bytes := []byte{}
 		offs := make([]uint32, length+1)
 		var off uint32
 		for slot := uint32(0); slot < length; slot++ {

--- a/runtime/ztests/expr/slice-array.yaml
+++ b/runtime/ztests/expr/slice-array.yaml
@@ -3,18 +3,18 @@ spq: "yield c[start:end]"
 vector: true
 
 input: |
-  {start:1,end:-1,c:null([int64])}
-  {start:1,end:-1,c:[1,2,3,4]}
-  {start:-3,end:3,c:[5,7,8,9]}
-  {start:-5,end:3,c:[5,7,8,9]}
-  {start:0,end:5,c:[5,7,8,9]}
-  {start:4,end:3,c:[5,7,8,9]}
+  {start:2,end:-1,c:null([int64])}
+  {start:2,end:-1,c:[1,2,3,4]}
+  {start:-3,end:4,c:[5,7,8,9]}
+  {start:-5,end:4,c:[5,7,8,9]}
+  {start:1,end:6,c:[5,7,8,9]}
+  {start:5,end:4,c:[5,7,8,9]}
 
 output: |
   null([int64])
   [2,3]
   [7,8]
-  error("slice out of bounds")
-  error("slice out of bounds")
-  error("slice out of bounds")
+  [5,7,8]
+  [5,7,8,9]
+  []
   

--- a/runtime/ztests/expr/slice-set.yaml
+++ b/runtime/ztests/expr/slice-set.yaml
@@ -3,17 +3,17 @@ spq: "yield c[start:end]"
 vector: true
 
 input: |
-  {start:1,end:-1,c:null(|[int64]|)}
-  {start:1,end:-1,c:|[1,2,3,4]|}
-  {start:-3,end:3,c:|[5,7,8,9]|}
-  {start:-5,end:3,c:|[5,7,8,9]|}
-  {start:0,end:5,c:|[5,7,8,9]|}
-  {start:4,end:3,c:|[5,7,8,9]|}
+  {start:2,end:-1,c:null(|[int64]|)}
+  {start:2,end:-1,c:|[1,2,3,4]|}
+  {start:-3,end:4,c:|[5,7,8,9]|}
+  {start:-5,end:4,c:|[5,7,8,9]|}
+  {start:0,end:6,c:|[5,7,8,9]|}
+  {start:5,end:4,c:|[5,7,8,9]|}
 
 output: |
   null(|[int64]|)
   |[2,3]|
   |[7,8]|
-  error("slice out of bounds")
-  error("slice out of bounds")
-  error("slice out of bounds")
+  |[5,7,8]|
+  |[5,7,8,9]|
+  |[]|

--- a/runtime/ztests/expr/slice.yaml
+++ b/runtime/ztests/expr/slice.yaml
@@ -1,4 +1,4 @@
-spq: "cut a1:=a[1:-1],a2:=a[1:],a3:=a[:1],a4:=a[:-1],a5:=a[:-100],a6:=a[-1:],a7:=a[-2:-1],a8:=(a IS NOT NULL and len(a)>0) ? a[:a[1]-8] : null"
+spq: "cut a1:=a[2:-1],a2:=a[2:],a3:=a[:2],a4:=a[:-1],a5:=a[:-100],a6:=a[-1:],a7:=a[-2:-1],a8:=(a IS NOT NULL and len(a)>0) ? a[:a[2]-8] : null"
 
 vector: true
 
@@ -22,12 +22,12 @@ output: |
   {a1:null(bytes),a2:null(bytes),a3:null(bytes),a4:null(bytes),a5:null(bytes),a6:null(bytes),a7:null(bytes),a8:null}
   {a1:null(string),a2:null(string),a3:null(string),a4:null(string),a5:null(string),a6:null(string),a7:null(string),a8:null}
   {a1:null([int32]),a2:null([int32]),a3:null([int32]),a4:null([int32]),a5:null([int32]),a6:null([int32]),a7:null([int32]),a8:null}
-  {a1:error("slice out of bounds"),a2:error("slice out of bounds"),a3:error("slice out of bounds"),a4:error("slice out of bounds"),a5:error("slice out of bounds"),a6:error("slice out of bounds"),a7:error("slice out of bounds"),a8:null}
-  {a1:error("slice out of bounds"),a2:error("slice out of bounds"),a3:error("slice out of bounds"),a4:error("slice out of bounds"),a5:error("slice out of bounds"),a6:error("slice out of bounds"),a7:error("slice out of bounds"),a8:null}
-  {a1:error("slice out of bounds"),a2:error("slice out of bounds"),a3:error("slice out of bounds"),a4:error("slice out of bounds"),a5:error("slice out of bounds"),a6:error("slice out of bounds"),a7:error("slice out of bounds"),a8:null}
-  {a1:0x1122,a2:0x112233,a3:0x00,a4:0x001122,a5:error("slice out of bounds"),a6:0x33,a7:0x22,a8:error("slice index is not a number")}
-  {a1:"12",a2:"123",a3:"0",a4:"012",a5:error("slice out of bounds"),a6:"3",a7:"2",a8:error("slice index is not a number")}
-  {a1:"ⁱ⁲",a2:"ⁱ⁲3",a3:"0",a4:"0ⁱ⁲",a5:error("slice out of bounds"),a6:"3",a7:"⁲",a8:error("slice index is not a number")}
-  {a1:"ⁱ⁲",a2:"ⁱ⁲⁳",a3:"⁰",a4:"⁰ⁱ⁲",a5:error("slice out of bounds"),a6:"⁳",a7:"⁲",a8:error("slice index is not a number")}
-  {a1:[11(int32),12(int32)],a2:[11(int32),12(int32),13(int32)],a3:[10(int32)],a4:[10(int32),11(int32),12(int32)],a5:error("slice out of bounds"),a6:[13(int32)],a7:[12(int32)],a8:[10(int32),11(int32)]}
-  {a1:|[11(int32),12(int32)]|,a2:|[11(int32),12(int32),13(int32)]|,a3:|[10(int32)]|,a4:|[10(int32),11(int32),12(int32)]|,a5:error("slice out of bounds"),a6:|[13(int32)]|,a7:|[12(int32)]|,a8:|[10(int32),11(int32)]|}
+  {a1:0x,a2:0x,a3:0x,a4:0x,a5:0x,a6:0x,a7:0x,a8:null}
+  {a1:"",a2:"",a3:"",a4:"",a5:"",a6:"",a7:"",a8:null}
+  {a1:[]([int32]),a2:[]([int32]),a3:[]([int32]),a4:[]([int32]),a5:[]([int32]),a6:[]([int32]),a7:[]([int32]),a8:null}
+  {a1:0x1122,a2:0x112233,a3:0x00,a4:0x001122,a5:0x,a6:0x33,a7:0x22,a8:error("slice index is not a number")}
+  {a1:"12",a2:"123",a3:"0",a4:"012",a5:"",a6:"3",a7:"2",a8:error("slice index is not a number")}
+  {a1:"ⁱ⁲",a2:"ⁱ⁲3",a3:"0",a4:"0ⁱ⁲",a5:"",a6:"3",a7:"⁲",a8:error("slice index is not a number")}
+  {a1:"ⁱ⁲",a2:"ⁱ⁲⁳",a3:"⁰",a4:"⁰ⁱ⁲",a5:"",a6:"⁳",a7:"⁲",a8:error("slice index is not a number")}
+  {a1:[11(int32),12(int32)],a2:[11(int32),12(int32),13(int32)],a3:[10(int32)],a4:[10(int32),11(int32),12(int32)],a5:[]([int32]),a6:[13(int32)],a7:[12(int32)],a8:[10(int32),11(int32)]}
+  {a1:|[11(int32),12(int32)]|,a2:|[11(int32),12(int32),13(int32)]|,a3:|[10(int32)]|,a4:|[10(int32),11(int32),12(int32)]|,a5:|[]|(|[int32]|),a6:|[13(int32)]|,a7:|[12(int32)]|,a8:|[10(int32),11(int32)]|}

--- a/vector/builder.go
+++ b/vector/builder.go
@@ -356,7 +356,7 @@ type bytesStringTypeBuilder struct {
 }
 
 func newBytesStringTypeBuilder(typ super.Type) Builder {
-	return &bytesStringTypeBuilder{typ: typ, offs: []uint32{0}}
+	return &bytesStringTypeBuilder{typ: typ, bytes: []byte{}, offs: []uint32{0}}
 }
 
 func (b *bytesStringTypeBuilder) Write(bytes zcode.Bytes) {


### PR DESCRIPTION
The commit updates the functionality of slice expressions so that they are now 1) 1-based like index expressions and 2) do not return an error if they overflow. It also fixes an issue with empty vector bytes values that was causing the new test values to fail on boomerang tests.

Closes #5688