### PR TITLE
Change the names of Super formats in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,7 +745,7 @@ questions.
 * zqd: Fix an issue with excess characters in Space names after upgrade (#1112)
 
 ## v0.19.0
-* zq: ZNG output is now LZ4-compressed by default (#1050, #1064, #1063, [ZNG spec](docs/formats/bsup.md#2-the-super-binary-format))
+* zq: ZNG output is now LZ4-compressed by default (#1050, #1064, #1063, [ZNG spec](docs/formats/bsup.md#2-the-bsup-format))
 * zar: Adjust import size threshold to account for compression (#1082)
 * zqd: Support starting `zqd` with datapath set to an S3 path (#1072)
 * zq: Fix an issue with panics during pcap import (#1090)

--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ FROM 'https://data.gharchive.org/2015-01-01-15.json.gz'
 | JOIN USING (user) repos
 ```
 
-## Super JSON
+## Super (SUP) Format
 
 Super-structured data is strongly typed and "polymorphic": any value can take on any type
 and sequences of data need not all conform to a predefined schema.  To this end,
 SuperDB extends the JSON format to support super-structured data in a format called
-[Super JSON](https://superdb.org/docs/formats/sup) where all JSON values
-are also Super JSON values.  Similarly,
-the [Super Binary](https://superdb.org/docs/formats/bsup) format is an efficient
-binary representation of Super JSON (a bit like Avro) and the
-[Super Columnar](https://superdb.org/docs/formats/csup) format is a columnar
-representation of Super JSON (a bit like Parquet).
+[Super (SUP)](https://superdb.org/docs/formats/sup) where all JSON values
+are also SUP.  Similarly,
+the [Super Binary (BSUP)](https://superdb.org/docs/formats/bsup) format is an efficient
+binary representation of SUP (a bit like Avro) and the
+[Super Columnar (CSUP)](https://superdb.org/docs/formats/csup) format is a columnar
+representation of SUP (a bit like Parquet).
 
 Even though SuperDB is based on these super-structured data formats, it can read and write
 most common data formats.

--- a/docs/commands/super-db.md
+++ b/docs/commands/super-db.md
@@ -117,8 +117,8 @@ replication easy to support and deploy.
 
 The cloud objects that comprise a lake, e.g., data objects,
 commit history, transaction journals, partial aggregations, etc.,
-are stored as super-structured data, i.e., either as [row-based Super Binary](../formats/bsup.md)
-or [Super Columnar](../formats/csup.md).
+are stored as super-structured data, i.e., either as [row-based Super Binary (BSUP)](../formats/bsup.md)
+or [Super Columnar (CSUP)](../formats/csup.md).
 This makes introspection of the lake structure straightforward as many key
 lake data structures can be queried with metadata queries and presented
 to a client for further processing by downstream tooling.
@@ -527,7 +527,7 @@ the collection of objects is generally not sorted.
 Each load operation creates a single [commit object](#commit-objects), which includes:
 * an author and message string,
 * a timestamp computed by the server, and
-* an optional metadata field of any type expressed as a Super JSON value.
+* an optional metadata field of any type expressed as a Super (SUP) value.
 This data has the type signature:
 ```
 {
@@ -550,7 +550,7 @@ The `date` field here is used by the lake system to do [time travel](#time-trave
 through the branch and pool history, allowing you to see the state of
 branches at any time in their commit history.
 
-Arbitrary metadata expressed as any [Super JSON value](../formats/sup.md)
+Arbitrary metadata expressed as any [SUP value](../formats/sup.md)
 may be attached to a commit via the `-meta` flag.  This allows an application
 or user to transactionally commit metadata alongside committed data for any
 purpose.  This approach allows external applications to implement arbitrary
@@ -558,7 +558,7 @@ data provenance and audit capabilities by embedding custom metadata in the
 commit history.
 
 Since commit objects are stored as super-structured data, the metadata can easily be
-queried by running the `log -f bsup` to retrieve the log in Super Binary format,
+queried by running the `log -f bsup` to retrieve the log in BSUP format,
 for example, and using [`super`](super.md) to pull the metadata out
 as in:
 ```
@@ -677,8 +677,8 @@ indicating the pool and branch to use as input.
 
 The pool/branch names are specified with `from` in the query.
 
-As with [`super`](super.md), the default output format is Super JSON for
-terminals and Super Binary otherwise, though this can be overridden with
+As with [`super`](super.md), the default output format is SUP for
+terminals and BSUP otherwise, though this can be overridden with
 `-f` to specify one of the various supported output formats.
 
 If a pool name is provided to `from` without a branch name, then branch
@@ -699,7 +699,7 @@ Filters on pool keys are efficiently implemented as the data is laid out
 according to the pool key and seek indexes keyed by the pool key
 are computed for each data object.
 
-When querying data to the [Super Binary](../formats/bsup.md) output format,
+When querying data to the [BSUP](../formats/bsup.md) output format,
 output from a pool can be easily piped to other commands like `super`, e.g.,
 ```
 super db query -f bsup 'from logs' | super -f table -c 'count() by field' -
@@ -741,7 +741,7 @@ There are three types of meta-queries:
 sources vary based on level.
 
 For example, a list of pools with configuration data can be obtained
-in the Super JSON format as follows:
+in the SUP format as follows:
 ```
 super db query -Z "from :pools"
 ```

--- a/docs/commands/super-db.md
+++ b/docs/commands/super-db.md
@@ -3,21 +3,23 @@ weight: 2
 title: super db
 ---
 
-> **TL;DR** `super db` is a sub-command of `super` to manage and query SuperDB data lakes.
-> You can import data from a variety of formats and it will automatically
-> be committed in [super-structured](../formats/_index.md)
-> format, providing full fidelity of the original format and the ability
-> to reconstruct the original data without loss of information.
->
-> SuperDB data lakes provide an easy-to-use substrate for data discovery, preparation,
-> and transformation as well as serving as a queryable and searchable store
-> for super-structured data both for online and archive use cases.
+## Synopsis
+
+`super db` is a sub-command of [`super`](./super.md) to manage and query SuperDB data lakes.
+You can import data from a variety of formats and it will automatically
+be committed in [super-structured](../formats/_index.md)
+format, providing full fidelity of the original format and the ability
+to reconstruct the original data without loss of information.
+
+SuperDB data lakes provide an easy-to-use substrate for data discovery, preparation,
+and transformation as well as serving as a queryable and searchable store
+for super-structured data both for online and archive use cases.
 
 <p id="status"></p>
 
 {{% tip "Status" %}}
 
-While [`super`](super.md) and its accompanying [formats](../formats/_index.md)
+While `super` and its accompanying formats
 are production quality, the SuperDB data lake is still fairly early in development
 and alpha quality.
 That said, SuperDB data lakes can be utilized quite effectively at small scale,

--- a/docs/commands/super.md
+++ b/docs/commands/super.md
@@ -6,7 +6,7 @@ title: super
 > **TL;DR** `super` is a command-line tool that uses [SuperSQL](../language/_index.md)
 > to query a variety of data formats in files, over HTTP, or in [S3](../integrations/amazon-s3.md)
 > storage. Best performance is achieved when operating on data in binary formats such as
-> [Super Binary](../formats/bsup.md), [Super Columnar](../formats/csup.md),
+> [Super Binary (BSUP)](../formats/bsup.md), [Super Columnar (CSUP)](../formats/csup.md),
 > [Parquet](https://github.com/apache/parquet-format), or
 > [Arrow](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format).
 
@@ -116,15 +116,15 @@ simply run `super` with no arguments.
 
 ## Data Formats
 
-`super` supports a number of [input](#input-formats) and [output](#output-formats) formats, but the super formats
-([Super Binary](../formats/bsup.md),
-[Super Columnar](../formats/csup.md),
-and [Super JSON](../formats/sup.md)) tend to be the most versatile and
+`super` supports a number of [input](#input-formats) and [output](#output-formats) formats, but the
+[Super (SUP)](../formats/sup.md),
+[Super Binary (BSUP)](../formats/bsup.md), and
+[Super Columnar (CSUP)](../formats/csup.md) formats tend to be the most versatile and
 easy to work with.
 
 `super` typically operates on binary-encoded data and when you want to inspect
-human-readable bits of output, you merely format it as Super JSON, which is the
-default format when output is directed to the terminal.  Super Binary is the default
+human-readable bits of output, you merely format it as SUP, which is the
+default format when output is directed to the terminal.  BSUP is the default
 when redirecting to a non-terminal output like a file or pipe.
 
 Unless the `-i` option specifies a specific input format,
@@ -139,16 +139,16 @@ in the order appearing on the command line forming the input stream.
 |  Option   | Auto | Specification                            |
 |-----------|------|------------------------------------------|
 | `arrows`  |  yes | [Arrow IPC Stream Format](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format) |
-| `bsup`    |  yes | [Super Binary](../formats/bsup.md) |
-| `csup`    |  yes | [Super Columnar](../formats/csup.md) |
+| `bsup`    |  yes | [BSUP](../formats/bsup.md) |
+| `csup`    |  yes | [CSUP](../formats/csup.md) |
 | `csv`     |  yes | [Comma-Separated Values (RFC 4180)](https://www.rfc-editor.org/rfc/rfc4180.html) |
 | `json`    |  yes | [JSON (RFC 8259)](https://www.rfc-editor.org/rfc/rfc8259.html) |
 | `line`    |  no  | One string value per input line |
 | `parquet` |  yes | [Apache Parquet](https://github.com/apache/parquet-format) |
-| `sup`     |  yes | [Super JSON](../formats/sup.md) |
+| `sup`     |  yes | [SUP](../formats/sup.md) |
 | `tsv`     |  yes | [Tab-Separated Values](https://en.wikipedia.org/wiki/Tab-separated_values) |
 | `zeek`    |  yes | [Zeek Logs](https://docs.zeek.org/en/master/logs/index.html) |
-| `zjson`   |  yes | [Super JSON over JSON](../formats/zjson.md) |
+| `zjson`   |  yes | [Super over JSON (JSUP)](../formats/zjson.md) |
 
 The input format is typically [detected automatically](#auto-detection) and the formats for which
 "Auto" is "yes" in the table above support _auto-detection_.
@@ -181,7 +181,7 @@ then the command
 ```mdtest-command
 super -z sample.csv sample.json
 ```
-would produce this output in the default Super JSON format
+would produce this output in the default SUP format
 ```mdtest-output
 {a:1.,b:"foo"}
 {a:2.,b:"bar"}
@@ -190,32 +190,32 @@ would produce this output in the default Super JSON format
 
 #### JSON Auto-detection: Super vs. Plain
 
-Since [Super JSON](../formats/sup.md) is a superset of plain JSON, `super` must be careful how it distinguishes the two cases when performing auto-inference.
+Since [SUP](../formats/sup.md) is a superset of plain JSON, `super` must be careful how it distinguishes the two cases when performing auto-inference.
 While you can always clarify your intent
 via `-i sup` or `-i json`, `super` attempts to "just do the right thing"
-when you run it with Super JSON vs. plain JSON.
+when you run it with SUP vs. plain JSON.
 
-While `super` can parse any JSON using its built-in Super JSON parser this is typically
-not desirable because (1) the Super JSON parser is not particularly performant and
-(2) all JSON numbers are floating point but the Super JSON parser will parse as
+While `super` can parse any JSON using its built-in SUP parser this is typically
+not desirable because (1) the SUP parser is not particularly performant and
+(2) all JSON numbers are floating point but the SUP parser will parse as
 JSON any number that appears without a decimal point as an integer type.
 
 {{% tip "Note" %}}
 
-The reason `super` is not particularly performant for Super JSON is that the [Super Binary](../formats/bsup.md) or
-[Super Columnar](../formats/csup.md) formats are semantically equivalent to Super JSON but much more efficient and
+The reason `super` is not particularly performant for SUP is that the [BSUP](../formats/bsup.md) or
+[CSUP](../formats/csup.md) formats are semantically equivalent to SUP but much more efficient and
 the design intent is that these efficient binary formats should be used in
-use cases where performance matters.  Super JSON is typically used only when
+use cases where performance matters.  SUP is typically used only when
 data needs to be human-readable in interactive settings or in automated tests.
 
 {{% /tip %}}
 
-To this end, `super` uses a heuristic to select between Super JSON and plain JSON when the
+To this end, `super` uses a heuristic to select between SUP and plain JSON when the
 `-i` option is not specified. Specifically, plain JSON is selected when the first values
 of the input are parsable as valid JSON and includes a JSON object either
 as an outer object or as a value nested somewhere within a JSON array.
 
-This heuristic almost always works in practice because Super JSON records
+This heuristic almost always works in practice because SUP records
 typically omit quotes around field names.
 
 ### Output Formats
@@ -225,24 +225,24 @@ typically omit quotes around field names.
 |  Option   | Specification                            |
 |-----------|------------------------------------------|
 | `arrows`  | [Arrow IPC Stream Format](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format) |
-| `bsup`    | [Super Binary](../formats/bsup.md) |
-| `csup`    | [Super Columnar](../formats/csup.md) |
+| `bsup`    | [BSUP](../formats/bsup.md) |
+| `csup`    | [CSUP](../formats/csup.md) |
 | `csv`     | [Comma-Separated Values (RFC 4180)](https://www.rfc-editor.org/rfc/rfc4180.html) |
 | `json`    | [JSON (RFC 8259)](https://www.rfc-editor.org/rfc/rfc8259.html) |
 | `lake`    | [SuperDB Data Lake Metadata Output](#superdb-data-lake-metadata-output) |
 | `line`    | (described [below](#simplified-text-outputs)) |
 | `parquet` | [Apache Parquet](https://github.com/apache/parquet-format) |
-| `sup`     | [Super JSON](../formats/sup.md) |
+| `sup`     | [SUP](../formats/sup.md) |
 | `table`   | (described [below](#simplified-text-outputs)) |
 | `text`    | (described [below](#simplified-text-outputs)) |
 | `tsv`     | [Tab-Separated Values](https://en.wikipedia.org/wiki/Tab-separated_values) |
 | `zeek`    | [Zeek Logs](https://docs.zeek.org/en/master/logs/index.html) |
-| `zjson`   | [Super JSON over JSON](../formats/zjson.md) |
+| `zjson`   | [SUP over JSON (JSUP)](../formats/zjson.md) |
 
-The output format defaults to either Super JSON or Super Binary and may be specified
+The output format defaults to either SUP or BSUP and may be specified
 with the `-f` option.
 
-Since Super JSON is a common format choice, the `-z` flag is a shortcut for
+Since SUP is a common format choice, the `-z` flag is a shortcut for
 `-f sup`.  Also, `-Z` is a shortcut for `-f sup` with `-pretty 4` as
 [described below](#pretty-printing).
 
@@ -251,18 +251,18 @@ And since plain JSON is another common format choice, the `-j` flag is a shortcu
 
 #### Output Format Selection
 
-When the format is not specified with `-f`, it defaults to Super JSON if the output
-is a terminal and to Super Binary otherwise.
+When the format is not specified with `-f`, it defaults to SUP if the output
+is a terminal and to BSUP otherwise.
 
 While this can cause an occasional surprise (e.g., forgetting `-f` or `-z`
 in a scripted test that works fine on the command line but fails in CI),
 we felt that the design of having a uniform default had worse consequences:
-* If the default format were Super JSON, it would be very easy to create pipelines
-and deploy to production systems that were accidentally using Super JSON instead of
-the much more efficient Super Binary format because the `-f bsup` had been mistakenly
+* If the default format were SUP, it would be very easy to create pipelines
+and deploy to production systems that were accidentally using SUP instead of
+the much more efficient BSUP format because the `-f bsup` had been mistakenly
 omitted from some command.  The beauty of SuperDB is that all of this "just works"
 but it would otherwise perform poorly.
-* If the default format were Super Binary, then users would be endlessly annoyed by
+* If the default format were BSUP, then users would be endlessly annoyed by
 binary output to their terminal when forgetting to type `-f sup`.
 
 In practice, we have found that the output defaults
@@ -270,7 +270,7 @@ In practice, we have found that the output defaults
 
 #### Pretty Printing
 
-Super JSON and plain JSON text may be "pretty printed" with the `-pretty` option, which takes
+SUP and plain JSON text may be "pretty printed" with the `-pretty` option, which takes
 the number of spaces to use for indentation.  As this is a common option,
 the `-Z` option is a shortcut for `-f sup -pretty 4` and `-J` is a shortcut
 for `-f json -pretty 4`.
@@ -313,17 +313,17 @@ produces
 When pretty printing, colorization is enabled by default when writing to a terminal,
 and can be disabled with `-color false`.
 
-#### Pipeline-friendly Super Binary
+#### Pipeline-friendly BSUP
 
-Though it's a compressed format, Super Binary data is self-describing and stream-oriented
+Though it's a compressed format, BSUP data is self-describing and stream-oriented
 and thus is pipeline friendly.
 
-Since data is self-describing you can simply take Super Binary output
+Since data is self-describing you can simply take BSUP output
 of one command and pipe it to the input of another.  It doesn't matter if the value
 sequence is scalars, complex types, or records.  There is no need to declare
 or register schemas or "protos" with the downstream entities.
 
-In particular, Super Binary data can simply be concatenated together, e.g.,
+In particular, BSUP data can simply be concatenated together, e.g.,
 ```mdtest-command
 super -f bsup -c 'select value 1, [1,2,3]' > a.bsup
 super -f bsup -c 'select value {s:"hello"}, {s:"world"}' > b.bsup
@@ -336,7 +336,7 @@ produces
 {s:"hello"}
 {s:"world"}
 ```
-And while this Super JSON output is human readable, the Super Binary files are binary, e.g.,
+And while this SUP output is human readable, the BSUP files are binary, e.g.,
 ```mdtest-command
 super -f bsup -c 'select value 1,[ 1,2,3]' > a.bsup
 hexdump -C a.bsup
@@ -431,7 +431,7 @@ formatting applied if any of the following escape sequences are present:
 | `\f`            | Form feed                               |
 | `\u`            | Unicode escape (e.g., `\u0041` for `A`) |
 
-Non-string values are formatted as [Super JSON](../formats/sup.md).
+Non-string values are formatted as [SUP](../formats/sup.md).
 
 For example:
 
@@ -663,7 +663,7 @@ _Hello, world_
 ```mdtest-command
 super -z -c "SELECT VALUE 'hello, world'"
 ```
-produces this Super JSON output
+produces this SUP output
 ```mdtest-output
 "hello, world"
 ```
@@ -738,7 +738,7 @@ a:=int64(a)
 {a:2,b:"bar"}
 ```
 
-_Make a schema-rigid Parquet file using fuse, then output the Parquet file as Super JSON_
+_Make a schema-rigid Parquet file using fuse, then output the Parquet file as SUP_
 ```mdtest-command
 echo '{a:1}{a:2}{b:3}' | super -f parquet -o tmp.parquet -c fuse -
 super -z tmp.parquet
@@ -766,7 +766,7 @@ measurements among SuperDB,
 We'll use the Parquet format to compare apples to apples
 and also report results for the custom columnar database format of DuckDB,
 the [new beta JSON type](https://clickhouse.com/blog/a-new-powerful-json-data-type-for-clickhouse) of ClickHouse,
-and the [Super Binary](../formats/bsup.md) format used by `super`.
+and the [BSUP](../formats/bsup.md) format used by `super`.
 
 The detailed steps shown [below](#appendix-2-running-the-tests) can be reproduced via
 [automated scripts](https://github.com/brimdata/super/blob/main/scripts/super-cmd-perf).
@@ -823,7 +823,7 @@ clickhouse-client --query "
 ```
 To create a super-structed file for the `super` command, there is no need to
 [`fuse`](../language/operators/fuse.md) the data into a single schema (though `super` can still work with the fused
-schema in the Parquet file), and we simply ran this command to create a Super Binary
+schema in the Parquet file), and we simply ran this command to create a BSUP
 file:
 ```
 super gharchive_gz/*.json.gz > gha.bsup
@@ -1081,7 +1081,7 @@ Since DuckDB with its native format could successfully run all queries with
 decent performance, we used it as the baseline for all of the speed-up factors.
 
 To summarize,
-`super` with Super Binary is substantially faster than multiple relational systems for
+`super` with BSUP is substantially faster than multiple relational systems for
 the search use cases, and with Parquet performs on par with the others for traditional OLAP queries,
 except for the _union_ query, where the super-structured data model trounces the relational
 model (by over 60x!) for stitching together disparate data types for analysis in an aggregation.
@@ -1156,7 +1156,7 @@ We now have the DuckDB database file for our GitHub Archive data called `gha.db`
 containing a single table called `gha` embedded in that database.
 What about the super-structured
 format for the `super` command?  There is no need to futz with sample sizes,
-schema inference, or union by name. Just run this to create a Super Binary file:
+schema inference, or union by name. Just run this to create a BSUP file:
 ```
 super gharchive_gz/*.json.gz > gha.bsup
 ```

--- a/docs/commands/super.md
+++ b/docs/commands/super.md
@@ -3,12 +3,14 @@ weight: 1
 title: super
 ---
 
-> **TL;DR** `super` is a command-line tool that uses [SuperSQL](../language/_index.md)
-> to query a variety of data formats in files, over HTTP, or in [S3](../integrations/amazon-s3.md)
-> storage. Best performance is achieved when operating on data in binary formats such as
-> [Super Binary (BSUP)](../formats/bsup.md), [Super Columnar (CSUP)](../formats/csup.md),
-> [Parquet](https://github.com/apache/parquet-format), or
-> [Arrow](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format).
+## Synopsis
+
+`super` is a command-line tool that uses [SuperSQL](../language/_index.md)
+to query a variety of data formats in files, over HTTP, or in [S3](../integrations/amazon-s3.md)
+storage. Best performance is achieved when operating on data in binary formats such as
+[Super Binary (BSUP)](../formats/bsup.md), [Super Columnar (CSUP)](../formats/csup.md),
+[Parquet](https://github.com/apache/parquet-format), or
+[Arrow](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format).
 
 {{% tip "Note" %}}
 
@@ -117,9 +119,9 @@ simply run `super` with no arguments.
 ## Data Formats
 
 `super` supports a number of [input](#input-formats) and [output](#output-formats) formats, but the
-[Super (SUP)](../formats/sup.md),
-[Super Binary (BSUP)](../formats/bsup.md), and
-[Super Columnar (CSUP)](../formats/csup.md) formats tend to be the most versatile and
+[SUP](../formats/sup.md),
+[BSUP](../formats/bsup.md), and
+[CSUP](../formats/csup.md) formats tend to be the most versatile and
 easy to work with.
 
 `super` typically operates on binary-encoded data and when you want to inspect

--- a/docs/formats/_index.md
+++ b/docs/formats/_index.md
@@ -11,7 +11,7 @@ weight: 5
 > providing a unified approach to row, columnar, and human-readable formats. Together these
 > represent a superset of both the dataframe/table model of relational systems and the
 > semi-structured model that is used ubiquitously in development as JSON and by NoSQL
-> data stores.  The Super JSON spec has [a few examples](sup.md#3-examples).
+> data stores.  The Super (SUP) format spec has [a few examples](sup.md#3-examples).
 
 ## 1. Background
 
@@ -156,7 +156,7 @@ say the JSON value
 is of type object and the value of key `a` is type array.
 In SuperDB, however, this value's type is type `record` with field `a`
 of type `array` of type `union` of `int64` and `string`,
-expressed succinctly in Super JSON as
+expressed succinctly in Super (SUP) format as
 ```
 {a:[(int64,string)]}
 ```
@@ -271,14 +271,14 @@ A set of companion documents define a family of tightly integrated
 serialization formats that all adhere to the same super data model,
 providing a unified approach to row, columnar, and human-readable formats:
 
-* [Super JSON](sup.md) is a human-readable format for super-structured data.  All JSON
-documents are Super JSON values as the Super JSON format is a strict superset of the JSON syntax.
-* [Super Binary](bsup.md) is a row-based, binary representation somewhat like
+* [Super (SUP)](sup.md) is a human-readable format for super-structured data.  All JSON
+documents are SUP values as the SUP format is a strict superset of the JSON syntax.
+* [Super Binary (BSUP)](bsup.md) is a row-based, binary representation somewhat like
 Avro but leveraging the super data model to represent a sequence of arbitrarily-typed
 values.
-* [Super Columnar](csup.md) is columnar like Parquet or ORC but also
+* [Super Columnar (CSUP)](csup.md) is columnar like Parquet or ORC but also
 embodies the super data model for heterogeneous and self-describing schemas.
-* [Super JSON over JSON](zjson.md) defines a format for encapsulating Super JSON
+* [SUP over JSON](zjson.md) defines a format for encapsulating SUP
 inside plain JSON for easy decoding by JSON-based clients, e.g.,
 the [JavaScript library used by SuperDB Desktop](https://github.com/brimdata/zui/tree/main/packages/superdb-types)
 and the [SuperDB Python library](../libraries/python.md).

--- a/docs/formats/bsup.md
+++ b/docs/formats/bsup.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title: BSUP (Super Binary)
+title: Super Binary (BSUP)
 heading: Super Binary (BSUP) Format Specification
 ---
 

--- a/docs/formats/bsup.md
+++ b/docs/formats/bsup.md
@@ -1,15 +1,15 @@
 ---
-weight: 2
-title: Super Binary
-heading: Super Binary Specification
+weight: 3
+title: BSUP (Super Binary)
+heading: Super Binary (BSUP) Format Specification
 ---
 
 ## 1. Introduction
 
-Super Binary is an efficient, sequence-oriented serialization format for any data
+Super Binary (BSUP) is an efficient, sequence-oriented serialization format for any data
 conforming to the [super data model](data-model.md).
 
-Super Binary is "row oriented" and
+BSUP is "row oriented" and
 analogous to [Apache Avro](https://avro.apache.org) but does not
 require schema definitions as it instead utilizes the fine-grained type system
 of the super data model.
@@ -18,32 +18,32 @@ encoding methodology inspired by Avro,
 [Parquet](https://en.wikipedia.org/wiki/Apache_Parquet), and
 [Protocol Buffers](https://developers.google.com/protocol-buffers).
 
-To this end, Super Binary embeds all type information
+To this end, BSUP embeds all type information
 in the stream itself while having a binary serialization format that
 allows "lazy parsing" of fields such that
 only the fields of interest in a stream need to be deserialized and interpreted.
-Unlike Avro, Super Binary embeds its "schemas" in the data stream as types and thereby admits
+Unlike Avro, BSUP embeds its "schemas" in the data stream as types and thereby admits
 an efficient multiplexing of heterogeneous data types by prepending to each
 data value a simple integer identifier to reference its type.
 
-Since no external schema definitions exist in Super Binary, a "type context" is constructed
+Since no external schema definitions exist in BSUP, a "type context" is constructed
 on the fly by composing dynamic type definitions embedded in the format.
-Super Binary can be readily adapted to systems like
+BSUP can be readily adapted to systems like
 [Apache Kafka](https://kafka.apache.org/) which utilize schema registries,
 by having a connector translate the schemas implied in the
-Super Binary stream into registered schemas and vice versa.  Better still, Kafka could
-be used natively with Super Binary obviating the need for the schema registry.
+BSUP stream into registered schemas and vice versa.  Better still, Kafka could
+be used natively with BSUP obviating the need for the schema registry.
 
-Multiple Super Binary streams with different type contexts are easily merged because the
+Multiple BSUP streams with different type contexts are easily merged because the
 serialization of values does not depend on the details of
 the type context.  One or more streams can be merged by simply merging the
 input contexts into an output context and adjusting the type reference of
 each value in the output sequence.  The values need not be traversed
 or otherwise rewritten to be merged in this fashion.
 
-## 2. The Super Binary Format
+## 2. The BSUP Format
 
-A Super Binary stream comprises a sequence of frames where
+A BSUP stream comprises a sequence of frames where
 each frame contains one of three types of data:
 _types_, _values_, or externally-defined _control_.
 
@@ -82,11 +82,11 @@ Each frame begins with a single-byte "frame code":
 ```
 
 Bit 7 of the frame code must be zero as it defines version 0
-of the Super Binary stream format.  If a future version of Super Binary
-arises, bit 7 of future Super Binary frames will be 1.
-Super Binary version 0 readers must ignore and skip over such frames using the
+of the BSUP stream format.  If a future version of BSUP
+arises, bit 7 of future BSUP frames will be 1.
+BSUP version 0 readers must ignore and skip over such frames using the
 `len` field, which must survive future versions.
-Any future versions of Super Binary must be able to integrate version 0 frames
+Any future versions of BSUP must be able to integrate version 0 frames
 for backward compatibility.
 
 Following the frame code is its encoded length followed by a "frame payload"
@@ -128,7 +128,7 @@ but is useful to an implementation to deterministically
 size decompression buffers in advance of decoding.
 
 Values for the `format` byte are defined in the
-[Super Binary compression format specification](./compression.md).
+[BSUP compression format specification](./compression.md).
 
 {{% tip "Note" %}}
 
@@ -196,7 +196,7 @@ with the following structure:
 ```
 Record types consist of an ordered set of fields where each field consists of
 a name and its type.  Unlike JSON, the ordering of the fields is significant
-and must be preserved through any APIs that consume, process, and emit Super Binary records.
+and must be preserved through any APIs that consume, process, and emit BSUP records.
 
 A record type is encoded as a count of fields, i.e., `<nfields>` from above,
 followed by the field definitions,
@@ -207,7 +207,7 @@ The field names in a record must be unique.
 
 The `<nfields>` value is encoded as a `uvarint`.
 
-The field name is encoded as a UTF-8 string defining a "Super Binary identifier".
+The field name is encoded as a UTF-8 string defining a "BSUP identifier".
 The UTF-8 string
 is further encoded as a "counted string", which is the `uvarint` encoding
 of the length of the string followed by that many bytes of UTF-8 encoded
@@ -215,7 +215,7 @@ string data.
 
 {{% tip "Note" %}}
 
-As defined by [Super JSON](sup.md), a field name can be any valid UTF-8 string much like JSON
+As defined by [Super (SUP)](sup.md), a field name can be any valid UTF-8 string much like JSON
 objects can be indexed with arbitrary string keys (via index operator)
 even if the field names available to the dot operator are restricted
 by language syntax for identifiers.
@@ -421,21 +421,21 @@ key/value pair).
 A _control frame_ contains an application-defined control message.
 
 Control frames are available to higher-layer protocols and are carried
-in Super Binary as a convenient signaling mechanism.  A Super Binary implementation
+in BSUP as a convenient signaling mechanism.  A BSUP implementation
 may skip over all control frames and is guaranteed by
 this specification to decode all of the data as described herein even if such
-frames provide additional semantics on top of the base Super Binary format.
+frames provide additional semantics on top of the base BSUP format.
 
 The body of a control frame is a control message and may be JSON,
-Super JSON, Super Binary, arbitrary binary, or UTF-8 text.  The serialization of the control
+SUP, BSUP, arbitrary binary, or UTF-8 text.  The serialization of the control
 frame body is independent of the stream containing the control frame.
 
-Any control message not known by a Super Binary data receiver shall be ignored.
+Any control message not known by a BSUP data receiver shall be ignored.
 
 The delivery order of control messages with respect to the delivery
-order of values of the Super Binary stream should be preserved by an API implementing
-Super Binary serialization and deserialization.
-In this way, system endpoints that communicate using Super Binary can embed
+order of values of the BSUP stream should be preserved by an API implementing
+BSUP serialization and deserialization.
+In this way, system endpoints that communicate using BSUP can embed
 protocol directives directly into the stream as control payloads
 in an order-preserving semantics rather than defining additional
 layers of encapsulation and synchronization between such layers.
@@ -448,36 +448,36 @@ A control frame has the following form:
 ```
 where
 * `<encoding>` is a single byte indicating whether the body is encoded
-as Super Binary (0), JSON (1), Super JSON (2), an arbitrary UTF-8 string (3), or arbitrary binary data (4),
+as BSUP (0), JSON (1), SUP (2), an arbitrary UTF-8 string (3), or arbitrary binary data (4),
 * `<len>` is a `uvarint` encoding the length in bytes of the body
 (exclusive of the length 1 encoding byte), and
 * `<body>` is a control message whose semantics are outside the scope of
-the base Super Binary specification.
+the base BSUP specification.
 
-If the encoding type is Super Binary, the embedded Super Binary data
-starts and ends a single Super Binary stream independent of the outer Super Binary stream.
+If the encoding type is BSUP, the embedded BSUP data
+starts and ends a single BSUP stream independent of the outer BSUP stream.
 
 ### 2.4 End of Stream
 
-A Super Binary stream must be terminated by an end-of-stream marker.
-A new Super Binary stream may begin immediately after an end-of-stream marker.
+A BSUP stream must be terminated by an end-of-stream marker.
+A new BSUP stream may begin immediately after an end-of-stream marker.
 Each such stream has its own, independent type context.
 
-In this way, the concatenation of Super Binary streams (or Super Binary files containing
-Super Binary streams) results in a valid Super Binary data sequence.
+In this way, the concatenation of BSUP streams (or BSUP files containing
+BSUP streams) results in a valid BSUP data sequence.
 
-For example, a large Super Binary file can be arranged into multiple, smaller streams
+For example, a large BSUP file can be arranged into multiple, smaller streams
 to facilitate random access at stream boundaries.
 This benefit comes at the cost of some additional overhead --
 the space consumed by stream boundary markers and repeated type definitions.
 Choosing an appropriate stream size that balances this overhead with the
 benefit of enabling random access is left up to implementations.
 
-End-of-stream markers are also useful in the context of sending Super Binary over Kafka,
+End-of-stream markers are also useful in the context of sending BSUP over Kafka,
 as a receiver can easily resynchronize with a live Kafka topic by
 discarding incomplete frames until a frame is found that is terminated
 by an end-of-stream marker (presuming the sender implementation aligns
-the Super Binary frames on Kafka message boundaries).
+the BSUP frames on Kafka message boundaries).
 
 A end-of-stream marker is encoded as follows:
 ```
@@ -495,14 +495,14 @@ be re-emitted
 
 ## 3. Primitive Types
 
-For each Super Binary primitive type, the following table describes:
+For each BSUP primitive type, the following table describes:
 * its type ID, and
 * the interpretation of a length `N` [value frame](#22-values-frame).
 
 All fixed-size multi-byte sequences representing machine words
 are serialized in little-endian format.
 
-| Type         | ID |    N     |      Super Binary Value Interpretation         |
+| Type         | ID |    N     |           BSUP Value Interpretation            |
 |--------------|---:|:--------:|------------------------------------------------|
 | `uint8`      |  0 | variable | unsigned int of length N                       |
 | `uint16`     |  1 | variable | unsigned int of length N                       |
@@ -537,7 +537,7 @@ are serialized in little-endian format.
 
 ## 4. Type Values
 
-As the super data model supports first-class types and because the Super Binary design goals
+As the super data model supports first-class types and because the BSUP design goals
 require that value serializations cannot change across type contexts, type values
 must be encoded in a fashion that is independent of the type context.
 Thus, a serialized type value encodes the entire type in a canonical form

--- a/docs/formats/compression.md
+++ b/docs/formats/compression.md
@@ -5,7 +5,7 @@ heading: BSUP Compression Types
 ---
 
 This document specifies values for the `<format>` byte of a
-[Super Binary compressed value message block](bsup.md#2-the-super-binary-format)
+[BSUP compressed value message block](bsup.md#2-the-bsup-format)
 and the corresponding algorithms for the `<compressed payload>` byte sequence.
 
 As new compression algorithms are specified, they will be documented

--- a/docs/formats/csup.md
+++ b/docs/formats/csup.md
@@ -1,38 +1,38 @@
 ---
 weight: 4
-title: Super Columnar
-heading: Super Columnar Specification
+title: CSUP (Super Columnar)
+heading: Super Columnar (CSUP) Format Specification
 ---
 
-Super Columnar is a file format based on
+Super Columnar (CSUP) is a file format based on
 the [super data model](data-model.md) where data is stacked to form columns.
 Its purpose is to provide for efficient analytics and search over
 bounded-length sequences of [super-structured data](./_index.md#2-a-super-structured-pattern) that is stored in columnar form.
 
 Like [Parquet](https://github.com/apache/parquet-format),
-Super Columnar provides an efficient representation for semi-structured data,
-but unlike Parquet, Super Columnar is not based on schemas and does not require
+CSUP provides an efficient representation for semi-structured data,
+but unlike Parquet, CSUP is not based on schemas and does not require
 a schema to be declared when writing data to a file.  Instead,
 it exploits the nature of super-structured data: columns of data
 self-organize around their type structure.
 
-## Super Columnar Files
+## CSUP Files
 
-A Super Columnar file encodes a bounded, ordered sequence of values.
-To provide for efficient access to subsets of Super Columnar-encoded data (e.g., columns),
+A CSUP file encodes a bounded, ordered sequence of values.
+To provide for efficient access to subsets of CSUP-encoded data (e.g., columns),
 the file is presumed to be accessible via random access
 (e.g., range requests to a cloud object store or seeks in a Unix file system)
 and is therefore not intended as a streaming or communication format.
 
-A Super Columnar file can be stored entirely as one storage object
+A CSUP file can be stored entirely as one storage object
 or split across separate objects that are treated
-together as a single Super Columnar entity.  While the format provides much flexibility
+together as a single CSUP entity.  While the format provides much flexibility
 for how data is laid out, it is left to an implementation to lay out data
 in intelligent ways for efficient sequential read accesses of related data.
 
 ## Column Streams
 
-The Super Columnar data abstraction is built around a collection of _column streams_.
+The CSUP data abstraction is built around a collection of _column streams_.
 
 There is one column stream for each top-level type encountered in the input where
 each column stream is encoded according to its type.  For top-level complex types,
@@ -51,7 +51,7 @@ the reconstruction process is recursive (as described below).
 
 ## The Physical Layout
 
-The overall layout of a Super Columnar file is comprised of the following sections,
+The overall layout of a CSUP file is comprised of the following sections,
 in this order:
 * the data section,
 * the reassembly section, and
@@ -61,7 +61,7 @@ This layout allows an implementation to buffer metadata in
 memory while writing column data in a natural order to the
 data section (based on the volume statistics of each column),
 then write the metadata into the reassembly section along with the trailer
-at the end.  This allows a stream to be converted to a Super Columnar file
+at the end.  This allows a stream to be converted to a CSUP file
 in a single pass.
 
 {{% tip "Note" %}}
@@ -69,7 +69,7 @@ in a single pass.
 That said, the layout is
 flexible enough that an implementation may optimize the data layout with
 additional passes or by writing the output to multiple files then
-merging them together (or even leaving the Super Columnar entity as separate files).
+merging them together (or even leaving the CSUP entity as separate files).
 
 {{% /tip %}}
 
@@ -80,12 +80,12 @@ where a segment is a seek offset and byte length relative to the
 data section.  Each segment contains a sequence of
 [primitive-type values](data-model.md#1-primitive-types),
 encoded as counted-length byte sequences where the counted-length is
-variable-length encoded as in the [Super Binary specification](bsup.md).
+variable-length encoded as in the [Super Binary (BSUP) specification](bsup.md).
 Segments may be compressed.
 
 There is no information in the data section for how segments relate
 to one another or how they are reconstructed into columns.  They are just
-blobs of Super Binary data.
+blobs of BSUP data.
 
 {{% tip "Note" %}}
 
@@ -128,26 +128,26 @@ from column streams, i.e., to map columns back to composite values.
 Of course, the reassembly section also provides the ability to extract just subsets of columns
 to be read and searched efficiently without ever needing to reconstruct
 the original rows.  How well this performs is up to any particular
-Super Columnar implementation.
+CSUP implementation.
 
 Also, the reassembly section is in general vastly smaller than the data section
 so the goal here isn't to express information in cute and obscure compact forms
 but rather to represent data in an easy-to-digest, programmer-friendly form that
-leverages Super Binary.
+leverages BSUP.
 
 {{% /tip %}}
 
-The reassembly section is a Super Binary stream.  Unlike Parquet,
+The reassembly section is a BSUP stream.  Unlike Parquet,
 which uses an externally described schema
 (via [Thrift](https://thrift.apache.org/)) to describe
-analogous data structures, we simply reuse Super Binary here.
+analogous data structures, we simply reuse BSUP here.
 
 #### The Super Types
 
 This reassembly stream encodes 2*N+1 values, where N is equal to the number
 of top-level types that are present in the encoded input.
 To simplify terminology, we call a top-level type a "super type",
-e.g., there are N unique super types encoded in the Super Columnar file.
+e.g., there are N unique super types encoded in the CSUP file.
 
 These N super types are defined by the first N values of the reassembly stream
 and are encoded as a null value of the indicated super type.
@@ -198,11 +198,11 @@ the reconstructed value.
 The sequence of super types is defined by each type's super ID (as defined above),
 0 to N-1, within the set of N super types.
 
-The super column stream is encoded as a sequence of Super Binary-encoded `int32` primitive values.
+The super column stream is encoded as a sequence of BSUP-encoded `int32` primitive values.
 While there are a large number of entries in the super column (one for each original row),
 the cardinality of super IDs is small in practice so this column
 will compress very significantly, e.g., in the special case that all the
-values in the Super Columnar file have the same super ID,
+values in the CSUP file have the same super ID,
 the super column will compress trivially.
 
 The reassembly map appears as the next value in the reassembly section
@@ -216,7 +216,7 @@ Each reassembly record is a record of type `<any_column>`, as defined below,
 where each reassembly record appears in the same sequence as the original N schemas.
 Note that there is no "any" type in the super data model, but rather this terminology is used
 here to refer to any of the concrete type structures that would appear
-in a given Super Columnar file.
+in a given CSUP file.
 
 In other words, the reassembly record of the super column
 combined with the N reassembly records collectively define the original sequence
@@ -264,7 +264,7 @@ where
 * `<fld1>` through `<fldn>` are the names of the top-level fields of the
 original row record,
 * the `column` fields are column stream definitions for each field, and
-* the [`presence` columns](#presence-columns) are `int32` Super Binary column streams comprised of a
+* the [`presence` columns](#presence-columns) are `int32` BSUP column streams comprised of a
 run-length encoding of the locations of column values in their respective rows,
 when there are null values.
 
@@ -339,26 +339,26 @@ compression based on segment compression).
 
 ### The Trailer
 
-After the reassembly section is a Super Binary stream with a single record defining
-the "trailer" of the Super Columnar file.  The trailer provides a magic field
+After the reassembly section is a BSUP stream with a single record defining
+the "trailer" of the CSUP file.  The trailer provides a magic field
 indicating the file format, a version number,
 the size of the segment threshold for decomposing segments into frames,
 the size of the skew threshold for flushing all segments to storage when
 the memory footprint roughly exceeds this threshold,
-and an array of sizes in bytes of the sections of the Super Columnar file.
+and an array of sizes in bytes of the sections of the CSUP file.
 
 This type of this record has the format
 ```
 {magic:string,type:string,version:int64,sections:[int64],meta:{skew_thresh:int64,segment_thresh:int64}}
 ```
 The trailer can be efficiently found by scanning backward from the end of the
-Super Columnar file to find a valid Super Binary stream containing a single record value
+CSUP file to find a valid BSUP stream containing a single record value
 conforming to the above type.
 
 ## Decoding
 
-To decode an entire Super Columnar file into rows, the trailer is read to find the sizes
-of the sections, then the Super Binary stream of the reassembly section is read,
+To decode an entire CSUP file into rows, the trailer is read to find the sizes
+of the sections, then the BSUP stream of the reassembly section is read,
 typically in its entirety.
 
 Since this data structure is relatively small compared to all of the columnar
@@ -373,7 +373,7 @@ reassembly records to figure out which segments will be needed, then construct
 an intelligent plan for reading the needed segments and attempt to read them
 in mostly sequential order, which could serve as
 an optimizing intermediary between any underlying storage API and the
-Super Columnar decoding logic.
+CSUP decoding logic.
 
 {{% /tip %}}
 
@@ -387,7 +387,7 @@ The top-level reassembly fetches column values as a `<record_column>`.
 
 For any `<record_column>`, a value from each field is read from each field's column,
 accounting for the presence column indicating null,
-and the results are encoded into the corresponding Super Binary record value using
+and the results are encoded into the corresponding BSUP record value using
 type information from the corresponding schema.
 
 For a `<primitive_column>` a value is determined by reading the next
@@ -395,29 +395,29 @@ value from its segmap.
 
 For an `<array_column>`, a length is read from its `lengths` segmap as an `int32`
 and that many values are read from its the `values` sub-column,
-encoding the result as a Super Binary array value.
+encoding the result as a BSUP array value.
 
 For a `<union_column>`, a value is read from its `tags` segmap
 and that value is used to select the corresponding column stream
-`c0`, `c1`, etc.  The value read is then encoded as a Super Binary union value
+`c0`, `c1`, etc.  The value read is then encoded as a BSUP union value
 using the same tag within the union value.
 
 ## Examples
 
 ### Hello, world
 
-Start with this [Super JSON](sup.md) file `hello.sup`:
+Start with this [Super (SUP)](sup.md) file `hello.sup`:
 ```
 {a:"hello",b:"world"}
 {a:"goodnight",b:"gracie"}
 ```
 
-To convert to Super Columnar format:
+To convert to CSUP format:
 ```
 super -f csup hello.sup > hello.csup
 ```
 
-Segments in the Super Columnar format would be laid out like this:
+Segments in the CSUP format would be laid out like this:
 ```
 === column for a
 hello

--- a/docs/formats/csup.md
+++ b/docs/formats/csup.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title: CSUP (Super Columnar)
+title: Super Columnar (CSUP)
 heading: Super Columnar (CSUP) Format Specification
 ---
 

--- a/docs/formats/sup.md
+++ b/docs/formats/sup.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title: SUP (Super)
+title: Super (SUP)
 heading: Super (SUP) Format Specification
 ---
 

--- a/docs/formats/sup.md
+++ b/docs/formats/sup.md
@@ -1,25 +1,25 @@
 ---
-weight: 3
-title: Super JSON
-heading: Super JSON Specification
+weight: 2
+title: SUP (Super)
+heading: Super (SUP) Format Specification
 ---
 
 ## 1. Introduction
 
-Super JSON is the human-readable, text-based serialization format of
+Super (SUP) is the human-readable, text-based serialization format of
 the [super data model](data-model.md).
 
-Super JSON builds upon the elegant simplicity of JSON with "type decorators".
+SUP builds upon the elegant simplicity of JSON with "type decorators".
 Where the type of a value is not implied by its syntax, a parenthesized
 type decorator is appended to the value thus establishing a well-defined
 type for every value expressed in source text.
 
-Super JSON is also a superset of JSON in that all JSON documents are valid
-Super JSON values.
+SUP is also a superset of JSON in that all JSON documents are valid
+SUP values.
 
-## 2. The Super JSON Format
+## 2. The SUP Format
 
-A Super JSON text is a sequence of UTF-8 characters organized either as a bounded input
+A SUP text is a sequence of UTF-8 characters organized either as a bounded input
 or an unbounded stream.
 
 The input text is organized as a sequence of one or more values optionally
@@ -33,7 +33,7 @@ If an input text includes data that is not valid UTF-8, the input is invalid.
 
 ### 2.1 Names
 
-Super JSON _names_ encode record fields, enum symbols, and named types.
+SUP _names_ encode record fields, enum symbols, and named types.
 A name is either an _identifier_ or a [quoted string](#231-strings).
 Names are referred to as `<name>` below.
 
@@ -242,7 +242,7 @@ A record value has the form:
 ```
 { <name> : <value>, <name> : <value>, ... }
 ```
-where `<name>` is a [Super JSON name](#21-names) and `<value>` is
+where `<name>` is a [SUP name](#21-names) and `<value>` is
 any optionally-decorated value inclusive of other records.
 Each name/value pair is called a _field_.
 There may be zero or more fields.
@@ -303,7 +303,7 @@ An enum value is indicated with the sigil `%` and has the form
 ```
 %<name>
 ```
-where the `<name>` is [Super JSON name](#21-names).
+where the `<name>` is [SUP name](#21-names).
 
 An enum value must appear in a context where the enum type is known, i.e.,
 with an explicit enum type decorator or within a complex type where the
@@ -335,7 +335,7 @@ A _record type_ has the form:
 ```
 { <name> : <type>, <name> : <type>, ... }
 ```
-where `<name>` is a [Super JSON name](#21-names) and
+where `<name>` is a [SUP name](#21-names) and
 `<type>` is any type.
 
 The order of the record fields is significant,
@@ -378,7 +378,7 @@ An _enum type_ has the form:
 ```
 enum( <name>, <name>, ... )
 ```
-where `<name>` is a [Super JSON name](#21-names).
+where `<name>` is a [SUP name](#21-names).
 Each enum name must be unique and the order is not significant, e.g.,
 enum type `enum(HEADS,TAILS)` is equal to type `enum(TAILS,HEADS)`.
 
@@ -426,7 +426,7 @@ out of null values of different types.
 
 ## 3. Examples
 
-The simplest Super JSON value is a single value, perhaps a string like this:
+The simplest SUP value is a single value, perhaps a string like this:
 ```
 "hello, world"
 ```
@@ -482,7 +482,7 @@ the `nets` field is an array of networks and illustrates the helpful range of
 primitive types.  Note that the syntax here implies
 the type of the array, as it is inferred from the type of the elements.
 
-Finally, there are four more values that show Super JSON's efficacy for
+Finally, there are four more values that show SUP's efficacy for
 representing metrics.  Here, there are no type decorators as all of the field
 types are implied by their syntax, and hence, the top-level record type is implied.
 For instance, the `ts` field is an RFC 3339 date and time string,
@@ -493,7 +493,7 @@ record type implied by each of the three variations of type of the `value` field
 
 ## 4. Grammar
 
-Here is a left-recursive pseudo-grammar of Super JSON.  Note that not all
+Here is a left-recursive pseudo-grammar of SUP.  Note that not all
 acceptable inputs are semantically valid as type mismatches may arise.
 For example, union and enum values must both appear in a context
 that defines their type.

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -8,12 +8,12 @@ heading: ZJSON Specification
 
 The [super data model](data-model.md)
 is based on richly typed records with a deterministic field order,
-as is implemented by the [Super JSON](sup.md), [Super Binary](bsup.md), and [Super Columnar](csup.md) formats.
+as is implemented by the [Super (SUP)](sup.md), [Super Binary (BSUP)](bsup.md), and [Super Columnar (CSUP)](csup.md) formats.
 Given the ubiquity of JSON, it is desirable to also be able to serialize
 super data into the JSON format.   However, encoding super data values
 directly as JSON values would not work without loss of information.
 
-For example, consider this [Super JSON](sup.md) data:
+For example, consider this [SUP](sup.md) data:
 ```
 {
     ts: 2018-03-24T17:15:21.926018012Z,
@@ -63,21 +63,21 @@ While JSON is well suited for data exchange of generic information, it is not
 sufficient for the [super-structured data model](./_index.md#2-a-super-structured-pattern).
 That said, JSON can be used as an encoding format for super data with another layer
 of encoding on top of a JSON-based protocol.  This allows clients like web apps or
-Electron apps to receive and understand Super JSON and, with the help of client
+Electron apps to receive and understand SUP and, with the help of client
 libraries like [superdb-types](https://github.com/brimdata/zui/tree/main/packages/superdb-types),
-to manipulate the rich, structured Super JSON types that are implemented on top of
+to manipulate the rich, structured SUP types that are implemented on top of
 the basic JavaScript types.
 
 In other words,
 because JSON objects do not have a deterministic field order nor does JSON
 in general have typing beyond the basics (i.e., strings, floating point numbers,
-objects, arrays, and booleans), Super JSON and
+objects, arrays, and booleans), SUP and
 its embedded type model is layered on top of regular JSON.
 
 ## 2. The Format
 
-The format for representing Super JSON data in JSON is called ZJSON.
-Converting Super JSON, Super Binary, or Super Columnar to ZJSON and back results in a complete and
+The format for representing SUP data in JSON is called ZJSON.
+Converting SUP, BSUP, or CSUP to ZJSON and back results in a complete and
 accurate restoration of the original super data.
 
 A ZJSON stream is defined as a sequence of JSON objects where each object
@@ -255,8 +255,8 @@ as described recursively herein,
 `[ <key>, <value> ]` where `key` and `value` are recursively encoded,
 * a type value is encoded [as above](#21-type-encoding),
 * each primitive that is not a type value
-is encoded as a string conforming to its Super JSON representation, as described in the
-[corresponding section of the Super JSON specification](sup.md#23-primitive-values).
+is encoded as a string conforming to its SUP representation, as described in the
+[corresponding section of the SUP specification](sup.md#23-primitive-values).
 
 For example, a record with three fields --- a string, an array of integers,
 and an array of union of string, and float64 --- might have a value that looks like this:

--- a/docs/getting_started/_index.md
+++ b/docs/getting_started/_index.md
@@ -33,7 +33,7 @@ For a non-technical user, SuperDB is as easy to use as web search
 while for a technical user, SuperDB exposes its technical underpinnings
 in a gradual slope, providing as much detail as desired,
 packaged up in the easy-to-understand
-[Super JSON data format](../formats/sup.md) and
+[Super (SUP) data format](../formats/sup.md) and
 [SuperSQL language](../language/_index.md).
 
 While `super` and its accompanying data formats are production quality for some use cases, the project's
@@ -46,7 +46,7 @@ a number of different elements of the system:
 * The [super data model](../formats/data-model.md) is the abstract definition of the data types and semantics
 that underlie the super-structured data formats.
 * The [super-structured data formats](../formats/_index.md) are a family of
-[human-readable (Super JSON, SUP)](../formats/sup.md),
+[human-readable (Super, SUP)](../formats/sup.md),
 [sequential (Super Binary, BSUP)](../formats/bsup.md), and
 [columnar (Super Columnar, CSUP)](../formats/csup.md) formats that all adhere to the
 same abstract super data model.

--- a/docs/integrations/fluentd.md
+++ b/docs/integrations/fluentd.md
@@ -395,10 +395,10 @@ options. Varying these may impact how quickly events appear in the pool and
 the size of the commit objects to which they're initially stored.
 
 2. **BSUP format** - In the [shaping example](#shaping-example) shown above, we
-used the [Super JSON format](../formats/sup.md) format for the shaped data output from
+used the [Super (SUP) format](../formats/sup.md) format for the shaped data output from
 [`super`](../commands/super.md). This text format is typically used in contexts
 where human readability is required. Due to its compact nature,
-[Super Binary](../formats/bsup.md) format would have been preferred, but in our research
+[Super Binary (BSUP)](../formats/bsup.md) format would have been preferred, but in our research
 we found Fluentd consistently steered us toward using only text formats.
 However, someone more proficient with Fluentd may be able to employ BSUP
 instead.

--- a/docs/integrations/zeek/data-type-compatibility.md
+++ b/docs/integrations/zeek/data-type-compatibility.md
@@ -5,8 +5,8 @@ title: Zed/Zeek Data Type Compatibility
 
 As the [super data model](../../formats/data-model.md) was in many ways inspired by the
 [Zeek TSV log format](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs),
-SuperDB's rich storage formats ([Super JSON](../../formats/sup.md),
-[Super Binary](../../formats/bsup.md), etc.) maintain comprehensive interoperability
+SuperDB's rich storage formats ([Super (SUP)](../../formats/sup.md),
+[Super Binary (BSUP)](../../formats/bsup.md), etc.) maintain comprehensive interoperability
 with Zeek. When Zeek is configured to output its logs in
 JSON format, much of the rich type information is lost in translation, but
 this can be restored by following the guidance for [shaping Zeek JSON](shaping-zeek-json.md).
@@ -21,7 +21,7 @@ representation of any Zeek data that is read or imported. Therefore, knowing
 the equivalent types will prove useful when performing operations in the
 [Zed language](../../language/_index.md) such as
 [type casting](../../language/shaping.md#cast) or looking at the data
-when output as Super JSON.
+when output as SUP.
 
 ## Equivalent Types
 
@@ -64,7 +64,7 @@ there is no authoritative specification of the Zeek TSV log format.
 ## Example
 
 The following example shows a TSV log that includes each Zeek data type, how
-it's output as Super JSON by [`super`](../../commands/super.md), and then how it's written back out again as a Zeek
+it's output as SUP by [`super`](../../commands/super.md), and then how it's written back out again as a Zeek
 log. You may find it helpful to refer to this example when reading the
 [type-specific details](#type-specific-details).
 
@@ -86,7 +86,7 @@ cat zeek_types.log
 T	123	456	123.4560	1592502151.123456	123.456	smile😁smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	things,in,a,set	order,is,important	Jeanne	122
 ```
 
-#### Reading the TSV log, outputting as Super JSON, and saving a copy:
+#### Reading the TSV log, outputting as SUP, and saving a copy:
 
 ```mdtest-command
 super -Z zeek_types.log | tee zeek_types.sup
@@ -126,7 +126,7 @@ super -Z zeek_types.log | tee zeek_types.sup
 }
 ```
 
-#### Reading the saved Super JSON output and outputting as Zeek TSV:
+#### Reading the saved SUP output and outputting as Zeek TSV:
 
 ```mdtest-command
 super -f zeek zeek_types.sup
@@ -146,8 +146,8 @@ T	123	456	123.456	1592502151.123456	123.456000	smile😁smile	\x09\x07\x04	80	12
 ## Type-Specific Details
 
 As `super` acts as a reference implementation for SuperDB storage formats such as
-Super JSON and BSUP, it's helpful to understand how it reads the following Zeek data
-types into readable text equivalents in the Super JSON format, then writes them back
+SUP and BSUP, it's helpful to understand how it reads the following Zeek data
+types into readable text equivalents in the SUP format, then writes them back
 out again in the Zeek TSV log format. Other implementations of the Zed storage
 formats (should they exist) may handle these differently.
 

--- a/docs/integrations/zeek/reading-zeek-log-formats.md
+++ b/docs/integrations/zeek/reading-zeek-log-formats.md
@@ -15,7 +15,7 @@ is Zeek's default output format for logs. This format can be read automatically
 with the Zed tools such as [`super`](../../commands/super.md).
 
 The following example shows a TSV [`conn.log`](https://docs.zeek.org/en/master/logs/conn.html) being read via `super` and
-output as [Super JSON](../../formats/sup.md).
+output as [Super (SUP)](../../formats/sup.md).
 
 #### conn.log
 

--- a/docs/integrations/zeek/shaping-zeek-json.md
+++ b/docs/integrations/zeek/shaping-zeek-json.md
@@ -183,7 +183,7 @@ The bulk of this Zed shaper consists of detailed per-field data type
 definitions for each record in the default set of JSON logs output by Zeek.
 These type definitions reference the types we defined above, such as `port`
 and `conn_id`. The syntax for defining primitive and complex types follows the
-relevant sections of the [Super JSON Format](../../formats/sup.md#2-the-super-json-format)
+relevant sections of the [Super (SUP) format](../../formats/sup.md#2-the-sup-format)
 specification.
 
 ```
@@ -319,7 +319,7 @@ produces
 
 If working in a directory containing many JSON logs, the
 reference shaper can be applied to all the records they contain and
-output them all in a single [Super Binary](../../formats/bsup.md) file as
+output them all in a single [Super Binary (BSUP)](../../formats/bsup.md) file as
 follows:
 
 ```
@@ -331,7 +331,7 @@ operations on the richly-typed records, the Zed query on the command line
 should begin with a `|`, as this appends it to the pipeline at the bottom of
 the shaper from the included file.
 
-For example, to see a Super JSON representation of just the errors that may have
+For example, to see a SUP representation of just the errors that may have
 come from attempting to shape all the logs in the current directory:
 
 ```

--- a/docs/language/data-types.md
+++ b/docs/language/data-types.md
@@ -7,17 +7,17 @@ The SuperSQL language includes most data types of a typical programming language
 as defined in the [super data model](../formats/data-model.md).
 
 The syntax of individual literal values generally follows
-the [Super JSON syntax](../formats/sup.md) with the exception that
+the [Super (SUP) syntax](../formats/sup.md) with the exception that
 [type decorators](../formats/sup.md#22-type-decorators)
 are not included in the language.  Instead, a
 [type cast](expressions.md#casts) may be used in any expression for explicit
 type conversion.
 
 In particular, the syntax of primitive types follows the
-[primitive-value definitions](../formats/sup.md#23-primitive-values) in Super JSON
+[primitive-value definitions](../formats/sup.md#23-primitive-values) in SUP
 as well as the various [complex value definitions](../formats/sup.md#24-complex-values)
 like records, arrays, sets, and so forth.  However, complex values are not limited to
-constant values like Super JSON and can be composed from [literal expressions](expressions.md#literals).
+constant values like SUP and can be composed from [literal expressions](expressions.md#literals).
 
 ## First-class Types
 
@@ -27,13 +27,13 @@ any type may be used as a value.
 The primitive types are listed in the
 [data model specification](../formats/data-model.md#1-primitive-types)
 and have the same syntax in SuperSQL.  Complex types also follow
-the Super JSON syntax.  Note that the type of a type value is simply `type`.
+the SUP syntax.  Note that the type of a type value is simply `type`.
 
-As in Super JSON, _when types are used as values_, e.g., in an expression,
+As in SUP, _when types are used as values_, e.g., in an expression,
 they must be referenced within angle brackets.  That is, the integer type
 `int64` is expressed as a type value using the syntax `<int64>`.
 
-Complex types in the SuperSQL language follow the Super JSON syntax as well.  Here are
+Complex types in the SuperSQL language follow the SUP syntax as well.  Here are
 a few examples:
 * a simple record type - `{x:int64,y:int64}`
 * an array of integers - `[int64]`

--- a/docs/language/functions/upper.md
+++ b/docs/language/functions/upper.md
@@ -19,9 +19,9 @@ to upper case and returns the result.
 # spq
 yield upper(this)
 # input
-"Super JSON"
+"Super format"
 # expected output
-"SUPER JSON"
+"SUPER FORMAT"
 ```
 
 [Slices](../expressions.md#slices) can be used to uppercase a subset of a string as well.
@@ -33,7 +33,7 @@ func capitalize(str): (
 )
 yield capitalize(this)
 # input
-"super JSON"
+"super format"
 # expected output
-"Super JSON"
+"Super format"
 ```

--- a/docs/language/pipeline-model.md
+++ b/docs/language/pipeline-model.md
@@ -35,7 +35,7 @@ echo '"hello, world"' | super -
 Many examples throughout the language documentation use this "echo pattern"
 to standard input of `super -`.
 Note that in these examples, the input values are expressed as a sequence of values serialized
-in the [Super JSON format](../formats/sup.md)
+in the [Super (SUP) format](../formats/sup.md)
 with query text expressed as the `-c` argument of the `super` command
 in the syntax of the SuperSQL language described here. Some examples are
 instead presented in an interactive form as described in the

--- a/docs/language/search-expressions.md
+++ b/docs/language/search-expressions.md
@@ -150,11 +150,11 @@ using Boolean logic to form search expressions.
 
 {{% tip "Note" %}}
 
-When processing [Super Binary](../formats/bsup.md) data, the SuperDB runtime performs a multi-threaded
+When processing [Super Binary (BSUP)](../formats/bsup.md) data, the SuperDB runtime performs a multi-threaded
 Boyer-Moore scan over decompressed data buffers before parsing any data.
 This allows large buffers of data to be efficiently discarded and skipped when
 searching for rarely occurring values.  For a [SuperDB data lake](../commands/super-db.md),
-a planned feature will use [Super Columnar](../formats/csup.md) files to further accelerate searches.
+a planned feature will use [Super Columnar (CSUP)](../formats/csup.md) files to further accelerate searches.
 
 {{% /tip %}}
 

--- a/docs/libraries/python.md
+++ b/docs/libraries/python.md
@@ -11,7 +11,7 @@ The Python client interacts with the Zed lake via the REST API served by
 [`super db serve`](../commands/super-db.md#serve).
 
 This approach works adequately when high data throughput is not required.
-We plan to introduce native [Super Binary](../formats/bsup.md) support for
+We plan to introduce native [Super Binary (BSUP)](../formats/bsup.md) support for
 Python that should increase performance substantially for more
 data intensive workloads.
 

--- a/docs/tutorials/super-for-jq.md
+++ b/docs/tutorials/super-for-jq.md
@@ -38,7 +38,7 @@ as well as [`jq`](https://jqlang.org/download/).
 ## But JSON
 
 While `super` is based on a new type of [data model](../formats/data-model.md),
-its human-readable format [Super JSON (SUP)](../formats/sup.md) just so
+its human-readable format [Super (SUP)](../formats/sup.md) just so
 happens to be a superset of JSON.
 
 So if all you ever use `super` for is manipulating JSON data,
@@ -177,14 +177,14 @@ trying to do high-precision stuff with data.
 When using `super`, it's handy to operate in the
 domain of [super-structured data](../formats/_index.md#2-a-super-structured-pattern) and only output to
 JSON when needed. Providing human-readability without losing detail is what
-[Super JSON (SUP)](../formats/sup.md) is all about.
+[SUP](../formats/sup.md) is all about.
 
 SUP is nice because it has a comprehensive type system and you can
-go from SUP to an efficient binary row format ([Super Binary, BSUP)](../formats/bsup.md)
-and columnar ([Super Columnar, CSUP)](../formats/csup.md) --- and vice versa ---
+go from SUP to an efficient binary row format ([Super Binary, BSUP](../formats/bsup.md))
+and columnar ([Super Columnar, CSUP](../formats/csup.md)) --- and vice versa ---
 with complete fidelity and no loss of information.  In this tour,
 we'll stick to SUP, though for large data sets
-[Super Binary is much faster](https://github.com/brimdata/super/tree/main/performance).
+[BSUP is much faster](https://github.com/brimdata/super/tree/main/performance).
 
 The first thing you'll notice about SUP is that you don't need
 quotations around field names.  We can see this by taking some JSON


### PR DESCRIPTION
## tl;dr

Similar to other recent rename exercises in the repo (#5762, #5768, #5765) this changes how the Super formats are referenced in the docs.

## Details

The general approach is to write out the "long form" name along with accompanying acronym (e.g., "Super Binary (BSUP)") once at the top of a given doc, then reference it only via acronym further down in the doc. I made a couple exceptions to this rule though, which I'll call out via in-line comments so reviewers know this was intentional.