### PR TITLE
Fix EOS handling in top operator

### DIFF
--- a/runtime/ztests/op/over-top.yaml
+++ b/runtime/ztests/op/over-top.yaml
@@ -1,0 +1,16 @@
+spq: over a => (top 2 this)
+
+vector: true
+
+input: |
+  {a:[10,9,11]}
+  {a:[3,2,1]}
+  {a:|[6,9]|}
+
+output: |
+  11
+  10
+  3
+  2
+  9
+  6


### PR DESCRIPTION
The top operator (both sequential and vector) doesn't return nil, nil
upon receiving EOS from its parent, preventing it from working properly
inside a scope over operator (e.g., "over a => (top 2 this)".  Fix that.