### PR TITLE
rename vector.NewView to vector.Pick

### DIFF
--- a/runtime/vam/expr/agg/math.go
+++ b/runtime/vam/expr/agg/math.go
@@ -107,7 +107,7 @@ func trimNulls(vec vector.Any) vector.Any {
 	case 0:
 		return vec
 	default:
-		return vector.NewInverseView(vec, index)
+		return vector.ReversePick(vec, index)
 	}
 }
 

--- a/runtime/vam/expr/arith.go
+++ b/runtime/vam/expr/arith.go
@@ -77,7 +77,7 @@ func enumToIndex(vec vector.Any) vector.Any {
 	switch vec := vec.(type) {
 	case *vector.View:
 		if enum, ok := vec.Any.(*vector.Enum); ok {
-			return vector.NewView(enum.Uint, vec.Index)
+			return vector.Pick(enum.Uint, vec.Index)
 		}
 	case *vector.Enum:
 		return vec.Uint

--- a/runtime/vam/expr/arith_test.go
+++ b/runtime/vam/expr/arith_test.go
@@ -13,12 +13,12 @@ func TestArithOpsAndForms(t *testing.T) {
 	// These are all [0, 1, 2].
 	lhsFlat := vector.NewInt(super.TypeInt64, []int64{0, 1, 2}, nil)
 	lhsDict := vector.NewDict(lhsFlat, []byte{0, 1, 2}, nil, nil)
-	lhsView := vector.NewView(lhsFlat, []uint32{0, 1, 2})
+	lhsView := vector.Pick(lhsFlat, []uint32{0, 1, 2})
 
 	// These are all [1, 1, 1].
 	rhsFlat := vector.NewInt(super.TypeInt64, []int64{1, 1, 1}, nil)
 	rhsDict := vector.NewDict(rhsFlat, []byte{0, 0, 0}, nil, nil)
-	rhsView := vector.NewView(rhsFlat, []uint32{0, 1, 2})
+	rhsView := vector.Pick(rhsFlat, []uint32{0, 1, 2})
 	Const := vector.NewConst(super.NewInt64(1), 3, nil)
 
 	cases := []struct {

--- a/runtime/vam/expr/cast/cast.go
+++ b/runtime/vam/expr/cast/cast.go
@@ -67,7 +67,7 @@ func assemble(sctx *super.Context, vec vector.Any, typ super.Type, fn caster) ve
 		return errCastFailed(sctx, vec, typ)
 	}
 	if len(errs) > 0 {
-		return vector.Combine(out, errs, errCastFailed(sctx, vector.NewView(vec, errs), typ))
+		return vector.Combine(out, errs, errCastFailed(sctx, vector.Pick(vec, errs), typ))
 	}
 	return out
 }

--- a/runtime/vam/expr/coerce.go
+++ b/runtime/vam/expr/coerce.go
@@ -116,7 +116,7 @@ func promoteWider(id int, val vector.Any) vector.Any {
 		return vector.NewDict(promoted, val.Index, val.Counts, val.Nulls)
 	case *vector.View:
 		promoted := val.Any.(vector.Promotable).Promote(typ)
-		return vector.NewView(promoted, val.Index)
+		return vector.Pick(promoted, val.Index)
 	default:
 		panic(fmt.Sprintf("promoteWider %T", val))
 	}
@@ -144,7 +144,7 @@ func promoteToSigned(val vector.Any) vector.Any {
 		return vector.NewDict(promoted, val.Index, val.Counts, val.Nulls)
 	case *vector.View:
 		promoted := promoteToSigned(val.Any)
-		return vector.NewView(promoted, val.Index)
+		return vector.Pick(promoted, val.Index)
 	default:
 		panic(fmt.Sprintf("promoteToSigned %T", val))
 	}
@@ -246,7 +246,7 @@ func intToFloat(val vector.Any) vector.Any {
 	case *vector.Dict:
 		return vector.NewDict(intToFloat(val.Any), val.Index, val.Counts, val.Nulls)
 	case *vector.View:
-		return vector.NewView(intToFloat(val.Any), val.Index)
+		return vector.Pick(intToFloat(val.Any), val.Index)
 	default:
 		panic(fmt.Sprintf("intToFloat invalid type: %T", val))
 	}

--- a/runtime/vam/expr/compare_test.go
+++ b/runtime/vam/expr/compare_test.go
@@ -21,12 +21,12 @@ func TestCompareOpsAndForms(t *testing.T) {
 	// These are all [0, 1, 2].
 	lhsFlat := vector.NewUint(super.TypeUint64, []uint64{0, 1, 2}, nil)
 	lhsDict := vector.NewDict(lhsFlat, []byte{0, 1, 2}, nil, nil)
-	lhsView := vector.NewView(lhsFlat, []uint32{0, 1, 2})
+	lhsView := vector.Pick(lhsFlat, []uint32{0, 1, 2})
 
 	// These are all [1, 1, 1].
 	rhsFlat := vector.NewUint(super.TypeUint64, []uint64{1, 1, 1}, nil)
 	rhsDict := vector.NewDict(rhsFlat, []byte{0, 0, 0}, nil, nil)
-	rhsView := vector.NewView(rhsFlat, []uint32{0, 1, 2})
+	rhsView := vector.Pick(rhsFlat, []uint32{0, 1, 2})
 	Const := vector.NewConst(super.NewUint64(1), 3, nil)
 
 	cases := []struct {

--- a/runtime/vam/expr/conditional.go
+++ b/runtime/vam/expr/conditional.go
@@ -34,12 +34,12 @@ func (c *conditional) Eval(this vector.Any) vector.Any {
 	if boolsMap.IsEmpty() && errsMap.IsEmpty() {
 		return c.elseExpr.Eval(this)
 	}
-	thenVec := c.thenExpr.Eval(vector.NewView(this, boolsMap.ToArray()))
+	thenVec := c.thenExpr.Eval(vector.Pick(this, boolsMap.ToArray()))
 	// elseMap is the difference between boolsMap or errsMap
 	elseMap := roaring.Or(boolsMap, errsMap)
 	elseMap.Flip(0, uint64(this.Len()))
 	elseIndex := elseMap.ToArray()
-	elseVec := c.elseExpr.Eval(vector.NewView(this, elseIndex))
+	elseVec := c.elseExpr.Eval(vector.Pick(this, elseIndex))
 	tags := make([]uint32, this.Len())
 	for _, idx := range elseIndex {
 		tags[idx] = 1
@@ -50,7 +50,7 @@ func (c *conditional) Eval(this vector.Any) vector.Any {
 		for _, idx := range errsIndex {
 			tags[idx] = 2
 		}
-		vecs = append(vecs, c.predicateError(vector.NewView(predVec, errsIndex)))
+		vecs = append(vecs, c.predicateError(vector.Pick(predVec, errsIndex)))
 	}
 	return vector.NewDynamic(tags, vecs)
 }

--- a/runtime/vam/expr/dot.go
+++ b/runtime/vam/expr/dot.go
@@ -79,7 +79,7 @@ func (d *DotExpr) eval(vecs ...vector.Any) vector.Any {
 	case *vector.Map:
 		panic("vam.DotExpr Map TBD")
 	case *vector.View:
-		return vector.NewView(d.eval(val.Any), val.Index)
+		return vector.Pick(d.eval(val.Any), val.Index)
 	default:
 		return vector.NewMissing(d.sctx, val.Len())
 	}

--- a/runtime/vam/expr/dropper.go
+++ b/runtime/vam/expr/dropper.go
@@ -102,7 +102,7 @@ func (d *Dropper) drop(vec vector.Any, fm fieldsMap) (vector.Any, bool) {
 		}
 	case *vector.View:
 		if newVec, ok := d.drop(vec.Any, fm); ok {
-			return vector.NewView(newVec, vec.Index), true
+			return vector.Pick(newVec, vec.Index), true
 		}
 	}
 	return vec, false

--- a/runtime/vam/expr/function/coalesce.go
+++ b/runtime/vam/expr/function/coalesce.go
@@ -42,7 +42,7 @@ func (c *Coalesce) Call(vecs ...vector.Any) vector.Any {
 	}
 	out := make([]vector.Any, n)
 	for i := range n {
-		out[i] = vector.NewView(vecs[i], c.viewIndexes[i])
+		out[i] = vector.Pick(vecs[i], c.viewIndexes[i])
 	}
 	if nullcnt > 0 {
 		out = append(out, vector.NewConst(super.Null, nullcnt, nil))

--- a/runtime/vam/expr/function/grep.go
+++ b/runtime/vam/expr/function/grep.go
@@ -41,8 +41,7 @@ func (g *Grep) Call(args ...vector.Any) vector.Any {
 		pattern = norm.NFC.String(pattern)
 		search := expr.NewSearchString(pattern, &expr.This{})
 		index[0] = i
-		view := vector.NewView(inputVec, index[:])
-		if match, _ := vector.BoolValue(search.Eval(view), 0); match {
+		if match, _ := vector.BoolValue(search.Eval(vector.Pick(inputVec, index[:])), 0); match {
 			out.Set(i)
 		}
 	}

--- a/runtime/vam/expr/function/grok.go
+++ b/runtime/vam/expr/function/grok.go
@@ -94,7 +94,7 @@ func (g *Grok) Call(args ...vector.Any) vector.Any {
 		combiner.Add(patErrsIdx, g.errorVec(patErrs, patErrsIdx, patternArg))
 	}
 	if len(inErrsIdx) > 0 {
-		combiner.Add(inErrsIdx, g.error("value does not match pattern", vector.NewView(inputArg, inErrsIdx)))
+		combiner.Add(inErrsIdx, g.error("value does not match pattern", vector.Pick(inputArg, inErrsIdx)))
 	}
 	return combiner.Result()
 }
@@ -104,7 +104,7 @@ func (g *Grok) errorVec(msgs []string, index []uint32, vec vector.Any) vector.An
 	for _, m := range msgs {
 		s.Append("grok(): " + m)
 	}
-	return vector.NewVecWrappedError(g.sctx, s, vector.NewView(vec, index))
+	return vector.NewVecWrappedError(g.sctx, s, vector.Pick(vec, index))
 }
 
 func (g *Grok) error(msg string, vec vector.Any) vector.Any {

--- a/runtime/vam/expr/function/has.go
+++ b/runtime/vam/expr/function/has.go
@@ -42,9 +42,9 @@ func (m *Missing) Call(args ...vector.Any) vector.Any {
 			errIndex := roaring.Flip(b, 0, uint64(n)).ToArray()
 			trueVec := vector.NewConst(super.True, uint32(len(index)), nil)
 			if !nbm.IsEmpty() {
-				trueVec.Nulls = vector.NewView(bitmapToBool(&nbm, n), index).(*vector.Bool)
+				trueVec.Nulls = vector.Pick(bitmapToBool(&nbm, n), index).(*vector.Bool)
 			}
-			return vector.Combine(trueVec, errIndex, vector.NewView(err, errIndex))
+			return vector.Combine(trueVec, errIndex, vector.Pick(err, errIndex))
 		}
 	}
 	return vector.NewConst(super.False, args[0].Len(), bitmapToBool(&nbm, n))

--- a/runtime/vam/expr/function/math.go
+++ b/runtime/vam/expr/function/math.go
@@ -39,7 +39,7 @@ func (a *Abs) abs(vec vector.Any) vector.Any {
 		}
 		return vector.NewConst(val, vec.Len(), vec.Nulls)
 	case *vector.View:
-		return vector.NewView(a.abs(vec.Any), vec.Index)
+		return vector.Pick(a.abs(vec.Any), vec.Index)
 	case *vector.Dict:
 		return vector.NewDict(a.abs(vec.Any), vec.Index, vec.Counts, vec.Nulls)
 	case *vector.Int:
@@ -84,7 +84,7 @@ func (c *Ceil) ceil(vec vector.Any) vector.Any {
 		val := super.NewFloat(vec.Type(), math.Ceil(vec.Value().Float()))
 		return vector.NewConst(val, vec.Len(), vec.Nulls)
 	case *vector.View:
-		return vector.NewView(c.ceil(vec.Any), vec.Index)
+		return vector.Pick(c.ceil(vec.Any), vec.Index)
 	case *vector.Dict:
 		return vector.NewDict(c.ceil(vec.Any), vec.Index, vec.Counts, vec.Nulls)
 	case *vector.Float:
@@ -120,7 +120,7 @@ func (f *Floor) floor(vec vector.Any) vector.Any {
 		val := super.NewFloat(vec.Type(), math.Floor(vec.Value().Float()))
 		return vector.NewConst(val, vec.Len(), vec.Nulls)
 	case *vector.View:
-		return vector.NewView(f.floor(vec.Any), vec.Index)
+		return vector.Pick(f.floor(vec.Any), vec.Index)
 	case *vector.Dict:
 		return vector.NewDict(f.floor(vec.Any), vec.Index, vec.Counts, vec.Nulls)
 	case *vector.Float:
@@ -173,7 +173,7 @@ func (l *Log) Call(args ...vector.Any) vector.Any {
 		nulls.SetLen(out.Len())
 	}
 	if len(errs) > 0 {
-		err := vector.NewWrappedError(l.sctx, "log: illegal argument", vector.NewView(arg, errs))
+		err := vector.NewWrappedError(l.sctx, "log: illegal argument", vector.Pick(arg, errs))
 		return vector.Combine(out, errs, err)
 	}
 	return out

--- a/runtime/vam/expr/function/nestdotted.go
+++ b/runtime/vam/expr/function/nestdotted.go
@@ -32,7 +32,7 @@ func (n *NestDotted) Call(args ...vector.Any) vector.Any {
 	}
 	out := vector.Any(b.New(record.Fields, record.Nulls))
 	if view != nil {
-		out = vector.NewView(out, view.Index)
+		out = vector.Pick(out, view.Index)
 	}
 	return out
 }

--- a/runtime/vam/expr/function/networkof.go
+++ b/runtime/vam/expr/function/networkof.go
@@ -57,7 +57,7 @@ func (n *NetworkOf) singleIP(vec vector.Any) vector.Any {
 		nets = vector.NewDict(netVals, index, counts, nulls)
 	}
 	if len(errs) > 0 {
-		return vector.Combine(nets, errs, errNotIP4(n.sctx, vector.NewView(vec, errs)))
+		return vector.Combine(nets, errs, errNotIP4(n.sctx, vector.Pick(vec, errs)))
 	}
 	return nets
 }
@@ -153,7 +153,7 @@ func (n *NetworkOf) intMask(ipvec, maskvec vector.Any) vector.Any {
 		out = vector.NewNet(nets, nil)
 	}
 	if len(errs) > 0 {
-		m := vector.NewView(addressAndMask(n.sctx, ipvec, maskvec), errs)
+		m := vector.Pick(addressAndMask(n.sctx, ipvec, maskvec), errs)
 		err := vector.NewWrappedError(n.sctx, "network_of: CIDR bit count out of range", m)
 		return vector.Combine(out, errs, err)
 	}

--- a/runtime/vam/expr/function/parse.go
+++ b/runtime/vam/expr/function/parse.go
@@ -76,7 +76,7 @@ func (p *ParseSUP) Call(args ...vector.Any) vector.Any {
 	}
 	out := builder.Build()
 	if len(errs) > 0 {
-		return vector.Combine(out, errs, vector.NewVecWrappedError(p.sctx, errMsgs, vector.NewView(args[0], errs)))
+		return vector.Combine(out, errs, vector.NewVecWrappedError(p.sctx, errMsgs, vector.Pick(args[0], errs)))
 	}
 	return out
 }

--- a/runtime/vam/expr/function/regexp.go
+++ b/runtime/vam/expr/function/regexp.go
@@ -61,7 +61,7 @@ func (r *Regexp) Call(args ...vector.Any) vector.Any {
 	}
 	out.Nulls.SetLen(out.Len())
 	if len(errs) > 0 {
-		return vector.Combine(out, errs, vector.NewVecWrappedError(r.sctx, errMsg, vector.NewView(regVec, errs)))
+		return vector.Combine(out, errs, vector.NewVecWrappedError(r.sctx, errMsg, vector.Pick(regVec, errs)))
 	}
 	return out
 }
@@ -116,8 +116,8 @@ func (r *RegexpReplace) Call(args ...vector.Any) vector.Any {
 		out.Append(r.re.ReplaceAllString(s, replace))
 	}
 	if len(errs) > 0 {
-		out.Nulls = vector.NewInverseView(out.Nulls, errs).(*vector.Bool)
-		return vector.Combine(out, errs, vector.NewVecWrappedError(r.sctx, errMsg, vector.NewView(args[1], errs)))
+		out.Nulls = vector.ReversePick(out.Nulls, errs).(*vector.Bool)
+		return vector.Combine(out, errs, vector.NewVecWrappedError(r.sctx, errMsg, vector.Pick(args[1], errs)))
 	}
 	return out
 }

--- a/runtime/vam/expr/function/time.go
+++ b/runtime/vam/expr/function/time.go
@@ -72,7 +72,7 @@ func (b *Bucket) constBin(tsVec vector.Any, bin nano.Duration) vector.Any {
 	}
 }
 
-func (b *Bucket) constBinFlat(tsVecFlat vector.Any, bin nano.Duration) vector.Any {
+func (b *Bucket) constBinFlat(tsVecFlat vector.Any, bin nano.Duration) *vector.Int {
 	tsVec := tsVecFlat.(*vector.Int)
 	ints := make([]int64, tsVec.Len())
 	for i := range tsVec.Len() {
@@ -184,7 +184,7 @@ func (s *Strftime) slowPath(fvec vector.Any, tvec vector.Any) vector.Any {
 		out.Append(f.FormatString(nano.Ts(t).Time()))
 	}
 	if len(errIndex) > 0 {
-		errVec := vector.NewVecWrappedError(s.sctx, errMsgs, vector.NewView(fvec, errIndex))
+		errVec := vector.NewVecWrappedError(s.sctx, errMsgs, vector.Pick(fvec, errIndex))
 		return vector.Combine(out, errIndex, errVec)
 	}
 	return out

--- a/runtime/vam/expr/function/types.go
+++ b/runtime/vam/expr/function/types.go
@@ -39,7 +39,7 @@ func (n *NameOf) Call(args ...vector.Any) vector.Any {
 		}
 	}
 	if len(errs) > 0 {
-		out.Nulls = vector.NewInverseView(out.Nulls, errs).(*vector.Bool)
+		out.Nulls = vector.ReversePick(out.Nulls, errs).(*vector.Bool)
 		return vector.Combine(out, errs, vector.NewMissing(n.sctx, uint32(len(errs))))
 	}
 	return out

--- a/runtime/vam/expr/function/under.go
+++ b/runtime/vam/expr/function/under.go
@@ -42,7 +42,7 @@ func (u *Under) Call(args ...vector.Any) vector.Any {
 		return args[0]
 	}
 	if index != nil {
-		return vector.NewView(out, index)
+		return vector.Pick(out, index)
 	}
 	return out
 }

--- a/runtime/vam/expr/index.go
+++ b/runtime/vam/expr/index.go
@@ -71,7 +71,7 @@ func indexArrayOrSet(sctx *super.Context, vec, indexVec vector.Any) vector.Any {
 		}
 		errs = append(errs, i)
 	}
-	out := vector.Deunion(vector.NewView(vals, viewIndexes))
+	out := vector.Deunion(vector.Pick(vals, viewIndexes))
 	if len(errs) > 0 {
 		return vector.Combine(out, errs, vector.NewMissing(sctx, uint32(len(errs))))
 	}
@@ -114,7 +114,7 @@ func indexRecord(sctx *super.Context, vec, indexVec vector.Any) vector.Any {
 	out := make([]vector.Any, n+1)
 	out[n] = vector.NewMissing(sctx, errcnt)
 	for i, field := range rec.Fields {
-		out[i] = vector.NewView(field, viewIndexes[i])
+		out[i] = vector.Pick(field, viewIndexes[i])
 	}
 	return vector.NewDynamic(tags, out)
 }

--- a/runtime/vam/expr/logic.go
+++ b/runtime/vam/expr/logic.go
@@ -100,8 +100,8 @@ func (a *And) andError(err vector.Any, vec vector.Any) vector.Any {
 		}
 	}
 	if len(index) > 0 {
-		base := vector.NewInverseView(vec, index)
-		return vector.Combine(base, index, vector.NewView(err, index))
+		base := vector.ReversePick(vec, index)
+		return vector.Combine(base, index, vector.Pick(err, index))
 	}
 	return vec
 }
@@ -145,8 +145,8 @@ func (o *Or) orError(err, vec vector.Any) vector.Any {
 		}
 	}
 	if len(index) > 0 {
-		base := vector.NewInverseView(vec, index)
-		return vector.Combine(base, index, vector.NewView(err, index))
+		base := vector.ReversePick(vec, index)
+		return vector.Combine(base, index, vector.Pick(err, index))
 	}
 	return vec
 }
@@ -254,7 +254,7 @@ func (p *PredicateWalk) Eval(vecs ...vector.Any) vector.Any {
 		out := vector.NewBoolEmpty(lhs.Len(), nil)
 		for _, f := range rhs.Fields {
 			if index != nil {
-				f = vector.NewView(f, index)
+				f = vector.Pick(f, index)
 			}
 			out = vector.Or(out, toBool(p.Eval(lhs, f)))
 		}
@@ -300,8 +300,8 @@ func (p *PredicateWalk) evalForList(lhs, rhs vector.Any, offsets, index []uint32
 			lhsIndex[k] = j
 			rhsIndex[k] = k + start
 		}
-		lhsView := vector.NewView(lhs, lhsIndex)
-		rhsView := vector.NewView(rhs, rhsIndex)
+		lhsView := vector.Pick(lhs, lhsIndex)
+		rhsView := vector.Pick(rhs, rhsIndex)
 		if toBool(p.Eval(lhsView, rhsView)).TrueCount() > 0 {
 			out.Set(j)
 		}

--- a/runtime/vam/expr/recordexpr.go
+++ b/runtime/vam/expr/recordexpr.go
@@ -76,7 +76,7 @@ func (r *recordExpr) spread(vec vector.Any) {
 	case *vector.View:
 		if rec, ok := vec.Any.(*vector.Record); ok {
 			for k, f := range super.TypeRecordOf(rec.Type()).Fields {
-				r.addOrUpdateField(f.Name, vector.NewView(rec.Fields[k], vec.Index))
+				r.addOrUpdateField(f.Name, vector.Pick(rec.Fields[k], vec.Index))
 			}
 		}
 	}

--- a/runtime/vam/expr/search.go
+++ b/runtime/vam/expr/search.go
@@ -77,7 +77,7 @@ func (s *search) eval(vecs ...vector.Any) vector.Any {
 		out := vector.NewBoolEmpty(n, nil)
 		for _, f := range vec.Fields {
 			if index != nil {
-				f = vector.NewView(f, index)
+				f = vector.Pick(f, index)
 			}
 			out = vector.Or(out, toBool(s.eval(f)))
 		}
@@ -113,7 +113,7 @@ func (s *search) evalForList(vec vector.Any, offsets, index []uint32, length uin
 		for k := range n {
 			index2[k] = k + start
 		}
-		view := vector.NewView(vec, index2)
+		view := vector.Pick(vec, index2)
 		if toBool(s.eval(view)).TrueCount() > 0 {
 			out.Set(j)
 		}

--- a/runtime/vam/expr/slice.go
+++ b/runtime/vam/expr/slice.go
@@ -113,7 +113,7 @@ func (s *sliceExpr) evalArrayOrSlice(vec, fromVec, toVec vector.Any) vector.Any 
 
 	}
 	var out vector.Any
-	inner = vector.NewView(inner, innerIndex)
+	inner = vector.Pick(inner, innerIndex)
 	if vector.KindOf(vec) == vector.KindArray {
 		out = vector.NewArray(vec.Type().(*super.TypeArray), newOffsets, inner, nullsOut)
 	} else {

--- a/runtime/vam/expr/unaryminus.go
+++ b/runtime/vam/expr/unaryminus.go
@@ -132,7 +132,7 @@ func (u *unaryMinus) slowPath(vec vector.Any) vector.Any {
 		nulls.SetLen(uint32(len(ints)))
 	}
 	out := vector.NewInt(vec.Type(), ints, nulls)
-	err := vector.NewWrappedError(u.sctx, "unary '-' underflow", vector.NewView(vec, errs))
+	err := vector.NewWrappedError(u.sctx, "unary '-' underflow", vector.Pick(vec, errs))
 	return vector.Combine(out, errs, err)
 }
 

--- a/runtime/vam/op/aggregate/aggtable.go
+++ b/runtime/vam/op/aggregate/aggtable.go
@@ -61,7 +61,7 @@ func (s *superTable) update(keys []vector.Any, args []vector.Any) {
 		row := s.rows[id]
 		for i, arg := range args {
 			if len(m) > 1 {
-				arg = vector.NewView(arg, index)
+				arg = vector.Pick(arg, index)
 			}
 			if s.partialsIn {
 				row.funcs[i].ConsumeAsPartial(arg)

--- a/runtime/vam/op/distinct.go
+++ b/runtime/vam/op/distinct.go
@@ -41,7 +41,7 @@ func (d *Distinct) Pull(done bool) (vector.Any, error) {
 			}
 		}
 		if len(index) > 0 {
-			return vector.NewView(vec, index), nil
+			return vector.Pick(vec, index), nil
 		}
 	}
 }

--- a/runtime/vam/op/exprswitch.go
+++ b/runtime/vam/op/exprswitch.go
@@ -50,8 +50,7 @@ func (s *ExprSwitch) forward(vec vector.Any) bool {
 		}
 	}
 	for route, index := range s.caseIndexes {
-		view := vector.NewView(vec, index)
-		if !route.send(view, nil) {
+		if !route.send(vector.Pick(vec, index), nil) {
 			return false
 		}
 	}

--- a/runtime/vam/op/filter.go
+++ b/runtime/vam/op/filter.go
@@ -39,5 +39,5 @@ func applyMask(vec, mask vector.Any) (vector.Any, bool) {
 	if b.GetCardinality() == uint64(mask.Len()) {
 		return vec, true
 	}
-	return vector.NewView(vec, b.ToArray()), true
+	return vector.Pick(vec, b.ToArray()), true
 }

--- a/runtime/vam/op/head.go
+++ b/runtime/vam/op/head.go
@@ -57,5 +57,5 @@ again:
 	for k := range index {
 		index[k] = uint32(k)
 	}
-	return vector.NewView(vec, index), nil
+	return vector.Pick(vec, index), nil
 }

--- a/runtime/vam/op/merge.go
+++ b/runtime/vam/op/merge.go
@@ -129,7 +129,7 @@ func (m *Merge) createViews() []vector.Any {
 			}
 		}
 		index := m.index[p.lastOff:p.off]
-		views[i] = vector.NewView(p.vec, index)
+		views[i] = vector.Pick(p.vec, index)
 		p.lastOff = p.off
 	}
 	return views

--- a/runtime/vam/op/over.go
+++ b/runtime/vam/op/over.go
@@ -92,12 +92,12 @@ func (o *Over) flatten(vec vector.Any, slot uint32) vector.Any {
 				{Name: "value", Type: f.Type},
 			})
 			keyVec := vector.NewArray(keyType, keyOffsets, vector.NewConst(super.NewString(f.Name), 1, nil), nil)
-			valVec := vector.NewView(vec.Fields[i], []uint32{slot})
+			valVec := vector.Pick(vec.Fields[i], []uint32{slot})
 			vecs = append(vecs, vector.NewRecord(typ, []vector.Any{keyVec, valVec}, keyVec.Len(), nil))
 		}
 		return vector.NewDynamic(tags, vecs)
 	}
-	return vector.NewView(vec, []uint32{slot})
+	return vector.Pick(vec, []uint32{slot})
 }
 
 func flattenArrayOrSet(vec vector.Any, offsets []uint32, slot uint32) vector.Any {
@@ -108,7 +108,7 @@ func flattenArrayOrSet(vec vector.Any, offsets []uint32, slot uint32) vector.Any
 	if len(index) == 0 {
 		return nil
 	}
-	return vector.NewView(vector.Deunion(vec), index)
+	return vector.Pick(vector.Deunion(vec), index)
 }
 
 type Scope struct {

--- a/runtime/vam/op/swtich.go
+++ b/runtime/vam/op/swtich.go
@@ -47,9 +47,9 @@ func (s *Switch) forward(vec vector.Any) bool {
 			if boolMap.IsEmpty() {
 				continue
 			}
-			vec2 = vector.NewView(vec, boolMap.ToArray())
+			vec2 = vector.Pick(vec, boolMap.ToArray())
 		} else if boolMap.IsEmpty() {
-			vec2 = vector.NewView(maskVec, errMap.ToArray())
+			vec2 = vector.Pick(maskVec, errMap.ToArray())
 		} else {
 			valIndex := boolMap.ToArray()
 			errIndex := errMap.ToArray()
@@ -65,8 +65,8 @@ func (s *Switch) forward(vec vector.Any) bool {
 			}
 			tags = append(tags, valIndex...)
 			tags = append(tags, errIndex...)
-			valVec := vector.NewView(vec, valIndex)
-			errVec := vector.NewView(maskVec, errIndex)
+			valVec := vector.Pick(vec, valIndex)
+			errVec := vector.Pick(maskVec, errIndex)
 			vec2 = vector.NewDynamic(tags, []vector.Any{valVec, errVec})
 		}
 		if !s.router.routes[i].send(vec2, nil) {

--- a/runtime/vam/op/tail.go
+++ b/runtime/vam/op/tail.go
@@ -77,7 +77,7 @@ func (t *Tail) tail() ([]vector.Any, error) {
 		for i := range int(vecs[0].Len()) - extra {
 			index = append(index, uint32(extra+i))
 		}
-		vecs[0] = vector.NewView(vecs[0], index)
+		vecs[0] = vector.Pick(vecs[0], index)
 	}
 	return vecs, nil
 }

--- a/vector/apply.go
+++ b/vector/apply.go
@@ -45,7 +45,7 @@ func rip(vecs []Any, d *Dynamic) [][]Any {
 				if vec == d {
 					newVecs = append(newVecs, d.Values[j])
 				} else {
-					newVecs = append(newVecs, NewView(vec, rev))
+					newVecs = append(newVecs, Pick(vec, rev))
 				}
 			}
 		}

--- a/vector/combine.go
+++ b/vector/combine.go
@@ -19,7 +19,7 @@ func NewCombiner(base Any) *Combiner {
 }
 
 func (c *Combiner) WrappedError(sctx *super.Context, index []uint32, msg string, inner Any) {
-	c.Add(index, NewWrappedError(sctx, msg, NewView(inner, index)))
+	c.Add(index, NewWrappedError(sctx, msg, Pick(inner, index)))
 }
 
 func (c *Combiner) Add(index []uint32, vec Any) {

--- a/vector/union.go
+++ b/vector/union.go
@@ -79,7 +79,7 @@ func addNullsToUnionDynamic(typ *super.TypeUnion, d *Dynamic, nulls *Bool) *Dyna
 	if rebuild {
 		for i, delIndex := range delIndexes {
 			if len(delIndex) > 0 {
-				vals[i] = NewInverseView(vals[i], delIndex)
+				vals[i] = ReversePick(vals[i], delIndex)
 			}
 		}
 		return NewDynamic(tags, vals)


### PR DESCRIPTION
This commit renames NewView and NewInverseView to Pick and ReversePick since NewView only creates a View when it has to.  This better reflects the verb of what's going on and makes the code easier to read.

We also created a real NewView function when the intention is to create a vector.View.  These changes exposed a couple places in the code where the intention was to create a View and not do a Pick so these call sites were left unchanged.