### PR TITLE
Remove parentheses after function name in error strings

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -327,7 +327,7 @@ func (b *Builder) compileCall(call dag.Call) (expr.Evaluator, error) {
 		var err error
 		fn, path, err = function.New(b.sctx(), call.Name, len(call.Args))
 		if err != nil {
-			return nil, fmt.Errorf("%s(): %w", call.Name, err)
+			return nil, fmt.Errorf("%s: %w", call.Name, err)
 		}
 	}
 	args := call.Args
@@ -337,7 +337,7 @@ func (b *Builder) compileCall(call dag.Call) (expr.Evaluator, error) {
 	}
 	exprs, err := b.compileExprs(args)
 	if err != nil {
-		return nil, fmt.Errorf("%s(): bad argument: %w", call.Name, err)
+		return nil, fmt.Errorf("%s: bad argument: %w", call.Name, err)
 	}
 	return expr.NewCall(fn, exprs), nil
 }

--- a/docs/language/functions/grok.md
+++ b/docs/language/functions/grok.md
@@ -212,7 +212,7 @@ grok("%{EMAILADDRESS:email}", this)
 # input
 "www.example.com"
 # expected output
-error({message:"grok(): value does not match pattern",on:"www.example.com"})
+error({message:"grok: value does not match pattern",on:"www.example.com"})
 ```
 
 Failure to parse due to mismatch outside of Grok patterns:
@@ -223,7 +223,7 @@ grok("%{WORD:one}     %{WORD:two}", this)
 # input
 "hello world"
 # expected output
-error({message:"grok(): value does not match pattern",on:"hello world"})
+error({message:"grok: value does not match pattern",on:"hello world"})
 ```
 
 Using a regular expression to match outside of Grok patterns:

--- a/pkg/storage/router.go
+++ b/pkg/storage/router.go
@@ -42,7 +42,7 @@ func (r *Router) Enable(scheme Scheme) {
 	case S3Scheme:
 		engine = NewS3()
 	default:
-		panic(fmt.Sprintf("storage.Router.Enable(): unknown scheme: %q", scheme))
+		panic(fmt.Sprintf("storage.Router.Enable: unknown scheme: %q", scheme))
 	}
 	r.engines[scheme] = engine
 }

--- a/runtime/sam/expr/function/grok.go
+++ b/runtime/sam/expr/function/grok.go
@@ -69,7 +69,7 @@ func (g *Grok) Call(_ super.Allocator, args []super.Value) super.Value {
 }
 
 func (g *Grok) error(msg string, val super.Value) super.Value {
-	return g.sctx.WrapError("grok(): "+msg, val)
+	return g.sctx.WrapError("grok: "+msg, val)
 }
 
 func (g *Grok) getHost(defs string) (*host, error) {

--- a/runtime/vam/expr/function/grok.go
+++ b/runtime/vam/expr/function/grok.go
@@ -103,13 +103,13 @@ func (g *Grok) Call(args ...vector.Any) vector.Any {
 func (g *Grok) errorVec(msgs []string, index []uint32, vec vector.Any) vector.Any {
 	s := vector.NewStringEmpty(0, bitvec.Zero)
 	for _, m := range msgs {
-		s.Append("grok(): " + m)
+		s.Append("grok: " + m)
 	}
 	return vector.NewVecWrappedError(g.sctx, s, vector.Pick(vec, index))
 }
 
 func (g *Grok) error(msg string, vec vector.Any) vector.Any {
-	return vector.NewWrappedError(g.sctx, "grok(): "+msg, vec)
+	return vector.NewWrappedError(g.sctx, "grok: "+msg, vec)
 }
 
 func (g *Grok) getHost(defs string) (*host, error) {

--- a/runtime/ztests/expr/function/grok.yaml
+++ b/runtime/ztests/expr/function/grok.yaml
@@ -60,11 +60,11 @@ output: |
   {int:"0"}
   {one:"2"}
   {}
-  error({message:"grok(): value does not match pattern",on:"foo"})
+  error({message:"grok: value does not match pattern",on:"foo"})
   null({})
   null({})
-  error({message:"grok(): value does not match pattern",on:"string value"})
-  error({message:"grok(): the 'DOESNOTEXIST' pattern doesn't exist",on:"%{DOESNOTEXIST:dne}"})
-  error({message:"grok(): pattern argument must be a string",on:1})
-  error({message:"grok(): input argument must be a string",on:1})
-  error({message:"grok(): definitions argument must be a string",on:1})
+  error({message:"grok: value does not match pattern",on:"string value"})
+  error({message:"grok: the 'DOESNOTEXIST' pattern doesn't exist",on:"%{DOESNOTEXIST:dne}"})
+  error({message:"grok: pattern argument must be a string",on:1})
+  error({message:"grok: input argument must be a string",on:1})
+  error({message:"grok: definitions argument must be a string",on:1})

--- a/sup/analyzer.go
+++ b/sup/analyzer.go
@@ -226,7 +226,7 @@ func (a Analyzer) convertAny(sctx *super.Context, val ast.Any, cast super.Type) 
 	case *ast.Error:
 		return a.convertError(sctx, val, cast)
 	}
-	return nil, fmt.Errorf("internal error: unknown ast type in Analyzer.convertAny(): %T", val)
+	return nil, fmt.Errorf("internal error: unknown ast type in Analyzer.convertAny: %T", val)
 }
 
 func (a Analyzer) convertPrimitive(sctx *super.Context, val *ast.Primitive, cast super.Type) (Value, error) {

--- a/sup/formatter.go
+++ b/sup/formatter.go
@@ -618,7 +618,7 @@ func (f *Formatter) formatTypeBody(typ super.Type) {
 	case *super.TypeOfType:
 		formatType(&f.builder, make(map[string]*super.TypeNamed), typ)
 	default:
-		panic("unknown case in formatTypeBody(): " + String(typ))
+		panic("unknown case in formatTypeBody: " + String(typ))
 	}
 }
 

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -64,7 +64,7 @@ func formatAny(val super.Value, inContainer bool) string {
 		}
 		return sup.FormatValue(val)
 	default:
-		return fmt.Sprintf("zeekio.StringOf(): unknown type: %T", t)
+		return fmt.Sprintf("zeekio.StringOf: unknown type: %T", t)
 	}
 }
 


### PR DESCRIPTION
A few error strings include parentheses after a function name (as in "f(): ...") but most do not.  Remove these parentheses for consistency.