### PR TITLE
Add vector runtime support for is()

### DIFF
--- a/compiler/parser/ztests/match-is.yaml
+++ b/compiler/parser/ztests/match-is.yaml
@@ -1,5 +1,7 @@
 spq: |
-  ? a is(s2,'string')
+  ? a is(s2,<string>)
+
+vector: true
 
 input: |
   {s1:"a",s2:"b"}

--- a/compiler/ztests/is-field.yaml
+++ b/compiler/ztests/is-field.yaml
@@ -1,4 +1,6 @@
-spq: is(a,'string')
+spq: is(a,<string>)
+
+vector: true
 
 input: |
   {a:1(int32),b:"foo"}

--- a/compiler/ztests/is.yaml
+++ b/compiler/ztests/is.yaml
@@ -1,4 +1,6 @@
-spq: is('{a:int32,b:string}')
+spq: is(<{a:int32,b:string}>)
+
+vector: true
 
 input: |
   {a:1(int32),b:"foo"}

--- a/runtime/sam/expr/function/types.go
+++ b/runtime/sam/expr/function/types.go
@@ -2,7 +2,6 @@ package function
 
 import (
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/sup"
 	"github.com/brimdata/super/zcode"
 )
 
@@ -87,11 +86,10 @@ func (i *Is) Call(_ super.Allocator, args []super.Value) super.Value {
 	}
 	var typ super.Type
 	var err error
-	if zvTypeVal.IsString() {
-		typ, err = sup.ParseType(i.sctx, string(zvTypeVal.Bytes()))
-	} else {
-		typ, err = i.sctx.LookupByValue(zvTypeVal.Bytes())
+	if zvTypeVal.Type().ID() != super.IDType {
+		return i.sctx.WrapError("is: type value argument expected", zvTypeVal)
 	}
+	typ, err = i.sctx.LookupByValue(zvTypeVal.Bytes())
 	return super.NewBool(err == nil && typ == zvSubject.Type())
 }
 

--- a/runtime/vam/expr/function/function.go
+++ b/runtime/vam/expr/function/function.go
@@ -59,6 +59,11 @@ func New(sctx *super.Context, name string, narg int) (expr.Function, field.Path,
 		f = newHas(sctx)
 	case "hex":
 		f = &Hex{sctx}
+	case "is":
+		argmin = 1
+		argmax = 2
+		path = field.Path{}
+		f = &Is{sctx: sctx}
 	case "join":
 		argmax = 2
 		f = &Join{sctx: sctx}

--- a/runtime/ztests/expr/function/is-late-binding.yaml
+++ b/runtime/ztests/expr/function/is-late-binding.yaml
@@ -1,5 +1,7 @@
 spq: is(<foo>)
 
+vector: true
+
 input: |
   {x:1}
   {x:2}(=foo)

--- a/runtime/ztests/expr/function/is-typedef.yaml
+++ b/runtime/ztests/expr/function/is-typedef.yaml
@@ -3,6 +3,8 @@ spq: |
   const PI=3.14
   is(src,<socket>) | put pi:=PI
 
+vector: true
+
 input: |
   {
       info: "Connection Example",

--- a/runtime/ztests/expr/function/is.yaml
+++ b/runtime/ztests/expr/function/is.yaml
@@ -1,5 +1,7 @@
 spq: cut isRecType:=is(r, <{a:int32}>), isString:=is(s, <string>)
 
+vector: true
+
 input: |
   {r:{a:1(int32)},s:123(int32)}
   {r:{a:1(int8)},s:"a"}


### PR DESCRIPTION
Also make it so the type argument must be a type value not a string that can be parsed as a type value.