### PR TITLE
add vector.BytesTable

### DIFF
--- a/runtime/vam/expr/cast/bool.go
+++ b/runtime/vam/expr/cast/bool.go
@@ -66,8 +66,7 @@ func stringToBool(vec *vector.String, index []uint32) (vector.Any, []uint32) {
 			boollen++
 			continue
 		}
-		bytes := vec.Bytes[vec.Offsets[idx]:vec.Offsets[idx+1]]
-		b, err := byteconv.ParseBool(bytes)
+		b, err := byteconv.ParseBool(vec.Table().Bytes(idx))
 		if err != nil {
 			errs = append(errs, i)
 			continue

--- a/runtime/vam/expr/cast/ip.go
+++ b/runtime/vam/expr/cast/ip.go
@@ -30,7 +30,7 @@ func castToIP(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
 				ips = append(ips, netip.Addr{})
 				continue
 			}
-			ip, err := byteconv.ParseIP(vec.Bytes[vec.Offsets[idx]:vec.Offsets[idx+1]])
+			ip, err := byteconv.ParseIP(vec.Table().Bytes(idx))
 			if err != nil {
 				errs = append(errs, i)
 				continue

--- a/runtime/vam/expr/cast/number.go
+++ b/runtime/vam/expr/cast/number.go
@@ -159,7 +159,7 @@ func stringToInt(vec *vector.String, typ super.Type, index []uint32) (vector.Any
 			ints = append(ints, 0)
 			continue
 		}
-		v, err := strconv.ParseInt(byteconv.UnsafeString(vec.Bytes[vec.Offsets[idx]:vec.Offsets[idx+1]]), 10, bits)
+		v, err := strconv.ParseInt(vec.Table().UnsafeString(idx), 10, bits)
 		if err != nil {
 			errs = append(errs, i)
 			continue
@@ -189,7 +189,7 @@ func stringToDuration(vec *vector.String, index []uint32) (vector.Any, []uint32)
 			durs = append(durs, 0)
 			continue
 		}
-		b := vec.Bytes[vec.Offsets[idx]:vec.Offsets[idx+1]]
+		b := vec.Table().Bytes(idx)
 		d, err := nano.ParseDuration(byteconv.UnsafeString(b))
 		if err != nil {
 			f, ferr := byteconv.ParseFloat64(b)
@@ -224,7 +224,7 @@ func stringToTime(vec *vector.String, index []uint32) (vector.Any, []uint32) {
 			ts = append(ts, 0)
 			continue
 		}
-		b := vec.Bytes[vec.Offsets[idx]:vec.Offsets[idx+1]]
+		b := vec.Table().Bytes(idx)
 		if gotime, err := dateparse.ParseAny(byteconv.UnsafeString(b)); err != nil {
 			f, ferr := byteconv.ParseFloat64(b)
 			if ferr != nil {
@@ -260,7 +260,7 @@ func stringToUint(vec *vector.String, typ super.Type, index []uint32) (vector.An
 			ints = append(ints, 0)
 			continue
 		}
-		v, err := strconv.ParseUint(byteconv.UnsafeString(vec.Bytes[vec.Offsets[idx]:vec.Offsets[idx+1]]), 10, bits)
+		v, err := strconv.ParseUint(vec.Table().UnsafeString(idx), 10, bits)
 		if err != nil {
 			errs = append(errs, i)
 			continue
@@ -290,7 +290,7 @@ func stringToFloat(vec *vector.String, typ super.Type, index []uint32) (vector.A
 			floats = append(floats, 0)
 			continue
 		}
-		v, err := byteconv.ParseFloat64(vec.Bytes[vec.Offsets[idx]:vec.Offsets[idx+1]])
+		v, err := byteconv.ParseFloat64(vec.Table().Bytes(idx))
 		if err != nil {
 			errs = append(errs, i)
 			continue

--- a/runtime/vam/expr/cast/string.go
+++ b/runtime/vam/expr/cast/string.go
@@ -115,7 +115,7 @@ func castToString(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
 			offs = append(offs, uint32(len(bytes)))
 		}
 	}
-	return vector.NewString(offs, bytes, nulls), nil, true
+	return vector.NewString(vector.NewBytesTable(offs, bytes), nulls), nil, true
 }
 
 func timeToString(vec *vector.Int, index []uint32, n uint32) ([]uint32, []byte) {

--- a/runtime/vam/op/aggregate/aggtable.go
+++ b/runtime/vam/op/aggregate/aggtable.go
@@ -180,8 +180,7 @@ func (c *countByString) updatePartial(keyvec, valvec vector.Any) {
 }
 
 func (c *countByString) count(vec *vector.String) {
-	offs := vec.Offsets
-	bytes := vec.Bytes
+	offs, bytes := vec.Table().Slices()
 	if vec.Nulls.IsZero() {
 		for k := range vec.Len() {
 			c.table[string(bytes[offs[k]:offs[k+1]])]++
@@ -198,8 +197,7 @@ func (c *countByString) count(vec *vector.String) {
 }
 
 func (c *countByString) countDict(vec *vector.String, counts []uint32, nulls bitvec.Bits) {
-	offs := vec.Offsets
-	bytes := vec.Bytes
+	offs, bytes := vec.Table().Slices()
 	for k := range vec.Len() {
 		if counts[k] > 0 {
 			c.table[string(bytes[offs[k]:offs[k+1]])] += uint64(counts[k])
@@ -258,7 +256,7 @@ func (c *countByString) materialize() vector.Any {
 		nulls = bitvec.NewFalse(uint32(length))
 		nulls.Set(uint32(length - 1))
 	}
-	keyVec := vector.NewString(offs, bytes, nulls)
+	keyVec := vector.NewString(vector.NewBytesTable(offs, bytes), nulls)
 	countVec := vector.NewUint(super.TypeUint64, counts, bitvec.Zero)
 	return c.builder.New([]vector.Any{keyVec, countVec}, bitvec.Zero)
 }

--- a/runtime/vcache/loader.go
+++ b/runtime/vcache/loader.go
@@ -302,7 +302,7 @@ func (l *loader) loadVals(typ super.Type, s *primitive, nulls bitvec.Bits) (vect
 			}
 		}
 		offs[length] = off
-		return vector.NewBytes(offs, bytes, nulls), nil
+		return vector.NewBytes(vector.NewBytesTable(offs, bytes), nulls), nil
 	case *super.TypeOfString:
 		var bytes []byte
 		offs := make([]uint32, length+1)
@@ -316,7 +316,7 @@ func (l *loader) loadVals(typ super.Type, s *primitive, nulls bitvec.Bits) (vect
 			}
 		}
 		offs[length] = off
-		return vector.NewString(offs, bytes, nulls), nil
+		return vector.NewString(vector.NewBytesTable(offs, bytes), nulls), nil
 	case *super.TypeOfIP:
 		values := make([]netip.Addr, length)
 		for slot := uint32(0); slot < length; slot++ {
@@ -346,7 +346,7 @@ func (l *loader) loadVals(typ super.Type, s *primitive, nulls bitvec.Bits) (vect
 			}
 		}
 		offs[length] = off
-		return vector.NewTypeValue(offs, bytes, nulls), nil
+		return vector.NewTypeValue(vector.NewBytesTable(offs, bytes), nulls), nil
 	case *super.TypeEnum:
 		values := make([]uint64, length)
 		for slot := range length {
@@ -407,15 +407,15 @@ func empty(typ super.Type, length uint32, nulls bitvec.Bits) vector.Any {
 	case *super.TypeOfBool:
 		return vector.NewBool(bitvec.NewFalse(length), nulls)
 	case *super.TypeOfBytes:
-		return vector.NewBytes(make([]uint32, length+1), nil, nulls)
+		return vector.NewBytes(vector.NewBytesTable(make([]uint32, length+1), nil), nulls)
 	case *super.TypeOfString:
-		return vector.NewString(make([]uint32, length+1), nil, nulls)
+		return vector.NewString(vector.NewBytesTable(make([]uint32, length+1), nil), nulls)
 	case *super.TypeOfIP:
 		return vector.NewIP(make([]netip.Addr, length), nulls)
 	case *super.TypeOfNet:
 		return vector.NewNet(make([]netip.Prefix, length), nulls)
 	case *super.TypeOfType:
-		return vector.NewTypeValue(make([]uint32, length+1), nil, nulls)
+		return vector.NewTypeValue(vector.NewBytesTable(make([]uint32, length+1), nil), nulls)
 	case *super.TypeOfNull:
 		return vector.NewConst(super.Null, length, bitvec.Zero)
 	default:

--- a/vector/builder.go
+++ b/vector/builder.go
@@ -368,11 +368,11 @@ func (b *bytesStringTypeBuilder) Write(bytes zcode.Bytes) {
 func (b *bytesStringTypeBuilder) Build() Any {
 	switch b.typ.ID() {
 	case super.IDString:
-		return NewString(b.offs, b.bytes, bitvec.Zero)
+		return NewString(NewBytesTable(b.offs, b.bytes), bitvec.Zero)
 	case super.IDBytes:
-		return NewBytes(b.offs, b.bytes, bitvec.Zero)
+		return NewBytes(NewBytesTable(b.offs, b.bytes), bitvec.Zero)
 	default:
-		return NewTypeValue(b.offs, b.bytes, bitvec.Zero)
+		return NewTypeValue(NewBytesTable(b.offs, b.bytes), bitvec.Zero)
 	}
 }
 

--- a/vector/bytes.go
+++ b/vector/bytes.go
@@ -42,7 +42,7 @@ func (b *Bytes) Value(slot uint32) []byte {
 	if b.Nulls.IsSet(slot) {
 		return nil
 	}
-	return b.Table().Bytes(slot)
+	return b.table.Bytes(slot)
 }
 
 func (b *Bytes) Table() BytesTable {

--- a/vector/bytes.go
+++ b/vector/bytes.go
@@ -2,29 +2,28 @@ package vector
 
 import (
 	"github.com/brimdata/super"
+	"github.com/brimdata/super/pkg/byteconv"
 	"github.com/brimdata/super/vector/bitvec"
 	"github.com/brimdata/super/zcode"
 )
 
 type Bytes struct {
-	Offs  []uint32
-	Bytes []byte
+	table BytesTable
 	Nulls bitvec.Bits
 }
 
 var _ Any = (*Bytes)(nil)
 
-func NewBytes(offs []uint32, bytes []byte, nulls bitvec.Bits) *Bytes {
-	return &Bytes{Offs: offs, Bytes: bytes, Nulls: nulls}
+func NewBytes(table BytesTable, nulls bitvec.Bits) *Bytes {
+	return &Bytes{table: table, Nulls: nulls}
 }
 
-func NewBytesEmpty(length uint32, nulls bitvec.Bits) *Bytes {
-	return NewBytes(make([]uint32, 1, length+1), nil, nulls)
+func NewBytesEmpty(cap uint32, nulls bitvec.Bits) *Bytes {
+	return NewBytes(NewBytesTableEmpty(cap), nulls)
 }
 
 func (b *Bytes) Append(v []byte) {
-	b.Bytes = append(b.Bytes, v...)
-	b.Offs = append(b.Offs, uint32(len(b.Bytes)))
+	b.table.Append(v)
 }
 
 func (b *Bytes) Type() super.Type {
@@ -32,7 +31,7 @@ func (b *Bytes) Type() super.Type {
 }
 
 func (b *Bytes) Len() uint32 {
-	return uint32(len(b.Offs) - 1)
+	return b.table.Len()
 }
 
 func (b *Bytes) Serialize(builder *zcode.Builder, slot uint32) {
@@ -43,7 +42,11 @@ func (b *Bytes) Value(slot uint32) []byte {
 	if b.Nulls.IsSet(slot) {
 		return nil
 	}
-	return b.Bytes[b.Offs[slot]:b.Offs[slot+1]]
+	return b.Table().Bytes(slot)
+}
+
+func (b *Bytes) Table() BytesTable {
+	return b.table
 }
 
 func BytesValue(val Any, slot uint32) ([]byte, bool) {
@@ -67,4 +70,45 @@ func BytesValue(val Any, slot uint32) ([]byte, bool) {
 		return BytesValue(val.Any, slot)
 	}
 	panic(val)
+}
+
+type BytesTable struct {
+	offsets []uint32
+	bytes   []byte
+}
+
+func NewBytesTable(offsets []uint32, bytes []byte) BytesTable {
+	return BytesTable{offsets, bytes}
+}
+
+func NewBytesTableEmpty(cap uint32) BytesTable {
+	return BytesTable{make([]uint32, 1, cap+1), nil}
+}
+
+func (b BytesTable) Bytes(slot uint32) []byte {
+	return b.bytes[b.offsets[slot]:b.offsets[slot+1]]
+}
+
+func (b BytesTable) String(slot uint32) string {
+	return string(b.bytes[b.offsets[slot]:b.offsets[slot+1]])
+}
+
+func (b BytesTable) UnsafeString(slot uint32) string {
+	return byteconv.UnsafeString(b.bytes[b.offsets[slot]:b.offsets[slot+1]])
+}
+
+func (b BytesTable) Slices() ([]uint32, []byte) {
+	return b.offsets, b.bytes
+}
+
+func (b *BytesTable) Append(bytes []byte) {
+	b.bytes = append(b.bytes, bytes...)
+	b.offsets = append(b.offsets, uint32(len(b.bytes)))
+}
+
+func (b *BytesTable) Len() uint32 {
+	if b.offsets == nil {
+		return 0
+	}
+	return uint32(len(b.offsets) - 1)
 }

--- a/vector/string.go
+++ b/vector/string.go
@@ -7,24 +7,23 @@ import (
 )
 
 type String struct {
-	Offsets []uint32
-	Bytes   []byte
-	Nulls   bitvec.Bits
+	table BytesTable
+	Nulls bitvec.Bits
 }
 
 var _ Any = (*String)(nil)
 
-func NewString(offsets []uint32, bytes []byte, nulls bitvec.Bits) *String {
-	return &String{Offsets: offsets, Bytes: bytes, Nulls: nulls}
+func NewString(table BytesTable, nulls bitvec.Bits) *String {
+	return &String{table: table, Nulls: nulls}
 }
 
-func NewStringEmpty(length uint32, nulls bitvec.Bits) *String {
-	return NewString(make([]uint32, 1, length+1), nil, nulls)
+func NewStringEmpty(cap uint32, nulls bitvec.Bits) *String {
+	return NewString(NewBytesTableEmpty(cap), nulls)
 }
 
 func (s *String) Append(v string) {
-	s.Bytes = append(s.Bytes, v...)
-	s.Offsets = append(s.Offsets, uint32(len(s.Bytes)))
+	s.table.bytes = append(s.table.bytes, v...)
+	s.table.offsets = append(s.table.offsets, uint32(len(s.table.bytes)))
 }
 
 func (s *String) Type() super.Type {
@@ -32,11 +31,15 @@ func (s *String) Type() super.Type {
 }
 
 func (s *String) Len() uint32 {
-	return uint32(len(s.Offsets) - 1)
+	return s.table.Len()
 }
 
 func (s *String) Value(slot uint32) string {
-	return string(s.Bytes[s.Offsets[slot]:s.Offsets[slot+1]])
+	return s.Table().String(slot)
+}
+
+func (s *String) Table() BytesTable {
+	return s.table
 }
 
 func (s *String) Serialize(b *zcode.Builder, slot uint32) {

--- a/vector/string.go
+++ b/vector/string.go
@@ -22,8 +22,7 @@ func NewStringEmpty(cap uint32, nulls bitvec.Bits) *String {
 }
 
 func (s *String) Append(v string) {
-	s.table.bytes = append(s.table.bytes, v...)
-	s.table.offsets = append(s.table.offsets, uint32(len(s.table.bytes)))
+	s.table.Append([]byte(v))
 }
 
 func (s *String) Type() super.Type {
@@ -35,7 +34,7 @@ func (s *String) Len() uint32 {
 }
 
 func (s *String) Value(slot uint32) string {
-	return s.Table().String(slot)
+	return s.table.String(slot)
 }
 
 func (s *String) Table() BytesTable {

--- a/zio/parquetio/vectorreader.go
+++ b/zio/parquetio/vectorreader.go
@@ -209,11 +209,11 @@ func (v *vectorBuilder) build(a arrow.Array) (vector.Any, error) {
 	case arrow.STRING:
 		arr := a.(*array.String)
 		offsets := reinterpretSlice[uint32](arr.ValueOffsets())
-		return vector.NewString(offsets, arr.ValueBytes(), makeNulls(a)), nil
+		return vector.NewString(vector.NewBytesTable(offsets, arr.ValueBytes()), makeNulls(a)), nil
 	case arrow.BINARY:
 		arr := a.(*array.Binary)
 		offsets := reinterpretSlice[uint32](arr.ValueOffsets())
-		return vector.NewBytes(offsets, arr.ValueBytes(), makeNulls(a)), nil
+		return vector.NewBytes(vector.NewBytesTable(offsets, arr.ValueBytes()), makeNulls(a)), nil
 	case arrow.FIXED_SIZE_BINARY:
 		value0 := a.(*array.FixedSizeBinary).Value(0)
 		bytes := value0[:int(length)*len(value0)]
@@ -221,7 +221,7 @@ func (v *vectorBuilder) build(a arrow.Array) (vector.Any, error) {
 		for i := range offsets {
 			offsets[i] = uint32(i * len(value0))
 		}
-		return vector.NewBytes(offsets, bytes, makeNulls(a)), nil
+		return vector.NewBytes(vector.NewBytesTable(offsets, bytes), makeNulls(a)), nil
 	case arrow.DATE32:
 		values := make([]int64, length)
 		for i, v := range a.(*array.Date32).Date32Values() {
@@ -353,7 +353,7 @@ func (v *vectorBuilder) build(a arrow.Array) (vector.Any, error) {
 				return nil, fmt.Errorf("string offset exceeds uint32 range")
 			}
 		}
-		return vector.NewString(offsets, arr.ValueBytes(), makeNulls(a)), nil
+		return vector.NewString(vector.NewBytesTable(offsets, arr.ValueBytes()), makeNulls(a)), nil
 
 	}
 	return nil, fmt.Errorf("unimplemented Parquet type %q", dt.Name())


### PR DESCRIPTION
This commits adds a bytes table for sharing across bytes, strings, and type-value vectors.  It abstracts away the complex offsets/bytes indexing logic and provides an interface that can act as the insertion point for more efficient mechanisms like German strings down the road.

This will also be used by the forthcoming lazy-types PR.