### PR TITLE
Fix links that broke due to deleted Zed-era tags

### DIFF
--- a/docs/integrations/fluentd.md
+++ b/docs/integrations/fluentd.md
@@ -22,7 +22,7 @@ Linux 24.04. At the time this article was written, the following versions
 were used for the referenced software:
 
 * [Fluentd v1.17.0](https://github.com/fluent/fluentd/releases/tag/v1.17.0)
-* [Zed v1.17.0](https://github.com/brimdata/super/releases/tag/v1.17.0)
+* [Zed v1.17.0](https://github.com/brimdata/super/commit/c81efd6a868a855ed6b7de983491b5f3a5832d19)
 * [Zeek v6.2.1](https://github.com/zeek/zeek/releases/tag/v6.2.1)
 
 ### Zeek
@@ -57,7 +57,7 @@ After making these changes, Zeek was started by running
 
 ### Zed
 
-A binary [release package](https://github.com/brimdata/super/releases) of Zed
+A binary [release package](https://github.com/brimdata/zed-archive/releases) of Zed
 executables compatible with our instance was downloaded and unpacked to a
 directory in our `$PATH`, then the [lake service](../commands/super-db.md#serve)
 was started with a specified storage path.

--- a/docs/integrations/zed-lake-auth/index.md
+++ b/docs/integrations/zed-lake-auth/index.md
@@ -151,7 +151,7 @@ Now that we've configured both Auth0 and the Zed lake service, we can test the
 authenticated login flow with our Zed clients. The video below shows this
 using [Zui v1.0.0](https://github.com/brimdata/zui/releases/tag/v1.0.0)
 and the Zed CLI tooling and Zed Python client
-[v1.6.0](https://github.com/brimdata/super/releases/tag/v1.6.0).
+[v1.6.0](https://github.com/brimdata/super/commit/6e15e99971b2c3f5ebb447457c18a7cad4ebe09a).
 
 ### Summary:
 


### PR DESCRIPTION
The articles will surely need more overhaul in the near future, but for now I'm just fixing the links so CI won't pester us.