### PR TITLE
Skip -version flag tests

### DIFF
--- a/cmd/super/db/ztests/version.yaml
+++ b/cmd/super/db/ztests/version.yaml
@@ -1,3 +1,5 @@
+skip: Enable after creating first Git release tag.
+
 script: |
   super -version
 

--- a/cmd/super/ztests/version.yaml
+++ b/cmd/super/ztests/version.yaml
@@ -1,3 +1,5 @@
+skip: Enable after creating first Git release tag.
+
 script: |
   super -version
 

--- a/service/ztests/version.yaml
+++ b/service/ztests/version.yaml
@@ -1,3 +1,5 @@
+skip: Enable after creating first Git release tag.
+
 script: |
   source service.sh
   super -version


### PR DESCRIPTION
They require the presence of a Git release tag.