### PR TITLE
csup: Fix MemLength and Length for ints and uint

### DIFF
--- a/csup/header.go
+++ b/csup/header.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Version     = 10
+	Version     = 11
 	HeaderSize  = 28
 	MaxMetaSize = 100 * 1024 * 1024
 	MaxDataSize = 2 * 1024 * 1024 * 1024

--- a/csup/int.go
+++ b/csup/int.go
@@ -48,12 +48,14 @@ func (i *IntEncoder) reset() {
 
 func (i *IntEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	loc := Segment{
-		Offset:            off,
+		Offset: off,
+		Length: uint64(len(i.out)),
+		// MemLength is the same as Length since we don't use generalized
+		// compression here.
 		MemLength:         uint64(len(i.out)),
-		Length:            uint64(len(i.vals)) * 8,
 		CompressionFormat: CompressionFormatNone,
 	}
-	off += loc.MemLength
+	off += loc.Length
 	return off, cctx.enter(&Int{
 		Typ:      i.typ,
 		Location: loc,
@@ -107,12 +109,14 @@ func (i *UintEncoder) reset() {
 
 func (u *UintEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	loc := Segment{
-		Offset:            off,
+		Offset: off,
+		Length: uint64(len(u.out)),
+		// MemLength is the same as Length since we don't use generalized
+		// compression here.
 		MemLength:         uint64(len(u.out)),
-		Length:            uint64(len(u.vals)) * 8,
 		CompressionFormat: CompressionFormatNone,
 	}
-	off += loc.MemLength
+	off += loc.Length
 	return off, cctx.enter(&Uint{
 		Typ:      u.typ,
 		Location: loc,

--- a/csup/ztests/const.yaml
+++ b/csup/ztests/const.yaml
@@ -12,5 +12,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {Version:10(uint32),MetaSize:35(uint64),DataSize:0(uint64),Root:0(uint32)}
+      {Version:11(uint32),MetaSize:35(uint64),DataSize:0(uint64),Root:0(uint32)}
       {Value:1,Count:3(uint32)}(=Const)


### PR DESCRIPTION
MemLength and Length for csup int and uint vectors were set incorrectly. Since they bypass general compression the length for both of these should be the size of the compressed data.