### PR TITLE
Parallelize sort and top with multiple sort exprs

### DIFF
--- a/compiler/ztests/par-sort.yaml
+++ b/compiler/ztests/par-sort.yaml
@@ -1,0 +1,15 @@
+script: |
+  SUPER_VAM=1 super compile -C -P 2 'from test.csup | sort a, b desc nulls last'
+
+outputs:
+  - name: stdout
+    data: |
+      file test.csup format csup
+      | scatter (
+        =>
+          sort a asc nulls last, b desc nulls last
+        =>
+          sort a asc nulls last, b desc nulls last
+      )
+      | merge a asc nulls last, b desc nulls last
+      | output main

--- a/compiler/ztests/par-top.yaml
+++ b/compiler/ztests/par-top.yaml
@@ -7,6 +7,8 @@ script: |
   super db compile -C -P 2 'from test | top 3 a' | sed -e 's/pool .*/.../'
   echo ===
   super db compile -C -P 2 'from test | top 3 b desc' | sed -e 's/pool .*/.../'
+  echo ===
+  SUPER_VAM=1 super compile -C -P 2 'from test.csup | top 3 a, b desc nulls last'
 
 outputs:
   - name: stdout
@@ -45,5 +47,16 @@ outputs:
           | top 3 b desc nulls last
       )
       | merge b desc nulls last
+      | head 3
+      | output main
+      ===
+      file test.csup format csup
+      | scatter (
+        =>
+          top 3 a asc nulls last, b desc nulls last
+        =>
+          top 3 a asc nulls last, b desc nulls last
+      )
+      | merge a asc nulls last, b desc nulls last
       | head 3
       | output main


### PR DESCRIPTION
The optimizer can parallelize a sort or top operator only if it has exactly one sort expression.  Relax that restriction and parallelize sort and top when they have at least one sort expression.

Closes #4524.