### PR TITLE
Fix projection pushdown bug affecting the join operator

### DIFF
--- a/compiler/optimizer/demand.go
+++ b/compiler/optimizer/demand.go
@@ -50,10 +50,7 @@ func demandForOp(op dag.Op, downstream demand.Demand) demand.Demand {
 	case *dag.Head:
 		return downstream
 	case *dag.Join:
-		d := downstream
-		d = demand.Union(d, demandForExpr(op.LeftKey))
-		d = demand.Union(d, demandForExpr(op.RightKey))
-		return demandForAssignments(op.Args, d)
+		return demand.All()
 	case *dag.Load:
 		return demand.All()
 	case *dag.Merge:

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -1,6 +1,8 @@
 script: |
   super compile -C -O "from file | a==1 or e==2 | yield c, b, d"
   echo ===
+  super compile -C -O "from file1 | join (from file2) on a | yield b"
+  echo ===
   export SUPER_DB_LAKE=test
   super db init -q
   super db create -q -orderby ts pool-ts
@@ -21,6 +23,17 @@ outputs:
     data: |
       file file fields a,b,c,d,e filter (a==1 or e==2)
       | yield c, b, d
+      | output main
+      ===
+      file file1
+      | fork (
+        =>
+          pass
+        =>
+          file file2
+      )
+      | join on a=a
+      | yield b
       | output main
       ===
       lister


### PR DESCRIPTION
The current structure of dag.Join requires all fields from both inputs. (Moving the inputs into dag.Join would allow greater precision.)