### PR TITLE
lazy type decoding for CSUP

### DIFF
--- a/csup/context.go
+++ b/csup/context.go
@@ -1,0 +1,70 @@
+package csup
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/sup"
+	"github.com/brimdata/super/zio/bsupio"
+)
+
+type Context struct {
+	mu     sync.Mutex
+	local  *super.Context // holds the types for the Metadata values
+	metas  []Metadata     // id to Metadata
+	values []super.Value  // id to unmarshaled Metadata
+	uctx   *sup.UnmarshalBSUPContext
+}
+
+type ID uint32
+
+func NewContext() *Context {
+	return &Context{local: super.NewContext()}
+}
+
+func (c *Context) enter(meta Metadata) ID {
+	id := ID(len(c.metas))
+	c.metas = append(c.metas, meta)
+	return id
+}
+
+func (c *Context) Lookup(id ID) Metadata {
+	if id >= ID(len(c.metas)) {
+		panic(fmt.Sprintf("csup.Context ID (%d) out of range (len %d)", id, len(c.values)))
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.metas[id] == nil {
+		if err := c.unmarshal(id); err != nil {
+			panic(err) //XXX
+		}
+	}
+	return c.metas[id]
+}
+
+func (c *Context) unmarshal(id ID) error {
+	if c.uctx == nil {
+		c.uctx = sup.NewBSUPUnmarshaler()
+		c.uctx.SetContext(c.local)
+		c.uctx.Bind(Template...)
+	}
+	if c.metas[id] != nil {
+		return nil
+	}
+	return c.uctx.Unmarshal(c.values[id], &c.metas[id])
+}
+
+func (c *Context) readMeta(r io.Reader) error {
+	zr := bsupio.NewReader(c.local, r)
+	defer zr.Close()
+	for {
+		val, err := zr.Read()
+		if val == nil || err != nil {
+			c.metas = make([]Metadata, len(c.values))
+			return err
+		}
+		c.values = append(c.values, val.Copy())
+	}
+}

--- a/csup/encoder.go
+++ b/csup/encoder.go
@@ -24,7 +24,7 @@ type Encoder interface {
 	// will land.  This is called in a sequential fashion (no parallelism) so
 	// that the metadata can be computed and the CSUP header written before the
 	// vector data is written via Emit.
-	Metadata(uint64) (uint64, Metadata)
+	Metadata(*Context, uint64) (uint64, ID)
 	Emit(w io.Writer) error
 }
 
@@ -74,16 +74,16 @@ type NamedEncoder struct {
 	name string
 }
 
-func (n *NamedEncoder) Metadata(off uint64) (uint64, Metadata) {
-	off, meta := n.Encoder.Metadata(off)
-	return off, &Named{n.name, meta}
+func (n *NamedEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
+	off, id := n.Encoder.Metadata(cctx, off)
+	return off, cctx.enter(&Named{n.name, id})
 }
 
 type ErrorEncoder struct {
 	Encoder
 }
 
-func (e *ErrorEncoder) Metadata(off uint64) (uint64, Metadata) {
-	off, meta := e.Encoder.Metadata(off)
-	return off, &Error{meta}
+func (e *ErrorEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
+	off, id := e.Encoder.Metadata(cctx, off)
+	return off, cctx.enter(&Error{id})
 }

--- a/csup/field.go
+++ b/csup/field.go
@@ -16,11 +16,11 @@ func (f *FieldEncoder) write(body zcode.Bytes) {
 	f.values.Write(body)
 }
 
-func (f *FieldEncoder) Metadata(off uint64) (uint64, Field) {
-	off, meta := f.values.Metadata(off)
+func (f *FieldEncoder) Metadata(cctx *Context, off uint64) (uint64, Field) {
+	off, id := f.values.Metadata(cctx, off)
 	return off, Field{
 		Name:   f.name,
-		Values: meta,
+		Values: id,
 	}
 }
 

--- a/csup/header.go
+++ b/csup/header.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	Version     = 8
-	HeaderSize  = 24
+	Version     = 9
+	HeaderSize  = 28
 	MaxMetaSize = 100 * 1024 * 1024
 	MaxDataSize = 2 * 1024 * 1024 * 1024
 )
@@ -18,6 +18,7 @@ type Header struct {
 	Version  uint32
 	MetaSize uint64
 	DataSize uint64
+	Root     uint32
 }
 
 func (h Header) Serialize() []byte {
@@ -28,6 +29,7 @@ func (h Header) Serialize() []byte {
 	binary.LittleEndian.PutUint32(bytes[4:], h.Version)
 	binary.LittleEndian.PutUint64(bytes[8:], h.MetaSize)
 	binary.LittleEndian.PutUint64(bytes[16:], h.DataSize)
+	binary.LittleEndian.PutUint32(bytes[24:], h.Root)
 	return bytes[:]
 }
 
@@ -38,6 +40,7 @@ func (h *Header) Deserialize(bytes []byte) error {
 	h.Version = binary.LittleEndian.Uint32(bytes[4:])
 	h.MetaSize = binary.LittleEndian.Uint64(bytes[8:])
 	h.DataSize = binary.LittleEndian.Uint64(bytes[16:])
+	h.Root = binary.LittleEndian.Uint32(bytes[24:])
 	if h.Version != Version {
 		return fmt.Errorf("unsupport CSUP version %d: expected version %d", h.Version, Version)
 	}

--- a/csup/int.go
+++ b/csup/int.go
@@ -46,7 +46,7 @@ func (i *IntEncoder) reset() {
 	i.vals, i.min, i.max = nil, 0, 0
 }
 
-func (i *IntEncoder) Metadata(off uint64) (uint64, Metadata) {
+func (i *IntEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	loc := Segment{
 		Offset:            off,
 		MemLength:         uint64(len(i.out)),
@@ -54,13 +54,13 @@ func (i *IntEncoder) Metadata(off uint64) (uint64, Metadata) {
 		CompressionFormat: CompressionFormatNone,
 	}
 	off += loc.MemLength
-	return off, &Int{
+	return off, cctx.enter(&Int{
 		Typ:      i.typ,
 		Location: loc,
 		Min:      i.min,
 		Max:      i.max,
 		Count:    uint32(len(i.vals)),
-	}
+	})
 }
 
 func (i *IntEncoder) Emit(w io.Writer) error {
@@ -105,7 +105,7 @@ func (i *UintEncoder) reset() {
 	i.vals, i.min, i.max = nil, 0, 0
 }
 
-func (u *UintEncoder) Metadata(off uint64) (uint64, Metadata) {
+func (u *UintEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	loc := Segment{
 		Offset:            off,
 		MemLength:         uint64(len(u.out)),
@@ -113,13 +113,13 @@ func (u *UintEncoder) Metadata(off uint64) (uint64, Metadata) {
 		CompressionFormat: CompressionFormatNone,
 	}
 	off += loc.MemLength
-	return off, &Uint{
+	return off, cctx.enter(&Uint{
 		Typ:      u.typ,
 		Location: loc,
 		Min:      u.min,
 		Max:      u.max,
 		Count:    uint32(len(u.vals)),
-	}
+	})
 }
 
 func (u *UintEncoder) Emit(w io.Writer) error {

--- a/csup/map.go
+++ b/csup/map.go
@@ -44,16 +44,16 @@ func (m *MapEncoder) Emit(w io.Writer) error {
 	return m.values.Emit(w)
 }
 
-func (m *MapEncoder) Metadata(off uint64) (uint64, Metadata) {
+func (m *MapEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	off, lens := m.lengths.Segment(off)
-	off, keys := m.keys.Metadata(off)
-	off, vals := m.values.Metadata(off)
-	return off, &Map{
+	off, keys := m.keys.Metadata(cctx, off)
+	off, vals := m.values.Metadata(cctx, off)
+	return off, cctx.enter(&Map{
 		Lengths: lens,
 		Keys:    keys,
 		Values:  vals,
 		Length:  m.count,
-	}
+	})
 }
 
 func (m *MapEncoder) Encode(group *errgroup.Group) {

--- a/csup/nulls.go
+++ b/csup/nulls.go
@@ -64,17 +64,17 @@ func (n *NullsEncoder) Encode(group *errgroup.Group) {
 	}
 }
 
-func (n *NullsEncoder) Metadata(off uint64) (uint64, Metadata) {
-	off, values := n.values.Metadata(off)
+func (n *NullsEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
+	off, values := n.values.Metadata(cctx, off)
 	if n.count == 0 {
 		return off, values
 	}
 	off, runs := n.runs.Segment(off)
-	return off, &Nulls{
+	return off, cctx.enter(&Nulls{
 		Runs:   runs,
 		Values: values,
 		Count:  n.count,
-	}
+	})
 }
 
 func (n *NullsEncoder) Emit(w io.Writer) error {

--- a/csup/primitive.go
+++ b/csup/primitive.go
@@ -70,7 +70,7 @@ func (p *PrimitiveEncoder) Encode(group *errgroup.Group) {
 	})
 }
 
-func (p *PrimitiveEncoder) Metadata(off uint64) (uint64, Metadata) {
+func (p *PrimitiveEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	loc := Segment{
 		Offset:            off,
 		Length:            uint64(len(p.out)),
@@ -78,13 +78,13 @@ func (p *PrimitiveEncoder) Metadata(off uint64) (uint64, Metadata) {
 		CompressionFormat: p.format,
 	}
 	off += uint64(len(p.out))
-	return off, &Primitive{
+	return off, cctx.enter(&Primitive{
 		Typ:      p.typ,
 		Location: loc,
 		Count:    p.count,
 		Min:      p.min,
 		Max:      p.max,
-	}
+	})
 }
 
 func (p *PrimitiveEncoder) Emit(w io.Writer) error {

--- a/csup/record.go
+++ b/csup/record.go
@@ -40,14 +40,14 @@ func (r *RecordEncoder) Encode(group *errgroup.Group) {
 	}
 }
 
-func (r *RecordEncoder) Metadata(off uint64) (uint64, Metadata) {
+func (r *RecordEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	fields := make([]Field, 0, len(r.fields))
 	for _, field := range r.fields {
-		next, m := field.Metadata(off)
+		next, m := field.Metadata(cctx, off)
 		fields = append(fields, m)
 		off = next
 	}
-	return off, &Record{Length: r.count, Fields: fields}
+	return off, cctx.enter(&Record{Length: r.count, Fields: fields})
 }
 
 func (r *RecordEncoder) Emit(w io.Writer) error {

--- a/csup/union.go
+++ b/csup/union.go
@@ -55,17 +55,17 @@ func (u *UnionEncoder) Encode(group *errgroup.Group) {
 	}
 }
 
-func (u *UnionEncoder) Metadata(off uint64) (uint64, Metadata) {
+func (u *UnionEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	off, tags := u.tags.Segment(off)
-	values := make([]Metadata, 0, len(u.values))
+	values := make([]ID, 0, len(u.values))
 	for _, val := range u.values {
-		var meta Metadata
-		off, meta = val.Metadata(off)
-		values = append(values, meta)
+		var id ID
+		off, id = val.Metadata(cctx, off)
+		values = append(values, id)
 	}
-	return off, &Union{
+	return off, cctx.enter(&Union{
 		Tags:   tags,
 		Values: values,
 		Length: u.count,
-	}
+	})
 }

--- a/csup/ztests/const.yaml
+++ b/csup/ztests/const.yaml
@@ -12,5 +12,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {Version:8(uint32),MetaSize:35(uint64),DataSize:0(uint64)}
+      {Version:9(uint32),MetaSize:35(uint64),DataSize:0(uint64),Root:0(uint32)}
       {Value:1,Count:3(uint32)}(=Const)

--- a/csup/ztests/dict.yaml
+++ b/csup/ztests/dict.yaml
@@ -1,6 +1,6 @@
 script: |
   super -f csup -o out.csup -
-  super dev csup out.csup | super -Z -c 'over Fields | yield nameof(Values)' -
+  super dev csup out.csup | super -z -c "nameof(this)=='Dict' | count()" -
   
 
 inputs:
@@ -14,5 +14,4 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      "Dict"
-      "Dict"
+      2(uint64)

--- a/csup/ztests/no-dict.yaml
+++ b/csup/ztests/no-dict.yaml
@@ -1,8 +1,7 @@
 script: |
   seq 100 | super -f csup -o out.csup -c "{x:this}" -
-  super dev csup out.csup | super -Z -c "over Fields | yield nameof(Values)" -
+  super dev csup out.csup | super -z -c "nameof(this)=='Dict'" -
 
 outputs:
   - name: stdout
     data: |
-      "Int"

--- a/runtime/vcache/loader.go
+++ b/runtime/vcache/loader.go
@@ -20,9 +20,10 @@ import (
 
 // loader handles loading vector data on demand for only the fields needed
 // as specified in the projection.  Each load is executed with a multiphase
-// process: first, we build a mirror of the CSUP metadata where each node has a
+// process: first, unmarshal builds a mirror of the CSUP metadata where each node has a
 // lock and places to store the bulk data so that it may be reused across
-// projections.  This is called the shadow object.  Then, we fill in the shadow
+// projections.  This is called the shadow object.  The shadow elements are also
+// restricted to just the pieces needed for the projection. Then, we fill in the shadow
 // with data vectors dynamically and create runtime vectors as follows:
 //
 //	(1) create a mirror data structure (shadow)
@@ -31,12 +32,13 @@ import (
 //	(4) load all data that is projected using the nulls to flatten any unloaded data (fetchVals)
 //	(5) form a projection from the fully loaded data nodes (project)
 //
-// The zctx passed into the loader is dynamic and comes from each query context that
-// uses the vcache.  No zctx types are stored in the shadow (except for primitive types
+// The sctx passed into the loader is dynamic and comes from each query context that
+// uses the vcache.  No sctx types are stored in the shadow (except for primitive types
 // in shadowed vector.Any primitives that are shared).  We otherwise allocate all
-// vector.Any super.Types using the passed-in zctx.
+// vector.Any super.Types using the passed-in sctx.
 type loader struct {
-	zctx *super.Context
+	cctx *csup.Context
+	sctx *super.Context
 	r    io.ReaderAt
 }
 
@@ -45,7 +47,8 @@ type loader struct {
 // concurrently on the same shadow and fine-grained locking insures that any given
 // data vector is loaded just once and such loads may be executed concurrently (even
 // when only one thread is calling load).  If paths is nil, then the entire value
-// is loaded.
+// is loaded.  All of the projected paths in the shadow must have been properly
+// unmarshaled before calling.
 func (l *loader) load(projection field.Projection, s shadow) (vector.Any, error) {
 	var group errgroup.Group
 	l.fetchNulls(&group, projection, s)
@@ -57,29 +60,31 @@ func (l *loader) load(projection field.Projection, s shadow) (vector.Any, error)
 	if err := group.Wait(); err != nil {
 		return nil, err
 	}
-	return project(l.zctx, projection, s), nil
+	return project(l.sctx, projection, s), nil
 }
 
 func (l *loader) loadVector(g *errgroup.Group, projection field.Projection, s shadow) {
 	switch s := s.(type) {
 	case *dynamic:
 		//XXX we need an ordered option to load tags only when needed
-		l.loadUint32(g, &s.mu, &s.tags, s.loc)
-		for _, m := range s.vals {
-			l.loadVector(g, projection, m)
+		l.loadUint32(g, &s.mu, &s.tags, s.meta.Tags)
+		for _, m := range s.values {
+			if m != nil {
+				l.loadVector(g, projection, m)
+			}
 		}
 	case *record:
 		l.loadRecord(g, projection, s)
 	case *array:
-		l.loadOffsets(g, &s.mu, &s.offs, s.loc, s.length(), s.nulls.flat)
-		l.loadVector(g, projection, s.vals)
+		l.loadOffsets(g, &s.mu, &s.offs, s.meta.Lengths, s.length(), s.nulls.flat)
+		l.loadVector(g, projection, s.values)
 	case *set:
-		l.loadOffsets(g, &s.mu, &s.offs, s.loc, s.length(), s.nulls.flat)
-		l.loadVector(g, projection, s.vals)
+		l.loadOffsets(g, &s.mu, &s.offs, s.meta.Lengths, s.length(), s.nulls.flat)
+		l.loadVector(g, projection, s.values)
 	case *map_:
-		l.loadOffsets(g, &s.mu, &s.offs, s.loc, s.length(), s.nulls.flat)
+		l.loadOffsets(g, &s.mu, &s.offs, s.meta.Lengths, s.length(), s.nulls.flat)
 		l.loadVector(g, projection, s.keys)
-		l.loadVector(g, projection, s.vals)
+		l.loadVector(g, projection, s.values)
 	case *union:
 		l.loadUnion(g, projection, s)
 	case *int_:
@@ -92,16 +97,23 @@ func (l *loader) loadVector(g *errgroup.Group, projection field.Projection, s sh
 		s.mu.Lock()
 		vec := s.vec
 		if vec == nil {
-			vec = vector.NewConst(s.val, s.length(), s.nulls.flat)
+			// Map the const super.Value in the csup's type context to
+			// a new one in the query type context.
+			val := s.meta.Value
+			typ, err := l.sctx.TranslateType(val.Type())
+			if err != nil {
+				panic(err)
+			}
+			vec = vector.NewConst(super.NewValue(typ, val.Bytes()), s.length(), s.nulls.flat)
 			s.vec = vec
 		}
 		s.mu.Unlock()
 	case *dict:
 		l.loadDict(g, projection, s)
 	case *error_:
-		l.loadVector(g, projection, s.vals)
+		l.loadVector(g, projection, s.values)
 	case *named:
-		l.loadVector(g, projection, s.vals)
+		l.loadVector(g, projection, s.values)
 	default:
 		panic(fmt.Sprintf("vector cache: shadow type %T not supported", s))
 	}
@@ -112,22 +124,24 @@ func (l *loader) loadRecord(g *errgroup.Group, projection field.Projection, s *r
 		// Load the whole record.  We're either loading all on demand (nil paths)
 		// or loading this record because it's referenced at the end of a projected path.
 		for _, f := range s.fields {
-			l.loadVector(g, nil, f.val)
+			if f != nil {
+				l.loadVector(g, nil, f)
+			}
 		}
 		return
 	}
 	switch elem := projection[0].(type) {
 	case string:
-		if k := indexOfField(elem, s.fields); k >= 0 {
-			l.loadVector(g, projection[1:], s.fields[k].val)
+		if k := indexOfField(elem, s.meta); k >= 0 {
+			l.loadVector(g, projection[1:], s.fields[k])
 		}
 	case field.Fork:
 		// Multiple fields at this level are being projected.
 		for _, path := range elem {
 			// records require a field name path element (i.e., string)
 			if name, ok := path[0].(string); ok {
-				if k := indexOfField(name, s.fields); k >= 0 {
-					l.loadVector(g, projection[1:], s.fields[k].val)
+				if k := indexOfField(name, s.meta); k >= 0 {
+					l.loadVector(g, projection[1:], s.fields[k])
 				}
 			}
 		}
@@ -137,8 +151,8 @@ func (l *loader) loadRecord(g *errgroup.Group, projection field.Projection, s *r
 }
 
 func (l *loader) loadUnion(g *errgroup.Group, projection field.Projection, s *union) {
-	l.loadUint32(g, &s.mu, &s.tags, s.loc)
-	for _, val := range s.vals {
+	l.loadUint32(g, &s.mu, &s.tags, s.meta.Tags)
+	for _, val := range s.values {
 		l.loadVector(g, projection, val)
 	}
 }
@@ -156,13 +170,17 @@ func (l *loader) loadInt(g *errgroup.Group, s *int_) {
 		if s.vec != nil {
 			return nil
 		}
-		bytes := make([]byte, s.csup.Location.MemLength)
-		if err := s.csup.Location.Read(l.r, bytes); err != nil {
+		bytes := make([]byte, s.meta.Location.MemLength)
+		if err := s.meta.Location.Read(l.r, bytes); err != nil {
 			return err
 		}
 		vals := intcomp.UncompressInt64(byteconv.ReinterpretSlice[uint64](bytes), nil)
 		vals = extendForNulls(vals, s.nulls.flat, s.count)
-		s.vec = vector.NewInt(s.csup.Type(l.zctx), vals, s.nulls.flat)
+		typ, err := l.sctx.TranslateType(s.meta.Typ)
+		if err != nil {
+			panic(err)
+		}
+		s.vec = vector.NewInt(typ, vals, s.nulls.flat)
 		return nil
 	})
 }
@@ -180,13 +198,17 @@ func (l *loader) loadUint(g *errgroup.Group, s *uint_) {
 		if s.vec != nil {
 			return nil
 		}
-		bytes := make([]byte, s.csup.Location.MemLength)
-		if err := s.csup.Location.Read(l.r, bytes); err != nil {
+		bytes := make([]byte, s.meta.Location.MemLength)
+		if err := s.meta.Location.Read(l.r, bytes); err != nil {
 			return err
 		}
 		vals := intcomp.UncompressUint64(byteconv.ReinterpretSlice[uint64](bytes), nil)
 		vals = extendForNulls(vals, s.nulls.flat, s.count)
-		s.vec = vector.NewUint(s.csup.Type(l.zctx), vals, s.nulls.flat)
+		typ, err := l.sctx.TranslateType(s.meta.Typ)
+		if err != nil {
+			panic(err)
+		}
+		s.vec = vector.NewUint(typ, vals, s.nulls.flat)
 		return nil
 	})
 }
@@ -204,7 +226,10 @@ func (l *loader) loadPrimitive(g *errgroup.Group, s *primitive) {
 		if s.vec != nil {
 			return nil
 		}
-		typ := s.csup.Type(l.zctx)
+		typ, err := l.sctx.TranslateType(s.meta.Typ)
+		if err != nil {
+			panic(err)
+		}
 		vec, err := l.loadVals(typ, s, s.nulls.flat)
 		if err != nil {
 			return err
@@ -215,11 +240,12 @@ func (l *loader) loadPrimitive(g *errgroup.Group, s *primitive) {
 }
 
 func (l *loader) loadVals(typ super.Type, s *primitive, nulls *vector.Bool) (vector.Any, error) {
-	if s.csup.Count == 0 {
+	if s.count.vals == 0 {
+		// no vals, just nulls
 		return empty(typ, s.length(), nulls), nil
 	}
-	bytes := make([]byte, s.csup.Location.MemLength)
-	if err := s.csup.Location.Read(l.r, bytes); err != nil {
+	bytes := make([]byte, s.meta.Location.MemLength)
+	if err := s.meta.Location.Read(l.r, bytes); err != nil {
 		return nil, err
 	}
 	length := s.length()
@@ -336,17 +362,16 @@ func (l *loader) loadVals(typ super.Type, s *primitive, nulls *vector.Bool) (vec
 }
 
 func (l *loader) loadDict(g *errgroup.Group, projection field.Projection, s *dict) {
-	if s.csup.Length == 0 {
+	if s.count.vals == 0 {
 		panic("empty dict") // empty dictionaries should not happen!
 	}
-	l.loadVector(g, projection, s.vals)
-	l.loadUint32(g, &s.mu, &s.counts, s.csup.Counts)
+	l.loadVector(g, projection, s.values)
+	l.loadUint32(g, &s.mu, &s.counts, s.meta.Counts)
 	g.Go(func() error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		loc := s.csup.Index
-		s.index = make([]byte, loc.MemLength)
-		if err := loc.Read(l.r, s.index); err != nil {
+		s.index = make([]byte, s.meta.Index.MemLength)
+		if err := s.meta.Index.Read(l.r, s.index); err != nil {
 			return err
 		}
 		s.index = extendForNulls(s.index, s.nulls.flat, s.count)
@@ -455,61 +480,61 @@ func (l *loader) loadOffsets(g *errgroup.Group, mu *sync.Mutex, slice *[]uint32,
 func (l *loader) fetchNulls(g *errgroup.Group, projection field.Projection, s shadow) {
 	switch s := s.(type) {
 	case *dynamic:
-		for _, m := range s.vals {
+		for _, m := range s.values {
 			l.fetchNulls(g, projection, m)
 		}
 	case *record:
-		s.nulls.fetch(g, l.r)
+		s.nulls.fetch(g, l.cctx, l.r)
 		if len(projection) == 0 {
 			for _, f := range s.fields {
-				l.fetchNulls(g, nil, f.val)
+				l.fetchNulls(g, nil, f)
 			}
 			return
 		}
 		switch elem := projection[0].(type) {
 		case string:
-			if k := indexOfField(elem, s.fields); k >= 0 {
-				l.fetchNulls(g, projection[1:], s.fields[k].val)
+			if k := indexOfField(elem, s.meta); k >= 0 {
+				l.fetchNulls(g, projection[1:], s.fields[k])
 			}
 		case field.Fork:
 			for _, path := range elem {
 				if name, ok := path[0].(string); ok {
-					if k := indexOfField(name, s.fields); k >= 0 {
-						l.fetchNulls(g, projection[1:], s.fields[k].val)
+					if k := indexOfField(name, s.meta); k >= 0 {
+						l.fetchNulls(g, projection[1:], s.fields[k])
 					}
 				}
 			}
 		}
 	case *array:
-		s.nulls.fetch(g, l.r)
-		l.fetchNulls(g, projection, s.vals)
+		s.nulls.fetch(g, l.cctx, l.r)
+		l.fetchNulls(g, projection, s.values)
 	case *set:
-		s.nulls.fetch(g, l.r)
-		l.fetchNulls(g, projection, s.vals)
+		s.nulls.fetch(g, l.cctx, l.r)
+		l.fetchNulls(g, projection, s.values)
 	case *map_:
-		s.nulls.fetch(g, l.r)
+		s.nulls.fetch(g, l.cctx, l.r)
 		l.fetchNulls(g, projection, s.keys)
-		l.fetchNulls(g, projection, s.vals)
+		l.fetchNulls(g, projection, s.values)
 	case *union:
-		s.nulls.fetch(g, l.r)
-		for _, val := range s.vals {
+		s.nulls.fetch(g, l.cctx, l.r)
+		for _, val := range s.values {
 			l.fetchNulls(g, projection, val)
 		}
 	case *int_:
-		s.nulls.fetch(g, l.r)
+		s.nulls.fetch(g, l.cctx, l.r)
 	case *uint_:
-		s.nulls.fetch(g, l.r)
+		s.nulls.fetch(g, l.cctx, l.r)
 	case *primitive:
-		s.nulls.fetch(g, l.r)
+		s.nulls.fetch(g, l.cctx, l.r)
 	case *const_:
-		s.nulls.fetch(g, l.r)
+		s.nulls.fetch(g, l.cctx, l.r)
 	case *dict:
-		s.nulls.fetch(g, l.r)
+		s.nulls.fetch(g, l.cctx, l.r)
 	case *error_:
-		s.nulls.fetch(g, l.r)
-		l.fetchNulls(g, projection, s.vals)
+		s.nulls.fetch(g, l.cctx, l.r)
+		l.fetchNulls(g, projection, s.values)
 	case *named:
-		l.fetchNulls(g, projection, s.vals)
+		l.fetchNulls(g, projection, s.values)
 	default:
 		panic(fmt.Sprintf("vector cache: type %T not supported", s))
 	}
@@ -518,44 +543,44 @@ func (l *loader) fetchNulls(g *errgroup.Group, projection field.Projection, s sh
 func flattenNulls(projection field.Projection, s shadow, parent *vector.Bool) {
 	switch s := s.(type) {
 	case *dynamic:
-		for _, m := range s.vals {
+		for _, m := range s.values {
 			flattenNulls(projection, m, nil)
 		}
 	case *record:
 		nulls := s.nulls.flatten(parent)
 		if len(projection) == 0 {
 			for _, f := range s.fields {
-				flattenNulls(nil, f.val, nulls)
+				flattenNulls(nil, f, nulls)
 			}
 			return
 		}
 		switch elem := projection[0].(type) {
 		case string:
-			if k := indexOfField(elem, s.fields); k >= 0 {
-				flattenNulls(projection[1:], s.fields[k].val, nulls)
+			if k := indexOfField(elem, s.meta); k >= 0 {
+				flattenNulls(projection[1:], s.fields[k], nulls)
 			}
 		case field.Fork:
 			for _, path := range elem {
 				if name, ok := path[0].(string); ok {
-					if k := indexOfField(name, s.fields); k >= 0 {
-						flattenNulls(projection[1:], s.fields[k].val, nulls)
+					if k := indexOfField(name, s.meta); k >= 0 {
+						flattenNulls(projection[1:], s.fields[k], nulls)
 					}
 				}
 			}
 		}
 	case *array:
 		s.nulls.flatten(parent)
-		flattenNulls(projection, s.vals, nil)
+		flattenNulls(projection, s.values, nil)
 	case *set:
 		s.nulls.flatten(parent)
-		flattenNulls(projection, s.vals, nil)
+		flattenNulls(projection, s.values, nil)
 	case *map_:
 		s.nulls.flatten(parent)
 		flattenNulls(nil, s.keys, nil)
-		flattenNulls(nil, s.vals, nil)
+		flattenNulls(nil, s.values, nil)
 	case *union:
 		s.nulls.flatten(parent)
-		for _, val := range s.vals {
+		for _, val := range s.values {
 			flattenNulls(projection, val, nil)
 		}
 	case *int_:
@@ -570,16 +595,16 @@ func flattenNulls(projection field.Projection, s shadow, parent *vector.Bool) {
 		s.nulls.flatten(parent)
 	case *error_:
 		s.nulls.flatten(parent)
-		flattenNulls(projection, s.vals, nil)
+		flattenNulls(projection, s.values, nil)
 	case *named:
-		flattenNulls(projection, s.vals, parent)
+		flattenNulls(projection, s.values, parent)
 	default:
 		panic(fmt.Sprintf("vector cache: type %T not supported", s))
 	}
 }
 
-func indexOfField(name string, fields []field_) int {
-	return slices.IndexFunc(fields, func(f field_) bool {
-		return f.name == name
+func indexOfField(name string, r *csup.Record) int {
+	return slices.IndexFunc(r.Fields, func(f csup.Field) bool {
+		return f.Name == name
 	})
 }

--- a/runtime/vcache/nulls.go
+++ b/runtime/vcache/nulls.go
@@ -16,7 +16,11 @@ type nulls struct {
 	flat  *vector.Bool
 }
 
-func (n *nulls) fetch(g *errgroup.Group, reader io.ReaderAt) {
+func (n *nulls) length() uint32 {
+	panic("vcacne.nulls.length shouldn't be called")
+}
+
+func (n *nulls) fetch(g *errgroup.Group, cctx *csup.Context, reader io.ReaderAt) {
 	if n == nil {
 		return
 	}
@@ -32,8 +36,7 @@ func (n *nulls) fetch(g *errgroup.Group, reader io.ReaderAt) {
 		if n.meta == nil {
 			return nil
 		}
-		length := n.meta.Count + n.meta.Values.Len()
-		n.local = vector.NewBoolEmpty(length, nil)
+		n.local = vector.NewBoolEmpty(n.meta.Len(cctx), nil)
 		runlens, err := csup.ReadUint32s(n.meta.Runs, reader)
 		if err != nil {
 			return err

--- a/runtime/vcache/object.go
+++ b/runtime/vcache/object.go
@@ -44,10 +44,7 @@ func NewObject(ctx context.Context, engine storage.Engine, uri *storage.URI) (*O
 }
 
 func NewObjectFromCSUP(object *csup.Object) *Object {
-	return &Object{
-		object: object,
-		root:   nil,
-	}
+	return &Object{object: object}
 }
 
 func (o *Object) Close() error {

--- a/runtime/vcache/object.go
+++ b/runtime/vcache/object.go
@@ -46,7 +46,7 @@ func NewObject(ctx context.Context, engine storage.Engine, uri *storage.URI) (*O
 func NewObjectFromCSUP(object *csup.Object) *Object {
 	return &Object{
 		object: object,
-		root:   newShadow(object.Metadata(), nil, 0),
+		root:   nil,
 	}
 }
 
@@ -57,8 +57,10 @@ func (o *Object) Close() error {
 // Fetch returns the indicated projection of data in this CSUP object.
 // If any required data is not memory resident, it will be fetched from
 // storage and cached in memory so that subsequent calls run from memory.
-// The vectors returned will have types from the provided zctx.  Multiple
+// The vectors returned will have types from the provided sctx.  Multiple
 // Fetch calls to the same object may run concurrently.
-func (o *Object) Fetch(zctx *super.Context, projection field.Projection) (vector.Any, error) {
-	return (&loader{zctx, o.object.DataReader()}).load(projection, o.root)
+func (o *Object) Fetch(sctx *super.Context, projection field.Projection) (vector.Any, error) {
+	cctx := o.object.Context()
+	o.root = unmarshal(cctx, o.object.Root(), o.root, projection, nil, 0)
+	return (&loader{cctx, sctx, o.object.DataReader()}).load(projection, o.root)
 }

--- a/runtime/vcache/shadow.go
+++ b/runtime/vcache/shadow.go
@@ -18,9 +18,9 @@ import (
 // vectors are mutated under locks here as needed.
 //
 // Shadows are created incrementally so that a sequence of projections will do the
-// minimal work unmarshaling the csup metadata as needed.  When processing a sequence
-// of csup files with a single projection, the incremental capability is not important
-// but when caching csup objects (e.g., in local from S3), multiple threads operating
+// minimal work unmarshaling the CSUP metadata as needed.  When processing a sequence
+// of CSUP files with a single projection, the incremental capability is not important
+// but when caching CSUP objects (e.g., in local from S3), multiple threads operating
 // concurrently on a single object benefit from incremental unmarshaling.  This is especially
 // important when processing thin projections over objects with lots of heteregenous types.
 //
@@ -164,7 +164,7 @@ func (c count) length() uint32 {
 }
 
 // unmarshal decodes the CSUP metadata structure to a (partial) shadow according
-// to the procided projection.  No vector data is actually loaded.
+// to the provided projection.  No vector data is actually loaded.
 // Nulls are read from storage and unwrapped
 // so that all leaves of a given type have the same number of slots.  The vcache
 // is then responsible for loading leaf vectors on demand as they are required

--- a/runtime/vcache/shadow.go
+++ b/runtime/vcache/shadow.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/brimdata/super"
 	"github.com/brimdata/super/csup"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/vector"
 )
 
@@ -16,131 +16,142 @@ import (
 // mutable shadow pieces that are dynamically loaded and maintained here.
 // The invariant is that runtime vectors are immutable while vcache.shadow
 // vectors are mutated under locks here as needed.
+//
+// Shadows are created incrementally so that a sequence of projections will do the
+// minimal work unmarshaling the csup metadata as needed.  When processing a sequence
+// of csup files with a single projection, the incremental capability is not important
+// but when caching csup objects (e.g., in local from S3), multiple threads operating
+// concurrently on a single object benefit from incremental unmarshaling.  This is especially
+// important when processing thin projections over objects with lots of heteregenous types.
+//
+// Note that the shadow doesn't know about the query type context, thereby allowing the shadow
+// to be shared across different queries.  Instead, the loader that builds a vector.Any
+// is reponsible for computing the shared type from the shadow hierarchy.
+//
+// Shadows are created with unmarshal and only the portion of the shadow tree is
+// created for the passed-in projection.  It is intended that a given shadow may be
+// updated incrementally and concurrently but there some locking missing and this
+// has not yet been tested so for now assume that unmarhsal here IS NOT REENTRANT.
 
 type shadow interface {
 	length() uint32
 }
 
 type dynamic struct {
-	mu   sync.Mutex
-	len  uint32
-	tags []uint32 // need not be loaded for unordered dynamics
-	loc  csup.Segment
-	vals []shadow
+	mu     sync.Mutex
+	meta   *csup.Dynamic
+	tags   []uint32 // need not be loaded for unordered dynamics
+	values []shadow
 }
 
 func (d *dynamic) length() uint32 {
-	return d.len
+	return d.meta.Length
 }
 
 type record struct {
+	mu   sync.Mutex
+	meta *csup.Record
 	count
-	fields []field_
+	fields []shadow
 	nulls  nulls
 }
 
-type field_ struct {
-	name string
-	val  shadow
-}
-
 type array struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Array
 	count
-	loc   csup.Segment
-	offs  []uint32
-	vals  shadow
-	nulls nulls
+	offs   []uint32
+	values shadow
+	nulls  nulls
 }
 
 type set struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Set
 	count
-	loc   csup.Segment
-	offs  []uint32
-	vals  shadow
-	nulls nulls
+	offs   []uint32
+	values shadow
+	nulls  nulls
 }
 
 type union struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Union
 	count
 	// XXX we should store TagMap here so it doesn't have to be recomputed
-	tags  []uint32
-	loc   csup.Segment
-	vals  []shadow
-	nulls nulls
+	tags   []uint32
+	values []shadow
+	nulls  nulls
 }
 
 type map_ struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Map
 	count
-	offs  []uint32
-	loc   csup.Segment
-	keys  shadow
-	vals  shadow
-	nulls nulls
+	offs   []uint32
+	keys   shadow
+	values shadow
+	nulls  nulls
 }
 
 type primitive struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Primitive
 	count
-	csup  *csup.Primitive
 	vec   vector.Any
 	nulls nulls
 }
 
 type int_ struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Int
 	count
-	csup  *csup.Int
 	vec   vector.Any
 	nulls nulls
 }
 
 type uint_ struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Uint
 	count
-	csup  *csup.Uint
 	vec   vector.Any
 	nulls nulls
 }
 
 type const_ struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Const
 	count
-	val super.Value //XXX map this value? XXX, maybe wrap a shadow vector?, which could
-	// have a named in it
 	vec   *vector.Const
 	nulls nulls
 }
 
 type dict struct {
-	mu sync.Mutex
+	mu   sync.Mutex
+	meta *csup.Dict
 	count
-	csup   *csup.Dict
 	nulls  nulls
-	vals   shadow
-	counts []uint32
-	index  []byte
+	values shadow
+	counts []uint32 // number of each entry indexed by dict offset
+	index  []byte   // dict offset of each value in vector
 }
 
 type error_ struct {
-	vals  shadow
-	nulls nulls
+	values shadow
+	nulls  nulls
 }
 
 func (e *error_) length() uint32 {
-	return e.vals.length()
+	return e.values.length()
 }
 
 type named struct {
-	name string
-	vals shadow
+	meta   *csup.Named
+	values shadow
 }
 
 func (n *named) length() uint32 {
-	return n.vals.length()
+	return n.values.length()
 }
 
 type count struct {
@@ -152,108 +163,213 @@ func (c count) length() uint32 {
 	return c.nulls + c.vals
 }
 
-// newShadow converts the CSUP metadata structure to a complete vector.Any
-// without loading any leaf columns.  Nulls are read from storage and unwrapped
+// unmarshal decodes the CSUP metadata structure to a (partial) shadow according
+// to the procided projection.  No vector data is actually loaded.
+// Nulls are read from storage and unwrapped
 // so that all leaves of a given type have the same number of slots.  The vcache
 // is then responsible for loading leaf vectors on demand as they are required
 // by the runtime.
-func newShadow(m csup.Metadata, n *csup.Nulls, nullsCnt uint32) shadow {
-	switch m := m.(type) {
+func unmarshal(cctx *csup.Context, id csup.ID, target shadow, projection field.Projection, n *csup.Nulls, nullsCnt uint32) shadow {
+	switch meta := cctx.Lookup(id).(type) {
 	case *csup.Dynamic:
-		vals := make([]shadow, 0, len(m.Values))
-		for _, val := range m.Values {
-			vals = append(vals, newShadow(val, nil, 0))
+		var d *dynamic
+		if target == nil {
+			d = &dynamic{
+				meta:   meta,
+				values: make([]shadow, len(meta.Values)),
+			}
+		} else {
+			d = target.(*dynamic)
 		}
-		return &dynamic{
-			vals: vals,
-			len:  m.Len(),
-			loc:  m.Tags,
+		for k := range d.values {
+			d.values[k] = unmarshal(cctx, meta.Values[k], d.values[k], projection, nil, 0)
 		}
+		return d
 	case *csup.Nulls:
 		if n != nil {
 			panic("can't wrap nulls inside of nulls")
 		}
-		nullsCnt += m.Count
-		return newShadow(m.Values, m, nullsCnt)
+		if target != nil {
+			// We already processed this Nulls data so the target is whatever
+			// it was transformed into.  Just recursively descend now.
+			return unmarshal(cctx, meta.Values, target, projection, nil, 0)
+		}
+		return unmarshal(cctx, meta.Values, nil, projection, meta, nullsCnt+meta.Count)
 	case *csup.Error:
-		return &error_{newShadow(m.Values, n, nullsCnt), nulls{meta: n}}
+		var e *error_
+		if target == nil {
+			e = &error_{nulls: nulls{meta: n}}
+		} else {
+			e = target.(*error_)
+		}
+		e.values = unmarshal(cctx, meta.Values, e.values, projection, nil, nullsCnt)
+		return e
 	case *csup.Named:
-		return &named{m.Name, newShadow(m.Values, n, nullsCnt)}
+		var nm *named
+		if target == nil {
+			nm = &named{meta: meta}
+		} else {
+			nm = target.(*named)
+		}
+		nm.values = unmarshal(cctx, meta.Values, nm.values, projection, n, nullsCnt)
+		return nm
 	case *csup.Record:
-		fields := make([]field_, 0, len(m.Fields))
-		for _, f := range m.Fields {
-			fields = append(fields, field_{f.Name, newShadow(f.Values, nil, nullsCnt)})
+		var r *record
+		if target == nil {
+			r = &record{
+				meta:   meta,
+				fields: make([]shadow, len(meta.Fields)),
+				nulls:  nulls{meta: n},
+				count:  count{meta.Length, nullsCnt},
+			}
+		} else {
+			r = target.(*record)
 		}
-		return &record{
-			count:  count{m.Len(), nullsCnt},
-			fields: fields,
-			nulls:  nulls{meta: n},
+		if len(projection) == 0 {
+			// Unmarshal all the fields of this record.  We're either loading all on demand (nil paths)
+			// or loading this record because it's referenced at the end of a projected path.
+			for k, f := range r.fields {
+				r.fields[k] = unmarshal(cctx, meta.Fields[k].Values, f, nil, nil, r.count.nulls)
+			}
+			return r
 		}
+		switch elem := projection[0].(type) {
+		case string:
+			if k := indexOfField(elem, r.meta); k >= 0 {
+				r.fields[k] = unmarshal(cctx, meta.Fields[k].Values, r.fields[k], nil, nil, r.count.nulls)
+			}
+		case field.Fork:
+			// Multiple fields at this level are being projected.
+			for _, path := range elem {
+				// records require a field name path element (i.e., string)
+				if name, ok := path[0].(string); ok {
+					if k := indexOfField(name, r.meta); k >= 0 {
+						r.fields[k] = unmarshal(cctx, meta.Fields[k].Values, r.fields[k], projection[1:], nil, r.count.nulls)
+					}
+				}
+			}
+		default:
+			panic(fmt.Sprintf("bad path reference vcache record: %T", elem))
+		}
+		return r
 	case *csup.Array:
-		return &array{
-			count: count{m.Len(), nullsCnt},
-			loc:   m.Lengths,
-			vals:  newShadow(m.Values, nil, 0),
-			nulls: nulls{meta: n},
+		var a *array
+		if target == nil {
+			a = &array{
+				meta:  meta,
+				nulls: nulls{meta: n},
+				count: count{meta.Length, nullsCnt},
+			}
+		} else {
+			a = target.(*array)
 		}
+		a.values = unmarshal(cctx, meta.Values, a.values, nil, nil, 0)
+		return a
 	case *csup.Set:
-		return &set{
-			count: count{m.Len(), nullsCnt},
-			loc:   m.Lengths,
-			vals:  newShadow(m.Values, nil, 0),
-			nulls: nulls{meta: n},
+		var s *set
+		if target == nil {
+			s = &set{
+				meta:  meta,
+				nulls: nulls{meta: n},
+				count: count{meta.Length, nullsCnt},
+			}
+		} else {
+			s = target.(*set)
 		}
+		s.values = unmarshal(cctx, meta.Values, s.values, nil, nil, 0)
+		return s
 	case *csup.Map:
-		return &map_{
-			count: count{m.Len(), nullsCnt},
-			loc:   m.Lengths,
-			keys:  newShadow(m.Keys, nil, 0),
-			vals:  newShadow(m.Values, nil, 0),
-			nulls: nulls{meta: n},
+		var m *map_
+		if target == nil {
+			m = &map_{
+				meta:  meta,
+				nulls: nulls{meta: n},
+				count: count{meta.Length, nullsCnt},
+			}
+		} else {
+			m = target.(*map_)
 		}
+		m.keys = unmarshal(cctx, meta.Keys, m.keys, nil, nil, 0)
+		m.values = unmarshal(cctx, meta.Values, m.values, nil, nil, 0)
+		return m
 	case *csup.Union:
-		vals := make([]shadow, 0, len(m.Values))
-		for k := range m.Values {
-			vals = append(vals, newShadow(m.Values[k], nil, 0))
+		var u *union
+		if target == nil {
+			u = &union{
+				meta:   meta,
+				values: make([]shadow, len(meta.Values)),
+				nulls:  nulls{meta: n},
+				count:  count{meta.Length, nullsCnt},
+			}
+		} else {
+			u = target.(*union)
 		}
-		return &union{
-			count: count{m.Len(), nullsCnt},
-			loc:   m.Tags,
-			vals:  vals,
-			nulls: nulls{meta: n},
+		for k, id := range meta.Values {
+			u.values[k] = unmarshal(cctx, id, u.values[k], projection, nil, 0)
 		}
+		return u
 	case *csup.Int:
-		return &int_{
-			count: count{m.Len(), nullsCnt},
-			csup:  m,
-			nulls: nulls{meta: n},
+		var i *int_
+		if target == nil {
+			i = &int_{
+				meta:  meta,
+				nulls: nulls{meta: n},
+				count: count{meta.Len(cctx), nullsCnt},
+			}
+		} else {
+			i = target.(*int_)
 		}
+		return i
 	case *csup.Uint:
-		return &uint_{
-			count: count{m.Len(), nullsCnt},
-			csup:  m,
-			nulls: nulls{meta: n},
+		var u *uint_
+		if target == nil {
+			u = &uint_{
+				meta:  meta,
+				nulls: nulls{meta: n},
+				count: count{meta.Len(cctx), nullsCnt},
+			}
+		} else {
+			u = target.(*uint_)
 		}
+		return u
 	case *csup.Primitive:
-		return &primitive{
-			count: count{m.Len(), nullsCnt},
-			csup:  m,
-			nulls: nulls{meta: n},
+		var p *primitive
+		if target == nil {
+			p = &primitive{
+				meta:  meta,
+				nulls: nulls{meta: n},
+				count: count{meta.Len(cctx), nullsCnt},
+			}
+		} else {
+			p = target.(*primitive)
 		}
+		return p
 	case *csup.Const:
-		return &const_{
-			count: count{m.Len(), nullsCnt},
-			val:   m.Value,
-			nulls: nulls{meta: n},
+		var c *const_
+		if target == nil {
+			c = &const_{
+				meta:  meta,
+				nulls: nulls{meta: n},
+				count: count{meta.Len(cctx), nullsCnt},
+			}
+		} else {
+			c = target.(*const_)
 		}
+		return c
 	case *csup.Dict:
-		return &dict{
-			vals:  newShadow(m.Values, nil, 0),
-			count: count{m.Len(), nullsCnt},
-			csup:  m,
-			nulls: nulls{meta: n},
+		var d *dict
+		if target == nil {
+			d = &dict{
+				meta:  meta,
+				nulls: nulls{meta: n},
+				count: count{meta.Len(cctx), nullsCnt},
+			}
+		} else {
+			d = target.(*dict)
 		}
+		d.values = unmarshal(cctx, meta.Values, d.values, projection, nil, 0)
+		return d
 	default:
-		panic(fmt.Sprintf("vector cache: type %T not supported", m))
+		panic(fmt.Sprintf("vector cache: type %T not supported", meta))
 	}
 }

--- a/zio/csupio/reader.go
+++ b/zio/csupio/reader.go
@@ -15,14 +15,14 @@ import (
 )
 
 type reader struct {
-	zctx       *super.Context
+	sctx       *super.Context
 	stream     *stream
 	projection field.Projection
 	readerAt   io.ReaderAt
 	vals       []super.Value
 }
 
-func NewReader(zctx *super.Context, r io.Reader, fields []field.Path) (zio.Reader, error) {
+func NewReader(sctx *super.Context, r io.Reader, fields []field.Path) (zio.Reader, error) {
 	ra, ok := r.(io.ReaderAt)
 	if !ok {
 		return nil, errors.New("Super Columnar requires a seekable input")
@@ -32,7 +32,7 @@ func NewReader(zctx *super.Context, r io.Reader, fields []field.Path) (zio.Reade
 		return nil, err
 	}
 	return &reader{
-		zctx:       zctx,
+		sctx:       sctx,
 		stream:     &stream{r: ra},
 		projection: field.NewProjection(fields),
 		readerAt:   ra,
@@ -46,7 +46,7 @@ again:
 		if o == nil || err != nil {
 			return nil, err
 		}
-		vec, err := vcache.NewObjectFromCSUP(o).Fetch(r.zctx, r.projection)
+		vec, err := vcache.NewObjectFromCSUP(o).Fetch(r.sctx, r.projection)
 		if err != nil {
 			return nil, err
 		}

--- a/zio/csupio/vectorreader.go
+++ b/zio/csupio/vectorreader.go
@@ -18,7 +18,7 @@ import (
 
 type VectorReader struct {
 	ctx  context.Context
-	zctx *super.Context
+	sctx *super.Context
 
 	activeReaders *atomic.Int64
 	stream        *stream
@@ -33,7 +33,7 @@ type metafilter struct {
 	projection field.Projection
 }
 
-func NewVectorReader(ctx context.Context, zctx *super.Context, r io.Reader, pushdown zbuf.Pushdown) (*VectorReader, error) {
+func NewVectorReader(ctx context.Context, sctx *super.Context, r io.Reader, pushdown zbuf.Pushdown) (*VectorReader, error) {
 	ra, ok := r.(io.ReaderAt)
 	if !ok {
 		return nil, errors.New("Super Columnar requires a seekable input")
@@ -58,7 +58,7 @@ func NewVectorReader(ctx context.Context, zctx *super.Context, r io.Reader, push
 	}
 	return &VectorReader{
 		ctx:           ctx,
-		zctx:          zctx,
+		sctx:          sctx,
 		activeReaders: &atomic.Int64{},
 		stream:        &stream{r: ra},
 		metaFilters:   mfPool,
@@ -71,7 +71,7 @@ func (v *VectorReader) NewConcurrentPuller() (vector.Puller, error) {
 	v.activeReaders.Add(1)
 	return &VectorReader{
 		ctx:           v.ctx,
-		zctx:          v.zctx,
+		sctx:          v.sctx,
 		activeReaders: v.activeReaders,
 		metaFilters:   v.metaFilters,
 		stream:        v.stream,
@@ -97,16 +97,16 @@ func (v *VectorReader) Pull(done bool) (vector.Any, error) {
 		// pollutes the type context.  We should use the csup local context for
 		// this filtering but this will require a little compiler refactoring to be
 		// able to build runtime expressions that use different type contexts.
-		if v.metaFilters == nil || !pruneObject(v.zctx, v.metaFilters, o.Metadata()) {
-			return vcache.NewObjectFromCSUP(o).Fetch(v.zctx, v.projection)
+		if v.metaFilters == nil || !pruneObject(v.sctx, v.metaFilters, o) {
+			return vcache.NewObjectFromCSUP(o).Fetch(v.sctx, v.projection)
 		}
 	}
 }
 
-func pruneObject(zctx *super.Context, metaFilters *sync.Pool, m csup.Metadata) bool {
+func pruneObject(sctx *super.Context, metaFilters *sync.Pool, o *csup.Object) bool {
 	mf := metaFilters.Get().(*metafilter)
 	defer metaFilters.Put(mf)
-	vals := csup.ProjectMetadata(zctx, m, mf.projection)
+	vals := o.ProjectMetadata(sctx, mf.projection)
 	for _, val := range vals {
 		if mf.filter.Eval(nil, val).Ptr().AsBool() {
 			return false


### PR DESCRIPTION
This commit addresses a scaling challenge for CSUP with respect to large numbers of types by arranging for the per-type metadata to be decoded on an as-needed basis.  To do so, we changed the metadata representation from a single super value to an array of flattened metadata records indexed by ID.  This allows us to incrementally unmarshal and build the shadow vectors for only the types needed by a query.  Additionally, the metadata object filter now performs projection too so that only the metadata values from the types needed are deserialized and acted upon by the metadata filter.

These changes affect the CSUP file format so we bumped its version number from 8 to 9.

The code that unmarshals the shadow vectors is not currently reentrant. If/when we want to allow concurrent updates (e.g., vcache used by parallel lake requests) we will need to invoke the proper locking protocol.

Some rough perf measurements indicate a 5X speedup for the Bluesky Million data set on a simple query projecting a single column.