### PR TITLE
csup: Encode offsets and bytes separate for strings

### DIFF
--- a/csup/bytes.go
+++ b/csup/bytes.go
@@ -1,0 +1,79 @@
+package csup
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/zcode"
+	"golang.org/x/sync/errgroup"
+)
+
+type BytesEncoder struct {
+	typ      super.Type
+	min, max []byte
+	bytes    zcode.Bytes
+	offsets  Uint32Encoder
+
+	// These values are used for the Encode pass.
+	bytesFmt uint8
+	bytesOut []byte
+	bytesLen uint64
+}
+
+func NewBytesEncoder(typ super.Type) *BytesEncoder {
+	return &BytesEncoder{typ: typ, offsets: Uint32Encoder{vals: []uint32{0}}}
+}
+
+func (b *BytesEncoder) Write(vb zcode.Bytes) {
+	if len(b.bytes) == 0 || bytes.Compare(vb, b.min) < 0 {
+		b.min = append(b.min[:0], vb...)
+	}
+	if len(b.bytes) == 0 || bytes.Compare(vb, b.max) > 0 {
+		b.max = append(b.max[:0], vb...)
+	}
+	b.bytes = append(b.bytes, vb...)
+	b.offsets.Write(uint32(len(b.bytes)))
+}
+
+func (b *BytesEncoder) Encode(group *errgroup.Group) {
+	group.Go(func() error {
+		fmt, out, err := compressBuffer(b.bytes)
+		if err != nil {
+			return err
+		}
+		b.bytesFmt = fmt
+		b.bytesOut = out
+		b.bytesLen = uint64(len(b.bytes))
+		b.bytes = nil // send to GC
+		return nil
+	})
+	b.offsets.Encode(group)
+}
+
+func (b *BytesEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
+	bytesLoc := Segment{
+		Offset:            off,
+		Length:            uint64(len(b.bytesOut)),
+		MemLength:         b.bytesLen,
+		CompressionFormat: b.bytesFmt,
+	}
+	off, offsLoc := b.offsets.Segment(off + bytesLoc.Length)
+	return off, cctx.enter(&Bytes{
+		Typ:     b.typ,
+		Bytes:   bytesLoc,
+		Offsets: offsLoc,
+		Min:     b.min,
+		Max:     b.max,
+		Count:   uint32(len(b.offsets.vals) - 1),
+	})
+}
+
+func (b *BytesEncoder) Emit(w io.Writer) error {
+	if len(b.bytesOut) > 0 {
+		if _, err := w.Write(b.bytesOut); err != nil {
+			return err
+		}
+	}
+	return b.offsets.Emit(w)
+}

--- a/csup/encoder.go
+++ b/csup/encoder.go
@@ -64,6 +64,8 @@ func newPrimitiveEncoder(typ super.Type) Encoder {
 		return NewUintEncoder(typ)
 	case super.IsFloat(id):
 		return NewFloatEncoder(typ)
+	case id == super.IDBytes || id == super.IDString || id == super.IDType:
+		return NewBytesEncoder(typ)
 	default:
 		return NewPrimitiveEncoder(typ)
 	}

--- a/csup/header.go
+++ b/csup/header.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Version     = 11
+	Version     = 12
 	HeaderSize  = 28
 	MaxMetaSize = 100 * 1024 * 1024
 	MaxDataSize = 2 * 1024 * 1024 * 1024

--- a/csup/metadata.go
+++ b/csup/metadata.go
@@ -150,6 +150,23 @@ func (f *Float) Len(*Context) uint32 {
 	return f.Count
 }
 
+type Bytes struct {
+	Typ     super.Type `super:"Type"`
+	Bytes   Segment
+	Offsets Segment
+	Min     []byte
+	Max     []byte
+	Count   uint32
+}
+
+func (b *Bytes) Type(*Context, *super.Context) super.Type {
+	return b.Typ
+}
+
+func (b *Bytes) Len(*Context) uint32 {
+	return b.Count
+}
+
 type Primitive struct {
 	Typ      super.Type `super:"Type"`
 	Location Segment
@@ -278,6 +295,8 @@ func metadataValue(cctx *Context, sctx *super.Context, b *zcode.Builder, id ID, 
 		return metadataLeaf(sctx, b, super.NewUint(m.Typ, m.Min), super.NewUint(m.Typ, m.Max))
 	case *Float:
 		return metadataLeaf(sctx, b, super.NewFloat(m.Typ, m.Min), super.NewFloat(m.Typ, m.Max))
+	case *Bytes:
+		return metadataLeaf(sctx, b, super.NewValue(m.Typ, m.Min), super.NewValue(m.Typ, m.Max))
 	case *Const:
 		return metadataLeaf(sctx, b, m.Value, m.Value)
 	default:
@@ -312,6 +331,7 @@ var Template = []any{
 	Int{},
 	Uint{},
 	Float{},
+	Bytes{},
 	Primitive{},
 	Named{},
 	Error{},

--- a/csup/ztests/const.yaml
+++ b/csup/ztests/const.yaml
@@ -12,5 +12,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {Version:11(uint32),MetaSize:35(uint64),DataSize:0(uint64),Root:0(uint32)}
+      {Version:12(uint32),MetaSize:35(uint64),DataSize:0(uint64),Root:0(uint32)}
       {Value:1,Count:3(uint32)}(=Const)

--- a/runtime/vcache/bytes.go
+++ b/runtime/vcache/bytes.go
@@ -1,0 +1,77 @@
+package vcache
+
+import (
+	"sync"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/csup"
+	"github.com/brimdata/super/pkg/field"
+	"github.com/brimdata/super/vector"
+	"github.com/brimdata/super/vector/bitvec"
+)
+
+type bytes struct {
+	mu   sync.Mutex
+	meta *csup.Bytes
+	count
+	nulls *nulls
+	table *vector.BytesTable
+}
+
+func newBytes(cctx *csup.Context, meta *csup.Bytes, nulls *nulls) *bytes {
+	return &bytes{
+		meta:  meta,
+		count: count{meta.Count, nulls.count()},
+		nulls: nulls,
+	}
+}
+
+func (*bytes) unmarshal(*csup.Context, field.Projection) {}
+
+func (b *bytes) project(loader *loader, projection field.Projection) vector.Any {
+	if len(projection) > 0 {
+		return vector.NewMissing(loader.sctx, b.length())
+	}
+	table, nulls := b.load(loader)
+	switch b.meta.Typ.ID() {
+	case super.IDString:
+		return vector.NewString(table, nulls)
+	case super.IDBytes:
+		return vector.NewBytes(table, nulls)
+	case super.IDType:
+		return vector.NewTypeValue(table, nulls)
+	default:
+		panic(b.meta.Typ)
+	}
+}
+
+func (b *bytes) load(loader *loader) (vector.BytesTable, bitvec.Bits) {
+	nulls := b.nulls.get(loader)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.table != nil {
+		return *b.table, nulls
+	}
+	offsets, err := loadOffsets(loader.r, b.meta.Offsets, b.count, nulls)
+	if err != nil {
+		panic(err)
+	}
+	bytes := make([]byte, b.meta.Bytes.MemLength)
+	if err := b.meta.Bytes.Read(loader.r, bytes); err != nil {
+		panic(err)
+	}
+	table := vector.NewBytesTable(offsets, bytes)
+	b.table = &table
+	return table, nulls
+}
+
+type bytesLoader struct {
+	loader *loader
+	shadow *bytes
+}
+
+var _ vector.BytesLoader = (*bytesLoader)(nil)
+
+func (b *bytesLoader) Load() (vector.BytesTable, bitvec.Bits) {
+	return b.shadow.load(b.loader)
+}

--- a/runtime/vcache/shadow.go
+++ b/runtime/vcache/shadow.go
@@ -82,6 +82,8 @@ func newShadow(cctx *csup.Context, id csup.ID, nulls *nulls) shadow {
 		return newUint(cctx, meta, nulls)
 	case *csup.Float:
 		return newFloat(cctx, meta, nulls)
+	case *csup.Bytes:
+		return newBytes(cctx, meta, nulls)
 	case *csup.Primitive:
 		return newPrimitive(cctx, meta, nulls)
 	case *csup.Const:


### PR DESCRIPTION
This commit changes the CSUP encoding for strings, type values, and bytes
    values where the offsets of string/byte vectors are stored as an array of
    uint32 values and bytes are stored as compressed bytes.