### PR TITLE
Fix EOS handling in top operator even more

### DIFF
--- a/runtime/sam/op/top/top.go
+++ b/runtime/sam/op/top/top.go
@@ -53,6 +53,9 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 			return nil, err
 		}
 		if batch == nil {
+			if o.records == nil {
+				return nil, nil
+			}
 			o.eos = true
 			defer o.resetter.Reset()
 			return o.sorted(), nil
@@ -88,9 +91,6 @@ func (o *Op) consume(rec super.Value) {
 }
 
 func (o *Op) sorted() zbuf.Batch {
-	if o.records == nil {
-		return nil
-	}
 	out := make([]super.Value, o.records.Len())
 	for i := o.records.Len() - 1; i >= 0; i-- {
 		out[i] = heap.Pop(o.records).(super.Value)

--- a/runtime/ztests/op/over-nested-top.yaml
+++ b/runtime/ztests/op/over-nested-top.yaml
@@ -1,0 +1,20 @@
+spq: |
+  over this => (
+    over this => (
+      top 2 this
+    )
+  )
+
+vector: true
+
+input: |
+  [[1,2,3],[4,5,6]]
+  [[7,8,9]]
+
+output: |
+  3
+  2
+  6
+  5
+  9
+  8


### PR DESCRIPTION
The top operator (both sequential and vector) returns an extra nil, nil upon receiving EOS from its parent, preventing it from working properly in a nested scoped over operator (e.g., "over a => (over b => (top 2 c))". Fix that.