### PR TITLE
Fix projection pushdown bugs for sort and top operators

### DIFF
--- a/compiler/ztests/pushdown-sort.yaml
+++ b/compiler/ztests/pushdown-sort.yaml
@@ -1,0 +1,29 @@
+script: |
+  super compile -C -O 'from file1 | sort'
+  echo ===
+  super compile -C -O 'from file1 | sort | yield a'
+  echo ===
+  super compile -C -O 'from file1 | sort a'
+  echo ===
+  super compile -C -O 'from file1 | sort a | yield b'
+
+outputs:
+  - name: stdout
+    data: |
+      file file1
+      | sort
+      | output main
+      ===
+      file file1
+      | sort
+      | yield a
+      | output main
+      ===
+      file file1
+      | sort a asc
+      | output main
+      ===
+      file file1 fields a,b
+      | sort a asc
+      | yield b
+      | output main

--- a/compiler/ztests/pushdown-top.yaml
+++ b/compiler/ztests/pushdown-top.yaml
@@ -1,0 +1,29 @@
+script: |
+  super compile -C -O 'from file1 | top'
+  echo ===
+  super compile -C -O 'from file1 | top | yield a'
+  echo ===
+  super compile -C -O 'from file1 | top 2 a'
+  echo ===
+  super compile -C -O 'from file1 | top 2 a | yield b'
+
+outputs:
+  - name: stdout
+    data: |
+      file file1
+      | top 1
+      | output main
+      ===
+      file file1
+      | top 1
+      | yield a
+      | output main
+      ===
+      file file1
+      | top 2 a asc
+      | output main
+      ===
+      file file1 fields a,b
+      | top 2 a asc
+      | yield b
+      | output main


### PR DESCRIPTION
Projection pushdown for sort and top must include all fields appearing in sort expressions.  In addition, in the absence of sort expressions, it must include all fields for the key-guessing heuristic.