### PR TITLE
Rename runtime/sam/expr.SortEvaluator to SortExpr

### DIFF
--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -178,13 +178,13 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		return distinct.New(parent, e), nil
 	case *dag.Sort:
 		b.resetResetters()
-		var sortExprs []expr.SortEvaluator
+		var sortExprs []expr.SortExpr
 		for _, s := range v.Args {
 			k, err := b.compileExpr(s.Key)
 			if err != nil {
 				return nil, err
 			}
-			sortExprs = append(sortExprs, expr.NewSortEvaluator(k, s.Order))
+			sortExprs = append(sortExprs, expr.NewSortExpr(k, s.Order))
 		}
 		return sort.New(b.rctx, parent, sortExprs, v.NullsFirst, v.Reverse, b.resetters), nil
 	case *dag.Head:
@@ -212,13 +212,13 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		return op.NewApplier(b.rctx, parent, expr.NewFilterApplier(b.sctx(), f), b.resetters), nil
 	case *dag.Top:
 		b.resetResetters()
-		var sortExprs []expr.SortEvaluator
+		var sortExprs []expr.SortExpr
 		for _, dagSortExpr := range v.Exprs {
 			e, err := b.compileExpr(dagSortExpr.Key)
 			if err != nil {
 				return nil, err
 			}
-			sortExprs = append(sortExprs, expr.NewSortEvaluator(e, dagSortExpr.Order))
+			sortExprs = append(sortExprs, expr.NewSortExpr(e, dagSortExpr.Order))
 		}
 		return top.New(b.sctx(), parent, v.Limit, sortExprs, v.NullsFirst, v.Reverse, b.resetters), nil
 	case *dag.Put:
@@ -686,7 +686,7 @@ func (b *Builder) compile(o dag.Op, parents []zbuf.Puller) ([]zbuf.Puller, error
 		if err != nil {
 			return nil, err
 		}
-		cmp := expr.NewComparator(true, expr.NewSortEvaluator(e, o.Order)).WithMissingAsNull()
+		cmp := expr.NewComparator(true, expr.NewSortExpr(e, o.Order)).WithMissingAsNull()
 		return []zbuf.Puller{merge.New(b.rctx, parents, cmp.Compare, b.resetters)}, nil
 	case *dag.Combine:
 		return []zbuf.Puller{combine.New(b.rctx, parents)}, nil

--- a/compiler/kernel/vop.go
+++ b/compiler/kernel/vop.go
@@ -64,7 +64,7 @@ func (b *Builder) compileVam(o dag.Op, parents []vector.Puller) ([]vector.Puller
 		if err != nil {
 			return nil, err
 		}
-		cmp := expr.NewComparator(true, expr.NewSortEvaluator(e, o.Order)).WithMissingAsNull()
+		cmp := expr.NewComparator(true, expr.NewSortExpr(e, o.Order)).WithMissingAsNull()
 		return []vector.Puller{vamop.NewMerge(b.rctx, parents, cmp.Compare)}, nil
 	case *dag.Scatter:
 		return b.compileVamScatter(o, parents)
@@ -295,13 +295,13 @@ func (b *Builder) compileVamLeaf(o dag.Op, parent vector.Puller) (vector.Puller,
 		return vam.NewDematerializer(zbufPuller), nil
 	case *dag.Sort:
 		b.resetResetters()
-		var sortExprs []expr.SortEvaluator
+		var sortExprs []expr.SortExpr
 		for _, s := range o.Args {
 			k, err := b.compileExpr(s.Key)
 			if err != nil {
 				return nil, err
 			}
-			sortExprs = append(sortExprs, expr.NewSortEvaluator(k, s.Order))
+			sortExprs = append(sortExprs, expr.NewSortExpr(k, s.Order))
 		}
 		return vamop.NewSort(b.rctx, parent, sortExprs, o.NullsFirst, o.Reverse, b.resetters), nil
 	case *dag.Tail:

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -296,16 +296,16 @@ func (s *ImportStats) Copy() ImportStats {
 }
 
 func ImportComparator(sctx *super.Context, pool *Pool) *expr.Comparator {
-	var exprs []expr.SortEvaluator
+	var exprs []expr.SortExpr
 	for _, s := range pool.SortKeys {
-		exprs = append(exprs, expr.NewSortEvaluator(expr.NewDottedExpr(sctx, s.Key), s.Order))
+		exprs = append(exprs, expr.NewSortExpr(expr.NewDottedExpr(sctx, s.Key), s.Order))
 	}
 	var o order.Which
 	if !pool.SortKeys.IsNil() {
 		o = pool.SortKeys.Primary().Order
 	}
 	// valueAsBytes establishes a total order.
-	exprs = append(exprs, expr.NewSortEvaluator(&valueAsBytes{}, o))
+	exprs = append(exprs, expr.NewSortExpr(&valueAsBytes{}, o))
 	return expr.NewComparator(true, exprs...).WithMissingAsNull()
 }
 

--- a/runtime/sam/expr/sort.go
+++ b/runtime/sam/expr/sort.go
@@ -13,13 +13,13 @@ import (
 	"github.com/brimdata/super/zio"
 )
 
-type SortEvaluator struct {
+type SortExpr struct {
 	Evaluator
 	Order order.Which
 }
 
-func NewSortEvaluator(eval Evaluator, o order.Which) SortEvaluator {
-	return SortEvaluator{eval, o}
+func NewSortExpr(eval Evaluator, o order.Which) SortExpr {
+	return SortExpr{eval, o}
 }
 
 func (c *Comparator) sortStableIndices(vals []super.Value) []uint32 {
@@ -91,13 +91,13 @@ func (c *Comparator) sortStableIndices(vals []super.Value) []uint32 {
 type CompareFn func(a, b super.Value) int
 
 func NewValueCompareFn(o order.Which, nullsMax bool) CompareFn {
-	e := SortEvaluator{&This{}, o}
+	e := SortExpr{&This{}, o}
 	return NewComparator(nullsMax, e).Compare
 }
 
 type Comparator struct {
 	ectx     Context
-	exprs    []SortEvaluator
+	exprs    []SortExpr
 	nullsMax bool
 }
 
@@ -106,7 +106,7 @@ type Comparator struct {
 // exprs, stopping when e(a)!=e(b).  nullsMax determines whether a null value
 // compares larger (if true) or smaller (if false) than a non-null value.
 // reverse reverses the sense of comparisons.
-func NewComparator(nullsMax bool, exprs ...SortEvaluator) *Comparator {
+func NewComparator(nullsMax bool, exprs ...SortExpr) *Comparator {
 	return &Comparator{
 		ectx:     NewContext(),
 		exprs:    slices.Clone(exprs),

--- a/runtime/sam/expr/sort_test.go
+++ b/runtime/sam/expr/sort_test.go
@@ -23,7 +23,7 @@ func BenchmarkSort(b *testing.B) {
 	}
 	for _, c := range cases {
 		b.Run(sup.FormatType(c.typ), func(b *testing.B) {
-			cmp := NewComparator(false, SortEvaluator{&This{}, order.Asc})
+			cmp := NewComparator(false, SortExpr{&This{}, order.Asc})
 			vals := make([]super.Value, 1048576)
 			for b.Loop() {
 				b.StopTimer()

--- a/runtime/sam/op/aggregate/aggregate.go
+++ b/runtime/sam/op/aggregate/aggregate.go
@@ -81,13 +81,13 @@ func NewAggregator(ctx context.Context, sctx *super.Context, keyRefs, keyExprs, 
 	nkeys := len(keyExprs)
 	o := order.Which(inputDir < 0)
 	if nkeys > 0 && inputDir != 0 {
-		keySortExpr := expr.NewSortEvaluator(keyRefs[0], o)
+		keySortExpr := expr.NewSortExpr(keyRefs[0], o)
 		keyCompare = expr.NewComparator(true, keySortExpr).WithMissingAsNull().Compare
 		valueCompare = expr.NewValueCompareFn(o, true)
 	}
-	var sortExprs []expr.SortEvaluator
+	var sortExprs []expr.SortExpr
 	for _, e := range keyRefs {
-		sortExprs = append(sortExprs, expr.NewSortEvaluator(e, o))
+		sortExprs = append(sortExprs, expr.NewSortExpr(e, o))
 	}
 	return &Aggregator{
 		ctx:            ctx,

--- a/runtime/sam/op/join/join.go
+++ b/runtime/sam/op/join/join.go
@@ -44,12 +44,12 @@ func New(rctx *runtime.Context, anti, inner bool, left, right zbuf.Puller, leftK
 	}
 	// Add sorts if needed.
 	if !leftDir.HasOrder(o) {
-		s := expr.NewSortEvaluator(leftKey, o)
-		left = sort.New(rctx, left, []expr.SortEvaluator{s}, false, false, resetter)
+		s := expr.NewSortExpr(leftKey, o)
+		left = sort.New(rctx, left, []expr.SortExpr{s}, false, false, resetter)
 	}
 	if !rightDir.HasOrder(o) {
-		s := expr.NewSortEvaluator(rightKey, o)
-		right = sort.New(rctx, right, []expr.SortEvaluator{s}, false, false, resetter)
+		s := expr.NewSortExpr(rightKey, o)
+		right = sort.New(rctx, right, []expr.SortExpr{s}, false, false, resetter)
 	}
 	ctx, cancel := context.WithCancel(rctx.Context)
 	return &Op{

--- a/runtime/sam/op/merge/merge_test.go
+++ b/runtime/sam/op/merge/merge_test.go
@@ -101,7 +101,7 @@ func TestParallelOrder(t *testing.T) {
 				r := supio.NewReader(sctx, strings.NewReader(input))
 				parents = append(parents, zbuf.NewPuller(r))
 			}
-			sortExpr := expr.NewSortEvaluator(expr.NewDottedExpr(sctx, field.Path{c.field}), c.order)
+			sortExpr := expr.NewSortExpr(expr.NewDottedExpr(sctx, field.Path{c.field}), c.order)
 			cmp := expr.NewComparator(c.order == order.Asc, sortExpr).Compare
 			om := merge.New(context.Background(), parents, cmp, expr.Resetters{})
 

--- a/runtime/sam/op/sort/sort.go
+++ b/runtime/sam/op/sort/sort.go
@@ -25,14 +25,14 @@ type Op struct {
 	resetter   expr.Resetter
 	reverse    bool
 
-	fieldResolvers []expr.SortEvaluator
+	fieldResolvers []expr.SortExpr
 	lastBatch      zbuf.Batch
 	once           sync.Once
 	resultCh       chan op.Result
 	comparator     *expr.Comparator
 }
 
-func New(rctx *runtime.Context, parent zbuf.Puller, fields []expr.SortEvaluator, nullsFirst, reverse bool, resetter expr.Resetter) *Op {
+func New(rctx *runtime.Context, parent zbuf.Puller, fields []expr.SortExpr, nullsFirst, reverse bool, resetter expr.Resetter) *Op {
 	return &Op{
 		rctx:           rctx,
 		parent:         parent,
@@ -197,11 +197,11 @@ func (o *Op) append(out []super.Value, batch zbuf.Batch) ([]super.Value, int) {
 	return out, nbytes
 }
 
-func NewComparator(sctx *super.Context, exprs []expr.SortEvaluator, nullsFirst, reverse bool, val super.Value) *expr.Comparator {
+func NewComparator(sctx *super.Context, exprs []expr.SortExpr, nullsFirst, reverse bool, val super.Value) *expr.Comparator {
 	if exprs == nil {
 		fld := GuessSortKey(val)
-		e := expr.NewSortEvaluator(expr.NewDottedExpr(sctx, fld), order.Asc)
-		exprs = []expr.SortEvaluator{e}
+		e := expr.NewSortExpr(expr.NewDottedExpr(sctx, fld), order.Asc)
+		exprs = []expr.SortExpr{e}
 	}
 	nullsMax := !nullsFirst
 	if reverse {

--- a/runtime/sam/op/top/top.go
+++ b/runtime/sam/op/top/top.go
@@ -14,7 +14,7 @@ type Op struct {
 	sctx       *super.Context
 	parent     zbuf.Puller
 	limit      int
-	exprs      []expr.SortEvaluator
+	exprs      []expr.SortExpr
 	nullsFirst bool
 	reverse    bool
 	resetter   expr.Resetter
@@ -25,7 +25,7 @@ type Op struct {
 }
 
 // New returns an operator that produces the first limit
-func New(sctx *super.Context, parent zbuf.Puller, limit int, exprs []expr.SortEvaluator, nullsFirst, reverse bool, resetter expr.Resetter) *Op {
+func New(sctx *super.Context, parent zbuf.Puller, limit int, exprs []expr.SortExpr, nullsFirst, reverse bool, resetter expr.Resetter) *Op {
 	return &Op{
 		sctx:       sctx,
 		parent:     parent,

--- a/runtime/vam/op/sort.go
+++ b/runtime/vam/op/sort.go
@@ -13,7 +13,7 @@ type Sort struct {
 	samsort *sort.Op
 }
 
-func NewSort(rctx *runtime.Context, parent vector.Puller, fields []expr.SortEvaluator, nullsFirst, reverse bool, resetter expr.Resetter) *Sort {
+func NewSort(rctx *runtime.Context, parent vector.Puller, fields []expr.SortExpr, nullsFirst, reverse bool, resetter expr.Resetter) *Sort {
 	materializer := vam.NewMaterializer(parent)
 	s := sort.New(rctx, materializer, fields, nullsFirst, reverse, resetter)
 	return &Sort{rctx: rctx, samsort: s}


### PR DESCRIPTION
SortExpr aligns with the names of the other types that implement the Evaluator interface.