### PR TITLE
Optimize queries by replacing sort followed by head or tail with top

### DIFF
--- a/compiler/ztests/par-sort-and-head-or-tail.yaml
+++ b/compiler/ztests/par-sort-and-head-or-tail.yaml
@@ -1,0 +1,49 @@
+script: |
+  export SUPER_DB_LAKE=test
+  super db init -q
+  super db create -q -orderby a test
+  super db compile -C -P 2 'from test | sort | head' | sed -e 's/pool .*/.../'
+  echo ===
+  super db compile -C -P 2 'from test | sort a | head 3' | sed -e 's/pool .*/.../'
+  echo ===
+  super db compile -C -P 2 'from test | sort b | tail 3' | sed -e 's/pool .*/.../'
+
+outputs:
+  - name: stdout
+    data: |
+      lister ...
+      | scatter (
+        =>
+          seqscan ...
+        =>
+          seqscan ...
+      )
+      | combine
+      | top 1
+      | output main
+      ===
+      lister ...
+      | scatter (
+        =>
+          seqscan ...
+          | top 3 a asc
+        =>
+          seqscan ...
+          | top 3 a asc
+      )
+      | merge a:asc
+      | head 3
+      | output main
+      ===
+      lister ...
+      | scatter (
+        =>
+          seqscan ...
+          | top -nulls first -r 3 b asc
+        =>
+          seqscan ...
+          | top -nulls first -r 3 b asc
+      )
+      | merge b:desc
+      | head 3
+      | output main

--- a/compiler/ztests/replace-sort-and-head-or-tail-with-top.yaml
+++ b/compiler/ztests/replace-sort-and-head-or-tail-with-top.yaml
@@ -1,0 +1,41 @@
+script: |
+  super compile -C -O 'sort | head'
+  echo ===
+  super compile -C -O 'sort | tail'
+  echo ===
+  super compile -C -O 'sort -nulls first -r a, b asc, c desc | head 3'
+  echo ===
+  super compile -C -O 'sort -nulls first -r a, b asc, c desc | tail 3'
+  echo ===
+  super compile -C -O 'sort | head 1048577'
+  echo ===
+  super compile -C -O 'sort | tail 1048577'
+
+outputs:
+  - name: stdout
+    data: |
+      null
+      | top 1
+      | output main
+      ===
+      null
+      | top -nulls first -r 1
+      | output main
+      ===
+      null
+      | top -nulls first -r 3 a asc, b asc, c desc
+      | output main
+      ===
+      null
+      | top 3 a asc, b asc, c desc
+      | output main
+      ===
+      null
+      | sort
+      | head 1048577
+      | output main
+      ===
+      null
+      | sort
+      | tail 1048577
+      | output main


### PR DESCRIPTION
This replaces, e.g., "sort a | head 5" with "top 5 a" and "sort a | tail 5" with "top -r 5 a".

To limit memory consumption, the replacement is not made if the limit argument to head or tail exceeds 1048576.