### PR TITLE
Fix null ordering bug when replacing "sort | tail" with top

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -656,15 +656,13 @@ func replaceSortAndHeadOrTailWithTop(seq dag.Seq) dag.Seq {
 				continue
 			}
 			var limit int
-			var nullsFirst, reverse bool
+			var reverse bool
 			switch op := seq[i+1].(type) {
 			case *dag.Head:
 				limit = op.Count
-				nullsFirst = sort.NullsFirst
 				reverse = sort.Reverse
 			case *dag.Tail:
 				limit = op.Count
-				nullsFirst = !sort.NullsFirst
 				reverse = !sort.Reverse
 			default:
 				continue
@@ -678,7 +676,7 @@ func replaceSortAndHeadOrTailWithTop(seq dag.Seq) dag.Seq {
 				Kind:       "Top",
 				Limit:      limit,
 				Exprs:      sort.Args,
-				NullsFirst: nullsFirst,
+				NullsFirst: sort.NullsFirst,
 				Reverse:    reverse,
 			}
 			seq.Delete(i+1, i+2)

--- a/compiler/ztests/par-sort-and-head-or-tail.yaml
+++ b/compiler/ztests/par-sort-and-head-or-tail.yaml
@@ -39,10 +39,10 @@ outputs:
       | scatter (
         =>
           seqscan ...
-          | top -nulls first -r 3 b asc
+          | top -r 3 b asc
         =>
           seqscan ...
-          | top -nulls first -r 3 b asc
+          | top -r 3 b asc
       )
       | merge b:desc
       | head 3

--- a/compiler/ztests/replace-sort-and-head-or-tail-with-top.yaml
+++ b/compiler/ztests/replace-sort-and-head-or-tail-with-top.yaml
@@ -19,7 +19,7 @@ outputs:
       | output main
       ===
       null
-      | top -nulls first -r 1
+      | top -r 1
       | output main
       ===
       null
@@ -27,7 +27,7 @@ outputs:
       | output main
       ===
       null
-      | top 3 a asc, b asc, c desc
+      | top -nulls first 3 a asc, b asc, c desc
       | output main
       ===
       null


### PR DESCRIPTION
The optimization that replaces "sort | tail" with top incorrectly changes the ordering of nulls in top's output.  Fix that.