### PR TITLE
streaming of CSUP objects

### DIFF
--- a/csup/header.go
+++ b/csup/header.go
@@ -50,9 +50,9 @@ func (h *Header) Deserialize(bytes []byte) error {
 	return nil
 }
 
-func ReadHeader(r io.Reader) (Header, error) {
+func ReadHeader(r io.ReaderAt) (Header, error) {
 	var bytes [HeaderSize]byte
-	cc, err := r.Read(bytes[:])
+	cc, err := r.ReadAt(bytes[:], 0)
 	if err != nil {
 		return Header{}, err
 	}

--- a/zio/csupio/stream.go
+++ b/zio/csupio/stream.go
@@ -1,0 +1,31 @@
+package csupio
+
+import (
+	"io"
+	"math"
+	"sync"
+
+	"github.com/brimdata/super/csup"
+)
+
+type stream struct {
+	mu  sync.Mutex
+	r   io.ReaderAt
+	off int64
+}
+
+func (s *stream) next() (*csup.Object, error) {
+	// NewObject puts the right end to the passed in SectionReader and since
+	// the end is unkown just pass MaxInt64.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	o, err := csup.NewObject(io.NewSectionReader(s.r, s.off, math.MaxInt64))
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
+		return nil, err
+	}
+	s.off += int64(o.Size())
+	return o, nil
+}

--- a/zio/csupio/stream.go
+++ b/zio/csupio/stream.go
@@ -15,10 +15,12 @@ type stream struct {
 }
 
 func (s *stream) next() (*csup.Object, error) {
-	// NewObject puts the right end to the passed in SectionReader and since
-	// the end is unkown just pass MaxInt64.
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// We read the next object by creating a section reader that starts
+	// at the end of the previous object without an upper bound.  The csup
+	// package won't read off the end of the object so this is not a problem.
 	o, err := csup.NewObject(io.NewSectionReader(s.r, s.off, math.MaxInt64))
 	if err != nil {
 		if err == io.EOF {

--- a/zio/csupio/vectorreader.go
+++ b/zio/csupio/vectorreader.go
@@ -105,6 +105,7 @@ func (v *VectorReader) Pull(done bool) (vector.Any, error) {
 
 func pruneObject(zctx *super.Context, metaFilters *sync.Pool, m csup.Metadata) bool {
 	mf := metaFilters.Get().(*metafilter)
+	defer metaFilters.Put(mf)
 	vals := csup.ProjectMetadata(zctx, m, mf.projection)
 	for _, val := range vals {
 		if mf.filter.Eval(nil, val).Ptr().AsBool() {

--- a/zio/csupio/vectorreader.go
+++ b/zio/csupio/vectorreader.go
@@ -45,7 +45,7 @@ func (v *VectorReader) NewConcurrentPuller() (vector.Puller, error) {
 	v.activeReaders.Add(1)
 	return &VectorReader{
 		ctx:           v.ctx,
-		zctx:          v.zctx, //XXX use csup object ctx?
+		zctx:          v.zctx,
 		activeReaders: v.activeReaders,
 		pushdown:      v.pushdown,
 		stream:        v.stream,

--- a/zio/csupio/vectorreader.go
+++ b/zio/csupio/vectorreader.go
@@ -36,6 +36,7 @@ func NewVectorReader(ctx context.Context, zctx *super.Context, r io.Reader, push
 		zctx:          zctx,
 		activeReaders: &atomic.Int64{},
 		stream:        &stream{r: ra},
+		pushdown:      pushdown,
 		projection:    pushdown.Projection(),
 		readerAt:      ra,
 	}, nil


### PR DESCRIPTION
This commit changes the CSUP reader to stream the objects found within any given file instead of reading them in all at once. The vector pullers provide concurrency so no additional attempts to read-ahead are implemented here.