### PR TITLE
Improve pushdown projection for join operator

### DIFF
--- a/compiler/optimizer/demand/demand.go
+++ b/compiler/optimizer/demand/demand.go
@@ -94,27 +94,25 @@ func Delete(a, b Demand) Demand {
 	return aa
 }
 
-func Union(a Demand, b Demand) Demand {
-	if _, ok := a.(all); ok {
-		return a
-	}
-	if _, ok := b.(all); ok {
-		return b
-	}
-
-	{
-		a, b := a.(keys), b.(keys)
-		demand := make(keys, len(a)+len(b))
-		maps.Copy(demand, a)
-		for k, v := range b {
-			if v2, ok := a[k]; ok {
-				demand[k] = Union(v, v2)
-			} else {
-				demand[k] = v
+func Union(demands ...Demand) Demand {
+	out := None().(keys)
+	for _, d := range demands {
+		switch d := d.(type) {
+		case all:
+			return All()
+		case keys:
+			for k, v := range d {
+				if v2, ok := out[k]; ok {
+					out[k] = Union(v, v2)
+				} else {
+					out[k] = v
+				}
 			}
+		default:
+			panic("Unreachable")
 		}
-		return demand
 	}
+	return out
 }
 
 func GetKey(demand Demand, key string) Demand {

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -1,7 +1,14 @@
 script: |
+  echo === debug
+  super compile -C -O 'from file | debug a | yield b'
+  echo === fork-join
+  super compile -C -O 'fork (=> from file1 => from file2) | join on a b | yield c'
+  echo === join
+  super compile -C -O "from file1 | join (from file2) on a b | yield c"
+  echo === switch-join
+  super compile -C -O 'from file | switch a (case b => put x:=c case d => put x:=e ) | join on f g | yield h'
+  echo === where
   super compile -C -O "from file | a==1 or e==2 | yield c, b, d"
-  echo ===
-  super compile -C -O "from file1 | join (from file2) on a | yield b"
   echo ===
   export SUPER_DB_LAKE=test
   super db init -q
@@ -21,19 +28,51 @@ script: |
 outputs:
   - name: stdout
     data: |
-      file file fields a,b,c,d,e filter (a==1 or e==2)
-      | yield c, b, d
+      === debug
+      file file fields a,b
+      | mirror (
+        =>
+          yield a
+          | output debug
+        =>
+          yield b
+          | output main
+      )
+      === fork-join
+      fork (
+        =>
+          file file1 unordered fields a,c
+        =>
+          file file2 unordered fields a,b
+      )
+      | join on a=a b:=b
+      | yield c
       | output main
-      ===
-      file file1 unordered
+      === join
+      file file1 unordered fields a,c
       | fork (
         =>
           pass
         =>
-          file file2 unordered
+          file file2 unordered fields a,b
       )
-      | join on a=a
-      | yield b
+      | join on a=a b:=b
+      | yield c
+      | output main
+      === switch-join
+      file file unordered fields a,b,c,d,e,f,g,h
+      | switch a (
+          case b =>
+            put x:=c
+          case d =>
+            put x:=e
+        )
+        | join on f=f g:=g
+        | yield h
+        | output main
+      === where
+      file file fields a,b,c,d,e filter (a==1 or e==2)
+      | yield c, b, d
       | output main
       ===
       lister

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -115,7 +115,7 @@ func RunQuery(t testing.TB, sctx *super.Context, readers []zio.Reader, querySour
 		t.Skipf("%v", err)
 	}
 	if len(dag) > 0 {
-		demand := optimizer.DemandForSeq(dag, demand.All())
+		demand := demand.Union(optimizer.DemandForSeq(dag, demand.All())...)
 		useDemand(demand)
 	}
 


### PR DESCRIPTION
The optimizer gives up on pushdown projection when it encounters a dag.Join.  Make that more accurate, in part by changing optimizer.DemandForSeq and demandForOp to work with demand.Demand slices so they can accomodate distinct projections for the left and right dag.Join inputs.