### PR TITLE
Clear unused bits in vector/bitvec.Bits.GetBits

### DIFF
--- a/vector/bitvec/bits.go
+++ b/vector/bitvec/bits.go
@@ -32,7 +32,14 @@ func (b Bits) IsZero() bool {
 	return b.length == 0
 }
 
+// GetBits returns b's underlying storage with used bits cleared.
+// GetBits may modify the underlying storage.
 func (b Bits) GetBits() []uint64 {
+	if unusedBits := 64 - (b.length % 64); unusedBits < 64 {
+		// Clear unused bits.
+		mask := ^uint64(0) >> unusedBits
+		b.bits[len(b.bits)-1] &= mask
+	}
 	return b.bits
 }
 

--- a/vector/bitvec/bits_test.go
+++ b/vector/bitvec/bits_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBitsGetBits(t *testing.T) {
+	assert.Equal(t, []uint64{0x0f}, New([]uint64{0xff}, 4).GetBits())
+}
+
 func TestBitsTrueCount(t *testing.T) {
 	assert.EqualValues(t, 0, Zero.TrueCount())
 	bits := []uint64{0xff}


### PR DESCRIPTION
Bits.GetBits returns a uint64 slice in which unused bits (i.e., those in excess of Bits.length) may be set, leading to surprising behavior when the slice is passed to roaring.FromDense.  To avoid surprises those, clear unused bits in GetBits before returning the slice.

This fixes the following panic.

    $ echo 'null(int64)' | SUPER_VAM=1 go run -trimpath ./cmd/super -c 'yield this | where this is not null' -
    panic: runtime error: index out of range [1] with length 1
    goroutine 1 [running]:
    runtime/debug.Stack()
	    runtime/debug/stack.go:26 +0x64
    github.com/brimdata/super/runtime/sam/op.(*Catcher).Pull.func1()
	    github.com/brimdata/super/runtime/sam/op/catcher.go:25 +0x3c
    panic({0x10474b820?, 0x14000041170?})
	    runtime/panic.go:792 +0x124
    github.com/brimdata/super/vector.(*Int).Serialize(0x30?, 0x14000438ea0, 0x4850b01?)
	    github.com/brimdata/super/vector/int.go:46 +0x2bc
    github.com/brimdata/super/vector.(*View).Serialize(0x14000438bd0?, 0x102d38800?, 0x419520?)
	    github.com/brimdata/super/vector/view.go:95 +0x44
    github.com/brimdata/super/runtime/vam.(*Materializer).Pull(0x4?, 0x4?)
	    github.com/brimdata/super/runtime/vam/materialize.go:39 +0x148
    github.com/brimdata/super/runtime/sam/op.(*Single).Pull(0x14000438c30, 0xc0?)
	    github.com/brimdata/super/runtime/sam/op/mux.go:120 +0x3c
    github.com/brimdata/super/runtime/sam/op.(*Catcher).Pull(0x83ab0f716d498814?, 0x4c?)
	    github.com/brimdata/super/runtime/sam/op/catcher.go:28 +0x5c
    github.com/brimdata/super/runtime/exec.(*Query).Pull(0x140002219f8?, 0x14?)
	    github.com/brimdata/super/runtime/exec/query.go:49 +0x44
    github.com/brimdata/super/zbuf.CopyMux(0x14000221c98, {0x10483cc40, 0x14000438c60})
	    github.com/brimdata/super/zbuf/mux.go:40 +0x40
    github.com/brimdata/super/cmd/super/root.(*Command).Run(0x140003f0200, {0x1400003a0f0, 0x1, 0x1})
	    github.com/brimdata/super/cmd/super/root/command.go:167 +0x6d8
    github.com/brimdata/super/pkg/charm.path.run({0x140003ac298, 0x1, 0x1}, {0x1400003a0f0, 0x1, 0x0?})
	    github.com/brimdata/super/pkg/charm/path.go:11 +0x64
    github.com/brimdata/super/pkg/charm.(*Spec).Exec(0x1058641a0, {0x1400003a0d0, 0x3, 0x3})
	    github.com/brimdata/super/pkg/charm/charm.go:71 +0xdc
    main.main()
	    github.com/brimdata/super/cmd/super/main.go:40 +0x5c