### PR TITLE
don't deunion vector.Union in constructor

### DIFF
--- a/vector/union.go
+++ b/vector/union.go
@@ -38,7 +38,7 @@ func (u *Union) Serialize(b *zcode.Builder, slot uint32) {
 
 func Deunion(vec Any) Any {
 	if u, ok := vec.(*Union); ok {
-		return addNullsToUnionDynamic(u.Typ, NewDynamic(u.Tags, u.Values), u.Nulls)
+		return addUnionNullsToDynamic(u.Typ, NewDynamic(u.Tags, u.Values), u.Nulls)
 	}
 	return vec
 }
@@ -48,7 +48,7 @@ func isUnionNullsVec(typ *super.TypeUnion, vec Any) bool {
 	return ok && c.val.IsNull() && c.val.Type() == typ
 }
 
-func addNullsToUnionDynamic(typ *super.TypeUnion, d *Dynamic, nulls bitvec.Bits) *Dynamic {
+func addUnionNullsToDynamic(typ *super.TypeUnion, d *Dynamic, nulls bitvec.Bits) *Dynamic {
 	if nulls.IsZero() {
 		return d
 	}

--- a/vector/union.go
+++ b/vector/union.go
@@ -17,8 +17,7 @@ type Union struct {
 var _ Any = (*Union)(nil)
 
 func NewUnion(typ *super.TypeUnion, tags []uint32, vals []Any, nulls bitvec.Bits) *Union {
-	d := addNullsToUnionDynamic(typ, NewDynamic(tags, vals), nulls)
-	return &Union{d, typ, nulls}
+	return &Union{NewDynamic(tags, vals), typ, nulls}
 }
 
 func (u *Union) Type() super.Type {
@@ -26,7 +25,7 @@ func (u *Union) Type() super.Type {
 }
 
 func (u *Union) Serialize(b *zcode.Builder, slot uint32) {
-	if vec := u.Values[u.Dynamic.Tags[slot]]; isUnionNullsVec(u.Typ, vec) {
+	if u.Nulls.IsSet(slot) {
 		b.Append(nil)
 		return
 	}
@@ -38,8 +37,8 @@ func (u *Union) Serialize(b *zcode.Builder, slot uint32) {
 }
 
 func Deunion(vec Any) Any {
-	if union, ok := vec.(*Union); ok {
-		return union.Dynamic
+	if u, ok := vec.(*Union); ok {
+		return addNullsToUnionDynamic(u.Typ, NewDynamic(u.Tags, u.Values), u.Nulls)
 	}
 	return vec
 }


### PR DESCRIPTION
This commit moves the deunioning logic for a Union vector will nulls to vector.Deunion intead of living inside the union vector constructor. The union vector shouldn't have to know about Dynamic's null union values in Serialize.  If we are concerned about performance, we can cache the result of Deunion under a lock inside the union vector but I wouldn't worry about it for now.

The upcoming lazy-vectors PR will make use of this refactoring.