### PR TITLE
Fix null handling for numeric casts of vector.View

### DIFF
--- a/runtime/vam/expr/cast/number.go
+++ b/runtime/vam/expr/cast/number.go
@@ -23,6 +23,9 @@ func castToNumber(vec vector.Any, typ super.Type, index []uint32) (vector.Any, [
 		return out, errs, true
 	}
 	nulls := vector.NullsOf(vec)
+	if index != nil {
+		nulls = nulls.Pick(index)
+	}
 	switch id := typ.ID(); {
 	case super.IsSigned(id):
 		vals, errs := toNumeric[int64](vec, typ, index)


### PR DESCRIPTION
This fixes the following bug.  (The output should be "1".)

    $ echo 'null(int64) 1' |
        SUPER_VAM=1 super -c 'yield this | where this is not null | yield int64(this)' -
    null(int64)

Fixes #5829.