### PR TITLE
Add compiler support for unordered dag.FileScan

### DIFF
--- a/compiler/dag/op.go
+++ b/compiler/dag/op.go
@@ -217,6 +217,7 @@ type (
 		Projection []field.Path `json:"projection"`
 		DataFilter *ScanFilter  `json:"data_filter"`
 		MetaFilter *ScanFilter  `json:"meta_filter"`
+		Unordered  bool         `json:"unordered"`
 	}
 	ScanFilter struct {
 		Projection []field.Path `json:"projection"`

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -737,12 +737,13 @@ func (b *Builder) newPushdown(e dag.Expr, projection []field.Path) *pushdown {
 	}
 }
 
-func (b *Builder) newMetaPushdown(e dag.Expr, projection, metaProjection []field.Path) *pushdown {
+func (b *Builder) newMetaPushdown(e dag.Expr, projection, metaProjection []field.Path, unordered bool) *pushdown {
 	return &pushdown{
 		metaFilter:     e,
 		builder:        b,
 		projection:     field.NewProjection(projection),
 		metaProjection: field.NewProjection(metaProjection),
+		unordred:       unordered,
 	}
 }
 

--- a/compiler/kernel/pushdown.go
+++ b/compiler/kernel/pushdown.go
@@ -13,6 +13,7 @@ type pushdown struct {
 	builder        *Builder
 	projection     field.Projection
 	metaProjection field.Projection
+	unordred       bool
 }
 
 var _ zbuf.Pushdown = (*pushdown)(nil)
@@ -47,6 +48,10 @@ func (p *pushdown) Projection() field.Projection {
 		return p.projection
 	}
 	return nil
+}
+
+func (p *pushdown) Unordered() bool {
+	return p.unordred
 }
 
 type deleter struct {

--- a/compiler/kernel/vop.go
+++ b/compiler/kernel/vop.go
@@ -249,7 +249,7 @@ func (b *Builder) compileVamLeaf(o dag.Op, parent vector.Puller) (vector.Puller,
 			metaFilter = mf.Expr
 			metaProjection = mf.Projection
 		}
-		pushdown := b.newMetaPushdown(metaFilter, o.Pushdown.Projection, metaProjection)
+		pushdown := b.newMetaPushdown(metaFilter, o.Pushdown.Projection, metaProjection, o.Pushdown.Unordered)
 		return b.env.VectorOpen(b.rctx, b.sctx(), o.Path, o.Format, pushdown)
 	case *dag.Filter:
 		e, err := b.compileVamExpr(o.Expr)

--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -42,9 +42,6 @@ func (o *Optimizer) Parallelize(seq dag.Seq, n int) (dag.Seq, error) {
 			}
 			front.Append(scan)
 			parallel, err = o.parallelizeFileScan(seq[1:], n)
-			// If we can parallelize, then parallel[0] is a
-			// dag.Scatter, for which input order doesn't matter.
-			scan.Pushdown.Unordered = len(parallel) > 0
 		}
 		if err != nil {
 			return nil, err

--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -40,6 +40,9 @@ func (o *Optimizer) Parallelize(seq dag.Seq, n int) (dag.Seq, error) {
 			}
 			front.Append(scan)
 			parallel, err = o.parallelizeFileScan(seq[1:], n)
+			// If we can parallelize, then parallel[0] is a
+			// dag.Scatter, for which input order doesn't matter.
+			scan.Pushdown.Unordered = len(parallel) > 0
 		}
 		if err != nil {
 			return nil, err

--- a/compiler/ztests/merge-filters.yaml
+++ b/compiler/ztests/merge-filters.yaml
@@ -15,9 +15,9 @@ outputs:
       ===
       fork (
         =>
-          file a filter (b and c and g)
+          file a unordered filter (b and c and g)
         =>
-          file d filter (e and f and g)
+          file d unordered filter (e and f and g)
       )
       | output main
       ===

--- a/compiler/ztests/par-groupby-func.yaml
+++ b/compiler/ztests/par-groupby-func.yaml
@@ -25,7 +25,7 @@ outputs:
           union:=union(s) by n:=n
       | output main
       ===
-      file test.csup format csup fields a,b unordered
+      file test.csup format csup unordered fields a,b
       | scatter (
         =>
           aggregate partials-out

--- a/compiler/ztests/par-groupby-func.yaml
+++ b/compiler/ztests/par-groupby-func.yaml
@@ -3,6 +3,8 @@ script: |
   super db init -q
   super db create -q -orderby s:asc test
   super db compile -P 2 -C "from test | union(s) by n:=len(s)" | sed -e 's/pool .*/.../'
+  echo ===
+  SUPER_VAM=1 super compile -C -P 2 'from test.csup | summarize count(a) by b'
 
 outputs:
   - name: stdout
@@ -21,4 +23,18 @@ outputs:
       | combine
       | aggregate partials-in
           union:=union(s) by n:=n
+      | output main
+      ===
+      file test.csup format csup fields a,b unordered
+      | scatter (
+        =>
+          aggregate partials-out
+              count:=count(a) by b:=b
+        =>
+          aggregate partials-out
+              count:=count(a) by b:=b
+      )
+      | combine
+      | aggregate partials-in
+          count:=count(a) by b:=b
       | output main

--- a/compiler/ztests/par-sort.yaml
+++ b/compiler/ztests/par-sort.yaml
@@ -4,7 +4,7 @@ script: |
 outputs:
   - name: stdout
     data: |
-      file test.csup format csup fields a,b,c unordered
+      file test.csup format csup unordered fields a,b,c
       | scatter (
         =>
           sort a asc nulls last, b desc nulls last

--- a/compiler/ztests/par-sort.yaml
+++ b/compiler/ztests/par-sort.yaml
@@ -1,0 +1,16 @@
+script: |
+  SUPER_VAM=1 super compile -C -P 2 'from test.csup | sort a | yield b'
+
+outputs:
+  - name: stdout
+    data: |
+      file test.csup format csup fields a,b unordered
+      | scatter (
+        =>
+          sort a asc nulls last
+        =>
+          sort a asc nulls last
+      )
+      | merge a asc nulls last
+      | yield b
+      | output main

--- a/compiler/ztests/par-top.yaml
+++ b/compiler/ztests/par-top.yaml
@@ -7,6 +7,8 @@ script: |
   super db compile -C -P 2 'from test | top 3 a' | sed -e 's/pool .*/.../'
   echo ===
   super db compile -C -P 2 'from test | top 3 b desc' | sed -e 's/pool .*/.../'
+  echo ===
+  SUPER_VAM=1 super compile -C -P 2 'from test.csup | top 3 a | yield b'
 
 outputs:
   - name: stdout
@@ -46,4 +48,16 @@ outputs:
       )
       | merge b desc nulls last
       | head 3
+      | output main
+      ===
+      file test.csup format csup fields a,b unordered
+      | scatter (
+        =>
+          top 3 a asc nulls last
+        =>
+          top 3 a asc nulls last
+      )
+      | merge a asc nulls last
+      | head 3
+      | yield b
       | output main

--- a/compiler/ztests/par-top.yaml
+++ b/compiler/ztests/par-top.yaml
@@ -50,7 +50,7 @@ outputs:
       | head 3
       | output main
       ===
-      file test.csup format csup fields a,b,c unordered
+      file test.csup format csup unordered fields a,b,c
       | scatter (
         =>
           top 3 a asc nulls last, b desc nulls last

--- a/compiler/ztests/pushdown-sort.yaml
+++ b/compiler/ztests/pushdown-sort.yaml
@@ -10,20 +10,20 @@ script: |
 outputs:
   - name: stdout
     data: |
-      file file1
+      file file1 unordered
       | sort
       | output main
       ===
-      file file1
+      file file1 unordered
       | sort
       | yield a
       | output main
       ===
-      file file1
+      file file1 unordered
       | sort a asc nulls last
       | output main
       ===
-      file file1 fields a,b
+      file file1 unordered fields a,b
       | sort a asc nulls last
       | yield b
       | output main

--- a/compiler/ztests/pushdown-top.yaml
+++ b/compiler/ztests/pushdown-top.yaml
@@ -10,20 +10,20 @@ script: |
 outputs:
   - name: stdout
     data: |
-      file file1
+      file file1 unordered
       | top 1
       | output main
       ===
-      file file1
+      file file1 unordered
       | top 1
       | yield a
       | output main
       ===
-      file file1
+      file file1 unordered
       | top 2 a asc nulls last
       | output main
       ===
-      file file1 fields a,b
+      file file1 unordered fields a,b
       | top 2 a asc nulls last
       | yield b
       | output main

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -25,12 +25,12 @@ outputs:
       | yield c, b, d
       | output main
       ===
-      file file1
+      file file1 unordered
       | fork (
         =>
           pass
         =>
-          file file2
+          file file2 unordered
       )
       | join on a=a
       | yield b

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -16,6 +16,8 @@ type Pushdown interface {
 	DataFilter() (expr.Evaluator, error)
 	BSUPFilter() (*expr.BufferFilter, error)
 	MetaFilter() (expr.Evaluator, field.Projection, error)
+	// Undordered reports whether a reader may return values in arbirary order.
+	Unordered() bool
 }
 
 // ScannerAble is implemented by Readers that provide an optimized

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -545,11 +545,11 @@ func (c *canonDAG) op(p dag.Op) {
 		if p.Format != "" {
 			c.write(" format %s", p.Format)
 		}
-		if len(p.Pushdown.Projection) > 0 {
-			c.fields(p.Pushdown.Projection)
-		}
 		if p.Pushdown.Unordered {
 			c.write(" unordered")
+		}
+		if len(p.Pushdown.Projection) > 0 {
+			c.fields(p.Pushdown.Projection)
 		}
 		if df := p.Pushdown.DataFilter; df != nil {
 			if len(df.Projection) > 0 {

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -548,6 +548,9 @@ func (c *canonDAG) op(p dag.Op) {
 		if len(p.Pushdown.Projection) > 0 {
 			c.fields(p.Pushdown.Projection)
 		}
+		if p.Pushdown.Unordered {
+			c.write(" unordered")
+		}
 		if df := p.Pushdown.DataFilter; df != nil {
 			if len(df.Projection) > 0 {
 				c.fields(df.Projection)


### PR DESCRIPTION
This provides a way for the optimizer to inform readers that they do not
need to preserve the order of values in a file and instead may return
values in arbitrary order.

It adds:

* A dag.Pushdown.Unordered field of type bool

* Logic in compiler/optimizer.setPushdownUnordered to set
  dag.Pushdown.Unordered in a dag.FileScan to true input order to the
  downstream DAG does not matter.

* An Unordered method in the zbuf.Pushdown interface to
  communicate the value of dag.Pushdown.Unordered to readers.