### PR TITLE
Fix bug causing "over a => (top)" to guess sort key more than once

### DIFF
--- a/runtime/sam/op/top/top.go
+++ b/runtime/sam/op/top/top.go
@@ -65,8 +65,10 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 
 func (o *Op) consume(rec super.Value) {
 	if o.records == nil {
-		// Package heap implements a min-heap.  Invert o.nullsFirst and o.reverse to get a max-heap.
-		o.compare = sort.NewComparator(o.sctx, o.exprs, !o.nullsFirst, !o.reverse, rec).Compare
+		if o.compare == nil {
+			// Package heap implements a min-heap.  Invert o.nullsFirst and o.reverse to get a max-heap.
+			o.compare = sort.NewComparator(o.sctx, o.exprs, !o.nullsFirst, !o.reverse, rec).Compare
+		}
 		o.records = expr.NewRecordSlice(o.compare)
 		heap.Init(o.records)
 	}

--- a/runtime/ztests/op/sort/guess-key-once.yaml
+++ b/runtime/ztests/op/sort/guess-key-once.yaml
@@ -1,0 +1,13 @@
+spq: over this => (sort)
+
+vector: true
+
+input: |
+  [{a:1},{a:2}]
+  [{b:22,a:1},{b:11,a:2}]
+
+output: |
+  {a:1}
+  {a:2}
+  {b:22,a:1}
+  {b:11,a:2}

--- a/runtime/ztests/op/top-guess-key-once.yaml
+++ b/runtime/ztests/op/top-guess-key-once.yaml
@@ -1,0 +1,13 @@
+spq: over this => (top 2)
+
+vector: true
+
+input: |
+  [{a:1},{a:2}]
+  [{b:22,a:1},{b:11,a:2}]
+
+output: |
+  {a:1}
+  {a:2}
+  {b:22,a:1}
+  {b:11,a:2}


### PR DESCRIPTION
#5804 incorrectly changed the behavior of the top operator in a lateral subquery to guess a new sort key each time the subquery is run.  Restore the old behavior by guessing only once.