### PR TITLE
move vcache.Path to field.Projection

### DIFF
--- a/pkg/field/projection.go
+++ b/pkg/field/projection.go
@@ -1,17 +1,15 @@
-package vcache
+package field
 
 import (
 	"fmt"
-
-	"github.com/brimdata/super/pkg/field"
 )
 
-// A path is an array of string or Forks
-type Path []any //XXX clean this up later
-type Fork []Path
+// A Projection is an array of string or Forks
+type Projection []any //XXX clean this up later
+type Fork []Projection
 
-func NewProjection(paths []field.Path) Path {
-	var out Path
+func NewProjection(paths []Path) Projection {
+	var out Projection
 	for _, path := range paths {
 		out = insertPath(out, path)
 	}
@@ -19,7 +17,7 @@ func NewProjection(paths []field.Path) Path {
 }
 
 // XXX this is N*N in path lengths... fix?
-func insertPath(existing Path, addition field.Path) Path {
+func insertPath(existing Projection, addition Path) Projection {
 	if len(addition) == 0 {
 		return existing
 	}
@@ -29,17 +27,17 @@ func insertPath(existing Path, addition field.Path) Path {
 	switch elem := existing[0].(type) {
 	case string:
 		if elem == addition[0] {
-			return append(Path{elem}, insertPath(existing[1:], addition[1:])...)
+			return append(Projection{elem}, insertPath(existing[1:], addition[1:])...)
 		}
-		return Path{Fork{existing, convertFieldPath(addition)}}
+		return Projection{Fork{existing, convertFieldPath(addition)}}
 	case Fork:
-		return Path{addToFork(elem, addition)}
+		return Projection{addToFork(elem, addition)}
 	default:
 		panic(fmt.Sprintf("bad type encounted in insertPath: %T", elem))
 	}
 }
 
-func addToFork(fork Fork, addition field.Path) Fork {
+func addToFork(fork Fork, addition Path) Fork {
 	// The first element of each path in a fork must be the key distinguishing
 	// the different paths (so no embedded Fork as the first element of a fork)
 	for k, path := range fork {
@@ -52,7 +50,7 @@ func addToFork(fork Fork, addition field.Path) Fork {
 	return append(fork, convertFieldPath(addition))
 }
 
-func convertFieldPath(path field.Path) Path {
+func convertFieldPath(path Path) Projection {
 	var out []any
 	for _, s := range path {
 		out = append(out, s)

--- a/pkg/field/projection.go
+++ b/pkg/field/projection.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// A Projection is an array of string or Forks
+// A Projection is a slice of string or Forks
 type Projection []any //XXX clean this up later
 type Fork []Projection
 

--- a/runtime/vam/op/scan.go
+++ b/runtime/vam/op/scan.go
@@ -23,7 +23,7 @@ type Scanner struct {
 	rctx       *runtime.Context
 	pool       *lake.Pool
 	once       sync.Once
-	projection vcache.Path
+	projection field.Projection
 	cache      *vcache.Cache
 	progress   *zbuf.Progress
 	resultCh   chan result
@@ -39,7 +39,7 @@ func NewScanner(rctx *runtime.Context, cache *vcache.Cache, parent zbuf.Puller, 
 		parent:     newObjectPuller(parent),
 		pruner:     pruner,
 		pool:       pool,
-		projection: vcache.NewProjection(paths),
+		projection: field.NewProjection(paths),
 		progress:   progress,
 		doneCh:     make(chan struct{}),
 		resultCh:   make(chan result),

--- a/runtime/vam/op/searcher.go
+++ b/runtime/vam/op/searcher.go
@@ -20,7 +20,7 @@ type Searcher struct {
 	once       sync.Once
 	parent     *objectPuller
 	pool       *lake.Pool
-	projection vcache.Path
+	projection field.Projection
 	rctx       *runtime.Context
 	resultCh   chan searchResult
 	doneCh     chan struct{}
@@ -32,7 +32,7 @@ func NewSearcher(rctx *runtime.Context, cache *vcache.Cache, parent zbuf.Puller,
 		filter:     filter,
 		parent:     newObjectPuller(parent),
 		pool:       pool,
-		projection: vcache.NewProjection(project),
+		projection: field.NewProjection(project),
 		rctx:       rctx,
 		resultCh:   make(chan searchResult),
 		doneCh:     make(chan struct{}),

--- a/runtime/vam/projection.go
+++ b/runtime/vam/projection.go
@@ -9,31 +9,31 @@ import (
 )
 
 type Projection struct {
-	zctx   *super.Context
-	object *vcache.Object
-	path   vcache.Path
+	zctx       *super.Context
+	object     *vcache.Object
+	projection field.Projection
 }
 
 func NewProjection(zctx *super.Context, o *vcache.Object, paths []field.Path) zbuf.Puller {
 	return NewMaterializer(&Projection{
-		zctx:   zctx,
-		object: o,
-		path:   vcache.NewProjection(paths),
+		zctx:       zctx,
+		object:     o,
+		projection: field.NewProjection(paths),
 	})
 }
 
 func NewVectorProjection(zctx *super.Context, o *vcache.Object, paths []field.Path) vector.Puller {
 	return &Projection{
-		zctx:   zctx,
-		object: o,
-		path:   vcache.NewProjection(paths),
+		zctx:       zctx,
+		object:     o,
+		projection: field.NewProjection(paths),
 	}
 }
 
 func (p *Projection) Pull(bool) (vector.Any, error) {
 	if o := p.object; o != nil {
 		p.object = nil
-		return o.Fetch(p.zctx, p.path)
+		return o.Fetch(p.zctx, p.projection)
 	}
 	return nil, nil
 }

--- a/runtime/vcache/object.go
+++ b/runtime/vcache/object.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/csup"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/vector"
 )
@@ -58,6 +59,6 @@ func (o *Object) Close() error {
 // storage and cached in memory so that subsequent calls run from memory.
 // The vectors returned will have types from the provided zctx.  Multiple
 // Fetch calls to the same object may run concurrently.
-func (o *Object) Fetch(zctx *super.Context, projection Path) (vector.Any, error) {
+func (o *Object) Fetch(zctx *super.Context, projection field.Projection) (vector.Any, error) {
 	return (&loader{zctx, o.object.DataReader()}).load(projection, o.root)
 }

--- a/zio/csupio/reader.go
+++ b/zio/csupio/reader.go
@@ -18,7 +18,7 @@ import (
 type reader struct {
 	zctx       *super.Context
 	objects    []*csup.Object
-	projection vcache.Path
+	projection field.Projection
 	readerAt   io.ReaderAt
 	vals       []super.Value
 }
@@ -35,7 +35,7 @@ func NewReader(zctx *super.Context, r io.Reader, fields []field.Path) (zio.Reade
 	return &reader{
 		zctx:       zctx,
 		objects:    objects,
-		projection: vcache.NewProjection(fields),
+		projection: field.NewProjection(fields),
 		readerAt:   ra,
 	}, nil
 }

--- a/zio/csupio/vectorreader.go
+++ b/zio/csupio/vectorreader.go
@@ -23,7 +23,7 @@ type VectorReader struct {
 	activeReaders *atomic.Int64
 	nextObject    *atomic.Int64
 	objects       []*csup.Object
-	projection    vcache.Path
+	projection    field.Projection
 	readerAt      io.ReaderAt
 	hasClosed     bool
 }
@@ -50,7 +50,7 @@ func NewVectorReader(ctx context.Context, zctx *super.Context, r io.Reader, fiel
 		activeReaders: &atomic.Int64{},
 		nextObject:    &atomic.Int64{},
 		objects:       filterObjects(zctx, evaluator, objects),
-		projection:    vcache.NewProjection(fields),
+		projection:    field.NewProjection(fields),
 		readerAt:      ra,
 	}, nil
 }


### PR DESCRIPTION
This commit moves the projection data structure used by vcache into the generic field package so it can be shared in more places without creating import cycles.

This is needed by an upcoming PR that will add projection pushdown to the CSUP metadata filter, which is needed by a subsequent PR that will make CSUP more efficient by allowing lazy loading of types.