### PR TITLE
super dev csup: Use CopyWithContext

### DIFF
--- a/cmd/super/dev/csup/command.go
+++ b/cmd/super/dev/csup/command.go
@@ -67,7 +67,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	meta := newReader(r)
-	err = zio.Copy(writer, meta)
+	err = zio.CopyWithContext(ctx, writer, meta)
 	if err2 := writer.Close(); err == nil {
 		err = err2
 	}


### PR DESCRIPTION
Use zio.CopyWithContext for command super dev csup so that a user can exit before completion on large files.