### PR TITLE
Rename ast.Sort.Args and dag.Sort.Args to Exprs

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -443,8 +443,8 @@ type (
 	}
 	Sort struct {
 		Kind    string     `json:"kind" unpack:""`
+		Exprs   []SortExpr `json:"exprs"`
 		Reverse bool       `json:"reverse"`
-		Args    []SortExpr `json:"args"`
 		Loc     `json:"loc"`
 	}
 	Cut struct {

--- a/compiler/dag/op.go
+++ b/compiler/dag/op.go
@@ -139,7 +139,7 @@ type (
 	}
 	Sort struct {
 		Kind    string     `json:"kind" unpack:""`
-		Args    []SortExpr `json:"args"`
+		Exprs   []SortExpr `json:"exprs"`
 		Reverse bool       `json:"reverse"` // Always false if len(Args)>0.
 	}
 	Switch struct {

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -179,12 +179,12 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 	case *dag.Sort:
 		b.resetResetters()
 		var sortExprs []expr.SortExpr
-		for _, s := range v.Args {
-			k, err := b.compileExpr(s.Key)
+		for _, e := range v.Exprs {
+			k, err := b.compileExpr(e.Key)
 			if err != nil {
 				return nil, err
 			}
-			sortExprs = append(sortExprs, expr.NewSortExpr(k, s.Order, s.Nulls))
+			sortExprs = append(sortExprs, expr.NewSortExpr(k, e.Order, e.Nulls))
 		}
 		return sort.New(b.rctx, parent, sortExprs, v.Reverse, b.resetters), nil
 	case *dag.Head:

--- a/compiler/kernel/vop.go
+++ b/compiler/kernel/vop.go
@@ -296,12 +296,12 @@ func (b *Builder) compileVamLeaf(o dag.Op, parent vector.Puller) (vector.Puller,
 	case *dag.Sort:
 		b.resetResetters()
 		var sortExprs []expr.SortExpr
-		for _, s := range o.Args {
-			k, err := b.compileExpr(s.Key)
+		for _, e := range o.Exprs {
+			k, err := b.compileExpr(e.Key)
 			if err != nil {
 				return nil, err
 			}
-			sortExprs = append(sortExprs, expr.NewSortExpr(k, s.Order, s.Nulls))
+			sortExprs = append(sortExprs, expr.NewSortExpr(k, e.Order, e.Nulls))
 		}
 		return vamop.NewSort(b.rctx, parent, sortExprs, o.Reverse, b.resetters), nil
 	case *dag.Tail:

--- a/compiler/optimizer/demand.go
+++ b/compiler/optimizer/demand.go
@@ -118,7 +118,7 @@ func demandForSimpleOp(op dag.Op, downstream demand.Demand) demand.Demand {
 	case *dag.Shape:
 		return downstream
 	case *dag.Sort:
-		return demandForSortExprs(op.Args, downstream)
+		return demandForSortExprs(op.Exprs, downstream)
 	case *dag.Tail:
 		return downstream
 	case *dag.Top:

--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -27,7 +27,7 @@ func (o *Optimizer) analyzeSortKeys(op dag.Op, in order.SortKeys) (order.SortKey
 		}
 		return pool.SortKeys, nil
 	case *dag.Sort:
-		return sortKeysOfSortExprs(op.Args), nil
+		return sortKeysOfSortExprs(op.Exprs), nil
 	case *dag.Top:
 		return sortKeysOfSortExprs(op.Exprs), nil
 	}

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -670,7 +670,7 @@ func replaceSortAndHeadOrTailWithTop(seq dag.Seq) dag.Seq {
 				continue
 			}
 			var limit int
-			exprs := sort.Args
+			exprs := sort.Exprs
 			reverse := sort.Reverse
 			switch op := seq[i+1].(type) {
 			case *dag.Head:

--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -198,7 +198,7 @@ func (o *Optimizer) liftIntoParPaths(seq dag.Seq) {
 			op.Keys[k].RHS = op.Keys[k].LHS
 		}
 	case *dag.Sort:
-		merge, ok := canLiftSortOrTopIntoParPaths(merge, op.Args)
+		merge, ok := canLiftSortOrTopIntoParPaths(merge, op.Exprs)
 		if !ok {
 			return
 		}
@@ -297,13 +297,13 @@ func (o *Optimizer) concurrentPath(seq dag.Seq, sortKeys order.SortKeys) (length
 			}
 			return k, nil, false, nil
 		case *dag.Sort:
-			if len(op.Args) == 0 {
+			if len(op.Exprs) == 0 {
 				// No analysis for sort without expression since we can't
 				// parallelize the heuristic.  We should revisit these semantics
 				// and define a global order across Zed type.
 				return 0, nil, false, nil
 			}
-			return k, op.Args, false, nil
+			return k, op.Exprs, false, nil
 		case *dag.Top:
 			if len(op.Exprs) == 0 {
 				// No analysis for top without expression since we can't

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -3250,30 +3250,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 439, col: 1, offset: 10706},
+			pos:  position{line: 439, col: 1, offset: 10707},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 12, offset: 10717},
+				pos: position{line: 439, col: 12, offset: 10718},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 439, col: 12, offset: 10717},
+					pos:   position{line: 439, col: 12, offset: 10718},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 439, col: 17, offset: 10722},
+						pos: position{line: 439, col: 17, offset: 10723},
 						expr: &actionExpr{
-							pos: position{line: 439, col: 18, offset: 10723},
+							pos: position{line: 439, col: 18, offset: 10724},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 439, col: 18, offset: 10723},
+								pos: position{line: 439, col: 18, offset: 10724},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 439, col: 18, offset: 10723},
+										pos:  position{line: 439, col: 18, offset: 10724},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 439, col: 20, offset: 10725},
+										pos:   position{line: 439, col: 20, offset: 10726},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 439, col: 22, offset: 10727},
+											pos:  position{line: 439, col: 22, offset: 10728},
 											name: "SortArg",
 										},
 									},
@@ -3288,12 +3288,12 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 441, col: 1, offset: 10784},
+			pos:  position{line: 441, col: 1, offset: 10785},
 			expr: &actionExpr{
-				pos: position{line: 442, col: 5, offset: 10796},
+				pos: position{line: 442, col: 5, offset: 10797},
 				run: (*parser).callonSortArg1,
 				expr: &litMatcher{
-					pos:        position{line: 442, col: 5, offset: 10796},
+					pos:        position{line: 442, col: 5, offset: 10797},
 					val:        "-r",
 					ignoreCase: false,
 					want:       "\"-r\"",
@@ -3304,52 +3304,52 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 444, col: 1, offset: 10860},
+			pos:  position{line: 444, col: 1, offset: 10861},
 			expr: &actionExpr{
-				pos: position{line: 445, col: 5, offset: 10870},
+				pos: position{line: 445, col: 5, offset: 10871},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 445, col: 5, offset: 10870},
+					pos: position{line: 445, col: 5, offset: 10871},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 445, col: 5, offset: 10870},
+							pos:  position{line: 445, col: 5, offset: 10871},
 							name: "TOP",
 						},
 						&andExpr{
-							pos: position{line: 445, col: 9, offset: 10874},
+							pos: position{line: 445, col: 9, offset: 10875},
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 10, offset: 10875},
+								pos:  position{line: 445, col: 10, offset: 10876},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 15, offset: 10880},
+							pos:   position{line: 445, col: 15, offset: 10881},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 20, offset: 10885},
+								pos:  position{line: 445, col: 20, offset: 10886},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 29, offset: 10894},
+							pos:   position{line: 445, col: 29, offset: 10895},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 445, col: 35, offset: 10900},
+								pos: position{line: 445, col: 35, offset: 10901},
 								expr: &actionExpr{
-									pos: position{line: 445, col: 36, offset: 10901},
+									pos: position{line: 445, col: 36, offset: 10902},
 									run: (*parser).callonTopOp10,
 									expr: &seqExpr{
-										pos: position{line: 445, col: 36, offset: 10901},
+										pos: position{line: 445, col: 36, offset: 10902},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 445, col: 36, offset: 10901},
+												pos:  position{line: 445, col: 36, offset: 10902},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 445, col: 38, offset: 10903},
+												pos:   position{line: 445, col: 38, offset: 10904},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 445, col: 40, offset: 10905},
+													pos:  position{line: 445, col: 40, offset: 10906},
 													name: "Expr",
 												},
 											},
@@ -3359,25 +3359,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 65, offset: 10930},
+							pos:   position{line: 445, col: 65, offset: 10931},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 445, col: 71, offset: 10936},
+								pos: position{line: 445, col: 71, offset: 10937},
 								expr: &actionExpr{
-									pos: position{line: 445, col: 72, offset: 10937},
+									pos: position{line: 445, col: 72, offset: 10938},
 									run: (*parser).callonTopOp17,
 									expr: &seqExpr{
-										pos: position{line: 445, col: 72, offset: 10937},
+										pos: position{line: 445, col: 72, offset: 10938},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 445, col: 72, offset: 10937},
+												pos:  position{line: 445, col: 72, offset: 10938},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 445, col: 74, offset: 10939},
+												pos:   position{line: 445, col: 74, offset: 10940},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 445, col: 76, offset: 10941},
+													pos:  position{line: 445, col: 76, offset: 10942},
 													name: "OrderByList",
 												},
 											},
@@ -3394,26 +3394,26 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 463, col: 1, offset: 11321},
+			pos:  position{line: 463, col: 1, offset: 11322},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 5, offset: 11331},
+				pos: position{line: 464, col: 5, offset: 11332},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 464, col: 5, offset: 11331},
+					pos: position{line: 464, col: 5, offset: 11332},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 464, col: 5, offset: 11331},
+							pos:  position{line: 464, col: 5, offset: 11332},
 							name: "CUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 464, col: 9, offset: 11335},
+							pos:  position{line: 464, col: 9, offset: 11336},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 464, col: 11, offset: 11337},
+							pos:   position{line: 464, col: 11, offset: 11338},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 464, col: 16, offset: 11342},
+								pos:  position{line: 464, col: 16, offset: 11343},
 								name: "FlexAssignments",
 							},
 						},
@@ -3425,26 +3425,26 @@ var g = &grammar{
 		},
 		{
 			name: "DistinctOp",
-			pos:  position{line: 472, col: 1, offset: 11490},
+			pos:  position{line: 472, col: 1, offset: 11491},
 			expr: &actionExpr{
-				pos: position{line: 473, col: 5, offset: 11505},
+				pos: position{line: 473, col: 5, offset: 11506},
 				run: (*parser).callonDistinctOp1,
 				expr: &seqExpr{
-					pos: position{line: 473, col: 5, offset: 11505},
+					pos: position{line: 473, col: 5, offset: 11506},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 473, col: 5, offset: 11505},
+							pos:  position{line: 473, col: 5, offset: 11506},
 							name: "DISTINCT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 473, col: 14, offset: 11514},
+							pos:  position{line: 473, col: 14, offset: 11515},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 473, col: 16, offset: 11516},
+							pos:   position{line: 473, col: 16, offset: 11517},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 473, col: 18, offset: 11518},
+								pos:  position{line: 473, col: 18, offset: 11519},
 								name: "Expr",
 							},
 						},
@@ -3456,26 +3456,26 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 481, col: 1, offset: 11654},
+			pos:  position{line: 481, col: 1, offset: 11655},
 			expr: &actionExpr{
-				pos: position{line: 482, col: 5, offset: 11665},
+				pos: position{line: 482, col: 5, offset: 11666},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 482, col: 5, offset: 11665},
+					pos: position{line: 482, col: 5, offset: 11666},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 482, col: 5, offset: 11665},
+							pos:  position{line: 482, col: 5, offset: 11666},
 							name: "DROP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 482, col: 10, offset: 11670},
+							pos:  position{line: 482, col: 10, offset: 11671},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 482, col: 12, offset: 11672},
+							pos:   position{line: 482, col: 12, offset: 11673},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 482, col: 17, offset: 11677},
+								pos:  position{line: 482, col: 17, offset: 11678},
 								name: "Lvals",
 							},
 						},
@@ -3487,45 +3487,45 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 490, col: 1, offset: 11817},
+			pos:  position{line: 490, col: 1, offset: 11818},
 			expr: &choiceExpr{
-				pos: position{line: 491, col: 5, offset: 11828},
+				pos: position{line: 491, col: 5, offset: 11829},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 491, col: 5, offset: 11828},
+						pos: position{line: 491, col: 5, offset: 11829},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 491, col: 5, offset: 11828},
+							pos: position{line: 491, col: 5, offset: 11829},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 491, col: 6, offset: 11829},
+									pos: position{line: 491, col: 6, offset: 11830},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 491, col: 6, offset: 11829},
+											pos:  position{line: 491, col: 6, offset: 11830},
 											name: "HEAD",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 491, col: 13, offset: 11836},
+											pos:  position{line: 491, col: 13, offset: 11837},
 											name: "LIMIT",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 491, col: 20, offset: 11843},
+									pos:  position{line: 491, col: 20, offset: 11844},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 491, col: 22, offset: 11845},
+									pos: position{line: 491, col: 22, offset: 11846},
 									expr: &ruleRefExpr{
-										pos:  position{line: 491, col: 23, offset: 11846},
+										pos:  position{line: 491, col: 23, offset: 11847},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 491, col: 31, offset: 11854},
+									pos:   position{line: 491, col: 31, offset: 11855},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 491, col: 37, offset: 11860},
+										pos:  position{line: 491, col: 37, offset: 11861},
 										name: "Expr",
 									},
 								},
@@ -3533,26 +3533,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 498, col: 5, offset: 11990},
+						pos: position{line: 498, col: 5, offset: 11991},
 						run: (*parser).callonHeadOp12,
 						expr: &seqExpr{
-							pos: position{line: 498, col: 5, offset: 11990},
+							pos: position{line: 498, col: 5, offset: 11991},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 498, col: 5, offset: 11990},
+									pos:  position{line: 498, col: 5, offset: 11991},
 									name: "HEAD",
 								},
 								&notExpr{
-									pos: position{line: 498, col: 10, offset: 11995},
+									pos: position{line: 498, col: 10, offset: 11996},
 									expr: &seqExpr{
-										pos: position{line: 498, col: 12, offset: 11997},
+										pos: position{line: 498, col: 12, offset: 11998},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 498, col: 12, offset: 11997},
+												pos:  position{line: 498, col: 12, offset: 11998},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 498, col: 15, offset: 12000},
+												pos:        position{line: 498, col: 15, offset: 12001},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3561,9 +3561,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 498, col: 20, offset: 12005},
+									pos: position{line: 498, col: 20, offset: 12006},
 									expr: &ruleRefExpr{
-										pos:  position{line: 498, col: 21, offset: 12006},
+										pos:  position{line: 498, col: 21, offset: 12007},
 										name: "EOKW",
 									},
 								},
@@ -3577,36 +3577,36 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 505, col: 1, offset: 12100},
+			pos:  position{line: 505, col: 1, offset: 12101},
 			expr: &choiceExpr{
-				pos: position{line: 506, col: 5, offset: 12111},
+				pos: position{line: 506, col: 5, offset: 12112},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 506, col: 5, offset: 12111},
+						pos: position{line: 506, col: 5, offset: 12112},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 506, col: 5, offset: 12111},
+							pos: position{line: 506, col: 5, offset: 12112},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 506, col: 5, offset: 12111},
+									pos:  position{line: 506, col: 5, offset: 12112},
 									name: "TAIL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 506, col: 10, offset: 12116},
+									pos:  position{line: 506, col: 10, offset: 12117},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 506, col: 12, offset: 12118},
+									pos: position{line: 506, col: 12, offset: 12119},
 									expr: &ruleRefExpr{
-										pos:  position{line: 506, col: 13, offset: 12119},
+										pos:  position{line: 506, col: 13, offset: 12120},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 506, col: 21, offset: 12127},
+									pos:   position{line: 506, col: 21, offset: 12128},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 506, col: 27, offset: 12133},
+										pos:  position{line: 506, col: 27, offset: 12134},
 										name: "Expr",
 									},
 								},
@@ -3614,26 +3614,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 513, col: 5, offset: 12263},
+						pos: position{line: 513, col: 5, offset: 12264},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 513, col: 5, offset: 12263},
+							pos: position{line: 513, col: 5, offset: 12264},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 513, col: 5, offset: 12263},
+									pos:  position{line: 513, col: 5, offset: 12264},
 									name: "TAIL",
 								},
 								&notExpr{
-									pos: position{line: 513, col: 10, offset: 12268},
+									pos: position{line: 513, col: 10, offset: 12269},
 									expr: &seqExpr{
-										pos: position{line: 513, col: 12, offset: 12270},
+										pos: position{line: 513, col: 12, offset: 12271},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 513, col: 12, offset: 12270},
+												pos:  position{line: 513, col: 12, offset: 12271},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 513, col: 15, offset: 12273},
+												pos:        position{line: 513, col: 15, offset: 12274},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3642,9 +3642,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 513, col: 20, offset: 12278},
+									pos: position{line: 513, col: 20, offset: 12279},
 									expr: &ruleRefExpr{
-										pos:  position{line: 513, col: 21, offset: 12279},
+										pos:  position{line: 513, col: 21, offset: 12280},
 										name: "EOKW",
 									},
 								},
@@ -3658,26 +3658,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 520, col: 1, offset: 12373},
+			pos:  position{line: 520, col: 1, offset: 12374},
 			expr: &actionExpr{
-				pos: position{line: 521, col: 5, offset: 12385},
+				pos: position{line: 521, col: 5, offset: 12386},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 521, col: 5, offset: 12385},
+					pos: position{line: 521, col: 5, offset: 12386},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 521, col: 5, offset: 12385},
+							pos:  position{line: 521, col: 5, offset: 12386},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 521, col: 11, offset: 12391},
+							pos:  position{line: 521, col: 11, offset: 12392},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 521, col: 13, offset: 12393},
+							pos:   position{line: 521, col: 13, offset: 12394},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 521, col: 18, offset: 12398},
+								pos:  position{line: 521, col: 18, offset: 12399},
 								name: "Expr",
 							},
 						},
@@ -3689,26 +3689,26 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 529, col: 1, offset: 12525},
+			pos:  position{line: 529, col: 1, offset: 12526},
 			expr: &choiceExpr{
-				pos: position{line: 530, col: 5, offset: 12536},
+				pos: position{line: 530, col: 5, offset: 12537},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 530, col: 5, offset: 12536},
+						pos: position{line: 530, col: 5, offset: 12537},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 530, col: 5, offset: 12536},
+							pos: position{line: 530, col: 5, offset: 12537},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 530, col: 5, offset: 12536},
+									pos:  position{line: 530, col: 5, offset: 12537},
 									name: "UNIQ",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 530, col: 10, offset: 12541},
+									pos:  position{line: 530, col: 10, offset: 12542},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 530, col: 12, offset: 12543},
+									pos:        position{line: 530, col: 12, offset: 12544},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3717,26 +3717,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 533, col: 5, offset: 12628},
+						pos: position{line: 533, col: 5, offset: 12629},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 533, col: 5, offset: 12628},
+							pos: position{line: 533, col: 5, offset: 12629},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 5, offset: 12628},
+									pos:  position{line: 533, col: 5, offset: 12629},
 									name: "UNIQ",
 								},
 								&notExpr{
-									pos: position{line: 533, col: 10, offset: 12633},
+									pos: position{line: 533, col: 10, offset: 12634},
 									expr: &seqExpr{
-										pos: position{line: 533, col: 12, offset: 12635},
+										pos: position{line: 533, col: 12, offset: 12636},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 533, col: 12, offset: 12635},
+												pos:  position{line: 533, col: 12, offset: 12636},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 533, col: 15, offset: 12638},
+												pos:        position{line: 533, col: 15, offset: 12639},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3745,9 +3745,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 533, col: 20, offset: 12643},
+									pos: position{line: 533, col: 20, offset: 12644},
 									expr: &ruleRefExpr{
-										pos:  position{line: 533, col: 21, offset: 12644},
+										pos:  position{line: 533, col: 21, offset: 12645},
 										name: "EOKW",
 									},
 								},
@@ -3761,26 +3761,26 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 537, col: 1, offset: 12713},
+			pos:  position{line: 537, col: 1, offset: 12714},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 5, offset: 12723},
+				pos: position{line: 538, col: 5, offset: 12724},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 538, col: 5, offset: 12723},
+					pos: position{line: 538, col: 5, offset: 12724},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 538, col: 5, offset: 12723},
+							pos:  position{line: 538, col: 5, offset: 12724},
 							name: "PUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 538, col: 9, offset: 12727},
+							pos:  position{line: 538, col: 9, offset: 12728},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 538, col: 11, offset: 12729},
+							pos:   position{line: 538, col: 11, offset: 12730},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 538, col: 16, offset: 12734},
+								pos:  position{line: 538, col: 16, offset: 12735},
 								name: "Assignments",
 							},
 						},
@@ -3792,59 +3792,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 546, col: 1, offset: 12884},
+			pos:  position{line: 546, col: 1, offset: 12885},
 			expr: &actionExpr{
-				pos: position{line: 547, col: 5, offset: 12897},
+				pos: position{line: 547, col: 5, offset: 12898},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 547, col: 5, offset: 12897},
+					pos: position{line: 547, col: 5, offset: 12898},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 547, col: 5, offset: 12897},
+							pos:  position{line: 547, col: 5, offset: 12898},
 							name: "RENAME",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 547, col: 12, offset: 12904},
+							pos:  position{line: 547, col: 12, offset: 12905},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 547, col: 14, offset: 12906},
+							pos:   position{line: 547, col: 14, offset: 12907},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 547, col: 20, offset: 12912},
+								pos:  position{line: 547, col: 20, offset: 12913},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 547, col: 31, offset: 12923},
+							pos:   position{line: 547, col: 31, offset: 12924},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 547, col: 36, offset: 12928},
+								pos: position{line: 547, col: 36, offset: 12929},
 								expr: &actionExpr{
-									pos: position{line: 547, col: 37, offset: 12929},
+									pos: position{line: 547, col: 37, offset: 12930},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 547, col: 37, offset: 12929},
+										pos: position{line: 547, col: 37, offset: 12930},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 547, col: 37, offset: 12929},
+												pos:  position{line: 547, col: 37, offset: 12930},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 547, col: 40, offset: 12932},
+												pos:        position{line: 547, col: 40, offset: 12933},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 547, col: 44, offset: 12936},
+												pos:  position{line: 547, col: 44, offset: 12937},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 547, col: 47, offset: 12939},
+												pos:   position{line: 547, col: 47, offset: 12940},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 547, col: 50, offset: 12942},
+													pos:  position{line: 547, col: 50, offset: 12943},
 													name: "Assignment",
 												},
 											},
@@ -3861,28 +3861,28 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 560, col: 1, offset: 13407},
+			pos:  position{line: 560, col: 1, offset: 13408},
 			expr: &actionExpr{
-				pos: position{line: 561, col: 5, offset: 13418},
+				pos: position{line: 561, col: 5, offset: 13419},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 561, col: 5, offset: 13418},
+					pos: position{line: 561, col: 5, offset: 13419},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 561, col: 5, offset: 13418},
+							pos:  position{line: 561, col: 5, offset: 13419},
 							name: "FUSE",
 						},
 						&notExpr{
-							pos: position{line: 561, col: 10, offset: 13423},
+							pos: position{line: 561, col: 10, offset: 13424},
 							expr: &seqExpr{
-								pos: position{line: 561, col: 12, offset: 13425},
+								pos: position{line: 561, col: 12, offset: 13426},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 561, col: 12, offset: 13425},
+										pos:  position{line: 561, col: 12, offset: 13426},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 561, col: 15, offset: 13428},
+										pos:        position{line: 561, col: 15, offset: 13429},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3891,9 +3891,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 561, col: 20, offset: 13433},
+							pos: position{line: 561, col: 20, offset: 13434},
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 21, offset: 13434},
+								pos:  position{line: 561, col: 21, offset: 13435},
 								name: "EOKW",
 							},
 						},
@@ -3905,28 +3905,28 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 565, col: 1, offset: 13503},
+			pos:  position{line: 565, col: 1, offset: 13504},
 			expr: &actionExpr{
-				pos: position{line: 566, col: 5, offset: 13515},
+				pos: position{line: 566, col: 5, offset: 13516},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 566, col: 5, offset: 13515},
+					pos: position{line: 566, col: 5, offset: 13516},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 566, col: 5, offset: 13515},
+							pos:  position{line: 566, col: 5, offset: 13516},
 							name: "SHAPE",
 						},
 						&notExpr{
-							pos: position{line: 566, col: 11, offset: 13521},
+							pos: position{line: 566, col: 11, offset: 13522},
 							expr: &seqExpr{
-								pos: position{line: 566, col: 13, offset: 13523},
+								pos: position{line: 566, col: 13, offset: 13524},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 566, col: 13, offset: 13523},
+										pos:  position{line: 566, col: 13, offset: 13524},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 566, col: 16, offset: 13526},
+										pos:        position{line: 566, col: 16, offset: 13527},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3935,9 +3935,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 566, col: 21, offset: 13531},
+							pos: position{line: 566, col: 21, offset: 13532},
 							expr: &ruleRefExpr{
-								pos:  position{line: 566, col: 22, offset: 13532},
+								pos:  position{line: 566, col: 22, offset: 13533},
 								name: "EOKW",
 							},
 						},
@@ -3949,55 +3949,55 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 570, col: 1, offset: 13603},
+			pos:  position{line: 570, col: 1, offset: 13604},
 			expr: &actionExpr{
-				pos: position{line: 571, col: 5, offset: 13614},
+				pos: position{line: 571, col: 5, offset: 13615},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 571, col: 5, offset: 13614},
+					pos: position{line: 571, col: 5, offset: 13615},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 571, col: 5, offset: 13614},
+							pos:   position{line: 571, col: 5, offset: 13615},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 571, col: 11, offset: 13620},
+								pos:  position{line: 571, col: 11, offset: 13621},
 								name: "JoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 571, col: 21, offset: 13630},
+							pos:  position{line: 571, col: 21, offset: 13631},
 							name: "JOIN",
 						},
 						&labeledExpr{
-							pos:   position{line: 571, col: 26, offset: 13635},
+							pos:   position{line: 571, col: 26, offset: 13636},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 571, col: 37, offset: 13646},
+								pos:  position{line: 571, col: 37, offset: 13647},
 								name: "JoinRightInput",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 571, col: 52, offset: 13661},
+							pos:   position{line: 571, col: 52, offset: 13662},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 571, col: 54, offset: 13663},
+								pos:  position{line: 571, col: 54, offset: 13664},
 								name: "JoinExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 571, col: 63, offset: 13672},
+							pos:   position{line: 571, col: 63, offset: 13673},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 571, col: 71, offset: 13680},
+								pos: position{line: 571, col: 71, offset: 13681},
 								expr: &seqExpr{
-									pos: position{line: 571, col: 72, offset: 13681},
+									pos: position{line: 571, col: 72, offset: 13682},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 571, col: 72, offset: 13681},
+											pos:  position{line: 571, col: 72, offset: 13682},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 571, col: 74, offset: 13683},
+											pos:  position{line: 571, col: 74, offset: 13684},
 											name: "FlexAssignments",
 										},
 									},
@@ -4012,83 +4012,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 587, col: 1, offset: 14049},
+			pos:  position{line: 587, col: 1, offset: 14050},
 			expr: &choiceExpr{
-				pos: position{line: 588, col: 5, offset: 14063},
+				pos: position{line: 588, col: 5, offset: 14064},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 14063},
+						pos: position{line: 588, col: 5, offset: 14064},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 588, col: 5, offset: 14063},
+							pos: position{line: 588, col: 5, offset: 14064},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 588, col: 5, offset: 14063},
+									pos:  position{line: 588, col: 5, offset: 14064},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 588, col: 10, offset: 14068},
+									pos:  position{line: 588, col: 10, offset: 14069},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 589, col: 5, offset: 14098},
+						pos: position{line: 589, col: 5, offset: 14099},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 589, col: 5, offset: 14098},
+							pos: position{line: 589, col: 5, offset: 14099},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 5, offset: 14098},
+									pos:  position{line: 589, col: 5, offset: 14099},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 11, offset: 14104},
+									pos:  position{line: 589, col: 11, offset: 14105},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 590, col: 5, offset: 14134},
+						pos: position{line: 590, col: 5, offset: 14135},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 590, col: 5, offset: 14134},
+							pos: position{line: 590, col: 5, offset: 14135},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 590, col: 5, offset: 14134},
+									pos:  position{line: 590, col: 5, offset: 14135},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 590, col: 11, offset: 14140},
+									pos:  position{line: 590, col: 11, offset: 14141},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 591, col: 5, offset: 14169},
+						pos: position{line: 591, col: 5, offset: 14170},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 591, col: 5, offset: 14169},
+							pos: position{line: 591, col: 5, offset: 14170},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 591, col: 5, offset: 14169},
+									pos:  position{line: 591, col: 5, offset: 14170},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 591, col: 11, offset: 14175},
+									pos:  position{line: 591, col: 11, offset: 14176},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 592, col: 5, offset: 14205},
+						pos: position{line: 592, col: 5, offset: 14206},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 592, col: 5, offset: 14205},
+							pos:        position{line: 592, col: 5, offset: 14206},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4101,44 +4101,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 594, col: 1, offset: 14240},
+			pos:  position{line: 594, col: 1, offset: 14241},
 			expr: &choiceExpr{
-				pos: position{line: 595, col: 5, offset: 14259},
+				pos: position{line: 595, col: 5, offset: 14260},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 595, col: 5, offset: 14259},
+						pos: position{line: 595, col: 5, offset: 14260},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 595, col: 5, offset: 14259},
+							pos: position{line: 595, col: 5, offset: 14260},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 595, col: 5, offset: 14259},
+									pos:  position{line: 595, col: 5, offset: 14260},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 595, col: 8, offset: 14262},
+									pos:        position{line: 595, col: 8, offset: 14263},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 595, col: 12, offset: 14266},
+									pos:  position{line: 595, col: 12, offset: 14267},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 595, col: 15, offset: 14269},
+									pos:   position{line: 595, col: 15, offset: 14270},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 595, col: 17, offset: 14271},
+										pos:  position{line: 595, col: 17, offset: 14272},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 595, col: 21, offset: 14275},
+									pos:  position{line: 595, col: 21, offset: 14276},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 595, col: 24, offset: 14278},
+									pos:        position{line: 595, col: 24, offset: 14279},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4147,10 +4147,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 596, col: 5, offset: 14304},
+						pos: position{line: 596, col: 5, offset: 14305},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 596, col: 5, offset: 14304},
+							pos:        position{line: 596, col: 5, offset: 14305},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4163,36 +4163,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 598, col: 1, offset: 14328},
+			pos:  position{line: 598, col: 1, offset: 14329},
 			expr: &choiceExpr{
-				pos: position{line: 599, col: 5, offset: 14340},
+				pos: position{line: 599, col: 5, offset: 14341},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 599, col: 5, offset: 14340},
+						pos:  position{line: 599, col: 5, offset: 14341},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 600, col: 5, offset: 14349},
+						pos: position{line: 600, col: 5, offset: 14350},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 600, col: 5, offset: 14349},
+							pos: position{line: 600, col: 5, offset: 14350},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 600, col: 5, offset: 14349},
+									pos:        position{line: 600, col: 5, offset: 14350},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 600, col: 9, offset: 14353},
+									pos:   position{line: 600, col: 9, offset: 14354},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 600, col: 14, offset: 14358},
+										pos:  position{line: 600, col: 14, offset: 14359},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 600, col: 19, offset: 14363},
+									pos:        position{line: 600, col: 19, offset: 14364},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4207,44 +4207,44 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 602, col: 1, offset: 14389},
+			pos:  position{line: 602, col: 1, offset: 14390},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 5, offset: 14402},
+				pos: position{line: 603, col: 5, offset: 14403},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 603, col: 5, offset: 14402},
+					pos: position{line: 603, col: 5, offset: 14403},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 603, col: 5, offset: 14402},
+							pos:  position{line: 603, col: 5, offset: 14403},
 							name: "SAMPLE",
 						},
 						&andExpr{
-							pos: position{line: 603, col: 12, offset: 14409},
+							pos: position{line: 603, col: 12, offset: 14410},
 							expr: &ruleRefExpr{
-								pos:  position{line: 603, col: 13, offset: 14410},
+								pos:  position{line: 603, col: 13, offset: 14411},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 603, col: 18, offset: 14415},
+							pos:   position{line: 603, col: 18, offset: 14416},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 603, col: 23, offset: 14420},
+								pos: position{line: 603, col: 23, offset: 14421},
 								expr: &actionExpr{
-									pos: position{line: 603, col: 24, offset: 14421},
+									pos: position{line: 603, col: 24, offset: 14422},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 603, col: 24, offset: 14421},
+										pos: position{line: 603, col: 24, offset: 14422},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 603, col: 24, offset: 14421},
+												pos:  position{line: 603, col: 24, offset: 14422},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 603, col: 26, offset: 14423},
+												pos:   position{line: 603, col: 26, offset: 14424},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 603, col: 28, offset: 14425},
+													pos:  position{line: 603, col: 28, offset: 14426},
 													name: "Lval",
 												},
 											},
@@ -4261,15 +4261,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 616, col: 1, offset: 14864},
+			pos:  position{line: 616, col: 1, offset: 14865},
 			expr: &actionExpr{
-				pos: position{line: 617, col: 5, offset: 14881},
+				pos: position{line: 617, col: 5, offset: 14882},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 617, col: 5, offset: 14881},
+					pos:   position{line: 617, col: 5, offset: 14882},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 617, col: 7, offset: 14883},
+						pos:  position{line: 617, col: 7, offset: 14884},
 						name: "Assignments",
 					},
 				},
@@ -4279,69 +4279,69 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 625, col: 1, offset: 15055},
+			pos:  position{line: 625, col: 1, offset: 15056},
 			expr: &actionExpr{
-				pos: position{line: 626, col: 5, offset: 15066},
+				pos: position{line: 626, col: 5, offset: 15067},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 626, col: 5, offset: 15066},
+					pos: position{line: 626, col: 5, offset: 15067},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 5, offset: 15066},
+							pos:  position{line: 626, col: 5, offset: 15067},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 10, offset: 15071},
+							pos:  position{line: 626, col: 10, offset: 15072},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 12, offset: 15073},
+							pos:   position{line: 626, col: 12, offset: 15074},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 626, col: 17, offset: 15078},
+								pos:  position{line: 626, col: 17, offset: 15079},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 22, offset: 15083},
+							pos:   position{line: 626, col: 22, offset: 15084},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 626, col: 29, offset: 15090},
+								pos: position{line: 626, col: 29, offset: 15091},
 								expr: &ruleRefExpr{
-									pos:  position{line: 626, col: 29, offset: 15090},
+									pos:  position{line: 626, col: 29, offset: 15091},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 41, offset: 15102},
+							pos:   position{line: 626, col: 41, offset: 15103},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 626, col: 48, offset: 15109},
+								pos: position{line: 626, col: 48, offset: 15110},
 								expr: &ruleRefExpr{
-									pos:  position{line: 626, col: 48, offset: 15109},
+									pos:  position{line: 626, col: 48, offset: 15110},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 59, offset: 15120},
+							pos:   position{line: 626, col: 59, offset: 15121},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 626, col: 67, offset: 15128},
+								pos: position{line: 626, col: 67, offset: 15129},
 								expr: &ruleRefExpr{
-									pos:  position{line: 626, col: 67, offset: 15128},
+									pos:  position{line: 626, col: 67, offset: 15129},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 79, offset: 15140},
+							pos:   position{line: 626, col: 79, offset: 15141},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 626, col: 84, offset: 15145},
+								pos: position{line: 626, col: 84, offset: 15146},
 								expr: &ruleRefExpr{
-									pos:  position{line: 626, col: 84, offset: 15145},
+									pos:  position{line: 626, col: 84, offset: 15146},
 									name: "MetaArg",
 								},
 							},
@@ -4354,30 +4354,30 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 638, col: 1, offset: 15427},
+			pos:  position{line: 638, col: 1, offset: 15428},
 			expr: &actionExpr{
-				pos: position{line: 639, col: 5, offset: 15441},
+				pos: position{line: 639, col: 5, offset: 15442},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 639, col: 5, offset: 15441},
+					pos: position{line: 639, col: 5, offset: 15442},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 639, col: 5, offset: 15441},
+							pos:  position{line: 639, col: 5, offset: 15442},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 639, col: 7, offset: 15443},
+							pos:  position{line: 639, col: 7, offset: 15444},
 							name: "AUTHOR",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 639, col: 14, offset: 15450},
+							pos:  position{line: 639, col: 14, offset: 15451},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 639, col: 16, offset: 15452},
+							pos:   position{line: 639, col: 16, offset: 15453},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 18, offset: 15454},
+								pos:  position{line: 639, col: 18, offset: 15455},
 								name: "Name",
 							},
 						},
@@ -4389,30 +4389,30 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 641, col: 1, offset: 15478},
+			pos:  position{line: 641, col: 1, offset: 15479},
 			expr: &actionExpr{
-				pos: position{line: 642, col: 5, offset: 15493},
+				pos: position{line: 642, col: 5, offset: 15494},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 642, col: 5, offset: 15493},
+					pos: position{line: 642, col: 5, offset: 15494},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 642, col: 5, offset: 15493},
+							pos:  position{line: 642, col: 5, offset: 15494},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 642, col: 7, offset: 15495},
+							pos:  position{line: 642, col: 7, offset: 15496},
 							name: "MESSAGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 642, col: 15, offset: 15503},
+							pos:  position{line: 642, col: 15, offset: 15504},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 642, col: 17, offset: 15505},
+							pos:   position{line: 642, col: 17, offset: 15506},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 642, col: 19, offset: 15507},
+								pos:  position{line: 642, col: 19, offset: 15508},
 								name: "Name",
 							},
 						},
@@ -4424,30 +4424,30 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 644, col: 1, offset: 15531},
+			pos:  position{line: 644, col: 1, offset: 15532},
 			expr: &actionExpr{
-				pos: position{line: 645, col: 5, offset: 15543},
+				pos: position{line: 645, col: 5, offset: 15544},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 645, col: 5, offset: 15543},
+					pos: position{line: 645, col: 5, offset: 15544},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 645, col: 5, offset: 15543},
+							pos:  position{line: 645, col: 5, offset: 15544},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 645, col: 7, offset: 15545},
+							pos:  position{line: 645, col: 7, offset: 15546},
 							name: "META",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 645, col: 12, offset: 15550},
+							pos:  position{line: 645, col: 12, offset: 15551},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 645, col: 14, offset: 15552},
+							pos:   position{line: 645, col: 14, offset: 15553},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 645, col: 16, offset: 15554},
+								pos:  position{line: 645, col: 16, offset: 15555},
 								name: "Name",
 							},
 						},
@@ -4459,24 +4459,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 647, col: 1, offset: 15578},
+			pos:  position{line: 647, col: 1, offset: 15579},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 5, offset: 15593},
+				pos: position{line: 648, col: 5, offset: 15594},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 648, col: 5, offset: 15593},
+					pos: position{line: 648, col: 5, offset: 15594},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 648, col: 5, offset: 15593},
+							pos:        position{line: 648, col: 5, offset: 15594},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 648, col: 9, offset: 15597},
+							pos:   position{line: 648, col: 9, offset: 15598},
 							label: "branch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 648, col: 16, offset: 15604},
+								pos:  position{line: 648, col: 16, offset: 15605},
 								name: "Name",
 							},
 						},
@@ -4488,26 +4488,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 650, col: 1, offset: 15633},
+			pos:  position{line: 650, col: 1, offset: 15634},
 			expr: &actionExpr{
-				pos: position{line: 651, col: 5, offset: 15646},
+				pos: position{line: 651, col: 5, offset: 15647},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 651, col: 5, offset: 15646},
+					pos: position{line: 651, col: 5, offset: 15647},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 651, col: 5, offset: 15646},
+							pos:  position{line: 651, col: 5, offset: 15647},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 651, col: 12, offset: 15653},
+							pos:  position{line: 651, col: 12, offset: 15654},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 651, col: 14, offset: 15655},
+							pos:   position{line: 651, col: 14, offset: 15656},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 19, offset: 15660},
+								pos:  position{line: 651, col: 19, offset: 15661},
 								name: "Identifier",
 							},
 						},
@@ -4519,44 +4519,44 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 659, col: 1, offset: 15794},
+			pos:  position{line: 659, col: 1, offset: 15795},
 			expr: &actionExpr{
-				pos: position{line: 660, col: 5, offset: 15806},
+				pos: position{line: 660, col: 5, offset: 15807},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 660, col: 5, offset: 15806},
+					pos: position{line: 660, col: 5, offset: 15807},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 660, col: 5, offset: 15806},
+							pos:  position{line: 660, col: 5, offset: 15807},
 							name: "DEBUG",
 						},
 						&andExpr{
-							pos: position{line: 660, col: 11, offset: 15812},
+							pos: position{line: 660, col: 11, offset: 15813},
 							expr: &ruleRefExpr{
-								pos:  position{line: 660, col: 12, offset: 15813},
+								pos:  position{line: 660, col: 12, offset: 15814},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 660, col: 17, offset: 15818},
+							pos:   position{line: 660, col: 17, offset: 15819},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 660, col: 22, offset: 15823},
+								pos: position{line: 660, col: 22, offset: 15824},
 								expr: &actionExpr{
-									pos: position{line: 660, col: 23, offset: 15824},
+									pos: position{line: 660, col: 23, offset: 15825},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 660, col: 23, offset: 15824},
+										pos: position{line: 660, col: 23, offset: 15825},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 660, col: 23, offset: 15824},
+												pos:  position{line: 660, col: 23, offset: 15825},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 660, col: 25, offset: 15826},
+												pos:   position{line: 660, col: 25, offset: 15827},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 660, col: 27, offset: 15828},
+													pos:  position{line: 660, col: 27, offset: 15829},
 													name: "Expr",
 												},
 											},
@@ -4573,26 +4573,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 671, col: 1, offset: 16021},
+			pos:  position{line: 671, col: 1, offset: 16022},
 			expr: &actionExpr{
-				pos: position{line: 672, col: 5, offset: 16032},
+				pos: position{line: 672, col: 5, offset: 16033},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 672, col: 5, offset: 16032},
+					pos: position{line: 672, col: 5, offset: 16033},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 672, col: 5, offset: 16032},
+							pos:  position{line: 672, col: 5, offset: 16033},
 							name: "FromKeyWord",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 672, col: 17, offset: 16044},
+							pos:  position{line: 672, col: 17, offset: 16045},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 672, col: 19, offset: 16046},
+							pos:   position{line: 672, col: 19, offset: 16047},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 672, col: 25, offset: 16052},
+								pos:  position{line: 672, col: 25, offset: 16053},
 								name: "FromElems",
 							},
 						},
@@ -4604,16 +4604,16 @@ var g = &grammar{
 		},
 		{
 			name: "FromKeyWord",
-			pos:  position{line: 680, col: 1, offset: 16195},
+			pos:  position{line: 680, col: 1, offset: 16196},
 			expr: &choiceExpr{
-				pos: position{line: 681, col: 5, offset: 16211},
+				pos: position{line: 681, col: 5, offset: 16212},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 681, col: 5, offset: 16211},
+						pos:  position{line: 681, col: 5, offset: 16212},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 682, col: 5, offset: 16220},
+						pos:  position{line: 682, col: 5, offset: 16221},
 						name: "DeprecatedFroms",
 					},
 				},
@@ -4623,24 +4623,24 @@ var g = &grammar{
 		},
 		{
 			name: "DeprecatedFroms",
-			pos:  position{line: 684, col: 1, offset: 16237},
+			pos:  position{line: 684, col: 1, offset: 16238},
 			expr: &choiceExpr{
-				pos: position{line: 684, col: 19, offset: 16255},
+				pos: position{line: 684, col: 19, offset: 16256},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 684, col: 19, offset: 16255},
+						pos:        position{line: 684, col: 19, offset: 16256},
 						val:        "get",
 						ignoreCase: false,
 						want:       "\"get\"",
 					},
 					&litMatcher{
-						pos:        position{line: 684, col: 27, offset: 16263},
+						pos:        position{line: 684, col: 27, offset: 16264},
 						val:        "file",
 						ignoreCase: false,
 						want:       "\"file\"",
 					},
 					&litMatcher{
-						pos:        position{line: 684, col: 36, offset: 16272},
+						pos:        position{line: 684, col: 36, offset: 16273},
 						val:        "pool",
 						ignoreCase: false,
 						want:       "\"pool\"",
@@ -4652,51 +4652,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 686, col: 1, offset: 16280},
+			pos:  position{line: 686, col: 1, offset: 16281},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 5, offset: 16294},
+				pos: position{line: 687, col: 5, offset: 16295},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 687, col: 5, offset: 16294},
+					pos: position{line: 687, col: 5, offset: 16295},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 687, col: 5, offset: 16294},
+							pos:   position{line: 687, col: 5, offset: 16295},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 11, offset: 16300},
+								pos:  position{line: 687, col: 11, offset: 16301},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 687, col: 20, offset: 16309},
+							pos:   position{line: 687, col: 20, offset: 16310},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 687, col: 25, offset: 16314},
+								pos: position{line: 687, col: 25, offset: 16315},
 								expr: &actionExpr{
-									pos: position{line: 687, col: 27, offset: 16316},
+									pos: position{line: 687, col: 27, offset: 16317},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 687, col: 27, offset: 16316},
+										pos: position{line: 687, col: 27, offset: 16317},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 687, col: 27, offset: 16316},
+												pos:  position{line: 687, col: 27, offset: 16317},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 687, col: 30, offset: 16319},
+												pos:        position{line: 687, col: 30, offset: 16320},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 687, col: 34, offset: 16323},
+												pos:  position{line: 687, col: 34, offset: 16324},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 687, col: 37, offset: 16326},
+												pos:   position{line: 687, col: 37, offset: 16327},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 687, col: 42, offset: 16331},
+													pos:  position{line: 687, col: 42, offset: 16332},
 													name: "FromElem",
 												},
 											},
@@ -4713,263 +4713,43 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 691, col: 1, offset: 16415},
+			pos:  position{line: 691, col: 1, offset: 16416},
 			expr: &actionExpr{
-				pos: position{line: 692, col: 5, offset: 16428},
+				pos: position{line: 692, col: 5, offset: 16429},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 692, col: 5, offset: 16428},
+					pos: position{line: 692, col: 5, offset: 16429},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 692, col: 5, offset: 16428},
+							pos:   position{line: 692, col: 5, offset: 16429},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 692, col: 12, offset: 16435},
+								pos:  position{line: 692, col: 12, offset: 16436},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 692, col: 23, offset: 16446},
+							pos:   position{line: 692, col: 23, offset: 16447},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 692, col: 28, offset: 16451},
+								pos:  position{line: 692, col: 28, offset: 16452},
 								name: "FromArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 692, col: 37, offset: 16460},
+							pos:   position{line: 692, col: 37, offset: 16461},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 692, col: 39, offset: 16462},
+								pos:  position{line: 692, col: 39, offset: 16463},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 692, col: 53, offset: 16476},
+							pos:   position{line: 692, col: 53, offset: 16477},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 692, col: 59, offset: 16482},
+								pos:  position{line: 692, col: 59, offset: 16483},
 								name: "OptAlias",
-							},
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: true,
-		},
-		{
-			name: "FromEntity",
-			pos:  position{line: 710, col: 1, offset: 16870},
-			expr: &choiceExpr{
-				pos: position{line: 711, col: 5, offset: 16885},
-				alternatives: []any{
-					&actionExpr{
-						pos: position{line: 711, col: 5, offset: 16885},
-						run: (*parser).callonFromEntity2,
-						expr: &labeledExpr{
-							pos:   position{line: 711, col: 5, offset: 16885},
-							label: "url",
-							expr: &ruleRefExpr{
-								pos:  position{line: 711, col: 9, offset: 16889},
-								name: "UnquotedURL",
-							},
-						},
-					},
-					&ruleRefExpr{
-						pos:  position{line: 718, col: 5, offset: 17021},
-						name: "Regexp",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 719, col: 5, offset: 17032},
-						name: "Glob",
-					},
-					&actionExpr{
-						pos: position{line: 720, col: 5, offset: 17041},
-						run: (*parser).callonFromEntity7,
-						expr: &seqExpr{
-							pos: position{line: 720, col: 5, offset: 17041},
-							exprs: []any{
-								&litMatcher{
-									pos:        position{line: 720, col: 5, offset: 17041},
-									val:        "*",
-									ignoreCase: false,
-									want:       "\"*\"",
-								},
-								&notExpr{
-									pos: position{line: 720, col: 9, offset: 17045},
-									expr: &ruleRefExpr{
-										pos:  position{line: 720, col: 10, offset: 17046},
-										name: "ExprGuard",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 721, col: 5, offset: 17127},
-						run: (*parser).callonFromEntity12,
-						expr: &seqExpr{
-							pos: position{line: 721, col: 5, offset: 17127},
-							exprs: []any{
-								&ruleRefExpr{
-									pos:  position{line: 721, col: 5, offset: 17127},
-									name: "EVAL",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 721, col: 10, offset: 17132},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 721, col: 13, offset: 17135},
-									val:        "(",
-									ignoreCase: false,
-									want:       "\"(\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 721, col: 17, offset: 17139},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 721, col: 20, offset: 17142},
-									label: "e",
-									expr: &ruleRefExpr{
-										pos:  position{line: 721, col: 22, offset: 17144},
-										name: "Expr",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 721, col: 27, offset: 17149},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 721, col: 30, offset: 17152},
-									val:        ")",
-									ignoreCase: false,
-									want:       "\")\"",
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 728, col: 5, offset: 17288},
-						run: (*parser).callonFromEntity22,
-						expr: &labeledExpr{
-							pos:   position{line: 728, col: 5, offset: 17288},
-							label: "meta",
-							expr: &ruleRefExpr{
-								pos:  position{line: 728, col: 10, offset: 17293},
-								name: "PoolMeta",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 735, col: 5, offset: 17436},
-						run: (*parser).callonFromEntity25,
-						expr: &seqExpr{
-							pos: position{line: 735, col: 5, offset: 17436},
-							exprs: []any{
-								&labeledExpr{
-									pos:   position{line: 735, col: 5, offset: 17436},
-									label: "join",
-									expr: &ruleRefExpr{
-										pos:  position{line: 735, col: 10, offset: 17441},
-										name: "JoinOperation",
-									},
-								},
-								&notExpr{
-									pos: position{line: 735, col: 24, offset: 17455},
-									expr: &ruleRefExpr{
-										pos:  position{line: 735, col: 25, offset: 17456},
-										name: "AliasClause",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 736, col: 5, offset: 17491},
-						run: (*parser).callonFromEntity31,
-						expr: &seqExpr{
-							pos: position{line: 736, col: 5, offset: 17491},
-							exprs: []any{
-								&litMatcher{
-									pos:        position{line: 736, col: 5, offset: 17491},
-									val:        "(",
-									ignoreCase: false,
-									want:       "\"(\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 736, col: 9, offset: 17495},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 736, col: 12, offset: 17498},
-									label: "join",
-									expr: &ruleRefExpr{
-										pos:  position{line: 736, col: 17, offset: 17503},
-										name: "JoinOperation",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 736, col: 31, offset: 17517},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 736, col: 34, offset: 17520},
-									val:        ")",
-									ignoreCase: false,
-									want:       "\")\"",
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 737, col: 5, offset: 17549},
-						run: (*parser).callonFromEntity39,
-						expr: &seqExpr{
-							pos: position{line: 737, col: 5, offset: 17549},
-							exprs: []any{
-								&litMatcher{
-									pos:        position{line: 737, col: 5, offset: 17549},
-									val:        "(",
-									ignoreCase: false,
-									want:       "\"(\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 737, col: 9, offset: 17553},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 737, col: 12, offset: 17556},
-									label: "s",
-									expr: &ruleRefExpr{
-										pos:  position{line: 737, col: 14, offset: 17558},
-										name: "SQLPipe",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 737, col: 22, offset: 17566},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 737, col: 25, offset: 17569},
-									val:        ")",
-									ignoreCase: false,
-									want:       "\")\"",
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 740, col: 6, offset: 17606},
-						run: (*parser).callonFromEntity47,
-						expr: &labeledExpr{
-							pos:   position{line: 740, col: 6, offset: 17606},
-							label: "name",
-							expr: &ruleRefExpr{
-								pos:  position{line: 740, col: 11, offset: 17611},
-								name: "Name",
 							},
 						},
 					},
@@ -4979,41 +4759,261 @@ var g = &grammar{
 			leftRecursive: true,
 		},
 		{
-			name: "FromArgs",
-			pos:  position{line: 743, col: 1, offset: 17709},
+			name: "FromEntity",
+			pos:  position{line: 710, col: 1, offset: 16871},
 			expr: &choiceExpr{
-				pos: position{line: 744, col: 5, offset: 17722},
+				pos: position{line: 711, col: 5, offset: 16886},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 744, col: 5, offset: 17722},
-						run: (*parser).callonFromArgs2,
+						pos: position{line: 711, col: 5, offset: 16886},
+						run: (*parser).callonFromEntity2,
+						expr: &labeledExpr{
+							pos:   position{line: 711, col: 5, offset: 16886},
+							label: "url",
+							expr: &ruleRefExpr{
+								pos:  position{line: 711, col: 9, offset: 16890},
+								name: "UnquotedURL",
+							},
+						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 718, col: 5, offset: 17022},
+						name: "Regexp",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 719, col: 5, offset: 17033},
+						name: "Glob",
+					},
+					&actionExpr{
+						pos: position{line: 720, col: 5, offset: 17042},
+						run: (*parser).callonFromEntity7,
 						expr: &seqExpr{
-							pos: position{line: 744, col: 5, offset: 17722},
+							pos: position{line: 720, col: 5, offset: 17042},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 720, col: 5, offset: 17042},
+									val:        "*",
+									ignoreCase: false,
+									want:       "\"*\"",
+								},
+								&notExpr{
+									pos: position{line: 720, col: 9, offset: 17046},
+									expr: &ruleRefExpr{
+										pos:  position{line: 720, col: 10, offset: 17047},
+										name: "ExprGuard",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 721, col: 5, offset: 17128},
+						run: (*parser).callonFromEntity12,
+						expr: &seqExpr{
+							pos: position{line: 721, col: 5, offset: 17128},
+							exprs: []any{
+								&ruleRefExpr{
+									pos:  position{line: 721, col: 5, offset: 17128},
+									name: "EVAL",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 721, col: 10, offset: 17133},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 721, col: 13, offset: 17136},
+									val:        "(",
+									ignoreCase: false,
+									want:       "\"(\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 721, col: 17, offset: 17140},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 721, col: 20, offset: 17143},
+									label: "e",
+									expr: &ruleRefExpr{
+										pos:  position{line: 721, col: 22, offset: 17145},
+										name: "Expr",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 721, col: 27, offset: 17150},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 721, col: 30, offset: 17153},
+									val:        ")",
+									ignoreCase: false,
+									want:       "\")\"",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 728, col: 5, offset: 17289},
+						run: (*parser).callonFromEntity22,
+						expr: &labeledExpr{
+							pos:   position{line: 728, col: 5, offset: 17289},
+							label: "meta",
+							expr: &ruleRefExpr{
+								pos:  position{line: 728, col: 10, offset: 17294},
+								name: "PoolMeta",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 735, col: 5, offset: 17437},
+						run: (*parser).callonFromEntity25,
+						expr: &seqExpr{
+							pos: position{line: 735, col: 5, offset: 17437},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 744, col: 5, offset: 17722},
+									pos:   position{line: 735, col: 5, offset: 17437},
+									label: "join",
+									expr: &ruleRefExpr{
+										pos:  position{line: 735, col: 10, offset: 17442},
+										name: "JoinOperation",
+									},
+								},
+								&notExpr{
+									pos: position{line: 735, col: 24, offset: 17456},
+									expr: &ruleRefExpr{
+										pos:  position{line: 735, col: 25, offset: 17457},
+										name: "AliasClause",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 736, col: 5, offset: 17492},
+						run: (*parser).callonFromEntity31,
+						expr: &seqExpr{
+							pos: position{line: 736, col: 5, offset: 17492},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 736, col: 5, offset: 17492},
+									val:        "(",
+									ignoreCase: false,
+									want:       "\"(\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 736, col: 9, offset: 17496},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 736, col: 12, offset: 17499},
+									label: "join",
+									expr: &ruleRefExpr{
+										pos:  position{line: 736, col: 17, offset: 17504},
+										name: "JoinOperation",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 736, col: 31, offset: 17518},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 736, col: 34, offset: 17521},
+									val:        ")",
+									ignoreCase: false,
+									want:       "\")\"",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 737, col: 5, offset: 17550},
+						run: (*parser).callonFromEntity39,
+						expr: &seqExpr{
+							pos: position{line: 737, col: 5, offset: 17550},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 737, col: 5, offset: 17550},
+									val:        "(",
+									ignoreCase: false,
+									want:       "\"(\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 737, col: 9, offset: 17554},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 737, col: 12, offset: 17557},
+									label: "s",
+									expr: &ruleRefExpr{
+										pos:  position{line: 737, col: 14, offset: 17559},
+										name: "SQLPipe",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 737, col: 22, offset: 17567},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 737, col: 25, offset: 17570},
+									val:        ")",
+									ignoreCase: false,
+									want:       "\")\"",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 740, col: 6, offset: 17607},
+						run: (*parser).callonFromEntity47,
+						expr: &labeledExpr{
+							pos:   position{line: 740, col: 6, offset: 17607},
+							label: "name",
+							expr: &ruleRefExpr{
+								pos:  position{line: 740, col: 11, offset: 17612},
+								name: "Name",
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: true,
+		},
+		{
+			name: "FromArgs",
+			pos:  position{line: 743, col: 1, offset: 17710},
+			expr: &choiceExpr{
+				pos: position{line: 744, col: 5, offset: 17723},
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 744, col: 5, offset: 17723},
+						run: (*parser).callonFromArgs2,
+						expr: &seqExpr{
+							pos: position{line: 744, col: 5, offset: 17723},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 744, col: 5, offset: 17723},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 744, col: 12, offset: 17729},
+										pos:  position{line: 744, col: 12, offset: 17730},
 										name: "PoolCommit",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 744, col: 23, offset: 17740},
+									pos:   position{line: 744, col: 23, offset: 17741},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 744, col: 28, offset: 17745},
+										pos: position{line: 744, col: 28, offset: 17746},
 										expr: &ruleRefExpr{
-											pos:  position{line: 744, col: 28, offset: 17745},
+											pos:  position{line: 744, col: 28, offset: 17746},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 744, col: 38, offset: 17755},
+									pos:   position{line: 744, col: 38, offset: 17756},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 744, col: 42, offset: 17759},
+										pos:  position{line: 744, col: 42, offset: 17760},
 										name: "TapArg",
 									},
 								},
@@ -5021,24 +5021,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 753, col: 5, offset: 17963},
+						pos: position{line: 753, col: 5, offset: 17964},
 						run: (*parser).callonFromArgs11,
 						expr: &seqExpr{
-							pos: position{line: 753, col: 5, offset: 17963},
+							pos: position{line: 753, col: 5, offset: 17964},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 753, col: 5, offset: 17963},
+									pos:   position{line: 753, col: 5, offset: 17964},
 									label: "meta",
 									expr: &ruleRefExpr{
-										pos:  position{line: 753, col: 10, offset: 17968},
+										pos:  position{line: 753, col: 10, offset: 17969},
 										name: "PoolMeta",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 753, col: 19, offset: 17977},
+									pos:   position{line: 753, col: 19, offset: 17978},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 753, col: 23, offset: 17981},
+										pos:  position{line: 753, col: 23, offset: 17982},
 										name: "TapArg",
 									},
 								},
@@ -5046,41 +5046,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 761, col: 5, offset: 18147},
+						pos: position{line: 761, col: 5, offset: 18148},
 						run: (*parser).callonFromArgs17,
 						expr: &seqExpr{
-							pos: position{line: 761, col: 5, offset: 18147},
+							pos: position{line: 761, col: 5, offset: 18148},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 761, col: 5, offset: 18147},
+									pos:   position{line: 761, col: 5, offset: 18148},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 761, col: 12, offset: 18154},
+										pos:  position{line: 761, col: 12, offset: 18155},
 										name: "FormatArg",
 									},
 								},
 								&notExpr{
-									pos: position{line: 761, col: 22, offset: 18164},
+									pos: position{line: 761, col: 22, offset: 18165},
 									expr: &seqExpr{
-										pos: position{line: 761, col: 24, offset: 18166},
+										pos: position{line: 761, col: 24, offset: 18167},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 761, col: 24, offset: 18166},
+												pos:  position{line: 761, col: 24, offset: 18167},
 												name: "_",
 											},
 											&choiceExpr{
-												pos: position{line: 761, col: 27, offset: 18169},
+												pos: position{line: 761, col: 27, offset: 18170},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 761, col: 27, offset: 18169},
+														pos:  position{line: 761, col: 27, offset: 18170},
 														name: "METHOD",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 761, col: 36, offset: 18178},
+														pos:  position{line: 761, col: 36, offset: 18179},
 														name: "HEADERS",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 761, col: 46, offset: 18188},
+														pos:  position{line: 761, col: 46, offset: 18189},
 														name: "BODY",
 													},
 												},
@@ -5092,51 +5092,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 768, col: 5, offset: 18333},
+						pos: position{line: 768, col: 5, offset: 18334},
 						run: (*parser).callonFromArgs28,
 						expr: &seqExpr{
-							pos: position{line: 768, col: 5, offset: 18333},
+							pos: position{line: 768, col: 5, offset: 18334},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 768, col: 5, offset: 18333},
+									pos:   position{line: 768, col: 5, offset: 18334},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 768, col: 12, offset: 18340},
+										pos: position{line: 768, col: 12, offset: 18341},
 										expr: &ruleRefExpr{
-											pos:  position{line: 768, col: 12, offset: 18340},
+											pos:  position{line: 768, col: 12, offset: 18341},
 											name: "FormatArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 768, col: 23, offset: 18351},
+									pos:   position{line: 768, col: 23, offset: 18352},
 									label: "method",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 768, col: 30, offset: 18358},
+										pos: position{line: 768, col: 30, offset: 18359},
 										expr: &ruleRefExpr{
-											pos:  position{line: 768, col: 30, offset: 18358},
+											pos:  position{line: 768, col: 30, offset: 18359},
 											name: "MethodArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 768, col: 41, offset: 18369},
+									pos:   position{line: 768, col: 41, offset: 18370},
 									label: "headers",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 768, col: 49, offset: 18377},
+										pos: position{line: 768, col: 49, offset: 18378},
 										expr: &ruleRefExpr{
-											pos:  position{line: 768, col: 49, offset: 18377},
+											pos:  position{line: 768, col: 49, offset: 18378},
 											name: "HeadersArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 768, col: 61, offset: 18389},
+									pos:   position{line: 768, col: 61, offset: 18390},
 									label: "body",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 768, col: 66, offset: 18394},
+										pos: position{line: 768, col: 66, offset: 18395},
 										expr: &ruleRefExpr{
-											pos:  position{line: 768, col: 66, offset: 18394},
+											pos:  position{line: 768, col: 66, offset: 18395},
 											name: "BodyArg",
 										},
 									},
@@ -5151,30 +5151,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 785, col: 1, offset: 18810},
+			pos:  position{line: 785, col: 1, offset: 18811},
 			expr: &actionExpr{
-				pos: position{line: 785, col: 13, offset: 18822},
+				pos: position{line: 785, col: 13, offset: 18823},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 785, col: 13, offset: 18822},
+					pos: position{line: 785, col: 13, offset: 18823},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 785, col: 13, offset: 18822},
+							pos:  position{line: 785, col: 13, offset: 18823},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 785, col: 15, offset: 18824},
+							pos:  position{line: 785, col: 15, offset: 18825},
 							name: "FORMAT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 785, col: 22, offset: 18831},
+							pos:  position{line: 785, col: 22, offset: 18832},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 785, col: 24, offset: 18833},
+							pos:   position{line: 785, col: 24, offset: 18834},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 785, col: 26, offset: 18835},
+								pos:  position{line: 785, col: 26, offset: 18836},
 								name: "Name",
 							},
 						},
@@ -5186,30 +5186,30 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 787, col: 1, offset: 18859},
+			pos:  position{line: 787, col: 1, offset: 18860},
 			expr: &actionExpr{
-				pos: position{line: 787, col: 13, offset: 18871},
+				pos: position{line: 787, col: 13, offset: 18872},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 787, col: 13, offset: 18871},
+					pos: position{line: 787, col: 13, offset: 18872},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 787, col: 13, offset: 18871},
+							pos:  position{line: 787, col: 13, offset: 18872},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 787, col: 15, offset: 18873},
+							pos:  position{line: 787, col: 15, offset: 18874},
 							name: "METHOD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 787, col: 22, offset: 18880},
+							pos:  position{line: 787, col: 22, offset: 18881},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 787, col: 24, offset: 18882},
+							pos:   position{line: 787, col: 24, offset: 18883},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 787, col: 26, offset: 18884},
+								pos:  position{line: 787, col: 26, offset: 18885},
 								name: "Name",
 							},
 						},
@@ -5221,30 +5221,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 789, col: 1, offset: 18908},
+			pos:  position{line: 789, col: 1, offset: 18909},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 14, offset: 18921},
+				pos: position{line: 789, col: 14, offset: 18922},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 14, offset: 18921},
+					pos: position{line: 789, col: 14, offset: 18922},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 14, offset: 18921},
+							pos:  position{line: 789, col: 14, offset: 18922},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 16, offset: 18923},
+							pos:  position{line: 789, col: 16, offset: 18924},
 							name: "HEADERS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 24, offset: 18931},
+							pos:  position{line: 789, col: 24, offset: 18932},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 26, offset: 18933},
+							pos:   position{line: 789, col: 26, offset: 18934},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 28, offset: 18935},
+								pos:  position{line: 789, col: 28, offset: 18936},
 								name: "Record",
 							},
 						},
@@ -5256,30 +5256,30 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 791, col: 1, offset: 18961},
+			pos:  position{line: 791, col: 1, offset: 18962},
 			expr: &actionExpr{
-				pos: position{line: 791, col: 11, offset: 18971},
+				pos: position{line: 791, col: 11, offset: 18972},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 791, col: 11, offset: 18971},
+					pos: position{line: 791, col: 11, offset: 18972},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 791, col: 11, offset: 18971},
+							pos:  position{line: 791, col: 11, offset: 18972},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 791, col: 13, offset: 18973},
+							pos:  position{line: 791, col: 13, offset: 18974},
 							name: "BODY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 791, col: 18, offset: 18978},
+							pos:  position{line: 791, col: 18, offset: 18979},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 791, col: 20, offset: 18980},
+							pos:   position{line: 791, col: 20, offset: 18981},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 791, col: 22, offset: 18982},
+								pos:  position{line: 791, col: 22, offset: 18983},
 								name: "Name",
 							},
 						},
@@ -5291,24 +5291,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 793, col: 1, offset: 19006},
+			pos:  position{line: 793, col: 1, offset: 19007},
 			expr: &actionExpr{
-				pos: position{line: 793, col: 15, offset: 19020},
+				pos: position{line: 793, col: 15, offset: 19021},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 793, col: 15, offset: 19020},
+					pos: position{line: 793, col: 15, offset: 19021},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 793, col: 16, offset: 19021},
+							pos: position{line: 793, col: 16, offset: 19022},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 793, col: 16, offset: 19021},
+									pos:        position{line: 793, col: 16, offset: 19022},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 793, col: 28, offset: 19033},
+									pos:        position{line: 793, col: 28, offset: 19034},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
@@ -5316,9 +5316,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 793, col: 40, offset: 19045},
+							pos: position{line: 793, col: 40, offset: 19046},
 							expr: &ruleRefExpr{
-								pos:  position{line: 793, col: 40, offset: 19045},
+								pos:  position{line: 793, col: 40, offset: 19046},
 								name: "URLChar",
 							},
 						},
@@ -5330,9 +5330,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 795, col: 1, offset: 19086},
+			pos:  position{line: 795, col: 1, offset: 19087},
 			expr: &charClassMatcher{
-				pos:        position{line: 795, col: 11, offset: 19096},
+				pos:        position{line: 795, col: 11, offset: 19097},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -5344,30 +5344,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 798, col: 1, offset: 19160},
+			pos:  position{line: 798, col: 1, offset: 19161},
 			expr: &actionExpr{
-				pos: position{line: 799, col: 5, offset: 19171},
+				pos: position{line: 799, col: 5, offset: 19172},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 799, col: 5, offset: 19171},
+					pos: position{line: 799, col: 5, offset: 19172},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 5, offset: 19171},
+							pos:  position{line: 799, col: 5, offset: 19172},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 7, offset: 19173},
+							pos:  position{line: 799, col: 7, offset: 19174},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 10, offset: 19176},
+							pos:  position{line: 799, col: 10, offset: 19177},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 799, col: 12, offset: 19178},
+							pos:   position{line: 799, col: 12, offset: 19179},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 799, col: 15, offset: 19181},
+								pos:  position{line: 799, col: 15, offset: 19182},
 								name: "KSUID",
 							},
 						},
@@ -5379,14 +5379,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 802, col: 1, offset: 19247},
+			pos:  position{line: 802, col: 1, offset: 19248},
 			expr: &actionExpr{
-				pos: position{line: 802, col: 9, offset: 19255},
+				pos: position{line: 802, col: 9, offset: 19256},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 802, col: 9, offset: 19255},
+					pos: position{line: 802, col: 9, offset: 19256},
 					expr: &charClassMatcher{
-						pos:        position{line: 802, col: 10, offset: 19256},
+						pos:        position{line: 802, col: 10, offset: 19257},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -5399,24 +5399,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 804, col: 1, offset: 19302},
+			pos:  position{line: 804, col: 1, offset: 19303},
 			expr: &actionExpr{
-				pos: position{line: 805, col: 5, offset: 19317},
+				pos: position{line: 805, col: 5, offset: 19318},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 805, col: 5, offset: 19317},
+					pos: position{line: 805, col: 5, offset: 19318},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 805, col: 5, offset: 19317},
+							pos:        position{line: 805, col: 5, offset: 19318},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 805, col: 9, offset: 19321},
+							pos:   position{line: 805, col: 9, offset: 19322},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 805, col: 11, offset: 19323},
+								pos:  position{line: 805, col: 11, offset: 19324},
 								name: "Name",
 							},
 						},
@@ -5428,24 +5428,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 807, col: 1, offset: 19347},
+			pos:  position{line: 807, col: 1, offset: 19348},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 5, offset: 19360},
+				pos: position{line: 808, col: 5, offset: 19361},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 5, offset: 19360},
+					pos: position{line: 808, col: 5, offset: 19361},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 808, col: 5, offset: 19360},
+							pos:        position{line: 808, col: 5, offset: 19361},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 9, offset: 19364},
+							pos:   position{line: 808, col: 9, offset: 19365},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 11, offset: 19366},
+								pos:  position{line: 808, col: 11, offset: 19367},
 								name: "Name",
 							},
 						},
@@ -5457,32 +5457,32 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 810, col: 1, offset: 19390},
+			pos:  position{line: 810, col: 1, offset: 19391},
 			expr: &choiceExpr{
-				pos: position{line: 811, col: 5, offset: 19401},
+				pos: position{line: 811, col: 5, offset: 19402},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 811, col: 5, offset: 19401},
+						pos: position{line: 811, col: 5, offset: 19402},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 811, col: 5, offset: 19401},
+							pos: position{line: 811, col: 5, offset: 19402},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 811, col: 5, offset: 19401},
+									pos:  position{line: 811, col: 5, offset: 19402},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 811, col: 7, offset: 19403},
+									pos:  position{line: 811, col: 7, offset: 19404},
 									name: "TAP",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 812, col: 5, offset: 19432},
+						pos: position{line: 812, col: 5, offset: 19433},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 812, col: 5, offset: 19432},
+							pos:        position{line: 812, col: 5, offset: 19433},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -5495,28 +5495,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 814, col: 1, offset: 19458},
+			pos:  position{line: 814, col: 1, offset: 19459},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 19469},
+				pos: position{line: 815, col: 5, offset: 19470},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 19469},
+					pos: position{line: 815, col: 5, offset: 19470},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 5, offset: 19469},
+							pos:  position{line: 815, col: 5, offset: 19470},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 815, col: 10, offset: 19474},
+							pos: position{line: 815, col: 10, offset: 19475},
 							expr: &seqExpr{
-								pos: position{line: 815, col: 12, offset: 19476},
+								pos: position{line: 815, col: 12, offset: 19477},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 815, col: 12, offset: 19476},
+										pos:  position{line: 815, col: 12, offset: 19477},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 815, col: 15, offset: 19479},
+										pos:        position{line: 815, col: 15, offset: 19480},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5525,9 +5525,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 815, col: 20, offset: 19484},
+							pos: position{line: 815, col: 20, offset: 19485},
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 21, offset: 19485},
+								pos:  position{line: 815, col: 21, offset: 19486},
 								name: "EOKW",
 							},
 						},
@@ -5539,44 +5539,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 821, col: 1, offset: 19676},
+			pos:  position{line: 821, col: 1, offset: 19677},
 			expr: &actionExpr{
-				pos: position{line: 822, col: 5, offset: 19690},
+				pos: position{line: 822, col: 5, offset: 19691},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 822, col: 5, offset: 19690},
+					pos: position{line: 822, col: 5, offset: 19691},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 822, col: 5, offset: 19690},
+							pos:  position{line: 822, col: 5, offset: 19691},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 822, col: 13, offset: 19698},
+							pos:  position{line: 822, col: 13, offset: 19699},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 15, offset: 19700},
+							pos:   position{line: 822, col: 15, offset: 19701},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 822, col: 20, offset: 19705},
+								pos:  position{line: 822, col: 20, offset: 19706},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 26, offset: 19711},
+							pos:   position{line: 822, col: 26, offset: 19712},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 822, col: 30, offset: 19715},
+								pos:  position{line: 822, col: 30, offset: 19716},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 38, offset: 19723},
+							pos:   position{line: 822, col: 38, offset: 19724},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 822, col: 41, offset: 19726},
+								pos: position{line: 822, col: 41, offset: 19727},
 								expr: &ruleRefExpr{
-									pos:  position{line: 822, col: 41, offset: 19726},
+									pos:  position{line: 822, col: 41, offset: 19727},
 									name: "AsArg",
 								},
 							},
@@ -5589,26 +5589,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 835, col: 1, offset: 19968},
+			pos:  position{line: 835, col: 1, offset: 19969},
 			expr: &actionExpr{
-				pos: position{line: 836, col: 5, offset: 19980},
+				pos: position{line: 836, col: 5, offset: 19981},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 836, col: 5, offset: 19980},
+					pos: position{line: 836, col: 5, offset: 19981},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 836, col: 5, offset: 19980},
+							pos:  position{line: 836, col: 5, offset: 19981},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 836, col: 11, offset: 19986},
+							pos:  position{line: 836, col: 11, offset: 19987},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 836, col: 13, offset: 19988},
+							pos:   position{line: 836, col: 13, offset: 19989},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 836, col: 19, offset: 19994},
+								pos:  position{line: 836, col: 19, offset: 19995},
 								name: "OrderByList",
 							},
 						},
@@ -5620,56 +5620,56 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 844, col: 1, offset: 20136},
+			pos:  position{line: 844, col: 1, offset: 20137},
 			expr: &actionExpr{
-				pos: position{line: 845, col: 5, offset: 20147},
+				pos: position{line: 845, col: 5, offset: 20148},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 845, col: 5, offset: 20147},
+					pos: position{line: 845, col: 5, offset: 20148},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 845, col: 6, offset: 20148},
+							pos: position{line: 845, col: 6, offset: 20149},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 845, col: 6, offset: 20148},
+									pos:  position{line: 845, col: 6, offset: 20149},
 									name: "OVER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 845, col: 13, offset: 20155},
+									pos:  position{line: 845, col: 13, offset: 20156},
 									name: "UNNEST",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 845, col: 21, offset: 20163},
+							pos:  position{line: 845, col: 21, offset: 20164},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 845, col: 23, offset: 20165},
+							pos:   position{line: 845, col: 23, offset: 20166},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 845, col: 29, offset: 20171},
+								pos:  position{line: 845, col: 29, offset: 20172},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 845, col: 35, offset: 20177},
+							pos:   position{line: 845, col: 35, offset: 20178},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 845, col: 42, offset: 20184},
+								pos: position{line: 845, col: 42, offset: 20185},
 								expr: &ruleRefExpr{
-									pos:  position{line: 845, col: 42, offset: 20184},
+									pos:  position{line: 845, col: 42, offset: 20185},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 845, col: 50, offset: 20192},
+							pos:   position{line: 845, col: 50, offset: 20193},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 845, col: 55, offset: 20197},
+								pos: position{line: 845, col: 55, offset: 20198},
 								expr: &ruleRefExpr{
-									pos:  position{line: 845, col: 55, offset: 20197},
+									pos:  position{line: 845, col: 55, offset: 20198},
 									name: "Lateral",
 								},
 							},
@@ -5682,54 +5682,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 860, col: 1, offset: 20522},
+			pos:  position{line: 860, col: 1, offset: 20523},
 			expr: &choiceExpr{
-				pos: position{line: 861, col: 5, offset: 20534},
+				pos: position{line: 861, col: 5, offset: 20535},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 861, col: 5, offset: 20534},
+						pos: position{line: 861, col: 5, offset: 20535},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 861, col: 5, offset: 20534},
+							pos: position{line: 861, col: 5, offset: 20535},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 5, offset: 20534},
+									pos:  position{line: 861, col: 5, offset: 20535},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 861, col: 8, offset: 20537},
+									pos:        position{line: 861, col: 8, offset: 20538},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 13, offset: 20542},
+									pos:  position{line: 861, col: 13, offset: 20543},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 861, col: 16, offset: 20545},
+									pos:        position{line: 861, col: 16, offset: 20546},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 20, offset: 20549},
+									pos:  position{line: 861, col: 20, offset: 20550},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 861, col: 23, offset: 20552},
+									pos:   position{line: 861, col: 23, offset: 20553},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 861, col: 29, offset: 20558},
+										pos:  position{line: 861, col: 29, offset: 20559},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 861, col: 35, offset: 20564},
+									pos:  position{line: 861, col: 35, offset: 20565},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 861, col: 38, offset: 20567},
+									pos:        position{line: 861, col: 38, offset: 20568},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5738,49 +5738,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 864, col: 5, offset: 20648},
+						pos: position{line: 864, col: 5, offset: 20649},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 864, col: 5, offset: 20648},
+							pos: position{line: 864, col: 5, offset: 20649},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 5, offset: 20648},
+									pos:  position{line: 864, col: 5, offset: 20649},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 864, col: 8, offset: 20651},
+									pos:        position{line: 864, col: 8, offset: 20652},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 13, offset: 20656},
+									pos:  position{line: 864, col: 13, offset: 20657},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 864, col: 16, offset: 20659},
+									pos:        position{line: 864, col: 16, offset: 20660},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 20, offset: 20663},
+									pos:  position{line: 864, col: 20, offset: 20664},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 864, col: 23, offset: 20666},
+									pos:   position{line: 864, col: 23, offset: 20667},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 864, col: 27, offset: 20670},
+										pos:  position{line: 864, col: 27, offset: 20671},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 864, col: 31, offset: 20674},
+									pos:  position{line: 864, col: 31, offset: 20675},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 864, col: 34, offset: 20677},
+									pos:        position{line: 864, col: 34, offset: 20678},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5795,63 +5795,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 868, col: 1, offset: 20733},
+			pos:  position{line: 868, col: 1, offset: 20734},
 			expr: &actionExpr{
-				pos: position{line: 869, col: 5, offset: 20744},
+				pos: position{line: 869, col: 5, offset: 20745},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 869, col: 5, offset: 20744},
+					pos: position{line: 869, col: 5, offset: 20745},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 869, col: 5, offset: 20744},
+							pos:  position{line: 869, col: 5, offset: 20745},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 869, col: 7, offset: 20746},
+							pos:  position{line: 869, col: 7, offset: 20747},
 							name: "WITH",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 869, col: 12, offset: 20751},
+							pos:  position{line: 869, col: 12, offset: 20752},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 869, col: 14, offset: 20753},
+							pos:   position{line: 869, col: 14, offset: 20754},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 869, col: 20, offset: 20759},
+								pos:  position{line: 869, col: 20, offset: 20760},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 869, col: 37, offset: 20776},
+							pos:   position{line: 869, col: 37, offset: 20777},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 869, col: 42, offset: 20781},
+								pos: position{line: 869, col: 42, offset: 20782},
 								expr: &actionExpr{
-									pos: position{line: 869, col: 43, offset: 20782},
+									pos: position{line: 869, col: 43, offset: 20783},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 869, col: 43, offset: 20782},
+										pos: position{line: 869, col: 43, offset: 20783},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 869, col: 43, offset: 20782},
+												pos:  position{line: 869, col: 43, offset: 20783},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 869, col: 46, offset: 20785},
+												pos:        position{line: 869, col: 46, offset: 20786},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 869, col: 50, offset: 20789},
+												pos:  position{line: 869, col: 50, offset: 20790},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 869, col: 53, offset: 20792},
+												pos:   position{line: 869, col: 53, offset: 20793},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 869, col: 55, offset: 20794},
+													pos:  position{line: 869, col: 55, offset: 20795},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5868,45 +5868,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 873, col: 1, offset: 20879},
+			pos:  position{line: 873, col: 1, offset: 20880},
 			expr: &actionExpr{
-				pos: position{line: 874, col: 5, offset: 20900},
+				pos: position{line: 874, col: 5, offset: 20901},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 874, col: 5, offset: 20900},
+					pos: position{line: 874, col: 5, offset: 20901},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 874, col: 5, offset: 20900},
+							pos:   position{line: 874, col: 5, offset: 20901},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 874, col: 10, offset: 20905},
+								pos:  position{line: 874, col: 10, offset: 20906},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 874, col: 21, offset: 20916},
+							pos:   position{line: 874, col: 21, offset: 20917},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 874, col: 25, offset: 20920},
+								pos: position{line: 874, col: 25, offset: 20921},
 								expr: &seqExpr{
-									pos: position{line: 874, col: 26, offset: 20921},
+									pos: position{line: 874, col: 26, offset: 20922},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 874, col: 26, offset: 20921},
+											pos:  position{line: 874, col: 26, offset: 20922},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 874, col: 29, offset: 20924},
+											pos:        position{line: 874, col: 29, offset: 20925},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 874, col: 33, offset: 20928},
+											pos:  position{line: 874, col: 33, offset: 20929},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 874, col: 36, offset: 20931},
+											pos:  position{line: 874, col: 36, offset: 20932},
 											name: "Expr",
 										},
 									},
@@ -5921,26 +5921,26 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 886, col: 1, offset: 21155},
+			pos:  position{line: 886, col: 1, offset: 21156},
 			expr: &actionExpr{
-				pos: position{line: 887, col: 5, offset: 21167},
+				pos: position{line: 887, col: 5, offset: 21168},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 887, col: 5, offset: 21167},
+					pos: position{line: 887, col: 5, offset: 21168},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 887, col: 5, offset: 21167},
+							pos:  position{line: 887, col: 5, offset: 21168},
 							name: "YIELD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 887, col: 11, offset: 21173},
+							pos:  position{line: 887, col: 11, offset: 21174},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 887, col: 13, offset: 21175},
+							pos:   position{line: 887, col: 13, offset: 21176},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 887, col: 19, offset: 21181},
+								pos:  position{line: 887, col: 19, offset: 21182},
 								name: "Exprs",
 							},
 						},
@@ -5952,30 +5952,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 895, col: 1, offset: 21325},
+			pos:  position{line: 895, col: 1, offset: 21326},
 			expr: &actionExpr{
-				pos: position{line: 896, col: 5, offset: 21337},
+				pos: position{line: 896, col: 5, offset: 21338},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 896, col: 5, offset: 21337},
+					pos: position{line: 896, col: 5, offset: 21338},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 896, col: 5, offset: 21337},
+							pos:  position{line: 896, col: 5, offset: 21338},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 896, col: 7, offset: 21339},
+							pos:  position{line: 896, col: 7, offset: 21340},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 896, col: 10, offset: 21342},
+							pos:  position{line: 896, col: 10, offset: 21343},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 896, col: 12, offset: 21344},
+							pos:   position{line: 896, col: 12, offset: 21345},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 896, col: 16, offset: 21348},
+								pos:  position{line: 896, col: 16, offset: 21349},
 								name: "Type",
 							},
 						},
@@ -5987,30 +5987,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 898, col: 1, offset: 21374},
+			pos:  position{line: 898, col: 1, offset: 21375},
 			expr: &actionExpr{
-				pos: position{line: 899, col: 5, offset: 21384},
+				pos: position{line: 899, col: 5, offset: 21385},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 899, col: 5, offset: 21384},
+					pos: position{line: 899, col: 5, offset: 21385},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 899, col: 5, offset: 21384},
+							pos:  position{line: 899, col: 5, offset: 21385},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 899, col: 7, offset: 21386},
+							pos:  position{line: 899, col: 7, offset: 21387},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 899, col: 10, offset: 21389},
+							pos:  position{line: 899, col: 10, offset: 21390},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 899, col: 12, offset: 21391},
+							pos:   position{line: 899, col: 12, offset: 21392},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 899, col: 16, offset: 21395},
+								pos:  position{line: 899, col: 16, offset: 21396},
 								name: "Lval",
 							},
 						},
@@ -6022,9 +6022,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 903, col: 1, offset: 21446},
+			pos:  position{line: 903, col: 1, offset: 21447},
 			expr: &ruleRefExpr{
-				pos:  position{line: 903, col: 8, offset: 21453},
+				pos:  position{line: 903, col: 8, offset: 21454},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -6032,51 +6032,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 905, col: 1, offset: 21464},
+			pos:  position{line: 905, col: 1, offset: 21465},
 			expr: &actionExpr{
-				pos: position{line: 906, col: 5, offset: 21474},
+				pos: position{line: 906, col: 5, offset: 21475},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 906, col: 5, offset: 21474},
+					pos: position{line: 906, col: 5, offset: 21475},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 906, col: 5, offset: 21474},
+							pos:   position{line: 906, col: 5, offset: 21475},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 906, col: 11, offset: 21480},
+								pos:  position{line: 906, col: 11, offset: 21481},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 906, col: 16, offset: 21485},
+							pos:   position{line: 906, col: 16, offset: 21486},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 906, col: 21, offset: 21490},
+								pos: position{line: 906, col: 21, offset: 21491},
 								expr: &actionExpr{
-									pos: position{line: 906, col: 22, offset: 21491},
+									pos: position{line: 906, col: 22, offset: 21492},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 906, col: 22, offset: 21491},
+										pos: position{line: 906, col: 22, offset: 21492},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 906, col: 22, offset: 21491},
+												pos:  position{line: 906, col: 22, offset: 21492},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 906, col: 25, offset: 21494},
+												pos:        position{line: 906, col: 25, offset: 21495},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 906, col: 29, offset: 21498},
+												pos:  position{line: 906, col: 29, offset: 21499},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 906, col: 32, offset: 21501},
+												pos:   position{line: 906, col: 32, offset: 21502},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 906, col: 37, offset: 21506},
+													pos:  position{line: 906, col: 37, offset: 21507},
 													name: "Lval",
 												},
 											},
@@ -6093,51 +6093,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 910, col: 1, offset: 21582},
+			pos:  position{line: 910, col: 1, offset: 21583},
 			expr: &actionExpr{
-				pos: position{line: 911, col: 5, offset: 21598},
+				pos: position{line: 911, col: 5, offset: 21599},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 911, col: 5, offset: 21598},
+					pos: position{line: 911, col: 5, offset: 21599},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 911, col: 5, offset: 21598},
+							pos:   position{line: 911, col: 5, offset: 21599},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 911, col: 11, offset: 21604},
+								pos:  position{line: 911, col: 11, offset: 21605},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 911, col: 22, offset: 21615},
+							pos:   position{line: 911, col: 22, offset: 21616},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 911, col: 27, offset: 21620},
+								pos: position{line: 911, col: 27, offset: 21621},
 								expr: &actionExpr{
-									pos: position{line: 911, col: 28, offset: 21621},
+									pos: position{line: 911, col: 28, offset: 21622},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 911, col: 28, offset: 21621},
+										pos: position{line: 911, col: 28, offset: 21622},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 911, col: 28, offset: 21621},
+												pos:  position{line: 911, col: 28, offset: 21622},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 911, col: 31, offset: 21624},
+												pos:        position{line: 911, col: 31, offset: 21625},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 911, col: 35, offset: 21628},
+												pos:  position{line: 911, col: 35, offset: 21629},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 911, col: 38, offset: 21631},
+												pos:   position{line: 911, col: 38, offset: 21632},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 911, col: 40, offset: 21633},
+													pos:  position{line: 911, col: 40, offset: 21634},
 													name: "Assignment",
 												},
 											},
@@ -6154,40 +6154,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 915, col: 1, offset: 21708},
+			pos:  position{line: 915, col: 1, offset: 21709},
 			expr: &actionExpr{
-				pos: position{line: 916, col: 5, offset: 21723},
+				pos: position{line: 916, col: 5, offset: 21724},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 916, col: 5, offset: 21723},
+					pos: position{line: 916, col: 5, offset: 21724},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 916, col: 5, offset: 21723},
+							pos:   position{line: 916, col: 5, offset: 21724},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 916, col: 9, offset: 21727},
+								pos:  position{line: 916, col: 9, offset: 21728},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 916, col: 14, offset: 21732},
+							pos:  position{line: 916, col: 14, offset: 21733},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 916, col: 17, offset: 21735},
+							pos:        position{line: 916, col: 17, offset: 21736},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 916, col: 22, offset: 21740},
+							pos:  position{line: 916, col: 22, offset: 21741},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 916, col: 25, offset: 21743},
+							pos:   position{line: 916, col: 25, offset: 21744},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 916, col: 29, offset: 21747},
+								pos:  position{line: 916, col: 29, offset: 21748},
 								name: "Expr",
 							},
 						},
@@ -6199,9 +6199,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 925, col: 1, offset: 21918},
+			pos:  position{line: 925, col: 1, offset: 21919},
 			expr: &ruleRefExpr{
-				pos:  position{line: 925, col: 8, offset: 21925},
+				pos:  position{line: 925, col: 8, offset: 21926},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -6209,63 +6209,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 927, col: 1, offset: 21942},
+			pos:  position{line: 927, col: 1, offset: 21943},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 5, offset: 21962},
+				pos: position{line: 928, col: 5, offset: 21963},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 928, col: 5, offset: 21962},
+					pos: position{line: 928, col: 5, offset: 21963},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 928, col: 5, offset: 21962},
+							pos:   position{line: 928, col: 5, offset: 21963},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 928, col: 10, offset: 21967},
+								pos:  position{line: 928, col: 10, offset: 21968},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 928, col: 24, offset: 21981},
+							pos:   position{line: 928, col: 24, offset: 21982},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 928, col: 28, offset: 21985},
+								pos: position{line: 928, col: 28, offset: 21986},
 								expr: &seqExpr{
-									pos: position{line: 928, col: 29, offset: 21986},
+									pos: position{line: 928, col: 29, offset: 21987},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 928, col: 29, offset: 21986},
+											pos:  position{line: 928, col: 29, offset: 21987},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 928, col: 32, offset: 21989},
+											pos:        position{line: 928, col: 32, offset: 21990},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 928, col: 36, offset: 21993},
+											pos:  position{line: 928, col: 36, offset: 21994},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 928, col: 39, offset: 21996},
+											pos:  position{line: 928, col: 39, offset: 21997},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 928, col: 44, offset: 22001},
+											pos:  position{line: 928, col: 44, offset: 22002},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 928, col: 47, offset: 22004},
+											pos:        position{line: 928, col: 47, offset: 22005},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 928, col: 51, offset: 22008},
+											pos:  position{line: 928, col: 51, offset: 22009},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 928, col: 54, offset: 22011},
+											pos:  position{line: 928, col: 54, offset: 22012},
 											name: "Expr",
 										},
 									},
@@ -6280,53 +6280,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 942, col: 1, offset: 22332},
+			pos:  position{line: 942, col: 1, offset: 22333},
 			expr: &actionExpr{
-				pos: position{line: 943, col: 5, offset: 22350},
+				pos: position{line: 943, col: 5, offset: 22351},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 943, col: 5, offset: 22350},
+					pos: position{line: 943, col: 5, offset: 22351},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 943, col: 5, offset: 22350},
+							pos:   position{line: 943, col: 5, offset: 22351},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 943, col: 11, offset: 22356},
+								pos:  position{line: 943, col: 11, offset: 22357},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 944, col: 5, offset: 22375},
+							pos:   position{line: 944, col: 5, offset: 22376},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 944, col: 10, offset: 22380},
+								pos: position{line: 944, col: 10, offset: 22381},
 								expr: &actionExpr{
-									pos: position{line: 944, col: 11, offset: 22381},
+									pos: position{line: 944, col: 11, offset: 22382},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 944, col: 11, offset: 22381},
+										pos: position{line: 944, col: 11, offset: 22382},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 944, col: 11, offset: 22381},
+												pos:  position{line: 944, col: 11, offset: 22382},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 944, col: 14, offset: 22384},
+												pos:   position{line: 944, col: 14, offset: 22385},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 944, col: 17, offset: 22387},
+													pos:  position{line: 944, col: 17, offset: 22388},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 944, col: 20, offset: 22390},
+												pos:  position{line: 944, col: 20, offset: 22391},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 944, col: 23, offset: 22393},
+												pos:   position{line: 944, col: 23, offset: 22394},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 944, col: 28, offset: 22398},
+													pos:  position{line: 944, col: 28, offset: 22399},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6343,53 +6343,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 948, col: 1, offset: 22512},
+			pos:  position{line: 948, col: 1, offset: 22513},
 			expr: &actionExpr{
-				pos: position{line: 949, col: 5, offset: 22531},
+				pos: position{line: 949, col: 5, offset: 22532},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 949, col: 5, offset: 22531},
+					pos: position{line: 949, col: 5, offset: 22532},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 949, col: 5, offset: 22531},
+							pos:   position{line: 949, col: 5, offset: 22532},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 949, col: 11, offset: 22537},
+								pos:  position{line: 949, col: 11, offset: 22538},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 950, col: 5, offset: 22549},
+							pos:   position{line: 950, col: 5, offset: 22550},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 950, col: 10, offset: 22554},
+								pos: position{line: 950, col: 10, offset: 22555},
 								expr: &actionExpr{
-									pos: position{line: 950, col: 11, offset: 22555},
+									pos: position{line: 950, col: 11, offset: 22556},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 950, col: 11, offset: 22555},
+										pos: position{line: 950, col: 11, offset: 22556},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 950, col: 11, offset: 22555},
+												pos:  position{line: 950, col: 11, offset: 22556},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 950, col: 14, offset: 22558},
+												pos:   position{line: 950, col: 14, offset: 22559},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 950, col: 17, offset: 22561},
+													pos:  position{line: 950, col: 17, offset: 22562},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 950, col: 21, offset: 22565},
+												pos:  position{line: 950, col: 21, offset: 22566},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 950, col: 24, offset: 22568},
+												pos:   position{line: 950, col: 24, offset: 22569},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 950, col: 29, offset: 22573},
+													pos:  position{line: 950, col: 29, offset: 22574},
 													name: "NotExpr",
 												},
 											},
@@ -6406,43 +6406,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 954, col: 1, offset: 22680},
+			pos:  position{line: 954, col: 1, offset: 22681},
 			expr: &choiceExpr{
-				pos: position{line: 955, col: 5, offset: 22692},
+				pos: position{line: 955, col: 5, offset: 22693},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 955, col: 5, offset: 22692},
+						pos: position{line: 955, col: 5, offset: 22693},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 955, col: 5, offset: 22692},
+							pos: position{line: 955, col: 5, offset: 22693},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 955, col: 6, offset: 22693},
+									pos: position{line: 955, col: 6, offset: 22694},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 955, col: 6, offset: 22693},
+											pos: position{line: 955, col: 6, offset: 22694},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 955, col: 6, offset: 22693},
+													pos:  position{line: 955, col: 6, offset: 22694},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 955, col: 10, offset: 22697},
+													pos:  position{line: 955, col: 10, offset: 22698},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 955, col: 14, offset: 22701},
+											pos: position{line: 955, col: 14, offset: 22702},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 955, col: 14, offset: 22701},
+													pos:        position{line: 955, col: 14, offset: 22702},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 955, col: 18, offset: 22705},
+													pos:  position{line: 955, col: 18, offset: 22706},
 													name: "__",
 												},
 											},
@@ -6450,10 +6450,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 955, col: 22, offset: 22709},
+									pos:   position{line: 955, col: 22, offset: 22710},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 955, col: 24, offset: 22711},
+										pos:  position{line: 955, col: 24, offset: 22712},
 										name: "NotExpr",
 									},
 								},
@@ -6461,7 +6461,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 963, col: 5, offset: 22877},
+						pos:  position{line: 963, col: 5, offset: 22878},
 						name: "BetweenExpr",
 					},
 				},
@@ -6471,42 +6471,42 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 965, col: 1, offset: 22892},
+			pos:  position{line: 965, col: 1, offset: 22893},
 			expr: &choiceExpr{
-				pos: position{line: 966, col: 5, offset: 22908},
+				pos: position{line: 966, col: 5, offset: 22909},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 966, col: 5, offset: 22908},
+						pos: position{line: 966, col: 5, offset: 22909},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 966, col: 5, offset: 22908},
+							pos: position{line: 966, col: 5, offset: 22909},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 966, col: 5, offset: 22908},
+									pos:   position{line: 966, col: 5, offset: 22909},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 966, col: 10, offset: 22913},
+										pos:  position{line: 966, col: 10, offset: 22914},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 966, col: 25, offset: 22928},
+									pos:  position{line: 966, col: 25, offset: 22929},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 966, col: 27, offset: 22930},
+									pos:   position{line: 966, col: 27, offset: 22931},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 966, col: 31, offset: 22934},
+										pos: position{line: 966, col: 31, offset: 22935},
 										expr: &seqExpr{
-											pos: position{line: 966, col: 32, offset: 22935},
+											pos: position{line: 966, col: 32, offset: 22936},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 966, col: 32, offset: 22935},
+													pos:  position{line: 966, col: 32, offset: 22936},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 966, col: 36, offset: 22939},
+													pos:  position{line: 966, col: 36, offset: 22940},
 													name: "_",
 												},
 											},
@@ -6514,38 +6514,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 966, col: 40, offset: 22943},
+									pos:  position{line: 966, col: 40, offset: 22944},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 966, col: 48, offset: 22951},
+									pos:  position{line: 966, col: 48, offset: 22952},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 966, col: 50, offset: 22953},
+									pos:   position{line: 966, col: 50, offset: 22954},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 966, col: 56, offset: 22959},
+										pos:  position{line: 966, col: 56, offset: 22960},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 966, col: 68, offset: 22971},
+									pos:  position{line: 966, col: 68, offset: 22972},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 966, col: 70, offset: 22973},
+									pos:  position{line: 966, col: 70, offset: 22974},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 966, col: 74, offset: 22977},
+									pos:  position{line: 966, col: 74, offset: 22978},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 966, col: 76, offset: 22979},
+									pos:   position{line: 966, col: 76, offset: 22980},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 966, col: 82, offset: 22985},
+										pos:  position{line: 966, col: 82, offset: 22986},
 										name: "BetweenExpr",
 									},
 								},
@@ -6553,7 +6553,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 976, col: 5, offset: 23217},
+						pos:  position{line: 976, col: 5, offset: 23218},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6563,46 +6563,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 978, col: 1, offset: 23233},
+			pos:  position{line: 978, col: 1, offset: 23234},
 			expr: &choiceExpr{
-				pos: position{line: 979, col: 5, offset: 23252},
+				pos: position{line: 979, col: 5, offset: 23253},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 979, col: 5, offset: 23252},
+						pos: position{line: 979, col: 5, offset: 23253},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 979, col: 5, offset: 23252},
+							pos: position{line: 979, col: 5, offset: 23253},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 979, col: 5, offset: 23252},
+									pos:   position{line: 979, col: 5, offset: 23253},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 979, col: 10, offset: 23257},
+										pos:  position{line: 979, col: 10, offset: 23258},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 979, col: 23, offset: 23270},
+									pos:  position{line: 979, col: 23, offset: 23271},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 979, col: 25, offset: 23272},
+									pos:  position{line: 979, col: 25, offset: 23273},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 979, col: 28, offset: 23275},
+									pos:   position{line: 979, col: 28, offset: 23276},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 979, col: 32, offset: 23279},
+										pos: position{line: 979, col: 32, offset: 23280},
 										expr: &seqExpr{
-											pos: position{line: 979, col: 33, offset: 23280},
+											pos: position{line: 979, col: 33, offset: 23281},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 979, col: 33, offset: 23280},
+													pos:  position{line: 979, col: 33, offset: 23281},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 979, col: 35, offset: 23282},
+													pos:  position{line: 979, col: 35, offset: 23283},
 													name: "NOT",
 												},
 											},
@@ -6610,82 +6610,82 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 979, col: 41, offset: 23288},
+									pos:  position{line: 979, col: 41, offset: 23289},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 979, col: 43, offset: 23290},
+									pos:  position{line: 979, col: 43, offset: 23291},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 987, col: 5, offset: 23458},
+						pos: position{line: 987, col: 5, offset: 23459},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 987, col: 5, offset: 23458},
+							pos: position{line: 987, col: 5, offset: 23459},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 987, col: 5, offset: 23458},
+									pos:   position{line: 987, col: 5, offset: 23459},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 987, col: 9, offset: 23462},
+										pos:  position{line: 987, col: 9, offset: 23463},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 987, col: 22, offset: 23475},
+									pos:   position{line: 987, col: 22, offset: 23476},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 987, col: 31, offset: 23484},
+										pos: position{line: 987, col: 31, offset: 23485},
 										expr: &choiceExpr{
-											pos: position{line: 987, col: 32, offset: 23485},
+											pos: position{line: 987, col: 32, offset: 23486},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 987, col: 32, offset: 23485},
+													pos: position{line: 987, col: 32, offset: 23486},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 987, col: 32, offset: 23485},
+															pos:  position{line: 987, col: 32, offset: 23486},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 987, col: 35, offset: 23488},
+															pos:  position{line: 987, col: 35, offset: 23489},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 987, col: 46, offset: 23499},
+															pos:  position{line: 987, col: 46, offset: 23500},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 987, col: 49, offset: 23502},
+															pos:  position{line: 987, col: 49, offset: 23503},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 987, col: 64, offset: 23517},
+													pos: position{line: 987, col: 64, offset: 23518},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 987, col: 64, offset: 23517},
+															pos:  position{line: 987, col: 64, offset: 23518},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 987, col: 68, offset: 23521},
+															pos: position{line: 987, col: 68, offset: 23522},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 987, col: 68, offset: 23521},
+																pos:        position{line: 987, col: 68, offset: 23522},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 987, col: 104, offset: 23557},
+															pos:  position{line: 987, col: 104, offset: 23558},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 987, col: 107, offset: 23560},
+															pos:  position{line: 987, col: 107, offset: 23561},
 															name: "Regexp",
 														},
 													},
@@ -6704,53 +6704,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 1000, col: 1, offset: 23846},
+			pos:  position{line: 1000, col: 1, offset: 23847},
 			expr: &actionExpr{
-				pos: position{line: 1001, col: 5, offset: 23863},
+				pos: position{line: 1001, col: 5, offset: 23864},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1001, col: 5, offset: 23863},
+					pos: position{line: 1001, col: 5, offset: 23864},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1001, col: 5, offset: 23863},
+							pos:   position{line: 1001, col: 5, offset: 23864},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1001, col: 11, offset: 23869},
+								pos:  position{line: 1001, col: 11, offset: 23870},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1002, col: 5, offset: 23892},
+							pos:   position{line: 1002, col: 5, offset: 23893},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1002, col: 10, offset: 23897},
+								pos: position{line: 1002, col: 10, offset: 23898},
 								expr: &actionExpr{
-									pos: position{line: 1002, col: 11, offset: 23898},
+									pos: position{line: 1002, col: 11, offset: 23899},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1002, col: 11, offset: 23898},
+										pos: position{line: 1002, col: 11, offset: 23899},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1002, col: 11, offset: 23898},
+												pos:  position{line: 1002, col: 11, offset: 23899},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1002, col: 14, offset: 23901},
+												pos:   position{line: 1002, col: 14, offset: 23902},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1002, col: 17, offset: 23904},
+													pos:  position{line: 1002, col: 17, offset: 23905},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1002, col: 34, offset: 23921},
+												pos:  position{line: 1002, col: 34, offset: 23922},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1002, col: 37, offset: 23924},
+												pos:   position{line: 1002, col: 37, offset: 23925},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1002, col: 42, offset: 23929},
+													pos:  position{line: 1002, col: 42, offset: 23930},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6767,21 +6767,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 1006, col: 1, offset: 24047},
+			pos:  position{line: 1006, col: 1, offset: 24048},
 			expr: &actionExpr{
-				pos: position{line: 1006, col: 20, offset: 24066},
+				pos: position{line: 1006, col: 20, offset: 24067},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 1006, col: 21, offset: 24067},
+					pos: position{line: 1006, col: 21, offset: 24068},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1006, col: 21, offset: 24067},
+							pos:        position{line: 1006, col: 21, offset: 24068},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1006, col: 27, offset: 24073},
+							pos:        position{line: 1006, col: 27, offset: 24074},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6794,53 +6794,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 1008, col: 1, offset: 24110},
+			pos:  position{line: 1008, col: 1, offset: 24111},
 			expr: &actionExpr{
-				pos: position{line: 1009, col: 5, offset: 24133},
+				pos: position{line: 1009, col: 5, offset: 24134},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1009, col: 5, offset: 24133},
+					pos: position{line: 1009, col: 5, offset: 24134},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1009, col: 5, offset: 24133},
+							pos:   position{line: 1009, col: 5, offset: 24134},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1009, col: 11, offset: 24139},
+								pos:  position{line: 1009, col: 11, offset: 24140},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1010, col: 5, offset: 24154},
+							pos:   position{line: 1010, col: 5, offset: 24155},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1010, col: 10, offset: 24159},
+								pos: position{line: 1010, col: 10, offset: 24160},
 								expr: &actionExpr{
-									pos: position{line: 1010, col: 11, offset: 24160},
+									pos: position{line: 1010, col: 11, offset: 24161},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1010, col: 11, offset: 24160},
+										pos: position{line: 1010, col: 11, offset: 24161},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1010, col: 11, offset: 24160},
+												pos:  position{line: 1010, col: 11, offset: 24161},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1010, col: 14, offset: 24163},
+												pos:   position{line: 1010, col: 14, offset: 24164},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1010, col: 17, offset: 24166},
+													pos:  position{line: 1010, col: 17, offset: 24167},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1010, col: 40, offset: 24189},
+												pos:  position{line: 1010, col: 40, offset: 24190},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1010, col: 43, offset: 24192},
+												pos:   position{line: 1010, col: 43, offset: 24193},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1010, col: 48, offset: 24197},
+													pos:  position{line: 1010, col: 48, offset: 24198},
 													name: "ConcatExpr",
 												},
 											},
@@ -6857,27 +6857,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 1014, col: 1, offset: 24307},
+			pos:  position{line: 1014, col: 1, offset: 24308},
 			expr: &actionExpr{
-				pos: position{line: 1014, col: 26, offset: 24332},
+				pos: position{line: 1014, col: 26, offset: 24333},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 1014, col: 27, offset: 24333},
+					pos: position{line: 1014, col: 27, offset: 24334},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1014, col: 27, offset: 24333},
+							pos:        position{line: 1014, col: 27, offset: 24334},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1014, col: 33, offset: 24339},
+							pos:        position{line: 1014, col: 33, offset: 24340},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1014, col: 39, offset: 24345},
+							pos:        position{line: 1014, col: 39, offset: 24346},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6890,51 +6890,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 1016, col: 1, offset: 24382},
+			pos:  position{line: 1016, col: 1, offset: 24383},
 			expr: &actionExpr{
-				pos: position{line: 1017, col: 5, offset: 24398},
+				pos: position{line: 1017, col: 5, offset: 24399},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1017, col: 5, offset: 24398},
+					pos: position{line: 1017, col: 5, offset: 24399},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1017, col: 5, offset: 24398},
+							pos:   position{line: 1017, col: 5, offset: 24399},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1017, col: 11, offset: 24404},
+								pos:  position{line: 1017, col: 11, offset: 24405},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1018, col: 5, offset: 24425},
+							pos:   position{line: 1018, col: 5, offset: 24426},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1018, col: 10, offset: 24430},
+								pos: position{line: 1018, col: 10, offset: 24431},
 								expr: &actionExpr{
-									pos: position{line: 1018, col: 11, offset: 24431},
+									pos: position{line: 1018, col: 11, offset: 24432},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1018, col: 11, offset: 24431},
+										pos: position{line: 1018, col: 11, offset: 24432},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1018, col: 11, offset: 24431},
+												pos:  position{line: 1018, col: 11, offset: 24432},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1018, col: 14, offset: 24434},
+												pos:        position{line: 1018, col: 14, offset: 24435},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1018, col: 19, offset: 24439},
+												pos:  position{line: 1018, col: 19, offset: 24440},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1018, col: 22, offset: 24442},
+												pos:   position{line: 1018, col: 22, offset: 24443},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1018, col: 27, offset: 24447},
+													pos:  position{line: 1018, col: 27, offset: 24448},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6951,40 +6951,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 1022, col: 1, offset: 24565},
+			pos:  position{line: 1022, col: 1, offset: 24566},
 			expr: &choiceExpr{
-				pos: position{line: 1023, col: 5, offset: 24586},
+				pos: position{line: 1023, col: 5, offset: 24587},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 24586},
+						pos: position{line: 1023, col: 5, offset: 24587},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 24586},
+							pos: position{line: 1023, col: 5, offset: 24587},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1023, col: 5, offset: 24586},
+									pos: position{line: 1023, col: 5, offset: 24587},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 6, offset: 24587},
+										pos:  position{line: 1023, col: 6, offset: 24588},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 14, offset: 24595},
+									pos:   position{line: 1023, col: 14, offset: 24596},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 17, offset: 24598},
+										pos:  position{line: 1023, col: 17, offset: 24599},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 31, offset: 24612},
+									pos:  position{line: 1023, col: 31, offset: 24613},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 34, offset: 24615},
+									pos:   position{line: 1023, col: 34, offset: 24616},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 36, offset: 24617},
+										pos:  position{line: 1023, col: 36, offset: 24618},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6992,7 +6992,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1032, col: 5, offset: 24801},
+						pos:  position{line: 1032, col: 5, offset: 24802},
 						name: "DerefExpr",
 					},
 				},
@@ -7002,21 +7002,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 1034, col: 1, offset: 24812},
+			pos:  position{line: 1034, col: 1, offset: 24813},
 			expr: &actionExpr{
-				pos: position{line: 1034, col: 17, offset: 24828},
+				pos: position{line: 1034, col: 17, offset: 24829},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 1034, col: 18, offset: 24829},
+					pos: position{line: 1034, col: 18, offset: 24830},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1034, col: 18, offset: 24829},
+							pos:        position{line: 1034, col: 18, offset: 24830},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1034, col: 24, offset: 24835},
+							pos:        position{line: 1034, col: 24, offset: 24836},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -7029,73 +7029,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 1036, col: 1, offset: 24872},
+			pos:  position{line: 1036, col: 1, offset: 24873},
 			expr: &choiceExpr{
-				pos: position{line: 1037, col: 5, offset: 24886},
+				pos: position{line: 1037, col: 5, offset: 24887},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1037, col: 5, offset: 24886},
+						pos: position{line: 1037, col: 5, offset: 24887},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1037, col: 5, offset: 24886},
+							pos: position{line: 1037, col: 5, offset: 24887},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1037, col: 5, offset: 24886},
+									pos:   position{line: 1037, col: 5, offset: 24887},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1037, col: 10, offset: 24891},
+										pos:  position{line: 1037, col: 10, offset: 24892},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1037, col: 20, offset: 24901},
+									pos:        position{line: 1037, col: 20, offset: 24902},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 24, offset: 24905},
+									pos:  position{line: 1037, col: 24, offset: 24906},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1037, col: 27, offset: 24908},
+									pos:   position{line: 1037, col: 27, offset: 24909},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1037, col: 32, offset: 24913},
+										pos:  position{line: 1037, col: 32, offset: 24914},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 45, offset: 24926},
+									pos:  position{line: 1037, col: 45, offset: 24927},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1037, col: 48, offset: 24929},
+									pos:        position{line: 1037, col: 48, offset: 24930},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 52, offset: 24933},
+									pos:  position{line: 1037, col: 52, offset: 24934},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1037, col: 55, offset: 24936},
+									pos:   position{line: 1037, col: 55, offset: 24937},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1037, col: 58, offset: 24939},
+										pos: position{line: 1037, col: 58, offset: 24940},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1037, col: 58, offset: 24939},
+											pos:  position{line: 1037, col: 58, offset: 24940},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1037, col: 72, offset: 24953},
+									pos:  position{line: 1037, col: 72, offset: 24954},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1037, col: 75, offset: 24956},
+									pos:        position{line: 1037, col: 75, offset: 24957},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7104,49 +7104,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1049, col: 5, offset: 25195},
+						pos: position{line: 1049, col: 5, offset: 25196},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1049, col: 5, offset: 25195},
+							pos: position{line: 1049, col: 5, offset: 25196},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1049, col: 5, offset: 25195},
+									pos:   position{line: 1049, col: 5, offset: 25196},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1049, col: 10, offset: 25200},
+										pos:  position{line: 1049, col: 10, offset: 25201},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1049, col: 20, offset: 25210},
+									pos:        position{line: 1049, col: 20, offset: 25211},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1049, col: 24, offset: 25214},
+									pos:  position{line: 1049, col: 24, offset: 25215},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1049, col: 27, offset: 25217},
+									pos:        position{line: 1049, col: 27, offset: 25218},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1049, col: 31, offset: 25221},
+									pos:  position{line: 1049, col: 31, offset: 25222},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1049, col: 34, offset: 25224},
+									pos:   position{line: 1049, col: 34, offset: 25225},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1049, col: 37, offset: 25227},
+										pos:  position{line: 1049, col: 37, offset: 25228},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1049, col: 50, offset: 25240},
+									pos:        position{line: 1049, col: 50, offset: 25241},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7155,35 +7155,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 25404},
+						pos: position{line: 1057, col: 5, offset: 25405},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 25404},
+							pos: position{line: 1057, col: 5, offset: 25405},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1057, col: 5, offset: 25404},
+									pos:   position{line: 1057, col: 5, offset: 25405},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1057, col: 10, offset: 25409},
+										pos:  position{line: 1057, col: 10, offset: 25410},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 20, offset: 25419},
+									pos:        position{line: 1057, col: 20, offset: 25420},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 24, offset: 25423},
+									pos:   position{line: 1057, col: 24, offset: 25424},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1057, col: 30, offset: 25429},
+										pos:  position{line: 1057, col: 30, offset: 25430},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 35, offset: 25434},
+									pos:        position{line: 1057, col: 35, offset: 25435},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7192,30 +7192,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 5, offset: 25604},
+						pos: position{line: 1065, col: 5, offset: 25605},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1065, col: 5, offset: 25604},
+							pos: position{line: 1065, col: 5, offset: 25605},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1065, col: 5, offset: 25604},
+									pos:   position{line: 1065, col: 5, offset: 25605},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 10, offset: 25609},
+										pos:  position{line: 1065, col: 10, offset: 25610},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1065, col: 20, offset: 25619},
+									pos:        position{line: 1065, col: 20, offset: 25620},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 24, offset: 25623},
+									pos:   position{line: 1065, col: 24, offset: 25624},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 27, offset: 25626},
+										pos:  position{line: 1065, col: 27, offset: 25627},
 										name: "Identifier",
 									},
 								},
@@ -7223,11 +7223,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1074, col: 5, offset: 25816},
+						pos:  position{line: 1074, col: 5, offset: 25817},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1075, col: 5, offset: 25829},
+						pos:  position{line: 1075, col: 5, offset: 25830},
 						name: "Primary",
 					},
 				},
@@ -7237,16 +7237,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 1077, col: 1, offset: 25838},
+			pos:  position{line: 1077, col: 1, offset: 25839},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 5, offset: 25851},
+				pos: position{line: 1078, col: 5, offset: 25852},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 5, offset: 25851},
+						pos:  position{line: 1078, col: 5, offset: 25852},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1079, col: 5, offset: 25860},
+						pos:  position{line: 1079, col: 5, offset: 25861},
 						name: "Function",
 					},
 				},
@@ -7256,20 +7256,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1081, col: 1, offset: 25870},
+			pos:  position{line: 1081, col: 1, offset: 25871},
 			expr: &seqExpr{
-				pos: position{line: 1081, col: 13, offset: 25882},
+				pos: position{line: 1081, col: 13, offset: 25883},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1081, col: 13, offset: 25882},
+						pos:  position{line: 1081, col: 13, offset: 25883},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1081, col: 22, offset: 25891},
+						pos:  position{line: 1081, col: 22, offset: 25892},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1081, col: 25, offset: 25894},
+						pos:        position{line: 1081, col: 25, offset: 25895},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -7281,16 +7281,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1083, col: 1, offset: 25899},
+			pos:  position{line: 1083, col: 1, offset: 25900},
 			expr: &choiceExpr{
-				pos: position{line: 1084, col: 5, offset: 25912},
+				pos: position{line: 1084, col: 5, offset: 25913},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1084, col: 5, offset: 25912},
+						pos:  position{line: 1084, col: 5, offset: 25913},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1085, col: 5, offset: 25920},
+						pos:  position{line: 1085, col: 5, offset: 25921},
 						name: "SELECT",
 					},
 				},
@@ -7300,58 +7300,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1087, col: 1, offset: 25928},
+			pos:  position{line: 1087, col: 1, offset: 25929},
 			expr: &actionExpr{
-				pos: position{line: 1088, col: 5, offset: 25937},
+				pos: position{line: 1088, col: 5, offset: 25938},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1088, col: 5, offset: 25937},
+					pos: position{line: 1088, col: 5, offset: 25938},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1088, col: 5, offset: 25937},
+							pos:   position{line: 1088, col: 5, offset: 25938},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1088, col: 9, offset: 25941},
+								pos:  position{line: 1088, col: 9, offset: 25942},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1088, col: 21, offset: 25953},
+							pos:  position{line: 1088, col: 21, offset: 25954},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1088, col: 24, offset: 25956},
+							pos:        position{line: 1088, col: 24, offset: 25957},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1088, col: 28, offset: 25960},
+							pos:  position{line: 1088, col: 28, offset: 25961},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1088, col: 31, offset: 25963},
+							pos:   position{line: 1088, col: 31, offset: 25964},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1088, col: 37, offset: 25969},
+								pos: position{line: 1088, col: 37, offset: 25970},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1088, col: 37, offset: 25969},
+										pos:  position{line: 1088, col: 37, offset: 25970},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1088, col: 48, offset: 25980},
+										pos:  position{line: 1088, col: 48, offset: 25981},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1088, col: 54, offset: 25986},
+							pos:  position{line: 1088, col: 54, offset: 25987},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1088, col: 57, offset: 25989},
+							pos:        position{line: 1088, col: 57, offset: 25990},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7364,85 +7364,85 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1092, col: 1, offset: 26102},
+			pos:  position{line: 1092, col: 1, offset: 26103},
 			expr: &choiceExpr{
-				pos: position{line: 1093, col: 5, offset: 26115},
+				pos: position{line: 1093, col: 5, offset: 26116},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1093, col: 5, offset: 26115},
+						pos:  position{line: 1093, col: 5, offset: 26116},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1095, col: 5, offset: 26202},
+						pos: position{line: 1095, col: 5, offset: 26203},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1095, col: 5, offset: 26202},
+							pos: position{line: 1095, col: 5, offset: 26203},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 5, offset: 26202},
+									pos:  position{line: 1095, col: 5, offset: 26203},
 									name: "REGEXP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 12, offset: 26209},
+									pos:  position{line: 1095, col: 12, offset: 26210},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1095, col: 15, offset: 26212},
+									pos:        position{line: 1095, col: 15, offset: 26213},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 19, offset: 26216},
+									pos:  position{line: 1095, col: 19, offset: 26217},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1095, col: 22, offset: 26219},
+									pos:   position{line: 1095, col: 22, offset: 26220},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1095, col: 27, offset: 26224},
+										pos:  position{line: 1095, col: 27, offset: 26225},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 43, offset: 26240},
+									pos:  position{line: 1095, col: 43, offset: 26241},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1095, col: 46, offset: 26243},
+									pos:        position{line: 1095, col: 46, offset: 26244},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 50, offset: 26247},
+									pos:  position{line: 1095, col: 50, offset: 26248},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1095, col: 53, offset: 26250},
+									pos:   position{line: 1095, col: 53, offset: 26251},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1095, col: 58, offset: 26255},
+										pos:  position{line: 1095, col: 58, offset: 26256},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 63, offset: 26260},
+									pos:  position{line: 1095, col: 63, offset: 26261},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1095, col: 66, offset: 26263},
+									pos:        position{line: 1095, col: 66, offset: 26264},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1095, col: 70, offset: 26267},
+									pos:   position{line: 1095, col: 70, offset: 26268},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1095, col: 76, offset: 26273},
+										pos: position{line: 1095, col: 76, offset: 26274},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1095, col: 76, offset: 26273},
+											pos:  position{line: 1095, col: 76, offset: 26274},
 											name: "WhereClause",
 										},
 									},
@@ -7451,98 +7451,98 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1099, col: 5, offset: 26452},
+						pos: position{line: 1099, col: 5, offset: 26453},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1099, col: 5, offset: 26452},
+							pos: position{line: 1099, col: 5, offset: 26453},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 5, offset: 26452},
+									pos:  position{line: 1099, col: 5, offset: 26453},
 									name: "REGEXP_REPLACE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 20, offset: 26467},
+									pos:  position{line: 1099, col: 20, offset: 26468},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1099, col: 23, offset: 26470},
+									pos:        position{line: 1099, col: 23, offset: 26471},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 27, offset: 26474},
+									pos:  position{line: 1099, col: 27, offset: 26475},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1099, col: 30, offset: 26477},
+									pos:   position{line: 1099, col: 30, offset: 26478},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1099, col: 35, offset: 26482},
+										pos:  position{line: 1099, col: 35, offset: 26483},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 40, offset: 26487},
+									pos:  position{line: 1099, col: 40, offset: 26488},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1099, col: 43, offset: 26490},
+									pos:        position{line: 1099, col: 43, offset: 26491},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 47, offset: 26494},
+									pos:  position{line: 1099, col: 47, offset: 26495},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1099, col: 50, offset: 26497},
+									pos:   position{line: 1099, col: 50, offset: 26498},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1099, col: 55, offset: 26502},
+										pos:  position{line: 1099, col: 55, offset: 26503},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 71, offset: 26518},
+									pos:  position{line: 1099, col: 71, offset: 26519},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1099, col: 74, offset: 26521},
+									pos:        position{line: 1099, col: 74, offset: 26522},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 78, offset: 26525},
+									pos:  position{line: 1099, col: 78, offset: 26526},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1099, col: 81, offset: 26528},
+									pos:   position{line: 1099, col: 81, offset: 26529},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1099, col: 86, offset: 26533},
+										pos:  position{line: 1099, col: 86, offset: 26534},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 91, offset: 26538},
+									pos:  position{line: 1099, col: 91, offset: 26539},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1099, col: 94, offset: 26541},
+									pos:        position{line: 1099, col: 94, offset: 26542},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1099, col: 98, offset: 26545},
+									pos:   position{line: 1099, col: 98, offset: 26546},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1099, col: 104, offset: 26551},
+										pos: position{line: 1099, col: 104, offset: 26552},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1099, col: 104, offset: 26551},
+											pos:  position{line: 1099, col: 104, offset: 26552},
 											name: "WhereClause",
 										},
 									},
@@ -7551,81 +7551,81 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1103, col: 5, offset: 26745},
+						pos: position{line: 1103, col: 5, offset: 26746},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1103, col: 5, offset: 26745},
+							pos: position{line: 1103, col: 5, offset: 26746},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1103, col: 5, offset: 26745},
+									pos: position{line: 1103, col: 5, offset: 26746},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 6, offset: 26746},
+										pos:  position{line: 1103, col: 6, offset: 26747},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 16, offset: 26756},
+									pos:  position{line: 1103, col: 16, offset: 26757},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 24, offset: 26764},
+									pos:  position{line: 1103, col: 24, offset: 26765},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 27, offset: 26767},
+									pos:        position{line: 1103, col: 27, offset: 26768},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 31, offset: 26771},
+									pos:  position{line: 1103, col: 31, offset: 26772},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 34, offset: 26774},
+									pos:   position{line: 1103, col: 34, offset: 26775},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 39, offset: 26779},
+										pos:  position{line: 1103, col: 39, offset: 26780},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 44, offset: 26784},
+									pos:  position{line: 1103, col: 44, offset: 26785},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 46, offset: 26786},
+									pos:  position{line: 1103, col: 46, offset: 26787},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 51, offset: 26791},
+									pos:  position{line: 1103, col: 51, offset: 26792},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 53, offset: 26793},
+									pos:   position{line: 1103, col: 53, offset: 26794},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 55, offset: 26795},
+										pos:  position{line: 1103, col: 55, offset: 26796},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 60, offset: 26800},
+									pos:  position{line: 1103, col: 60, offset: 26801},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 63, offset: 26803},
+									pos:        position{line: 1103, col: 63, offset: 26804},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 67, offset: 26807},
+									pos:   position{line: 1103, col: 67, offset: 26808},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1103, col: 73, offset: 26813},
+										pos: position{line: 1103, col: 73, offset: 26814},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1103, col: 73, offset: 26813},
+											pos:  position{line: 1103, col: 73, offset: 26814},
 											name: "WhereClause",
 										},
 									},
@@ -7634,70 +7634,70 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1111, col: 5, offset: 26992},
+						pos: position{line: 1111, col: 5, offset: 26993},
 						run: (*parser).callonFunction64,
 						expr: &seqExpr{
-							pos: position{line: 1111, col: 5, offset: 26992},
+							pos: position{line: 1111, col: 5, offset: 26993},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1111, col: 5, offset: 26992},
+									pos: position{line: 1111, col: 5, offset: 26993},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 6, offset: 26993},
+										pos:  position{line: 1111, col: 6, offset: 26994},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 16, offset: 27003},
+									pos:  position{line: 1111, col: 16, offset: 27004},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 21, offset: 27008},
+									pos:  position{line: 1111, col: 21, offset: 27009},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 24, offset: 27011},
+									pos:        position{line: 1111, col: 24, offset: 27012},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 28, offset: 27015},
+									pos:  position{line: 1111, col: 28, offset: 27016},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 31, offset: 27018},
+									pos:   position{line: 1111, col: 31, offset: 27019},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 33, offset: 27020},
+										pos:  position{line: 1111, col: 33, offset: 27021},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 38, offset: 27025},
+									pos:  position{line: 1111, col: 38, offset: 27026},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 40, offset: 27027},
+									pos:  position{line: 1111, col: 40, offset: 27028},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 43, offset: 27030},
+									pos:  position{line: 1111, col: 43, offset: 27031},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 45, offset: 27032},
+									pos:   position{line: 1111, col: 45, offset: 27033},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 49, offset: 27036},
+										pos:  position{line: 1111, col: 49, offset: 27037},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 60, offset: 27047},
+									pos:  position{line: 1111, col: 60, offset: 27048},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 63, offset: 27050},
+									pos:        position{line: 1111, col: 63, offset: 27051},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7706,72 +7706,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1119, col: 5, offset: 27209},
+						pos: position{line: 1119, col: 5, offset: 27210},
 						run: (*parser).callonFunction81,
 						expr: &seqExpr{
-							pos: position{line: 1119, col: 5, offset: 27209},
+							pos: position{line: 1119, col: 5, offset: 27210},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1119, col: 5, offset: 27209},
+									pos: position{line: 1119, col: 5, offset: 27210},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1119, col: 6, offset: 27210},
+										pos:  position{line: 1119, col: 6, offset: 27211},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1119, col: 16, offset: 27220},
+									pos:  position{line: 1119, col: 16, offset: 27221},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1119, col: 26, offset: 27230},
+									pos:  position{line: 1119, col: 26, offset: 27231},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1119, col: 29, offset: 27233},
+									pos:        position{line: 1119, col: 29, offset: 27234},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1119, col: 33, offset: 27237},
+									pos:  position{line: 1119, col: 33, offset: 27238},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1119, col: 36, offset: 27240},
+									pos:   position{line: 1119, col: 36, offset: 27241},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1119, col: 41, offset: 27245},
+										pos:  position{line: 1119, col: 41, offset: 27246},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1119, col: 46, offset: 27250},
+									pos:   position{line: 1119, col: 46, offset: 27251},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1119, col: 51, offset: 27255},
+										pos: position{line: 1119, col: 51, offset: 27256},
 										expr: &actionExpr{
-											pos: position{line: 1119, col: 52, offset: 27256},
+											pos: position{line: 1119, col: 52, offset: 27257},
 											run: (*parser).callonFunction93,
 											expr: &seqExpr{
-												pos: position{line: 1119, col: 52, offset: 27256},
+												pos: position{line: 1119, col: 52, offset: 27257},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1119, col: 52, offset: 27256},
+														pos:  position{line: 1119, col: 52, offset: 27257},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1119, col: 54, offset: 27258},
+														pos:  position{line: 1119, col: 54, offset: 27259},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1119, col: 59, offset: 27263},
+														pos:  position{line: 1119, col: 59, offset: 27264},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1119, col: 61, offset: 27265},
+														pos:   position{line: 1119, col: 61, offset: 27266},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1119, col: 63, offset: 27267},
+															pos:  position{line: 1119, col: 63, offset: 27268},
 															name: "Expr",
 														},
 													},
@@ -7781,33 +7781,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1119, col: 88, offset: 27292},
+									pos:   position{line: 1119, col: 88, offset: 27293},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1119, col: 93, offset: 27297},
+										pos: position{line: 1119, col: 93, offset: 27298},
 										expr: &actionExpr{
-											pos: position{line: 1119, col: 94, offset: 27298},
+											pos: position{line: 1119, col: 94, offset: 27299},
 											run: (*parser).callonFunction102,
 											expr: &seqExpr{
-												pos: position{line: 1119, col: 94, offset: 27298},
+												pos: position{line: 1119, col: 94, offset: 27299},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1119, col: 94, offset: 27298},
+														pos:  position{line: 1119, col: 94, offset: 27299},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1119, col: 96, offset: 27300},
+														pos:  position{line: 1119, col: 96, offset: 27301},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1119, col: 100, offset: 27304},
+														pos:  position{line: 1119, col: 100, offset: 27305},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1119, col: 102, offset: 27306},
+														pos:   position{line: 1119, col: 102, offset: 27307},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1119, col: 104, offset: 27308},
+															pos:  position{line: 1119, col: 104, offset: 27309},
 															name: "Expr",
 														},
 													},
@@ -7817,7 +7817,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1119, col: 129, offset: 27333},
+									pos:        position{line: 1119, col: 129, offset: 27334},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7826,65 +7826,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1133, col: 5, offset: 27616},
+						pos: position{line: 1133, col: 5, offset: 27617},
 						run: (*parser).callonFunction110,
 						expr: &seqExpr{
-							pos: position{line: 1133, col: 5, offset: 27616},
+							pos: position{line: 1133, col: 5, offset: 27617},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1133, col: 5, offset: 27616},
+									pos: position{line: 1133, col: 5, offset: 27617},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1133, col: 6, offset: 27617},
+										pos:  position{line: 1133, col: 6, offset: 27618},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1133, col: 16, offset: 27627},
+									pos:   position{line: 1133, col: 16, offset: 27628},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1133, col: 19, offset: 27630},
+										pos:  position{line: 1133, col: 19, offset: 27631},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1133, col: 30, offset: 27641},
+									pos:  position{line: 1133, col: 30, offset: 27642},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1133, col: 33, offset: 27644},
+									pos:        position{line: 1133, col: 33, offset: 27645},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1133, col: 37, offset: 27648},
+									pos:  position{line: 1133, col: 37, offset: 27649},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1133, col: 40, offset: 27651},
+									pos:   position{line: 1133, col: 40, offset: 27652},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1133, col: 45, offset: 27656},
+										pos:  position{line: 1133, col: 45, offset: 27657},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1133, col: 58, offset: 27669},
+									pos:  position{line: 1133, col: 58, offset: 27670},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1133, col: 61, offset: 27672},
+									pos:        position{line: 1133, col: 61, offset: 27673},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1133, col: 65, offset: 27676},
+									pos:   position{line: 1133, col: 65, offset: 27677},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1133, col: 71, offset: 27682},
+										pos: position{line: 1133, col: 71, offset: 27683},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1133, col: 71, offset: 27682},
+											pos:  position{line: 1133, col: 71, offset: 27683},
 											name: "WhereClause",
 										},
 									},
@@ -7893,7 +7893,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1136, col: 5, offset: 27753},
+						pos:  position{line: 1136, col: 5, offset: 27754},
 						name: "CountStar",
 					},
 				},
@@ -7903,15 +7903,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1138, col: 1, offset: 27764},
+			pos:  position{line: 1138, col: 1, offset: 27765},
 			expr: &actionExpr{
-				pos: position{line: 1139, col: 5, offset: 27784},
+				pos: position{line: 1139, col: 5, offset: 27785},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1139, col: 5, offset: 27784},
+					pos:   position{line: 1139, col: 5, offset: 27785},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1139, col: 9, offset: 27788},
+						pos:  position{line: 1139, col: 9, offset: 27789},
 						name: "RegexpPattern",
 					},
 				},
@@ -7921,24 +7921,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1141, col: 1, offset: 27859},
+			pos:  position{line: 1141, col: 1, offset: 27860},
 			expr: &choiceExpr{
-				pos: position{line: 1142, col: 5, offset: 27876},
+				pos: position{line: 1142, col: 5, offset: 27877},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1142, col: 5, offset: 27876},
+						pos: position{line: 1142, col: 5, offset: 27877},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1142, col: 5, offset: 27876},
+							pos:   position{line: 1142, col: 5, offset: 27877},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1142, col: 7, offset: 27878},
+								pos:  position{line: 1142, col: 7, offset: 27879},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1143, col: 5, offset: 27916},
+						pos:  position{line: 1143, col: 5, offset: 27917},
 						name: "OptionalExprs",
 					},
 				},
@@ -7948,96 +7948,96 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1145, col: 1, offset: 27931},
+			pos:  position{line: 1145, col: 1, offset: 27932},
 			expr: &actionExpr{
-				pos: position{line: 1146, col: 5, offset: 27940},
+				pos: position{line: 1146, col: 5, offset: 27941},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1146, col: 5, offset: 27940},
+					pos: position{line: 1146, col: 5, offset: 27941},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1146, col: 5, offset: 27940},
+							pos:  position{line: 1146, col: 5, offset: 27941},
 							name: "GREP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1146, col: 10, offset: 27945},
+							pos:  position{line: 1146, col: 10, offset: 27946},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1146, col: 13, offset: 27948},
+							pos:        position{line: 1146, col: 13, offset: 27949},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1146, col: 17, offset: 27952},
+							pos:  position{line: 1146, col: 17, offset: 27953},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1146, col: 20, offset: 27955},
+							pos:   position{line: 1146, col: 20, offset: 27956},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1146, col: 29, offset: 27964},
+								pos: position{line: 1146, col: 29, offset: 27965},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1146, col: 29, offset: 27964},
+										pos:  position{line: 1146, col: 29, offset: 27965},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1146, col: 38, offset: 27973},
+										pos:  position{line: 1146, col: 38, offset: 27974},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1146, col: 45, offset: 27980},
+										pos:  position{line: 1146, col: 45, offset: 27981},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1146, col: 51, offset: 27986},
+							pos:  position{line: 1146, col: 51, offset: 27987},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1146, col: 54, offset: 27989},
+							pos:   position{line: 1146, col: 54, offset: 27990},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1146, col: 58, offset: 27993},
+								pos: position{line: 1146, col: 58, offset: 27994},
 								expr: &actionExpr{
-									pos: position{line: 1146, col: 59, offset: 27994},
+									pos: position{line: 1146, col: 59, offset: 27995},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1146, col: 59, offset: 27994},
+										pos: position{line: 1146, col: 59, offset: 27995},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1146, col: 59, offset: 27994},
+												pos:        position{line: 1146, col: 59, offset: 27995},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1146, col: 63, offset: 27998},
+												pos:  position{line: 1146, col: 63, offset: 27999},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1146, col: 66, offset: 28001},
+												pos:   position{line: 1146, col: 66, offset: 28002},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1146, col: 69, offset: 28004},
+													pos: position{line: 1146, col: 69, offset: 28005},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1146, col: 69, offset: 28004},
+															pos:  position{line: 1146, col: 69, offset: 28005},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1146, col: 80, offset: 28015},
+															pos:  position{line: 1146, col: 80, offset: 28016},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1146, col: 86, offset: 28021},
+												pos:  position{line: 1146, col: 86, offset: 28022},
 												name: "__",
 											},
 										},
@@ -8046,7 +8046,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1146, col: 109, offset: 28044},
+							pos:        position{line: 1146, col: 109, offset: 28045},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8059,19 +8059,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1158, col: 1, offset: 28257},
+			pos:  position{line: 1158, col: 1, offset: 28258},
 			expr: &choiceExpr{
-				pos: position{line: 1159, col: 5, offset: 28275},
+				pos: position{line: 1159, col: 5, offset: 28276},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1159, col: 5, offset: 28275},
+						pos:  position{line: 1159, col: 5, offset: 28276},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1160, col: 5, offset: 28285},
+						pos: position{line: 1160, col: 5, offset: 28286},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1160, col: 5, offset: 28285},
+							pos:  position{line: 1160, col: 5, offset: 28286},
 							name: "__",
 						},
 					},
@@ -8082,51 +8082,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1162, col: 1, offset: 28313},
+			pos:  position{line: 1162, col: 1, offset: 28314},
 			expr: &actionExpr{
-				pos: position{line: 1163, col: 5, offset: 28323},
+				pos: position{line: 1163, col: 5, offset: 28324},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1163, col: 5, offset: 28323},
+					pos: position{line: 1163, col: 5, offset: 28324},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1163, col: 5, offset: 28323},
+							pos:   position{line: 1163, col: 5, offset: 28324},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1163, col: 11, offset: 28329},
+								pos:  position{line: 1163, col: 11, offset: 28330},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1163, col: 16, offset: 28334},
+							pos:   position{line: 1163, col: 16, offset: 28335},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1163, col: 21, offset: 28339},
+								pos: position{line: 1163, col: 21, offset: 28340},
 								expr: &actionExpr{
-									pos: position{line: 1163, col: 22, offset: 28340},
+									pos: position{line: 1163, col: 22, offset: 28341},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1163, col: 22, offset: 28340},
+										pos: position{line: 1163, col: 22, offset: 28341},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1163, col: 22, offset: 28340},
+												pos:  position{line: 1163, col: 22, offset: 28341},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1163, col: 25, offset: 28343},
+												pos:        position{line: 1163, col: 25, offset: 28344},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1163, col: 29, offset: 28347},
+												pos:  position{line: 1163, col: 29, offset: 28348},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1163, col: 32, offset: 28350},
+												pos:   position{line: 1163, col: 32, offset: 28351},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1163, col: 34, offset: 28352},
+													pos:  position{line: 1163, col: 34, offset: 28353},
 													name: "Expr",
 												},
 											},
@@ -8143,56 +8143,56 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1167, col: 1, offset: 28425},
+			pos:  position{line: 1167, col: 1, offset: 28426},
 			expr: &choiceExpr{
-				pos: position{line: 1168, col: 5, offset: 28437},
+				pos: position{line: 1168, col: 5, offset: 28438},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1168, col: 5, offset: 28437},
+						pos:  position{line: 1168, col: 5, offset: 28438},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1169, col: 5, offset: 28450},
+						pos:  position{line: 1169, col: 5, offset: 28451},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1170, col: 5, offset: 28461},
+						pos:  position{line: 1170, col: 5, offset: 28462},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1171, col: 5, offset: 28471},
+						pos:  position{line: 1171, col: 5, offset: 28472},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1172, col: 5, offset: 28479},
+						pos:  position{line: 1172, col: 5, offset: 28480},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1173, col: 5, offset: 28487},
+						pos:  position{line: 1173, col: 5, offset: 28488},
 						name: "SQLTimeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1174, col: 5, offset: 28504},
+						pos:  position{line: 1174, col: 5, offset: 28505},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1175, col: 5, offset: 28516},
+						pos: position{line: 1175, col: 5, offset: 28517},
 						run: (*parser).callonPrimary9,
 						expr: &seqExpr{
-							pos: position{line: 1175, col: 5, offset: 28516},
+							pos: position{line: 1175, col: 5, offset: 28517},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1175, col: 5, offset: 28516},
+									pos: position{line: 1175, col: 5, offset: 28517},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1175, col: 6, offset: 28517},
+										pos:  position{line: 1175, col: 6, offset: 28518},
 										name: "PipeKeyword",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1175, col: 18, offset: 28529},
+									pos:   position{line: 1175, col: 18, offset: 28530},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1175, col: 21, offset: 28532},
+										pos:  position{line: 1175, col: 21, offset: 28533},
 										name: "Identifier",
 									},
 								},
@@ -8200,39 +8200,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1176, col: 5, offset: 28566},
+						pos:  position{line: 1176, col: 5, offset: 28567},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1177, col: 5, offset: 28576},
+						pos: position{line: 1177, col: 5, offset: 28577},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1177, col: 5, offset: 28576},
+							pos: position{line: 1177, col: 5, offset: 28577},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1177, col: 5, offset: 28576},
+									pos:        position{line: 1177, col: 5, offset: 28577},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1177, col: 9, offset: 28580},
+									pos:  position{line: 1177, col: 9, offset: 28581},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1177, col: 12, offset: 28583},
+									pos:   position{line: 1177, col: 12, offset: 28584},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1177, col: 17, offset: 28588},
+										pos:  position{line: 1177, col: 17, offset: 28589},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1177, col: 26, offset: 28597},
+									pos:  position{line: 1177, col: 26, offset: 28598},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1177, col: 29, offset: 28600},
+									pos:        position{line: 1177, col: 29, offset: 28601},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8241,35 +8241,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1178, col: 5, offset: 28629},
+						pos: position{line: 1178, col: 5, offset: 28630},
 						run: (*parser).callonPrimary24,
 						expr: &seqExpr{
-							pos: position{line: 1178, col: 5, offset: 28629},
+							pos: position{line: 1178, col: 5, offset: 28630},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1178, col: 5, offset: 28629},
+									pos:        position{line: 1178, col: 5, offset: 28630},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1178, col: 9, offset: 28633},
+									pos:  position{line: 1178, col: 9, offset: 28634},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1178, col: 12, offset: 28636},
+									pos:   position{line: 1178, col: 12, offset: 28637},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1178, col: 17, offset: 28641},
+										pos:  position{line: 1178, col: 17, offset: 28642},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1178, col: 22, offset: 28646},
+									pos:  position{line: 1178, col: 22, offset: 28647},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1178, col: 25, offset: 28649},
+									pos:        position{line: 1178, col: 25, offset: 28650},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8284,53 +8284,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1180, col: 1, offset: 28675},
+			pos:  position{line: 1180, col: 1, offset: 28676},
 			expr: &choiceExpr{
-				pos: position{line: 1181, col: 5, offset: 28688},
+				pos: position{line: 1181, col: 5, offset: 28689},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1181, col: 5, offset: 28688},
+						pos: position{line: 1181, col: 5, offset: 28689},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1181, col: 5, offset: 28688},
+							pos: position{line: 1181, col: 5, offset: 28689},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1181, col: 5, offset: 28688},
+									pos:  position{line: 1181, col: 5, offset: 28689},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 10, offset: 28693},
+									pos:   position{line: 1181, col: 10, offset: 28694},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1181, col: 16, offset: 28699},
+										pos: position{line: 1181, col: 16, offset: 28700},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1181, col: 16, offset: 28699},
+											pos:  position{line: 1181, col: 16, offset: 28700},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 22, offset: 28705},
+									pos:   position{line: 1181, col: 22, offset: 28706},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1181, col: 28, offset: 28711},
+										pos: position{line: 1181, col: 28, offset: 28712},
 										expr: &seqExpr{
-											pos: position{line: 1181, col: 29, offset: 28712},
+											pos: position{line: 1181, col: 29, offset: 28713},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1181, col: 29, offset: 28712},
+													pos:  position{line: 1181, col: 29, offset: 28713},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1181, col: 31, offset: 28714},
+													pos:  position{line: 1181, col: 31, offset: 28715},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1181, col: 36, offset: 28719},
+													pos:  position{line: 1181, col: 36, offset: 28720},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1181, col: 38, offset: 28721},
+													pos:  position{line: 1181, col: 38, offset: 28722},
 													name: "Expr",
 												},
 											},
@@ -8338,24 +8338,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1181, col: 45, offset: 28728},
+									pos:  position{line: 1181, col: 45, offset: 28729},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1181, col: 47, offset: 28730},
+									pos:  position{line: 1181, col: 47, offset: 28731},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1181, col: 51, offset: 28734},
+									pos: position{line: 1181, col: 51, offset: 28735},
 									expr: &seqExpr{
-										pos: position{line: 1181, col: 52, offset: 28735},
+										pos: position{line: 1181, col: 52, offset: 28736},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1181, col: 52, offset: 28735},
+												pos:  position{line: 1181, col: 52, offset: 28736},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1181, col: 54, offset: 28737},
+												pos:  position{line: 1181, col: 54, offset: 28738},
 												name: "CASE",
 											},
 										},
@@ -8365,60 +8365,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1205, col: 5, offset: 29386},
+						pos: position{line: 1205, col: 5, offset: 29387},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1205, col: 5, offset: 29386},
+							pos: position{line: 1205, col: 5, offset: 29387},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1205, col: 5, offset: 29386},
+									pos:  position{line: 1205, col: 5, offset: 29387},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1205, col: 10, offset: 29391},
+									pos:  position{line: 1205, col: 10, offset: 29392},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1205, col: 12, offset: 29393},
+									pos:   position{line: 1205, col: 12, offset: 29394},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1205, col: 17, offset: 29398},
+										pos:  position{line: 1205, col: 17, offset: 29399},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1205, col: 22, offset: 29403},
+									pos:   position{line: 1205, col: 22, offset: 29404},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1205, col: 28, offset: 29409},
+										pos: position{line: 1205, col: 28, offset: 29410},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1205, col: 28, offset: 29409},
+											pos:  position{line: 1205, col: 28, offset: 29410},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1205, col: 34, offset: 29415},
+									pos:   position{line: 1205, col: 34, offset: 29416},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1205, col: 40, offset: 29421},
+										pos: position{line: 1205, col: 40, offset: 29422},
 										expr: &seqExpr{
-											pos: position{line: 1205, col: 41, offset: 29422},
+											pos: position{line: 1205, col: 41, offset: 29423},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1205, col: 41, offset: 29422},
+													pos:  position{line: 1205, col: 41, offset: 29423},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1205, col: 43, offset: 29424},
+													pos:  position{line: 1205, col: 43, offset: 29425},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1205, col: 48, offset: 29429},
+													pos:  position{line: 1205, col: 48, offset: 29430},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1205, col: 50, offset: 29431},
+													pos:  position{line: 1205, col: 50, offset: 29432},
 													name: "Expr",
 												},
 											},
@@ -8426,24 +8426,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1205, col: 57, offset: 29438},
+									pos:  position{line: 1205, col: 57, offset: 29439},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1205, col: 59, offset: 29440},
+									pos:  position{line: 1205, col: 59, offset: 29441},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1205, col: 63, offset: 29444},
+									pos: position{line: 1205, col: 63, offset: 29445},
 									expr: &seqExpr{
-										pos: position{line: 1205, col: 64, offset: 29445},
+										pos: position{line: 1205, col: 64, offset: 29446},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1205, col: 64, offset: 29445},
+												pos:  position{line: 1205, col: 64, offset: 29446},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1205, col: 66, offset: 29447},
+												pos:  position{line: 1205, col: 66, offset: 29448},
 												name: "CASE",
 											},
 										},
@@ -8459,50 +8459,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1218, col: 1, offset: 29753},
+			pos:  position{line: 1218, col: 1, offset: 29754},
 			expr: &actionExpr{
-				pos: position{line: 1219, col: 5, offset: 29762},
+				pos: position{line: 1219, col: 5, offset: 29763},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1219, col: 5, offset: 29762},
+					pos: position{line: 1219, col: 5, offset: 29763},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1219, col: 5, offset: 29762},
+							pos:  position{line: 1219, col: 5, offset: 29763},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1219, col: 7, offset: 29764},
+							pos:  position{line: 1219, col: 7, offset: 29765},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1219, col: 12, offset: 29769},
+							pos:  position{line: 1219, col: 12, offset: 29770},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1219, col: 14, offset: 29771},
+							pos:   position{line: 1219, col: 14, offset: 29772},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1219, col: 19, offset: 29776},
+								pos:  position{line: 1219, col: 19, offset: 29777},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1219, col: 24, offset: 29781},
+							pos:  position{line: 1219, col: 24, offset: 29782},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1219, col: 26, offset: 29783},
+							pos:  position{line: 1219, col: 26, offset: 29784},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1219, col: 31, offset: 29788},
+							pos:  position{line: 1219, col: 31, offset: 29789},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1219, col: 33, offset: 29790},
+							pos:   position{line: 1219, col: 33, offset: 29791},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1219, col: 38, offset: 29795},
+								pos:  position{line: 1219, col: 38, offset: 29796},
 								name: "Expr",
 							},
 						},
@@ -8514,57 +8514,57 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1228, col: 1, offset: 29954},
+			pos:  position{line: 1228, col: 1, offset: 29955},
 			expr: &actionExpr{
-				pos: position{line: 1229, col: 5, offset: 29967},
+				pos: position{line: 1229, col: 5, offset: 29968},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1229, col: 5, offset: 29967},
+					pos: position{line: 1229, col: 5, offset: 29968},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1229, col: 5, offset: 29967},
+							pos:  position{line: 1229, col: 5, offset: 29968},
 							name: "OVER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1229, col: 10, offset: 29972},
+							pos:  position{line: 1229, col: 10, offset: 29973},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1229, col: 12, offset: 29974},
+							pos:   position{line: 1229, col: 12, offset: 29975},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1229, col: 18, offset: 29980},
+								pos:  position{line: 1229, col: 18, offset: 29981},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1229, col: 24, offset: 29986},
+							pos:   position{line: 1229, col: 24, offset: 29987},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1229, col: 31, offset: 29993},
+								pos: position{line: 1229, col: 31, offset: 29994},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1229, col: 31, offset: 29993},
+									pos:  position{line: 1229, col: 31, offset: 29994},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1229, col: 39, offset: 30001},
+							pos:  position{line: 1229, col: 39, offset: 30002},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1229, col: 42, offset: 30004},
+							pos:  position{line: 1229, col: 42, offset: 30005},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1229, col: 47, offset: 30009},
+							pos:  position{line: 1229, col: 47, offset: 30010},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1229, col: 50, offset: 30012},
+							pos:   position{line: 1229, col: 50, offset: 30013},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1229, col: 55, offset: 30017},
+								pos:  position{line: 1229, col: 55, offset: 30018},
 								name: "Seq",
 							},
 						},
@@ -8576,37 +8576,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1239, col: 1, offset: 30248},
+			pos:  position{line: 1239, col: 1, offset: 30249},
 			expr: &actionExpr{
-				pos: position{line: 1240, col: 5, offset: 30259},
+				pos: position{line: 1240, col: 5, offset: 30260},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1240, col: 5, offset: 30259},
+					pos: position{line: 1240, col: 5, offset: 30260},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1240, col: 5, offset: 30259},
+							pos:        position{line: 1240, col: 5, offset: 30260},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1240, col: 9, offset: 30263},
+							pos:  position{line: 1240, col: 9, offset: 30264},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1240, col: 12, offset: 30266},
+							pos:   position{line: 1240, col: 12, offset: 30267},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1240, col: 18, offset: 30272},
+								pos:  position{line: 1240, col: 18, offset: 30273},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1240, col: 30, offset: 30284},
+							pos:  position{line: 1240, col: 30, offset: 30285},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1240, col: 33, offset: 30287},
+							pos:        position{line: 1240, col: 33, offset: 30288},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8619,31 +8619,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1248, col: 1, offset: 30445},
+			pos:  position{line: 1248, col: 1, offset: 30446},
 			expr: &choiceExpr{
-				pos: position{line: 1249, col: 5, offset: 30461},
+				pos: position{line: 1249, col: 5, offset: 30462},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1249, col: 5, offset: 30461},
+						pos: position{line: 1249, col: 5, offset: 30462},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1249, col: 5, offset: 30461},
+							pos: position{line: 1249, col: 5, offset: 30462},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1249, col: 5, offset: 30461},
+									pos:   position{line: 1249, col: 5, offset: 30462},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1249, col: 11, offset: 30467},
+										pos:  position{line: 1249, col: 11, offset: 30468},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1249, col: 22, offset: 30478},
+									pos:   position{line: 1249, col: 22, offset: 30479},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1249, col: 27, offset: 30483},
+										pos: position{line: 1249, col: 27, offset: 30484},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1249, col: 27, offset: 30483},
+											pos:  position{line: 1249, col: 27, offset: 30484},
 											name: "RecordElemTail",
 										},
 									},
@@ -8652,10 +8652,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1252, col: 5, offset: 30546},
+						pos: position{line: 1252, col: 5, offset: 30547},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1252, col: 5, offset: 30546},
+							pos:  position{line: 1252, col: 5, offset: 30547},
 							name: "__",
 						},
 					},
@@ -8666,32 +8666,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1254, col: 1, offset: 30570},
+			pos:  position{line: 1254, col: 1, offset: 30571},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 18, offset: 30587},
+				pos: position{line: 1254, col: 18, offset: 30588},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1254, col: 18, offset: 30587},
+					pos: position{line: 1254, col: 18, offset: 30588},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1254, col: 18, offset: 30587},
+							pos:  position{line: 1254, col: 18, offset: 30588},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1254, col: 21, offset: 30590},
+							pos:        position{line: 1254, col: 21, offset: 30591},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1254, col: 25, offset: 30594},
+							pos:  position{line: 1254, col: 25, offset: 30595},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1254, col: 28, offset: 30597},
+							pos:   position{line: 1254, col: 28, offset: 30598},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1254, col: 33, offset: 30602},
+								pos:  position{line: 1254, col: 33, offset: 30603},
 								name: "RecordElem",
 							},
 						},
@@ -8703,20 +8703,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1256, col: 1, offset: 30635},
+			pos:  position{line: 1256, col: 1, offset: 30636},
 			expr: &choiceExpr{
-				pos: position{line: 1257, col: 5, offset: 30650},
+				pos: position{line: 1257, col: 5, offset: 30651},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1257, col: 5, offset: 30650},
+						pos:  position{line: 1257, col: 5, offset: 30651},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1258, col: 5, offset: 30661},
+						pos:  position{line: 1258, col: 5, offset: 30662},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 5, offset: 30675},
+						pos:  position{line: 1259, col: 5, offset: 30676},
 						name: "Identifier",
 					},
 				},
@@ -8726,28 +8726,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1261, col: 1, offset: 30687},
+			pos:  position{line: 1261, col: 1, offset: 30688},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 5, offset: 30698},
+				pos: position{line: 1262, col: 5, offset: 30699},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1262, col: 5, offset: 30698},
+					pos: position{line: 1262, col: 5, offset: 30699},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1262, col: 5, offset: 30698},
+							pos:        position{line: 1262, col: 5, offset: 30699},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1262, col: 11, offset: 30704},
+							pos:  position{line: 1262, col: 11, offset: 30705},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1262, col: 14, offset: 30707},
+							pos:   position{line: 1262, col: 14, offset: 30708},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1262, col: 19, offset: 30712},
+								pos:  position{line: 1262, col: 19, offset: 30713},
 								name: "Expr",
 							},
 						},
@@ -8759,40 +8759,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1266, col: 1, offset: 30808},
+			pos:  position{line: 1266, col: 1, offset: 30809},
 			expr: &actionExpr{
-				pos: position{line: 1267, col: 5, offset: 30822},
+				pos: position{line: 1267, col: 5, offset: 30823},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1267, col: 5, offset: 30822},
+					pos: position{line: 1267, col: 5, offset: 30823},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1267, col: 5, offset: 30822},
+							pos:   position{line: 1267, col: 5, offset: 30823},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1267, col: 10, offset: 30827},
+								pos:  position{line: 1267, col: 10, offset: 30828},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1267, col: 15, offset: 30832},
+							pos:  position{line: 1267, col: 15, offset: 30833},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1267, col: 18, offset: 30835},
+							pos:        position{line: 1267, col: 18, offset: 30836},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1267, col: 22, offset: 30839},
+							pos:  position{line: 1267, col: 22, offset: 30840},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1267, col: 25, offset: 30842},
+							pos:   position{line: 1267, col: 25, offset: 30843},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1267, col: 31, offset: 30848},
+								pos:  position{line: 1267, col: 31, offset: 30849},
 								name: "Expr",
 							},
 						},
@@ -8804,37 +8804,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1276, col: 1, offset: 31017},
+			pos:  position{line: 1276, col: 1, offset: 31018},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 5, offset: 31027},
+				pos: position{line: 1277, col: 5, offset: 31028},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1277, col: 5, offset: 31027},
+					pos: position{line: 1277, col: 5, offset: 31028},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1277, col: 5, offset: 31027},
+							pos:        position{line: 1277, col: 5, offset: 31028},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1277, col: 9, offset: 31031},
+							pos:  position{line: 1277, col: 9, offset: 31032},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1277, col: 12, offset: 31034},
+							pos:   position{line: 1277, col: 12, offset: 31035},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1277, col: 18, offset: 31040},
+								pos:  position{line: 1277, col: 18, offset: 31041},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1277, col: 30, offset: 31052},
+							pos:  position{line: 1277, col: 30, offset: 31053},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1277, col: 33, offset: 31055},
+							pos:        position{line: 1277, col: 33, offset: 31056},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8847,37 +8847,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1285, col: 1, offset: 31211},
+			pos:  position{line: 1285, col: 1, offset: 31212},
 			expr: &actionExpr{
-				pos: position{line: 1286, col: 5, offset: 31219},
+				pos: position{line: 1286, col: 5, offset: 31220},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1286, col: 5, offset: 31219},
+					pos: position{line: 1286, col: 5, offset: 31220},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1286, col: 5, offset: 31219},
+							pos:        position{line: 1286, col: 5, offset: 31220},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1286, col: 10, offset: 31224},
+							pos:  position{line: 1286, col: 10, offset: 31225},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1286, col: 13, offset: 31227},
+							pos:   position{line: 1286, col: 13, offset: 31228},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1286, col: 19, offset: 31233},
+								pos:  position{line: 1286, col: 19, offset: 31234},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1286, col: 31, offset: 31245},
+							pos:  position{line: 1286, col: 31, offset: 31246},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1286, col: 34, offset: 31248},
+							pos:        position{line: 1286, col: 34, offset: 31249},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8890,54 +8890,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1294, col: 1, offset: 31401},
+			pos:  position{line: 1294, col: 1, offset: 31402},
 			expr: &choiceExpr{
-				pos: position{line: 1295, col: 5, offset: 31417},
+				pos: position{line: 1295, col: 5, offset: 31418},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1295, col: 5, offset: 31417},
+						pos: position{line: 1295, col: 5, offset: 31418},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1295, col: 5, offset: 31417},
+							pos: position{line: 1295, col: 5, offset: 31418},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1295, col: 5, offset: 31417},
+									pos:   position{line: 1295, col: 5, offset: 31418},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1295, col: 11, offset: 31423},
+										pos:  position{line: 1295, col: 11, offset: 31424},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1295, col: 22, offset: 31434},
+									pos:   position{line: 1295, col: 22, offset: 31435},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1295, col: 27, offset: 31439},
+										pos: position{line: 1295, col: 27, offset: 31440},
 										expr: &actionExpr{
-											pos: position{line: 1295, col: 28, offset: 31440},
+											pos: position{line: 1295, col: 28, offset: 31441},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1295, col: 28, offset: 31440},
+												pos: position{line: 1295, col: 28, offset: 31441},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1295, col: 28, offset: 31440},
+														pos:  position{line: 1295, col: 28, offset: 31441},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1295, col: 31, offset: 31443},
+														pos:        position{line: 1295, col: 31, offset: 31444},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1295, col: 35, offset: 31447},
+														pos:  position{line: 1295, col: 35, offset: 31448},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1295, col: 38, offset: 31450},
+														pos:   position{line: 1295, col: 38, offset: 31451},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1295, col: 40, offset: 31452},
+															pos:  position{line: 1295, col: 40, offset: 31453},
 															name: "VectorElem",
 														},
 													},
@@ -8950,10 +8950,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1298, col: 5, offset: 31534},
+						pos: position{line: 1298, col: 5, offset: 31535},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1298, col: 5, offset: 31534},
+							pos:  position{line: 1298, col: 5, offset: 31535},
 							name: "__",
 						},
 					},
@@ -8964,22 +8964,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1300, col: 1, offset: 31558},
+			pos:  position{line: 1300, col: 1, offset: 31559},
 			expr: &choiceExpr{
-				pos: position{line: 1301, col: 5, offset: 31573},
+				pos: position{line: 1301, col: 5, offset: 31574},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1301, col: 5, offset: 31573},
+						pos:  position{line: 1301, col: 5, offset: 31574},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1302, col: 5, offset: 31584},
+						pos: position{line: 1302, col: 5, offset: 31585},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1302, col: 5, offset: 31584},
+							pos:   position{line: 1302, col: 5, offset: 31585},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1302, col: 7, offset: 31586},
+								pos:  position{line: 1302, col: 7, offset: 31587},
 								name: "Expr",
 							},
 						},
@@ -8991,37 +8991,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1304, col: 1, offset: 31677},
+			pos:  position{line: 1304, col: 1, offset: 31678},
 			expr: &actionExpr{
-				pos: position{line: 1305, col: 5, offset: 31685},
+				pos: position{line: 1305, col: 5, offset: 31686},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1305, col: 5, offset: 31685},
+					pos: position{line: 1305, col: 5, offset: 31686},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1305, col: 5, offset: 31685},
+							pos:        position{line: 1305, col: 5, offset: 31686},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1305, col: 10, offset: 31690},
+							pos:  position{line: 1305, col: 10, offset: 31691},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1305, col: 13, offset: 31693},
+							pos:   position{line: 1305, col: 13, offset: 31694},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1305, col: 19, offset: 31699},
+								pos:  position{line: 1305, col: 19, offset: 31700},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1305, col: 27, offset: 31707},
+							pos:  position{line: 1305, col: 27, offset: 31708},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1305, col: 30, offset: 31710},
+							pos:        position{line: 1305, col: 30, offset: 31711},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -9034,31 +9034,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1313, col: 1, offset: 31864},
+			pos:  position{line: 1313, col: 1, offset: 31865},
 			expr: &choiceExpr{
-				pos: position{line: 1314, col: 5, offset: 31876},
+				pos: position{line: 1314, col: 5, offset: 31877},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 31876},
+						pos: position{line: 1314, col: 5, offset: 31877},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1314, col: 5, offset: 31876},
+							pos: position{line: 1314, col: 5, offset: 31877},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1314, col: 5, offset: 31876},
+									pos:   position{line: 1314, col: 5, offset: 31877},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1314, col: 11, offset: 31882},
+										pos:  position{line: 1314, col: 11, offset: 31883},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1314, col: 17, offset: 31888},
+									pos:   position{line: 1314, col: 17, offset: 31889},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1314, col: 22, offset: 31893},
+										pos: position{line: 1314, col: 22, offset: 31894},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1314, col: 22, offset: 31893},
+											pos:  position{line: 1314, col: 22, offset: 31894},
 											name: "EntryTail",
 										},
 									},
@@ -9067,10 +9067,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 31951},
+						pos: position{line: 1317, col: 5, offset: 31952},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1317, col: 5, offset: 31951},
+							pos:  position{line: 1317, col: 5, offset: 31952},
 							name: "__",
 						},
 					},
@@ -9081,32 +9081,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1320, col: 1, offset: 31976},
+			pos:  position{line: 1320, col: 1, offset: 31977},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 13, offset: 31988},
+				pos: position{line: 1320, col: 13, offset: 31989},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1320, col: 13, offset: 31988},
+					pos: position{line: 1320, col: 13, offset: 31989},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1320, col: 13, offset: 31988},
+							pos:  position{line: 1320, col: 13, offset: 31989},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1320, col: 16, offset: 31991},
+							pos:        position{line: 1320, col: 16, offset: 31992},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1320, col: 20, offset: 31995},
+							pos:  position{line: 1320, col: 20, offset: 31996},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1320, col: 23, offset: 31998},
+							pos:   position{line: 1320, col: 23, offset: 31999},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1320, col: 25, offset: 32000},
+								pos:  position{line: 1320, col: 25, offset: 32001},
 								name: "Entry",
 							},
 						},
@@ -9118,40 +9118,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1322, col: 1, offset: 32025},
+			pos:  position{line: 1322, col: 1, offset: 32026},
 			expr: &actionExpr{
-				pos: position{line: 1323, col: 5, offset: 32035},
+				pos: position{line: 1323, col: 5, offset: 32036},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1323, col: 5, offset: 32035},
+					pos: position{line: 1323, col: 5, offset: 32036},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1323, col: 5, offset: 32035},
+							pos:   position{line: 1323, col: 5, offset: 32036},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1323, col: 9, offset: 32039},
+								pos:  position{line: 1323, col: 9, offset: 32040},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1323, col: 14, offset: 32044},
+							pos:  position{line: 1323, col: 14, offset: 32045},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1323, col: 17, offset: 32047},
+							pos:        position{line: 1323, col: 17, offset: 32048},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1323, col: 21, offset: 32051},
+							pos:  position{line: 1323, col: 21, offset: 32052},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1323, col: 24, offset: 32054},
+							pos:   position{line: 1323, col: 24, offset: 32055},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1323, col: 30, offset: 32060},
+								pos:  position{line: 1323, col: 30, offset: 32061},
 								name: "Expr",
 							},
 						},
@@ -9163,61 +9163,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1327, col: 1, offset: 32163},
+			pos:  position{line: 1327, col: 1, offset: 32164},
 			expr: &actionExpr{
-				pos: position{line: 1328, col: 5, offset: 32173},
+				pos: position{line: 1328, col: 5, offset: 32174},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1328, col: 5, offset: 32173},
+					pos: position{line: 1328, col: 5, offset: 32174},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1328, col: 5, offset: 32173},
+							pos:        position{line: 1328, col: 5, offset: 32174},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1328, col: 9, offset: 32177},
+							pos:  position{line: 1328, col: 9, offset: 32178},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1328, col: 12, offset: 32180},
+							pos:   position{line: 1328, col: 12, offset: 32181},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1328, col: 18, offset: 32186},
+								pos:  position{line: 1328, col: 18, offset: 32187},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1328, col: 23, offset: 32191},
+							pos:   position{line: 1328, col: 23, offset: 32192},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1328, col: 28, offset: 32196},
+								pos: position{line: 1328, col: 28, offset: 32197},
 								expr: &actionExpr{
-									pos: position{line: 1328, col: 29, offset: 32197},
+									pos: position{line: 1328, col: 29, offset: 32198},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1328, col: 29, offset: 32197},
+										pos: position{line: 1328, col: 29, offset: 32198},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1328, col: 29, offset: 32197},
+												pos:  position{line: 1328, col: 29, offset: 32198},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1328, col: 32, offset: 32200},
+												pos:        position{line: 1328, col: 32, offset: 32201},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1328, col: 36, offset: 32204},
+												pos:  position{line: 1328, col: 36, offset: 32205},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1328, col: 39, offset: 32207},
+												pos:   position{line: 1328, col: 39, offset: 32208},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1328, col: 41, offset: 32209},
+													pos:  position{line: 1328, col: 41, offset: 32210},
 													name: "Expr",
 												},
 											},
@@ -9227,11 +9227,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1328, col: 66, offset: 32234},
+							pos:  position{line: 1328, col: 66, offset: 32235},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1328, col: 69, offset: 32237},
+							pos:        position{line: 1328, col: 69, offset: 32238},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -9244,39 +9244,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1336, col: 1, offset: 32396},
+			pos:  position{line: 1336, col: 1, offset: 32397},
 			expr: &actionExpr{
-				pos: position{line: 1337, col: 5, offset: 32413},
+				pos: position{line: 1337, col: 5, offset: 32414},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1337, col: 5, offset: 32413},
+					pos: position{line: 1337, col: 5, offset: 32414},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1337, col: 5, offset: 32413},
+							pos:   position{line: 1337, col: 5, offset: 32414},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1337, col: 10, offset: 32418},
+								pos: position{line: 1337, col: 10, offset: 32419},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1337, col: 10, offset: 32418},
+										pos:  position{line: 1337, col: 10, offset: 32419},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1337, col: 17, offset: 32425},
+										pos:  position{line: 1337, col: 17, offset: 32426},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1337, col: 28, offset: 32436},
+							pos:  position{line: 1337, col: 28, offset: 32437},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1337, col: 30, offset: 32438},
+							pos:   position{line: 1337, col: 30, offset: 32439},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1337, col: 32, offset: 32440},
+								pos:  position{line: 1337, col: 32, offset: 32441},
 								name: "StringLiteral",
 							},
 						},
@@ -9288,56 +9288,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1348, col: 1, offset: 32657},
+			pos:  position{line: 1348, col: 1, offset: 32658},
 			expr: &choiceExpr{
-				pos: position{line: 1349, col: 5, offset: 32669},
+				pos: position{line: 1349, col: 5, offset: 32670},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1349, col: 5, offset: 32669},
+						pos:  position{line: 1349, col: 5, offset: 32670},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1350, col: 5, offset: 32685},
+						pos:  position{line: 1350, col: 5, offset: 32686},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1351, col: 5, offset: 32703},
+						pos:  position{line: 1351, col: 5, offset: 32704},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1352, col: 5, offset: 32715},
+						pos:  position{line: 1352, col: 5, offset: 32716},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1353, col: 5, offset: 32733},
+						pos:  position{line: 1353, col: 5, offset: 32734},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1354, col: 5, offset: 32752},
+						pos:  position{line: 1354, col: 5, offset: 32753},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1355, col: 5, offset: 32769},
+						pos:  position{line: 1355, col: 5, offset: 32770},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1356, col: 5, offset: 32782},
+						pos:  position{line: 1356, col: 5, offset: 32783},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1357, col: 5, offset: 32791},
+						pos:  position{line: 1357, col: 5, offset: 32792},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1358, col: 5, offset: 32808},
+						pos:  position{line: 1358, col: 5, offset: 32809},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1359, col: 5, offset: 32827},
+						pos:  position{line: 1359, col: 5, offset: 32828},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1360, col: 5, offset: 32846},
+						pos:  position{line: 1360, col: 5, offset: 32847},
 						name: "NullLiteral",
 					},
 				},
@@ -9347,28 +9347,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1362, col: 1, offset: 32859},
+			pos:  position{line: 1362, col: 1, offset: 32860},
 			expr: &choiceExpr{
-				pos: position{line: 1363, col: 5, offset: 32877},
+				pos: position{line: 1363, col: 5, offset: 32878},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1363, col: 5, offset: 32877},
+						pos: position{line: 1363, col: 5, offset: 32878},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1363, col: 5, offset: 32877},
+							pos: position{line: 1363, col: 5, offset: 32878},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1363, col: 5, offset: 32877},
+									pos:   position{line: 1363, col: 5, offset: 32878},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1363, col: 7, offset: 32879},
+										pos:  position{line: 1363, col: 7, offset: 32880},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1363, col: 14, offset: 32886},
+									pos: position{line: 1363, col: 14, offset: 32887},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1363, col: 15, offset: 32887},
+										pos:  position{line: 1363, col: 15, offset: 32888},
 										name: "IdentifierRest",
 									},
 								},
@@ -9376,13 +9376,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1366, col: 5, offset: 32967},
+						pos: position{line: 1366, col: 5, offset: 32968},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1366, col: 5, offset: 32967},
+							pos:   position{line: 1366, col: 5, offset: 32968},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1366, col: 7, offset: 32969},
+								pos:  position{line: 1366, col: 7, offset: 32970},
 								name: "IP4Net",
 							},
 						},
@@ -9394,28 +9394,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1370, col: 1, offset: 33038},
+			pos:  position{line: 1370, col: 1, offset: 33039},
 			expr: &choiceExpr{
-				pos: position{line: 1371, col: 5, offset: 33057},
+				pos: position{line: 1371, col: 5, offset: 33058},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1371, col: 5, offset: 33057},
+						pos: position{line: 1371, col: 5, offset: 33058},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1371, col: 5, offset: 33057},
+							pos: position{line: 1371, col: 5, offset: 33058},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1371, col: 5, offset: 33057},
+									pos:   position{line: 1371, col: 5, offset: 33058},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1371, col: 7, offset: 33059},
+										pos:  position{line: 1371, col: 7, offset: 33060},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1371, col: 11, offset: 33063},
+									pos: position{line: 1371, col: 11, offset: 33064},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1371, col: 12, offset: 33064},
+										pos:  position{line: 1371, col: 12, offset: 33065},
 										name: "IdentifierRest",
 									},
 								},
@@ -9423,13 +9423,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1374, col: 5, offset: 33143},
+						pos: position{line: 1374, col: 5, offset: 33144},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1374, col: 5, offset: 33143},
+							pos:   position{line: 1374, col: 5, offset: 33144},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1374, col: 7, offset: 33145},
+								pos:  position{line: 1374, col: 7, offset: 33146},
 								name: "IP",
 							},
 						},
@@ -9441,15 +9441,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1378, col: 1, offset: 33209},
+			pos:  position{line: 1378, col: 1, offset: 33210},
 			expr: &actionExpr{
-				pos: position{line: 1379, col: 5, offset: 33226},
+				pos: position{line: 1379, col: 5, offset: 33227},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1379, col: 5, offset: 33226},
+					pos:   position{line: 1379, col: 5, offset: 33227},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1379, col: 7, offset: 33228},
+						pos:  position{line: 1379, col: 7, offset: 33229},
 						name: "FloatString",
 					},
 				},
@@ -9459,15 +9459,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1383, col: 1, offset: 33306},
+			pos:  position{line: 1383, col: 1, offset: 33307},
 			expr: &actionExpr{
-				pos: position{line: 1384, col: 5, offset: 33325},
+				pos: position{line: 1384, col: 5, offset: 33326},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1384, col: 5, offset: 33325},
+					pos:   position{line: 1384, col: 5, offset: 33326},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1384, col: 7, offset: 33327},
+						pos:  position{line: 1384, col: 7, offset: 33328},
 						name: "IntString",
 					},
 				},
@@ -9477,23 +9477,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1388, col: 1, offset: 33401},
+			pos:  position{line: 1388, col: 1, offset: 33402},
 			expr: &choiceExpr{
-				pos: position{line: 1389, col: 5, offset: 33420},
+				pos: position{line: 1389, col: 5, offset: 33421},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1389, col: 5, offset: 33420},
+						pos: position{line: 1389, col: 5, offset: 33421},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1389, col: 5, offset: 33420},
+							pos:  position{line: 1389, col: 5, offset: 33421},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1390, col: 5, offset: 33478},
+						pos: position{line: 1390, col: 5, offset: 33479},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1390, col: 5, offset: 33478},
+							pos:  position{line: 1390, col: 5, offset: 33479},
 							name: "FALSE",
 						},
 					},
@@ -9504,12 +9504,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1392, col: 1, offset: 33534},
+			pos:  position{line: 1392, col: 1, offset: 33535},
 			expr: &actionExpr{
-				pos: position{line: 1393, col: 5, offset: 33550},
+				pos: position{line: 1393, col: 5, offset: 33551},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1393, col: 5, offset: 33550},
+					pos:  position{line: 1393, col: 5, offset: 33551},
 					name: "NULL",
 				},
 			},
@@ -9518,23 +9518,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1395, col: 1, offset: 33600},
+			pos:  position{line: 1395, col: 1, offset: 33601},
 			expr: &actionExpr{
-				pos: position{line: 1396, col: 5, offset: 33617},
+				pos: position{line: 1396, col: 5, offset: 33618},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1396, col: 5, offset: 33617},
+					pos: position{line: 1396, col: 5, offset: 33618},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1396, col: 5, offset: 33617},
+							pos:        position{line: 1396, col: 5, offset: 33618},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1396, col: 10, offset: 33622},
+							pos: position{line: 1396, col: 10, offset: 33623},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1396, col: 10, offset: 33622},
+								pos:  position{line: 1396, col: 10, offset: 33623},
 								name: "HexDigit",
 							},
 						},
@@ -9546,29 +9546,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1400, col: 1, offset: 33696},
+			pos:  position{line: 1400, col: 1, offset: 33697},
 			expr: &actionExpr{
-				pos: position{line: 1401, col: 5, offset: 33712},
+				pos: position{line: 1401, col: 5, offset: 33713},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1401, col: 5, offset: 33712},
+					pos: position{line: 1401, col: 5, offset: 33713},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1401, col: 5, offset: 33712},
+							pos:        position{line: 1401, col: 5, offset: 33713},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1401, col: 9, offset: 33716},
+							pos:   position{line: 1401, col: 9, offset: 33717},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1401, col: 13, offset: 33720},
+								pos:  position{line: 1401, col: 13, offset: 33721},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1401, col: 18, offset: 33725},
+							pos:        position{line: 1401, col: 18, offset: 33726},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -9581,16 +9581,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1409, col: 1, offset: 33858},
+			pos:  position{line: 1409, col: 1, offset: 33859},
 			expr: &choiceExpr{
-				pos: position{line: 1410, col: 5, offset: 33867},
+				pos: position{line: 1410, col: 5, offset: 33868},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1410, col: 5, offset: 33867},
+						pos:  position{line: 1410, col: 5, offset: 33868},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 5, offset: 33885},
+						pos:  position{line: 1411, col: 5, offset: 33886},
 						name: "ComplexType",
 					},
 				},
@@ -9600,28 +9600,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1413, col: 1, offset: 33898},
+			pos:  position{line: 1413, col: 1, offset: 33899},
 			expr: &choiceExpr{
-				pos: position{line: 1414, col: 5, offset: 33916},
+				pos: position{line: 1414, col: 5, offset: 33917},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1414, col: 5, offset: 33916},
+						pos: position{line: 1414, col: 5, offset: 33917},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1414, col: 5, offset: 33916},
+							pos: position{line: 1414, col: 5, offset: 33917},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1414, col: 5, offset: 33916},
+									pos:   position{line: 1414, col: 5, offset: 33917},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1414, col: 10, offset: 33921},
+										pos:  position{line: 1414, col: 10, offset: 33922},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1414, col: 24, offset: 33935},
+									pos: position{line: 1414, col: 24, offset: 33936},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1414, col: 25, offset: 33936},
+										pos:  position{line: 1414, col: 25, offset: 33937},
 										name: "IdentifierRest",
 									},
 								},
@@ -9629,43 +9629,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1415, col: 5, offset: 33976},
+						pos: position{line: 1415, col: 5, offset: 33977},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1415, col: 5, offset: 33976},
+							pos: position{line: 1415, col: 5, offset: 33977},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1415, col: 5, offset: 33976},
+									pos:  position{line: 1415, col: 5, offset: 33977},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1415, col: 11, offset: 33982},
+									pos:  position{line: 1415, col: 11, offset: 33983},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1415, col: 14, offset: 33985},
+									pos:        position{line: 1415, col: 14, offset: 33986},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1415, col: 18, offset: 33989},
+									pos:  position{line: 1415, col: 18, offset: 33990},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1415, col: 21, offset: 33992},
+									pos:   position{line: 1415, col: 21, offset: 33993},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1415, col: 23, offset: 33994},
+										pos:  position{line: 1415, col: 23, offset: 33995},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1415, col: 28, offset: 33999},
+									pos:  position{line: 1415, col: 28, offset: 34000},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1415, col: 31, offset: 34002},
+									pos:        position{line: 1415, col: 31, offset: 34003},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9674,43 +9674,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1422, col: 5, offset: 34142},
+						pos: position{line: 1422, col: 5, offset: 34143},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1422, col: 5, offset: 34142},
+							pos: position{line: 1422, col: 5, offset: 34143},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1422, col: 5, offset: 34142},
+									pos:   position{line: 1422, col: 5, offset: 34143},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1422, col: 10, offset: 34147},
+										pos:  position{line: 1422, col: 10, offset: 34148},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1422, col: 15, offset: 34152},
+									pos:   position{line: 1422, col: 15, offset: 34153},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1422, col: 19, offset: 34156},
+										pos: position{line: 1422, col: 19, offset: 34157},
 										expr: &seqExpr{
-											pos: position{line: 1422, col: 20, offset: 34157},
+											pos: position{line: 1422, col: 20, offset: 34158},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1422, col: 20, offset: 34157},
+													pos:  position{line: 1422, col: 20, offset: 34158},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1422, col: 23, offset: 34160},
+													pos:        position{line: 1422, col: 23, offset: 34161},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1422, col: 27, offset: 34164},
+													pos:  position{line: 1422, col: 27, offset: 34165},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1422, col: 30, offset: 34167},
+													pos:  position{line: 1422, col: 30, offset: 34168},
 													name: "Type",
 												},
 											},
@@ -9721,31 +9721,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1433, col: 5, offset: 34492},
+						pos: position{line: 1433, col: 5, offset: 34493},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1433, col: 5, offset: 34492},
+							pos: position{line: 1433, col: 5, offset: 34493},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1433, col: 5, offset: 34492},
+									pos:        position{line: 1433, col: 5, offset: 34493},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1433, col: 9, offset: 34496},
+									pos:  position{line: 1433, col: 9, offset: 34497},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1433, col: 12, offset: 34499},
+									pos:   position{line: 1433, col: 12, offset: 34500},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1433, col: 18, offset: 34505},
+										pos:  position{line: 1433, col: 18, offset: 34506},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1433, col: 27, offset: 34514},
+									pos:        position{line: 1433, col: 27, offset: 34515},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9760,28 +9760,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1441, col: 1, offset: 34658},
+			pos:  position{line: 1441, col: 1, offset: 34659},
 			expr: &actionExpr{
-				pos: position{line: 1442, col: 5, offset: 34671},
+				pos: position{line: 1442, col: 5, offset: 34672},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1442, col: 5, offset: 34671},
+					pos: position{line: 1442, col: 5, offset: 34672},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1442, col: 5, offset: 34671},
+							pos:   position{line: 1442, col: 5, offset: 34672},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1442, col: 11, offset: 34677},
+								pos:  position{line: 1442, col: 11, offset: 34678},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1442, col: 16, offset: 34682},
+							pos:   position{line: 1442, col: 16, offset: 34683},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1442, col: 21, offset: 34687},
+								pos: position{line: 1442, col: 21, offset: 34688},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1442, col: 21, offset: 34687},
+									pos:  position{line: 1442, col: 21, offset: 34688},
 									name: "TypeListTail",
 								},
 							},
@@ -9794,32 +9794,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1446, col: 1, offset: 34745},
+			pos:  position{line: 1446, col: 1, offset: 34746},
 			expr: &actionExpr{
-				pos: position{line: 1446, col: 16, offset: 34760},
+				pos: position{line: 1446, col: 16, offset: 34761},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1446, col: 16, offset: 34760},
+					pos: position{line: 1446, col: 16, offset: 34761},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1446, col: 16, offset: 34760},
+							pos:  position{line: 1446, col: 16, offset: 34761},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1446, col: 19, offset: 34763},
+							pos:        position{line: 1446, col: 19, offset: 34764},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1446, col: 23, offset: 34767},
+							pos:  position{line: 1446, col: 23, offset: 34768},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1446, col: 26, offset: 34770},
+							pos:   position{line: 1446, col: 26, offset: 34771},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1446, col: 30, offset: 34774},
+								pos:  position{line: 1446, col: 30, offset: 34775},
 								name: "Type",
 							},
 						},
@@ -9831,40 +9831,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1448, col: 1, offset: 34800},
+			pos:  position{line: 1448, col: 1, offset: 34801},
 			expr: &choiceExpr{
-				pos: position{line: 1449, col: 5, offset: 34816},
+				pos: position{line: 1449, col: 5, offset: 34817},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1449, col: 5, offset: 34816},
+						pos: position{line: 1449, col: 5, offset: 34817},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1449, col: 5, offset: 34816},
+							pos: position{line: 1449, col: 5, offset: 34817},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1449, col: 5, offset: 34816},
+									pos:        position{line: 1449, col: 5, offset: 34817},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1449, col: 9, offset: 34820},
+									pos:  position{line: 1449, col: 9, offset: 34821},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1449, col: 12, offset: 34823},
+									pos:   position{line: 1449, col: 12, offset: 34824},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1449, col: 19, offset: 34830},
+										pos:  position{line: 1449, col: 19, offset: 34831},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1449, col: 33, offset: 34844},
+									pos:  position{line: 1449, col: 33, offset: 34845},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1449, col: 36, offset: 34847},
+									pos:        position{line: 1449, col: 36, offset: 34848},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9873,35 +9873,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1456, col: 5, offset: 35009},
+						pos: position{line: 1456, col: 5, offset: 35010},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1456, col: 5, offset: 35009},
+							pos: position{line: 1456, col: 5, offset: 35010},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1456, col: 5, offset: 35009},
+									pos:        position{line: 1456, col: 5, offset: 35010},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1456, col: 9, offset: 35013},
+									pos:  position{line: 1456, col: 9, offset: 35014},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1456, col: 12, offset: 35016},
+									pos:   position{line: 1456, col: 12, offset: 35017},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1456, col: 16, offset: 35020},
+										pos:  position{line: 1456, col: 16, offset: 35021},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1456, col: 21, offset: 35025},
+									pos:  position{line: 1456, col: 21, offset: 35026},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1456, col: 24, offset: 35028},
+									pos:        position{line: 1456, col: 24, offset: 35029},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9910,35 +9910,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1463, col: 5, offset: 35170},
+						pos: position{line: 1463, col: 5, offset: 35171},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1463, col: 5, offset: 35170},
+							pos: position{line: 1463, col: 5, offset: 35171},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1463, col: 5, offset: 35170},
+									pos:        position{line: 1463, col: 5, offset: 35171},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1463, col: 10, offset: 35175},
+									pos:  position{line: 1463, col: 10, offset: 35176},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1463, col: 13, offset: 35178},
+									pos:   position{line: 1463, col: 13, offset: 35179},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1463, col: 17, offset: 35182},
+										pos:  position{line: 1463, col: 17, offset: 35183},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1463, col: 22, offset: 35187},
+									pos:  position{line: 1463, col: 22, offset: 35188},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1463, col: 25, offset: 35190},
+									pos:        position{line: 1463, col: 25, offset: 35191},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9947,57 +9947,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1470, col: 5, offset: 35329},
+						pos: position{line: 1470, col: 5, offset: 35330},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1470, col: 5, offset: 35329},
+							pos: position{line: 1470, col: 5, offset: 35330},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1470, col: 5, offset: 35329},
+									pos:        position{line: 1470, col: 5, offset: 35330},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1470, col: 10, offset: 35334},
+									pos:  position{line: 1470, col: 10, offset: 35335},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1470, col: 13, offset: 35337},
+									pos:   position{line: 1470, col: 13, offset: 35338},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1470, col: 21, offset: 35345},
+										pos:  position{line: 1470, col: 21, offset: 35346},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1470, col: 26, offset: 35350},
+									pos:  position{line: 1470, col: 26, offset: 35351},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1470, col: 29, offset: 35353},
+									pos:        position{line: 1470, col: 29, offset: 35354},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1470, col: 33, offset: 35357},
+									pos:  position{line: 1470, col: 33, offset: 35358},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1470, col: 36, offset: 35360},
+									pos:   position{line: 1470, col: 36, offset: 35361},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1470, col: 44, offset: 35368},
+										pos:  position{line: 1470, col: 44, offset: 35369},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1470, col: 49, offset: 35373},
+									pos:  position{line: 1470, col: 49, offset: 35374},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1470, col: 52, offset: 35376},
+									pos:        position{line: 1470, col: 52, offset: 35377},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -10012,35 +10012,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1479, col: 1, offset: 35550},
+			pos:  position{line: 1479, col: 1, offset: 35551},
 			expr: &choiceExpr{
-				pos: position{line: 1480, col: 5, offset: 35568},
+				pos: position{line: 1480, col: 5, offset: 35569},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1480, col: 5, offset: 35568},
+						pos: position{line: 1480, col: 5, offset: 35569},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1480, col: 5, offset: 35568},
+							pos: position{line: 1480, col: 5, offset: 35569},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1480, col: 5, offset: 35568},
+									pos:        position{line: 1480, col: 5, offset: 35569},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1480, col: 9, offset: 35572},
+									pos:   position{line: 1480, col: 9, offset: 35573},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1480, col: 11, offset: 35574},
+										pos: position{line: 1480, col: 11, offset: 35575},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1480, col: 11, offset: 35574},
+											pos:  position{line: 1480, col: 11, offset: 35575},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1480, col: 29, offset: 35592},
+									pos:        position{line: 1480, col: 29, offset: 35593},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -10049,30 +10049,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1481, col: 5, offset: 35656},
+						pos: position{line: 1481, col: 5, offset: 35657},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1481, col: 5, offset: 35656},
+							pos: position{line: 1481, col: 5, offset: 35657},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1481, col: 5, offset: 35656},
+									pos:        position{line: 1481, col: 5, offset: 35657},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1481, col: 9, offset: 35660},
+									pos:   position{line: 1481, col: 9, offset: 35661},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1481, col: 11, offset: 35662},
+										pos: position{line: 1481, col: 11, offset: 35663},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1481, col: 11, offset: 35662},
+											pos:  position{line: 1481, col: 11, offset: 35663},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1481, col: 29, offset: 35680},
+									pos:        position{line: 1481, col: 29, offset: 35681},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -10087,35 +10087,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1483, col: 1, offset: 35741},
+			pos:  position{line: 1483, col: 1, offset: 35742},
 			expr: &choiceExpr{
-				pos: position{line: 1484, col: 5, offset: 35753},
+				pos: position{line: 1484, col: 5, offset: 35754},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1484, col: 5, offset: 35753},
+						pos: position{line: 1484, col: 5, offset: 35754},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1484, col: 5, offset: 35753},
+							pos: position{line: 1484, col: 5, offset: 35754},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1484, col: 5, offset: 35753},
+									pos:        position{line: 1484, col: 5, offset: 35754},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1484, col: 11, offset: 35759},
+									pos:   position{line: 1484, col: 11, offset: 35760},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1484, col: 13, offset: 35761},
+										pos: position{line: 1484, col: 13, offset: 35762},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1484, col: 13, offset: 35761},
+											pos:  position{line: 1484, col: 13, offset: 35762},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1484, col: 38, offset: 35786},
+									pos:        position{line: 1484, col: 38, offset: 35787},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -10124,30 +10124,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1491, col: 5, offset: 35932},
+						pos: position{line: 1491, col: 5, offset: 35933},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1491, col: 5, offset: 35932},
+							pos: position{line: 1491, col: 5, offset: 35933},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1491, col: 5, offset: 35932},
+									pos:        position{line: 1491, col: 5, offset: 35933},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1491, col: 10, offset: 35937},
+									pos:   position{line: 1491, col: 10, offset: 35938},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1491, col: 12, offset: 35939},
+										pos: position{line: 1491, col: 12, offset: 35940},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1491, col: 12, offset: 35939},
+											pos:  position{line: 1491, col: 12, offset: 35940},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1491, col: 37, offset: 35964},
+									pos:        position{line: 1491, col: 37, offset: 35965},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -10162,24 +10162,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1499, col: 1, offset: 36107},
+			pos:  position{line: 1499, col: 1, offset: 36108},
 			expr: &choiceExpr{
-				pos: position{line: 1500, col: 5, offset: 36135},
+				pos: position{line: 1500, col: 5, offset: 36136},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1500, col: 5, offset: 36135},
+						pos:  position{line: 1500, col: 5, offset: 36136},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1501, col: 5, offset: 36151},
+						pos: position{line: 1501, col: 5, offset: 36152},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1501, col: 5, offset: 36151},
+							pos:   position{line: 1501, col: 5, offset: 36152},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1501, col: 7, offset: 36153},
+								pos: position{line: 1501, col: 7, offset: 36154},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1501, col: 7, offset: 36153},
+									pos:  position{line: 1501, col: 7, offset: 36154},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -10192,27 +10192,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1505, col: 1, offset: 36276},
+			pos:  position{line: 1505, col: 1, offset: 36277},
 			expr: &choiceExpr{
-				pos: position{line: 1506, col: 5, offset: 36304},
+				pos: position{line: 1506, col: 5, offset: 36305},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1506, col: 5, offset: 36304},
+						pos: position{line: 1506, col: 5, offset: 36305},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1506, col: 5, offset: 36304},
+							pos: position{line: 1506, col: 5, offset: 36305},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1506, col: 5, offset: 36304},
+									pos:        position{line: 1506, col: 5, offset: 36305},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1506, col: 10, offset: 36309},
+									pos:   position{line: 1506, col: 10, offset: 36310},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1506, col: 12, offset: 36311},
+										pos:        position{line: 1506, col: 12, offset: 36312},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -10222,25 +10222,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1507, col: 5, offset: 36337},
+						pos: position{line: 1507, col: 5, offset: 36338},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1507, col: 5, offset: 36337},
+							pos: position{line: 1507, col: 5, offset: 36338},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1507, col: 5, offset: 36337},
+									pos: position{line: 1507, col: 5, offset: 36338},
 									expr: &litMatcher{
-										pos:        position{line: 1507, col: 7, offset: 36339},
+										pos:        position{line: 1507, col: 7, offset: 36340},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1507, col: 12, offset: 36344},
+									pos:   position{line: 1507, col: 12, offset: 36345},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1507, col: 14, offset: 36346},
+										pos:  position{line: 1507, col: 14, offset: 36347},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -10254,24 +10254,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1509, col: 1, offset: 36382},
+			pos:  position{line: 1509, col: 1, offset: 36383},
 			expr: &choiceExpr{
-				pos: position{line: 1510, col: 5, offset: 36410},
+				pos: position{line: 1510, col: 5, offset: 36411},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1510, col: 5, offset: 36410},
+						pos:  position{line: 1510, col: 5, offset: 36411},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1511, col: 5, offset: 36426},
+						pos: position{line: 1511, col: 5, offset: 36427},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1511, col: 5, offset: 36426},
+							pos:   position{line: 1511, col: 5, offset: 36427},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1511, col: 7, offset: 36428},
+								pos: position{line: 1511, col: 7, offset: 36429},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1511, col: 7, offset: 36428},
+									pos:  position{line: 1511, col: 7, offset: 36429},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -10284,27 +10284,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1515, col: 1, offset: 36551},
+			pos:  position{line: 1515, col: 1, offset: 36552},
 			expr: &choiceExpr{
-				pos: position{line: 1516, col: 5, offset: 36579},
+				pos: position{line: 1516, col: 5, offset: 36580},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1516, col: 5, offset: 36579},
+						pos: position{line: 1516, col: 5, offset: 36580},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1516, col: 5, offset: 36579},
+							pos: position{line: 1516, col: 5, offset: 36580},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1516, col: 5, offset: 36579},
+									pos:        position{line: 1516, col: 5, offset: 36580},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1516, col: 10, offset: 36584},
+									pos:   position{line: 1516, col: 10, offset: 36585},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1516, col: 12, offset: 36586},
+										pos:        position{line: 1516, col: 12, offset: 36587},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -10314,25 +10314,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1517, col: 5, offset: 36612},
+						pos: position{line: 1517, col: 5, offset: 36613},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1517, col: 5, offset: 36612},
+							pos: position{line: 1517, col: 5, offset: 36613},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1517, col: 5, offset: 36612},
+									pos: position{line: 1517, col: 5, offset: 36613},
 									expr: &litMatcher{
-										pos:        position{line: 1517, col: 7, offset: 36614},
+										pos:        position{line: 1517, col: 7, offset: 36615},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1517, col: 12, offset: 36619},
+									pos:   position{line: 1517, col: 12, offset: 36620},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1517, col: 14, offset: 36621},
+										pos:  position{line: 1517, col: 14, offset: 36622},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -10346,37 +10346,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1519, col: 1, offset: 36657},
+			pos:  position{line: 1519, col: 1, offset: 36658},
 			expr: &actionExpr{
-				pos: position{line: 1520, col: 5, offset: 36673},
+				pos: position{line: 1520, col: 5, offset: 36674},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1520, col: 5, offset: 36673},
+					pos: position{line: 1520, col: 5, offset: 36674},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1520, col: 5, offset: 36673},
+							pos:        position{line: 1520, col: 5, offset: 36674},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1520, col: 9, offset: 36677},
+							pos:  position{line: 1520, col: 9, offset: 36678},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1520, col: 12, offset: 36680},
+							pos:   position{line: 1520, col: 12, offset: 36681},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1520, col: 14, offset: 36682},
+								pos:  position{line: 1520, col: 14, offset: 36683},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1520, col: 19, offset: 36687},
+							pos:  position{line: 1520, col: 19, offset: 36688},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1520, col: 22, offset: 36690},
+							pos:        position{line: 1520, col: 22, offset: 36691},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -10389,129 +10389,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1528, col: 1, offset: 36825},
+			pos:  position{line: 1528, col: 1, offset: 36826},
 			expr: &actionExpr{
-				pos: position{line: 1529, col: 5, offset: 36843},
+				pos: position{line: 1529, col: 5, offset: 36844},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1529, col: 9, offset: 36847},
+					pos: position{line: 1529, col: 9, offset: 36848},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1529, col: 9, offset: 36847},
+							pos:        position{line: 1529, col: 9, offset: 36848},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1529, col: 19, offset: 36857},
+							pos:        position{line: 1529, col: 19, offset: 36858},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1529, col: 30, offset: 36868},
+							pos:        position{line: 1529, col: 30, offset: 36869},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1529, col: 41, offset: 36879},
+							pos:        position{line: 1529, col: 41, offset: 36880},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1530, col: 9, offset: 36896},
+							pos:        position{line: 1530, col: 9, offset: 36897},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1530, col: 18, offset: 36905},
+							pos:        position{line: 1530, col: 18, offset: 36906},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1530, col: 28, offset: 36915},
+							pos:        position{line: 1530, col: 28, offset: 36916},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1530, col: 38, offset: 36925},
+							pos:        position{line: 1530, col: 38, offset: 36926},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1531, col: 9, offset: 36941},
+							pos:        position{line: 1531, col: 9, offset: 36942},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1531, col: 21, offset: 36953},
+							pos:        position{line: 1531, col: 21, offset: 36954},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1531, col: 33, offset: 36965},
+							pos:        position{line: 1531, col: 33, offset: 36966},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1532, col: 9, offset: 36983},
+							pos:        position{line: 1532, col: 9, offset: 36984},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1532, col: 18, offset: 36992},
+							pos:        position{line: 1532, col: 18, offset: 36993},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1533, col: 9, offset: 37009},
+							pos:        position{line: 1533, col: 9, offset: 37010},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1533, col: 22, offset: 37022},
+							pos:        position{line: 1533, col: 22, offset: 37023},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1534, col: 9, offset: 37037},
+							pos:        position{line: 1534, col: 9, offset: 37038},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1535, col: 9, offset: 37053},
+							pos:        position{line: 1535, col: 9, offset: 37054},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1535, col: 16, offset: 37060},
+							pos:        position{line: 1535, col: 16, offset: 37061},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1536, col: 9, offset: 37074},
+							pos:        position{line: 1536, col: 9, offset: 37075},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1536, col: 18, offset: 37083},
+							pos:        position{line: 1536, col: 18, offset: 37084},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -10524,31 +10524,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1544, col: 1, offset: 37268},
+			pos:  position{line: 1544, col: 1, offset: 37269},
 			expr: &choiceExpr{
-				pos: position{line: 1545, col: 5, offset: 37286},
+				pos: position{line: 1545, col: 5, offset: 37287},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1545, col: 5, offset: 37286},
+						pos: position{line: 1545, col: 5, offset: 37287},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1545, col: 5, offset: 37286},
+							pos: position{line: 1545, col: 5, offset: 37287},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1545, col: 5, offset: 37286},
+									pos:   position{line: 1545, col: 5, offset: 37287},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1545, col: 11, offset: 37292},
+										pos:  position{line: 1545, col: 11, offset: 37293},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1545, col: 21, offset: 37302},
+									pos:   position{line: 1545, col: 21, offset: 37303},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1545, col: 26, offset: 37307},
+										pos: position{line: 1545, col: 26, offset: 37308},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1545, col: 26, offset: 37307},
+											pos:  position{line: 1545, col: 26, offset: 37308},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10557,10 +10557,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1548, col: 5, offset: 37373},
+						pos: position{line: 1548, col: 5, offset: 37374},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1548, col: 5, offset: 37373},
+							pos:        position{line: 1548, col: 5, offset: 37374},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10573,32 +10573,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1550, col: 1, offset: 37397},
+			pos:  position{line: 1550, col: 1, offset: 37398},
 			expr: &actionExpr{
-				pos: position{line: 1550, col: 21, offset: 37417},
+				pos: position{line: 1550, col: 21, offset: 37418},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1550, col: 21, offset: 37417},
+					pos: position{line: 1550, col: 21, offset: 37418},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1550, col: 21, offset: 37417},
+							pos:  position{line: 1550, col: 21, offset: 37418},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1550, col: 24, offset: 37420},
+							pos:        position{line: 1550, col: 24, offset: 37421},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1550, col: 28, offset: 37424},
+							pos:  position{line: 1550, col: 28, offset: 37425},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1550, col: 31, offset: 37427},
+							pos:   position{line: 1550, col: 31, offset: 37428},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1550, col: 35, offset: 37431},
+								pos:  position{line: 1550, col: 35, offset: 37432},
 								name: "TypeField",
 							},
 						},
@@ -10610,40 +10610,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1552, col: 1, offset: 37462},
+			pos:  position{line: 1552, col: 1, offset: 37463},
 			expr: &actionExpr{
-				pos: position{line: 1553, col: 5, offset: 37476},
+				pos: position{line: 1553, col: 5, offset: 37477},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1553, col: 5, offset: 37476},
+					pos: position{line: 1553, col: 5, offset: 37477},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1553, col: 5, offset: 37476},
+							pos:   position{line: 1553, col: 5, offset: 37477},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1553, col: 10, offset: 37481},
+								pos:  position{line: 1553, col: 10, offset: 37482},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1553, col: 15, offset: 37486},
+							pos:  position{line: 1553, col: 15, offset: 37487},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1553, col: 18, offset: 37489},
+							pos:        position{line: 1553, col: 18, offset: 37490},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1553, col: 22, offset: 37493},
+							pos:  position{line: 1553, col: 22, offset: 37494},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1553, col: 25, offset: 37496},
+							pos:   position{line: 1553, col: 25, offset: 37497},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1553, col: 29, offset: 37500},
+								pos:  position{line: 1553, col: 29, offset: 37501},
 								name: "Type",
 							},
 						},
@@ -10655,54 +10655,54 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1561, col: 1, offset: 37649},
+			pos:  position{line: 1561, col: 1, offset: 37650},
 			expr: &choiceExpr{
-				pos: position{line: 1562, col: 5, offset: 37658},
+				pos: position{line: 1562, col: 5, offset: 37659},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1562, col: 5, offset: 37658},
+						pos: position{line: 1562, col: 5, offset: 37659},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1562, col: 5, offset: 37658},
+							pos:   position{line: 1562, col: 5, offset: 37659},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1562, col: 7, offset: 37660},
+								pos:  position{line: 1562, col: 7, offset: 37661},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1563, col: 5, offset: 37749},
+						pos: position{line: 1563, col: 5, offset: 37750},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1563, col: 5, offset: 37749},
+							pos:   position{line: 1563, col: 5, offset: 37750},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1563, col: 7, offset: 37751},
+								pos:  position{line: 1563, col: 7, offset: 37752},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1564, col: 5, offset: 37840},
+						pos: position{line: 1564, col: 5, offset: 37841},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1564, col: 5, offset: 37840},
+							pos:   position{line: 1564, col: 5, offset: 37841},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1564, col: 7, offset: 37842},
+								pos:  position{line: 1564, col: 7, offset: 37843},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1565, col: 5, offset: 37931},
+						pos: position{line: 1565, col: 5, offset: 37932},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1565, col: 5, offset: 37931},
+							pos:   position{line: 1565, col: 5, offset: 37932},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1565, col: 7, offset: 37933},
+								pos:  position{line: 1565, col: 7, offset: 37934},
 								name: "KSUID",
 							},
 						},
@@ -10714,22 +10714,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1567, col: 1, offset: 38019},
+			pos:  position{line: 1567, col: 1, offset: 38020},
 			expr: &actionExpr{
-				pos: position{line: 1568, col: 5, offset: 38033},
+				pos: position{line: 1568, col: 5, offset: 38034},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1568, col: 5, offset: 38033},
+					pos: position{line: 1568, col: 5, offset: 38034},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1568, col: 6, offset: 38034},
+							pos: position{line: 1568, col: 6, offset: 38035},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1568, col: 6, offset: 38034},
+									pos:  position{line: 1568, col: 6, offset: 38035},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1568, col: 24, offset: 38052},
+									pos:        position{line: 1568, col: 24, offset: 38053},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -10737,16 +10737,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1568, col: 29, offset: 38057},
+							pos: position{line: 1568, col: 29, offset: 38058},
 							expr: &choiceExpr{
-								pos: position{line: 1568, col: 30, offset: 38058},
+								pos: position{line: 1568, col: 30, offset: 38059},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1568, col: 30, offset: 38058},
+										pos:  position{line: 1568, col: 30, offset: 38059},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1568, col: 47, offset: 38075},
+										pos:        position{line: 1568, col: 47, offset: 38076},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -10762,15 +10762,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1570, col: 1, offset: 38113},
+			pos:  position{line: 1570, col: 1, offset: 38114},
 			expr: &actionExpr{
-				pos: position{line: 1571, col: 5, offset: 38128},
+				pos: position{line: 1571, col: 5, offset: 38129},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1571, col: 5, offset: 38128},
+					pos:   position{line: 1571, col: 5, offset: 38129},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1571, col: 8, offset: 38131},
+						pos:  position{line: 1571, col: 8, offset: 38132},
 						name: "IdentifierName",
 					},
 				},
@@ -10780,51 +10780,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1579, col: 1, offset: 38264},
+			pos:  position{line: 1579, col: 1, offset: 38265},
 			expr: &actionExpr{
-				pos: position{line: 1580, col: 5, offset: 38280},
+				pos: position{line: 1580, col: 5, offset: 38281},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1580, col: 5, offset: 38280},
+					pos: position{line: 1580, col: 5, offset: 38281},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1580, col: 5, offset: 38280},
+							pos:   position{line: 1580, col: 5, offset: 38281},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1580, col: 11, offset: 38286},
+								pos:  position{line: 1580, col: 11, offset: 38287},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1580, col: 22, offset: 38297},
+							pos:   position{line: 1580, col: 22, offset: 38298},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1580, col: 27, offset: 38302},
+								pos: position{line: 1580, col: 27, offset: 38303},
 								expr: &actionExpr{
-									pos: position{line: 1580, col: 28, offset: 38303},
+									pos: position{line: 1580, col: 28, offset: 38304},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1580, col: 28, offset: 38303},
+										pos: position{line: 1580, col: 28, offset: 38304},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1580, col: 28, offset: 38303},
+												pos:  position{line: 1580, col: 28, offset: 38304},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1580, col: 31, offset: 38306},
+												pos:        position{line: 1580, col: 31, offset: 38307},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1580, col: 35, offset: 38310},
+												pos:  position{line: 1580, col: 35, offset: 38311},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1580, col: 38, offset: 38313},
+												pos:   position{line: 1580, col: 38, offset: 38314},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1580, col: 43, offset: 38318},
+													pos:  position{line: 1580, col: 43, offset: 38319},
 													name: "Identifier",
 												},
 											},
@@ -10841,29 +10841,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1584, col: 1, offset: 38396},
+			pos:  position{line: 1584, col: 1, offset: 38397},
 			expr: &choiceExpr{
-				pos: position{line: 1585, col: 5, offset: 38415},
+				pos: position{line: 1585, col: 5, offset: 38416},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1585, col: 5, offset: 38415},
+						pos: position{line: 1585, col: 5, offset: 38416},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1585, col: 5, offset: 38415},
+							pos: position{line: 1585, col: 5, offset: 38416},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1585, col: 5, offset: 38415},
+									pos: position{line: 1585, col: 5, offset: 38416},
 									expr: &seqExpr{
-										pos: position{line: 1585, col: 7, offset: 38417},
+										pos: position{line: 1585, col: 7, offset: 38418},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1585, col: 7, offset: 38417},
+												pos:  position{line: 1585, col: 7, offset: 38418},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1585, col: 15, offset: 38425},
+												pos: position{line: 1585, col: 15, offset: 38426},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1585, col: 16, offset: 38426},
+													pos:  position{line: 1585, col: 16, offset: 38427},
 													name: "IdentifierRest",
 												},
 											},
@@ -10871,13 +10871,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1585, col: 32, offset: 38442},
+									pos:  position{line: 1585, col: 32, offset: 38443},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1585, col: 48, offset: 38458},
+									pos: position{line: 1585, col: 48, offset: 38459},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1585, col: 48, offset: 38458},
+										pos:  position{line: 1585, col: 48, offset: 38459},
 										name: "IdentifierRest",
 									},
 								},
@@ -10885,32 +10885,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1586, col: 5, offset: 38509},
+						pos: position{line: 1586, col: 5, offset: 38510},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1586, col: 5, offset: 38509},
+							pos:        position{line: 1586, col: 5, offset: 38510},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1587, col: 5, offset: 38548},
+						pos: position{line: 1587, col: 5, offset: 38549},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1587, col: 5, offset: 38548},
+							pos: position{line: 1587, col: 5, offset: 38549},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1587, col: 5, offset: 38548},
+									pos:        position{line: 1587, col: 5, offset: 38549},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1587, col: 10, offset: 38553},
+									pos:   position{line: 1587, col: 10, offset: 38554},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1587, col: 13, offset: 38556},
+										pos:  position{line: 1587, col: 13, offset: 38557},
 										name: "IDGuard",
 									},
 								},
@@ -10918,17 +10918,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1589, col: 5, offset: 38647},
+						pos: position{line: 1589, col: 5, offset: 38648},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1589, col: 5, offset: 38647},
+							pos:        position{line: 1589, col: 5, offset: 38648},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 5, offset: 38689},
+						pos:  position{line: 1590, col: 5, offset: 38690},
 						name: "BacktickString",
 					},
 				},
@@ -10938,22 +10938,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1592, col: 1, offset: 38706},
+			pos:  position{line: 1592, col: 1, offset: 38707},
 			expr: &choiceExpr{
-				pos: position{line: 1593, col: 5, offset: 38726},
+				pos: position{line: 1593, col: 5, offset: 38727},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1593, col: 5, offset: 38726},
+						pos:  position{line: 1593, col: 5, offset: 38727},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1594, col: 5, offset: 38744},
+						pos:        position{line: 1594, col: 5, offset: 38745},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1595, col: 5, offset: 38752},
+						pos:        position{line: 1595, col: 5, offset: 38753},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10965,24 +10965,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1597, col: 1, offset: 38757},
+			pos:  position{line: 1597, col: 1, offset: 38758},
 			expr: &choiceExpr{
-				pos: position{line: 1598, col: 5, offset: 38776},
+				pos: position{line: 1598, col: 5, offset: 38777},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1598, col: 5, offset: 38776},
+						pos:  position{line: 1598, col: 5, offset: 38777},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1599, col: 5, offset: 38796},
+						pos:  position{line: 1599, col: 5, offset: 38797},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1600, col: 5, offset: 38821},
+						pos:  position{line: 1600, col: 5, offset: 38822},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1601, col: 5, offset: 38838},
+						pos:  position{line: 1601, col: 5, offset: 38839},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10992,24 +10992,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1603, col: 1, offset: 38867},
+			pos:  position{line: 1603, col: 1, offset: 38868},
 			expr: &choiceExpr{
-				pos: position{line: 1604, col: 5, offset: 38879},
+				pos: position{line: 1604, col: 5, offset: 38880},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 5, offset: 38879},
+						pos:  position{line: 1604, col: 5, offset: 38880},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1605, col: 5, offset: 38898},
+						pos:  position{line: 1605, col: 5, offset: 38899},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1606, col: 5, offset: 38914},
+						pos:  position{line: 1606, col: 5, offset: 38915},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1607, col: 5, offset: 38922},
+						pos:  position{line: 1607, col: 5, offset: 38923},
 						name: "Infinity",
 					},
 				},
@@ -11019,25 +11019,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1609, col: 1, offset: 38932},
+			pos:  position{line: 1609, col: 1, offset: 38933},
 			expr: &actionExpr{
-				pos: position{line: 1610, col: 5, offset: 38941},
+				pos: position{line: 1610, col: 5, offset: 38942},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1610, col: 5, offset: 38941},
+					pos: position{line: 1610, col: 5, offset: 38942},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1610, col: 5, offset: 38941},
+							pos:  position{line: 1610, col: 5, offset: 38942},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1610, col: 14, offset: 38950},
+							pos:        position{line: 1610, col: 14, offset: 38951},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1610, col: 18, offset: 38954},
+							pos:  position{line: 1610, col: 18, offset: 38955},
 							name: "FullTime",
 						},
 					},
@@ -11048,32 +11048,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1614, col: 1, offset: 39030},
+			pos:  position{line: 1614, col: 1, offset: 39031},
 			expr: &seqExpr{
-				pos: position{line: 1614, col: 12, offset: 39041},
+				pos: position{line: 1614, col: 12, offset: 39042},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1614, col: 12, offset: 39041},
+						pos:  position{line: 1614, col: 12, offset: 39042},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1614, col: 15, offset: 39044},
+						pos:        position{line: 1614, col: 15, offset: 39045},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1614, col: 19, offset: 39048},
+						pos:  position{line: 1614, col: 19, offset: 39049},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1614, col: 22, offset: 39051},
+						pos:        position{line: 1614, col: 22, offset: 39052},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1614, col: 26, offset: 39055},
+						pos:  position{line: 1614, col: 26, offset: 39056},
 						name: "D2",
 					},
 				},
@@ -11083,33 +11083,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1616, col: 1, offset: 39059},
+			pos:  position{line: 1616, col: 1, offset: 39060},
 			expr: &seqExpr{
-				pos: position{line: 1616, col: 6, offset: 39064},
+				pos: position{line: 1616, col: 6, offset: 39065},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1616, col: 6, offset: 39064},
+						pos:        position{line: 1616, col: 6, offset: 39065},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1616, col: 11, offset: 39069},
+						pos:        position{line: 1616, col: 11, offset: 39070},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1616, col: 16, offset: 39074},
+						pos:        position{line: 1616, col: 16, offset: 39075},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1616, col: 21, offset: 39079},
+						pos:        position{line: 1616, col: 21, offset: 39080},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11122,19 +11122,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1617, col: 1, offset: 39085},
+			pos:  position{line: 1617, col: 1, offset: 39086},
 			expr: &seqExpr{
-				pos: position{line: 1617, col: 6, offset: 39090},
+				pos: position{line: 1617, col: 6, offset: 39091},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1617, col: 6, offset: 39090},
+						pos:        position{line: 1617, col: 6, offset: 39091},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1617, col: 11, offset: 39095},
+						pos:        position{line: 1617, col: 11, offset: 39096},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11147,16 +11147,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1619, col: 1, offset: 39102},
+			pos:  position{line: 1619, col: 1, offset: 39103},
 			expr: &seqExpr{
-				pos: position{line: 1619, col: 12, offset: 39113},
+				pos: position{line: 1619, col: 12, offset: 39114},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1619, col: 12, offset: 39113},
+						pos:  position{line: 1619, col: 12, offset: 39114},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1619, col: 24, offset: 39125},
+						pos:  position{line: 1619, col: 24, offset: 39126},
 						name: "TimeOffset",
 					},
 				},
@@ -11166,49 +11166,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1621, col: 1, offset: 39137},
+			pos:  position{line: 1621, col: 1, offset: 39138},
 			expr: &seqExpr{
-				pos: position{line: 1621, col: 15, offset: 39151},
+				pos: position{line: 1621, col: 15, offset: 39152},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1621, col: 15, offset: 39151},
+						pos:  position{line: 1621, col: 15, offset: 39152},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1621, col: 18, offset: 39154},
+						pos:        position{line: 1621, col: 18, offset: 39155},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1621, col: 22, offset: 39158},
+						pos:  position{line: 1621, col: 22, offset: 39159},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1621, col: 25, offset: 39161},
+						pos:        position{line: 1621, col: 25, offset: 39162},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1621, col: 29, offset: 39165},
+						pos:  position{line: 1621, col: 29, offset: 39166},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1621, col: 32, offset: 39168},
+						pos: position{line: 1621, col: 32, offset: 39169},
 						expr: &seqExpr{
-							pos: position{line: 1621, col: 33, offset: 39169},
+							pos: position{line: 1621, col: 33, offset: 39170},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1621, col: 33, offset: 39169},
+									pos:        position{line: 1621, col: 33, offset: 39170},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1621, col: 37, offset: 39173},
+									pos: position{line: 1621, col: 37, offset: 39174},
 									expr: &charClassMatcher{
-										pos:        position{line: 1621, col: 37, offset: 39173},
+										pos:        position{line: 1621, col: 37, offset: 39174},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11225,30 +11225,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1623, col: 1, offset: 39183},
+			pos:  position{line: 1623, col: 1, offset: 39184},
 			expr: &choiceExpr{
-				pos: position{line: 1624, col: 5, offset: 39198},
+				pos: position{line: 1624, col: 5, offset: 39199},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1624, col: 5, offset: 39198},
+						pos:        position{line: 1624, col: 5, offset: 39199},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1625, col: 5, offset: 39206},
+						pos: position{line: 1625, col: 5, offset: 39207},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1625, col: 6, offset: 39207},
+								pos: position{line: 1625, col: 6, offset: 39208},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1625, col: 6, offset: 39207},
+										pos:        position{line: 1625, col: 6, offset: 39208},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1625, col: 12, offset: 39213},
+										pos:        position{line: 1625, col: 12, offset: 39214},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -11256,34 +11256,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1625, col: 17, offset: 39218},
+								pos:  position{line: 1625, col: 17, offset: 39219},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1625, col: 20, offset: 39221},
+								pos:        position{line: 1625, col: 20, offset: 39222},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1625, col: 24, offset: 39225},
+								pos:  position{line: 1625, col: 24, offset: 39226},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1625, col: 27, offset: 39228},
+								pos: position{line: 1625, col: 27, offset: 39229},
 								expr: &seqExpr{
-									pos: position{line: 1625, col: 28, offset: 39229},
+									pos: position{line: 1625, col: 28, offset: 39230},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1625, col: 28, offset: 39229},
+											pos:        position{line: 1625, col: 28, offset: 39230},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1625, col: 32, offset: 39233},
+											pos: position{line: 1625, col: 32, offset: 39234},
 											expr: &charClassMatcher{
-												pos:        position{line: 1625, col: 32, offset: 39233},
+												pos:        position{line: 1625, col: 32, offset: 39234},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -11302,33 +11302,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1627, col: 1, offset: 39243},
+			pos:  position{line: 1627, col: 1, offset: 39244},
 			expr: &actionExpr{
-				pos: position{line: 1628, col: 5, offset: 39256},
+				pos: position{line: 1628, col: 5, offset: 39257},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1628, col: 5, offset: 39256},
+					pos: position{line: 1628, col: 5, offset: 39257},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1628, col: 5, offset: 39256},
+							pos: position{line: 1628, col: 5, offset: 39257},
 							expr: &litMatcher{
-								pos:        position{line: 1628, col: 5, offset: 39256},
+								pos:        position{line: 1628, col: 5, offset: 39257},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1628, col: 10, offset: 39261},
+							pos: position{line: 1628, col: 10, offset: 39262},
 							expr: &seqExpr{
-								pos: position{line: 1628, col: 11, offset: 39262},
+								pos: position{line: 1628, col: 11, offset: 39263},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1628, col: 11, offset: 39262},
+										pos:  position{line: 1628, col: 11, offset: 39263},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1628, col: 19, offset: 39270},
+										pos:  position{line: 1628, col: 19, offset: 39271},
 										name: "TimeUnit",
 									},
 								},
@@ -11342,27 +11342,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1632, col: 1, offset: 39352},
+			pos:  position{line: 1632, col: 1, offset: 39353},
 			expr: &seqExpr{
-				pos: position{line: 1632, col: 11, offset: 39362},
+				pos: position{line: 1632, col: 11, offset: 39363},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1632, col: 11, offset: 39362},
+						pos:  position{line: 1632, col: 11, offset: 39363},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1632, col: 16, offset: 39367},
+						pos: position{line: 1632, col: 16, offset: 39368},
 						expr: &seqExpr{
-							pos: position{line: 1632, col: 17, offset: 39368},
+							pos: position{line: 1632, col: 17, offset: 39369},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1632, col: 17, offset: 39368},
+									pos:        position{line: 1632, col: 17, offset: 39369},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1632, col: 21, offset: 39372},
+									pos:  position{line: 1632, col: 21, offset: 39373},
 									name: "UInt",
 								},
 							},
@@ -11375,60 +11375,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1634, col: 1, offset: 39380},
+			pos:  position{line: 1634, col: 1, offset: 39381},
 			expr: &choiceExpr{
-				pos: position{line: 1635, col: 5, offset: 39393},
+				pos: position{line: 1635, col: 5, offset: 39394},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1635, col: 5, offset: 39393},
+						pos:        position{line: 1635, col: 5, offset: 39394},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1636, col: 5, offset: 39402},
+						pos:        position{line: 1636, col: 5, offset: 39403},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1637, col: 5, offset: 39411},
+						pos:        position{line: 1637, col: 5, offset: 39412},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1638, col: 5, offset: 39420},
+						pos:        position{line: 1638, col: 5, offset: 39421},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1639, col: 5, offset: 39428},
+						pos:        position{line: 1639, col: 5, offset: 39429},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1640, col: 5, offset: 39436},
+						pos:        position{line: 1640, col: 5, offset: 39437},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1641, col: 5, offset: 39444},
+						pos:        position{line: 1641, col: 5, offset: 39445},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1642, col: 5, offset: 39452},
+						pos:        position{line: 1642, col: 5, offset: 39453},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1643, col: 5, offset: 39460},
+						pos:        position{line: 1643, col: 5, offset: 39461},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -11440,45 +11440,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1645, col: 1, offset: 39465},
+			pos:  position{line: 1645, col: 1, offset: 39466},
 			expr: &actionExpr{
-				pos: position{line: 1646, col: 5, offset: 39472},
+				pos: position{line: 1646, col: 5, offset: 39473},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1646, col: 5, offset: 39472},
+					pos: position{line: 1646, col: 5, offset: 39473},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1646, col: 5, offset: 39472},
+							pos:  position{line: 1646, col: 5, offset: 39473},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1646, col: 10, offset: 39477},
+							pos:        position{line: 1646, col: 10, offset: 39478},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1646, col: 14, offset: 39481},
+							pos:  position{line: 1646, col: 14, offset: 39482},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1646, col: 19, offset: 39486},
+							pos:        position{line: 1646, col: 19, offset: 39487},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1646, col: 23, offset: 39490},
+							pos:  position{line: 1646, col: 23, offset: 39491},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1646, col: 28, offset: 39495},
+							pos:        position{line: 1646, col: 28, offset: 39496},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1646, col: 32, offset: 39499},
+							pos:  position{line: 1646, col: 32, offset: 39500},
 							name: "UInt",
 						},
 					},
@@ -11489,43 +11489,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1648, col: 1, offset: 39536},
+			pos:  position{line: 1648, col: 1, offset: 39537},
 			expr: &actionExpr{
-				pos: position{line: 1649, col: 5, offset: 39544},
+				pos: position{line: 1649, col: 5, offset: 39545},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1649, col: 5, offset: 39544},
+					pos: position{line: 1649, col: 5, offset: 39545},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1649, col: 5, offset: 39544},
+							pos: position{line: 1649, col: 5, offset: 39545},
 							expr: &seqExpr{
-								pos: position{line: 1649, col: 7, offset: 39546},
+								pos: position{line: 1649, col: 7, offset: 39547},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1649, col: 7, offset: 39546},
+										pos:  position{line: 1649, col: 7, offset: 39547},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1649, col: 11, offset: 39550},
+										pos:        position{line: 1649, col: 11, offset: 39551},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1649, col: 15, offset: 39554},
+										pos:  position{line: 1649, col: 15, offset: 39555},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1649, col: 19, offset: 39558},
+										pos: position{line: 1649, col: 19, offset: 39559},
 										expr: &choiceExpr{
-											pos: position{line: 1649, col: 21, offset: 39560},
+											pos: position{line: 1649, col: 21, offset: 39561},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1649, col: 21, offset: 39560},
+													pos:  position{line: 1649, col: 21, offset: 39561},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1649, col: 32, offset: 39571},
+													pos:        position{line: 1649, col: 32, offset: 39572},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11537,10 +11537,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1649, col: 38, offset: 39577},
+							pos:   position{line: 1649, col: 38, offset: 39578},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1649, col: 40, offset: 39579},
+								pos:  position{line: 1649, col: 40, offset: 39580},
 								name: "IP6Variations",
 							},
 						},
@@ -11552,32 +11552,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1653, col: 1, offset: 39743},
+			pos:  position{line: 1653, col: 1, offset: 39744},
 			expr: &choiceExpr{
-				pos: position{line: 1654, col: 5, offset: 39761},
+				pos: position{line: 1654, col: 5, offset: 39762},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1654, col: 5, offset: 39761},
+						pos: position{line: 1654, col: 5, offset: 39762},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1654, col: 5, offset: 39761},
+							pos: position{line: 1654, col: 5, offset: 39762},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1654, col: 5, offset: 39761},
+									pos:   position{line: 1654, col: 5, offset: 39762},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1654, col: 7, offset: 39763},
+										pos: position{line: 1654, col: 7, offset: 39764},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1654, col: 7, offset: 39763},
+											pos:  position{line: 1654, col: 7, offset: 39764},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1654, col: 17, offset: 39773},
+									pos:   position{line: 1654, col: 17, offset: 39774},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1654, col: 19, offset: 39775},
+										pos:  position{line: 1654, col: 19, offset: 39776},
 										name: "IP6Tail",
 									},
 								},
@@ -11585,52 +11585,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1657, col: 5, offset: 39839},
+						pos: position{line: 1657, col: 5, offset: 39840},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1657, col: 5, offset: 39839},
+							pos: position{line: 1657, col: 5, offset: 39840},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1657, col: 5, offset: 39839},
+									pos:   position{line: 1657, col: 5, offset: 39840},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1657, col: 7, offset: 39841},
+										pos:  position{line: 1657, col: 7, offset: 39842},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1657, col: 11, offset: 39845},
+									pos:   position{line: 1657, col: 11, offset: 39846},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1657, col: 13, offset: 39847},
+										pos: position{line: 1657, col: 13, offset: 39848},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1657, col: 13, offset: 39847},
+											pos:  position{line: 1657, col: 13, offset: 39848},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1657, col: 23, offset: 39857},
+									pos:        position{line: 1657, col: 23, offset: 39858},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1657, col: 28, offset: 39862},
+									pos:   position{line: 1657, col: 28, offset: 39863},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1657, col: 30, offset: 39864},
+										pos: position{line: 1657, col: 30, offset: 39865},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1657, col: 30, offset: 39864},
+											pos:  position{line: 1657, col: 30, offset: 39865},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1657, col: 40, offset: 39874},
+									pos:   position{line: 1657, col: 40, offset: 39875},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1657, col: 42, offset: 39876},
+										pos:  position{line: 1657, col: 42, offset: 39877},
 										name: "IP6Tail",
 									},
 								},
@@ -11638,33 +11638,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1660, col: 5, offset: 39975},
+						pos: position{line: 1660, col: 5, offset: 39976},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1660, col: 5, offset: 39975},
+							pos: position{line: 1660, col: 5, offset: 39976},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1660, col: 5, offset: 39975},
+									pos:        position{line: 1660, col: 5, offset: 39976},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1660, col: 10, offset: 39980},
+									pos:   position{line: 1660, col: 10, offset: 39981},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1660, col: 12, offset: 39982},
+										pos: position{line: 1660, col: 12, offset: 39983},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1660, col: 12, offset: 39982},
+											pos:  position{line: 1660, col: 12, offset: 39983},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1660, col: 22, offset: 39992},
+									pos:   position{line: 1660, col: 22, offset: 39993},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1660, col: 24, offset: 39994},
+										pos:  position{line: 1660, col: 24, offset: 39995},
 										name: "IP6Tail",
 									},
 								},
@@ -11672,32 +11672,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1663, col: 5, offset: 40065},
+						pos: position{line: 1663, col: 5, offset: 40066},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1663, col: 5, offset: 40065},
+							pos: position{line: 1663, col: 5, offset: 40066},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1663, col: 5, offset: 40065},
+									pos:   position{line: 1663, col: 5, offset: 40066},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1663, col: 7, offset: 40067},
+										pos:  position{line: 1663, col: 7, offset: 40068},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1663, col: 11, offset: 40071},
+									pos:   position{line: 1663, col: 11, offset: 40072},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1663, col: 13, offset: 40073},
+										pos: position{line: 1663, col: 13, offset: 40074},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1663, col: 13, offset: 40073},
+											pos:  position{line: 1663, col: 13, offset: 40074},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1663, col: 23, offset: 40083},
+									pos:        position{line: 1663, col: 23, offset: 40084},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -11706,10 +11706,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1666, col: 5, offset: 40151},
+						pos: position{line: 1666, col: 5, offset: 40152},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1666, col: 5, offset: 40151},
+							pos:        position{line: 1666, col: 5, offset: 40152},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11722,16 +11722,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1670, col: 1, offset: 40188},
+			pos:  position{line: 1670, col: 1, offset: 40189},
 			expr: &choiceExpr{
-				pos: position{line: 1671, col: 5, offset: 40200},
+				pos: position{line: 1671, col: 5, offset: 40201},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1671, col: 5, offset: 40200},
+						pos:  position{line: 1671, col: 5, offset: 40201},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1672, col: 5, offset: 40207},
+						pos:  position{line: 1672, col: 5, offset: 40208},
 						name: "Hex",
 					},
 				},
@@ -11741,24 +11741,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1674, col: 1, offset: 40212},
+			pos:  position{line: 1674, col: 1, offset: 40213},
 			expr: &actionExpr{
-				pos: position{line: 1674, col: 12, offset: 40223},
+				pos: position{line: 1674, col: 12, offset: 40224},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1674, col: 12, offset: 40223},
+					pos: position{line: 1674, col: 12, offset: 40224},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1674, col: 12, offset: 40223},
+							pos:        position{line: 1674, col: 12, offset: 40224},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1674, col: 16, offset: 40227},
+							pos:   position{line: 1674, col: 16, offset: 40228},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1674, col: 18, offset: 40229},
+								pos:  position{line: 1674, col: 18, offset: 40230},
 								name: "Hex",
 							},
 						},
@@ -11770,23 +11770,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1676, col: 1, offset: 40267},
+			pos:  position{line: 1676, col: 1, offset: 40268},
 			expr: &actionExpr{
-				pos: position{line: 1676, col: 12, offset: 40278},
+				pos: position{line: 1676, col: 12, offset: 40279},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1676, col: 12, offset: 40278},
+					pos: position{line: 1676, col: 12, offset: 40279},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1676, col: 12, offset: 40278},
+							pos:   position{line: 1676, col: 12, offset: 40279},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1676, col: 14, offset: 40280},
+								pos:  position{line: 1676, col: 14, offset: 40281},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1676, col: 18, offset: 40284},
+							pos:        position{line: 1676, col: 18, offset: 40285},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11799,32 +11799,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1678, col: 1, offset: 40322},
+			pos:  position{line: 1678, col: 1, offset: 40323},
 			expr: &actionExpr{
-				pos: position{line: 1679, col: 5, offset: 40333},
+				pos: position{line: 1679, col: 5, offset: 40334},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1679, col: 5, offset: 40333},
+					pos: position{line: 1679, col: 5, offset: 40334},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1679, col: 5, offset: 40333},
+							pos:   position{line: 1679, col: 5, offset: 40334},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 7, offset: 40335},
+								pos:  position{line: 1679, col: 7, offset: 40336},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1679, col: 10, offset: 40338},
+							pos:        position{line: 1679, col: 10, offset: 40339},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1679, col: 14, offset: 40342},
+							pos:   position{line: 1679, col: 14, offset: 40343},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 16, offset: 40344},
+								pos:  position{line: 1679, col: 16, offset: 40345},
 								name: "UIntString",
 							},
 						},
@@ -11836,32 +11836,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1683, col: 1, offset: 40412},
+			pos:  position{line: 1683, col: 1, offset: 40413},
 			expr: &actionExpr{
-				pos: position{line: 1684, col: 5, offset: 40423},
+				pos: position{line: 1684, col: 5, offset: 40424},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1684, col: 5, offset: 40423},
+					pos: position{line: 1684, col: 5, offset: 40424},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1684, col: 5, offset: 40423},
+							pos:   position{line: 1684, col: 5, offset: 40424},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1684, col: 7, offset: 40425},
+								pos:  position{line: 1684, col: 7, offset: 40426},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1684, col: 11, offset: 40429},
+							pos:        position{line: 1684, col: 11, offset: 40430},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1684, col: 15, offset: 40433},
+							pos:   position{line: 1684, col: 15, offset: 40434},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1684, col: 17, offset: 40435},
+								pos:  position{line: 1684, col: 17, offset: 40436},
 								name: "UIntString",
 							},
 						},
@@ -11873,15 +11873,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1688, col: 1, offset: 40503},
+			pos:  position{line: 1688, col: 1, offset: 40504},
 			expr: &actionExpr{
-				pos: position{line: 1689, col: 4, offset: 40511},
+				pos: position{line: 1689, col: 4, offset: 40512},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1689, col: 4, offset: 40511},
+					pos:   position{line: 1689, col: 4, offset: 40512},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1689, col: 6, offset: 40513},
+						pos:  position{line: 1689, col: 6, offset: 40514},
 						name: "UIntString",
 					},
 				},
@@ -11891,16 +11891,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1691, col: 1, offset: 40553},
+			pos:  position{line: 1691, col: 1, offset: 40554},
 			expr: &choiceExpr{
-				pos: position{line: 1692, col: 5, offset: 40567},
+				pos: position{line: 1692, col: 5, offset: 40568},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1692, col: 5, offset: 40567},
+						pos:  position{line: 1692, col: 5, offset: 40568},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1693, col: 5, offset: 40582},
+						pos:  position{line: 1693, col: 5, offset: 40583},
 						name: "MinusIntString",
 					},
 				},
@@ -11910,14 +11910,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1695, col: 1, offset: 40598},
+			pos:  position{line: 1695, col: 1, offset: 40599},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 14, offset: 40611},
+				pos: position{line: 1695, col: 14, offset: 40612},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1695, col: 14, offset: 40611},
+					pos: position{line: 1695, col: 14, offset: 40612},
 					expr: &charClassMatcher{
-						pos:        position{line: 1695, col: 14, offset: 40611},
+						pos:        position{line: 1695, col: 14, offset: 40612},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11930,21 +11930,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1697, col: 1, offset: 40650},
+			pos:  position{line: 1697, col: 1, offset: 40651},
 			expr: &actionExpr{
-				pos: position{line: 1698, col: 5, offset: 40669},
+				pos: position{line: 1698, col: 5, offset: 40670},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1698, col: 5, offset: 40669},
+					pos: position{line: 1698, col: 5, offset: 40670},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1698, col: 5, offset: 40669},
+							pos:        position{line: 1698, col: 5, offset: 40670},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1698, col: 9, offset: 40673},
+							pos:  position{line: 1698, col: 9, offset: 40674},
 							name: "UIntString",
 						},
 					},
@@ -11955,29 +11955,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1700, col: 1, offset: 40716},
+			pos:  position{line: 1700, col: 1, offset: 40717},
 			expr: &choiceExpr{
-				pos: position{line: 1701, col: 5, offset: 40732},
+				pos: position{line: 1701, col: 5, offset: 40733},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1701, col: 5, offset: 40732},
+						pos: position{line: 1701, col: 5, offset: 40733},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1701, col: 5, offset: 40732},
+							pos: position{line: 1701, col: 5, offset: 40733},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1701, col: 5, offset: 40732},
+									pos: position{line: 1701, col: 5, offset: 40733},
 									expr: &litMatcher{
-										pos:        position{line: 1701, col: 5, offset: 40732},
+										pos:        position{line: 1701, col: 5, offset: 40733},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1701, col: 10, offset: 40737},
+									pos: position{line: 1701, col: 10, offset: 40738},
 									expr: &charClassMatcher{
-										pos:        position{line: 1701, col: 10, offset: 40737},
+										pos:        position{line: 1701, col: 10, offset: 40738},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11985,15 +11985,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1701, col: 17, offset: 40744},
+									pos:        position{line: 1701, col: 17, offset: 40745},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1701, col: 21, offset: 40748},
+									pos: position{line: 1701, col: 21, offset: 40749},
 									expr: &charClassMatcher{
-										pos:        position{line: 1701, col: 21, offset: 40748},
+										pos:        position{line: 1701, col: 21, offset: 40749},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -12001,9 +12001,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1701, col: 28, offset: 40755},
+									pos: position{line: 1701, col: 28, offset: 40756},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1701, col: 28, offset: 40755},
+										pos:  position{line: 1701, col: 28, offset: 40756},
 										name: "ExponentPart",
 									},
 								},
@@ -12011,30 +12011,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1702, col: 5, offset: 40804},
+						pos: position{line: 1702, col: 5, offset: 40805},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1702, col: 5, offset: 40804},
+							pos: position{line: 1702, col: 5, offset: 40805},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1702, col: 5, offset: 40804},
+									pos: position{line: 1702, col: 5, offset: 40805},
 									expr: &litMatcher{
-										pos:        position{line: 1702, col: 5, offset: 40804},
+										pos:        position{line: 1702, col: 5, offset: 40805},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1702, col: 10, offset: 40809},
+									pos:        position{line: 1702, col: 10, offset: 40810},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1702, col: 14, offset: 40813},
+									pos: position{line: 1702, col: 14, offset: 40814},
 									expr: &charClassMatcher{
-										pos:        position{line: 1702, col: 14, offset: 40813},
+										pos:        position{line: 1702, col: 14, offset: 40814},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -12042,9 +12042,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1702, col: 21, offset: 40820},
+									pos: position{line: 1702, col: 21, offset: 40821},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1702, col: 21, offset: 40820},
+										pos:  position{line: 1702, col: 21, offset: 40821},
 										name: "ExponentPart",
 									},
 								},
@@ -12052,17 +12052,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1703, col: 5, offset: 40869},
+						pos: position{line: 1703, col: 5, offset: 40870},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1703, col: 6, offset: 40870},
+							pos: position{line: 1703, col: 6, offset: 40871},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1703, col: 6, offset: 40870},
+									pos:  position{line: 1703, col: 6, offset: 40871},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1703, col: 12, offset: 40876},
+									pos:  position{line: 1703, col: 12, offset: 40877},
 									name: "Infinity",
 								},
 							},
@@ -12075,20 +12075,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1706, col: 1, offset: 40919},
+			pos:  position{line: 1706, col: 1, offset: 40920},
 			expr: &seqExpr{
-				pos: position{line: 1706, col: 16, offset: 40934},
+				pos: position{line: 1706, col: 16, offset: 40935},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1706, col: 16, offset: 40934},
+						pos:        position{line: 1706, col: 16, offset: 40935},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1706, col: 21, offset: 40939},
+						pos: position{line: 1706, col: 21, offset: 40940},
 						expr: &charClassMatcher{
-							pos:        position{line: 1706, col: 21, offset: 40939},
+							pos:        position{line: 1706, col: 21, offset: 40940},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -12096,7 +12096,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1706, col: 27, offset: 40945},
+						pos:  position{line: 1706, col: 27, offset: 40946},
 						name: "UIntString",
 					},
 				},
@@ -12106,9 +12106,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1708, col: 1, offset: 40957},
+			pos:  position{line: 1708, col: 1, offset: 40958},
 			expr: &litMatcher{
-				pos:        position{line: 1708, col: 7, offset: 40963},
+				pos:        position{line: 1708, col: 7, offset: 40964},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -12118,23 +12118,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1710, col: 1, offset: 40970},
+			pos:  position{line: 1710, col: 1, offset: 40971},
 			expr: &seqExpr{
-				pos: position{line: 1710, col: 12, offset: 40981},
+				pos: position{line: 1710, col: 12, offset: 40982},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1710, col: 12, offset: 40981},
+						pos: position{line: 1710, col: 12, offset: 40982},
 						expr: &choiceExpr{
-							pos: position{line: 1710, col: 13, offset: 40982},
+							pos: position{line: 1710, col: 13, offset: 40983},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1710, col: 13, offset: 40982},
+									pos:        position{line: 1710, col: 13, offset: 40983},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1710, col: 19, offset: 40988},
+									pos:        position{line: 1710, col: 19, offset: 40989},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -12143,7 +12143,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1710, col: 25, offset: 40994},
+						pos:        position{line: 1710, col: 25, offset: 40995},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -12155,14 +12155,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1712, col: 1, offset: 41001},
+			pos:  position{line: 1712, col: 1, offset: 41002},
 			expr: &actionExpr{
-				pos: position{line: 1712, col: 7, offset: 41007},
+				pos: position{line: 1712, col: 7, offset: 41008},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1712, col: 7, offset: 41007},
+					pos: position{line: 1712, col: 7, offset: 41008},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1712, col: 7, offset: 41007},
+						pos:  position{line: 1712, col: 7, offset: 41008},
 						name: "HexDigit",
 					},
 				},
@@ -12172,9 +12172,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1714, col: 1, offset: 41049},
+			pos:  position{line: 1714, col: 1, offset: 41050},
 			expr: &charClassMatcher{
-				pos:        position{line: 1714, col: 12, offset: 41060},
+				pos:        position{line: 1714, col: 12, offset: 41061},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -12185,35 +12185,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1716, col: 1, offset: 41073},
+			pos:  position{line: 1716, col: 1, offset: 41074},
 			expr: &choiceExpr{
-				pos: position{line: 1717, col: 5, offset: 41090},
+				pos: position{line: 1717, col: 5, offset: 41091},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1717, col: 5, offset: 41090},
+						pos: position{line: 1717, col: 5, offset: 41091},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1717, col: 5, offset: 41090},
+							pos: position{line: 1717, col: 5, offset: 41091},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1717, col: 5, offset: 41090},
+									pos:        position{line: 1717, col: 5, offset: 41091},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1717, col: 9, offset: 41094},
+									pos:   position{line: 1717, col: 9, offset: 41095},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1717, col: 11, offset: 41096},
+										pos: position{line: 1717, col: 11, offset: 41097},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1717, col: 11, offset: 41096},
+											pos:  position{line: 1717, col: 11, offset: 41097},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1717, col: 29, offset: 41114},
+									pos:        position{line: 1717, col: 29, offset: 41115},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -12222,30 +12222,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1718, col: 5, offset: 41151},
+						pos: position{line: 1718, col: 5, offset: 41152},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1718, col: 5, offset: 41151},
+							pos: position{line: 1718, col: 5, offset: 41152},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1718, col: 5, offset: 41151},
+									pos:        position{line: 1718, col: 5, offset: 41152},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1718, col: 9, offset: 41155},
+									pos:   position{line: 1718, col: 9, offset: 41156},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1718, col: 11, offset: 41157},
+										pos: position{line: 1718, col: 11, offset: 41158},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1718, col: 11, offset: 41157},
+											pos:  position{line: 1718, col: 11, offset: 41158},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1718, col: 29, offset: 41175},
+									pos:        position{line: 1718, col: 29, offset: 41176},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -12260,57 +12260,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1720, col: 1, offset: 41209},
+			pos:  position{line: 1720, col: 1, offset: 41210},
 			expr: &choiceExpr{
-				pos: position{line: 1721, col: 5, offset: 41230},
+				pos: position{line: 1721, col: 5, offset: 41231},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1721, col: 5, offset: 41230},
+						pos: position{line: 1721, col: 5, offset: 41231},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1721, col: 5, offset: 41230},
+							pos: position{line: 1721, col: 5, offset: 41231},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1721, col: 5, offset: 41230},
+									pos: position{line: 1721, col: 5, offset: 41231},
 									expr: &choiceExpr{
-										pos: position{line: 1721, col: 7, offset: 41232},
+										pos: position{line: 1721, col: 7, offset: 41233},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1721, col: 7, offset: 41232},
+												pos:        position{line: 1721, col: 7, offset: 41233},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1721, col: 13, offset: 41238},
+												pos:  position{line: 1721, col: 13, offset: 41239},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1721, col: 26, offset: 41251,
+									line: 1721, col: 26, offset: 41252,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1722, col: 5, offset: 41288},
+						pos: position{line: 1722, col: 5, offset: 41289},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1722, col: 5, offset: 41288},
+							pos: position{line: 1722, col: 5, offset: 41289},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1722, col: 5, offset: 41288},
+									pos:        position{line: 1722, col: 5, offset: 41289},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1722, col: 10, offset: 41293},
+									pos:   position{line: 1722, col: 10, offset: 41294},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1722, col: 12, offset: 41295},
+										pos:  position{line: 1722, col: 12, offset: 41296},
 										name: "EscapeSequence",
 									},
 								},
@@ -12324,32 +12324,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1724, col: 1, offset: 41329},
+			pos:  position{line: 1724, col: 1, offset: 41330},
 			expr: &actionExpr{
-				pos: position{line: 1725, col: 5, offset: 41348},
+				pos: position{line: 1725, col: 5, offset: 41349},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1725, col: 5, offset: 41348},
+					pos: position{line: 1725, col: 5, offset: 41349},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1725, col: 5, offset: 41348},
+							pos:        position{line: 1725, col: 5, offset: 41349},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1725, col: 9, offset: 41352},
+							pos:   position{line: 1725, col: 9, offset: 41353},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1725, col: 11, offset: 41354},
+								pos: position{line: 1725, col: 11, offset: 41355},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1725, col: 11, offset: 41354},
+									pos:  position{line: 1725, col: 11, offset: 41355},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1725, col: 25, offset: 41368},
+							pos:        position{line: 1725, col: 25, offset: 41369},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -12362,57 +12362,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1727, col: 1, offset: 41402},
+			pos:  position{line: 1727, col: 1, offset: 41403},
 			expr: &choiceExpr{
-				pos: position{line: 1728, col: 5, offset: 41419},
+				pos: position{line: 1728, col: 5, offset: 41420},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1728, col: 5, offset: 41419},
+						pos: position{line: 1728, col: 5, offset: 41420},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1728, col: 5, offset: 41419},
+							pos: position{line: 1728, col: 5, offset: 41420},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1728, col: 5, offset: 41419},
+									pos: position{line: 1728, col: 5, offset: 41420},
 									expr: &choiceExpr{
-										pos: position{line: 1728, col: 7, offset: 41421},
+										pos: position{line: 1728, col: 7, offset: 41422},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1728, col: 7, offset: 41421},
+												pos:        position{line: 1728, col: 7, offset: 41422},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1728, col: 13, offset: 41427},
+												pos:  position{line: 1728, col: 13, offset: 41428},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1728, col: 26, offset: 41440,
+									line: 1728, col: 26, offset: 41441,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1729, col: 5, offset: 41477},
+						pos: position{line: 1729, col: 5, offset: 41478},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1729, col: 5, offset: 41477},
+							pos: position{line: 1729, col: 5, offset: 41478},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1729, col: 5, offset: 41477},
+									pos:        position{line: 1729, col: 5, offset: 41478},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1729, col: 10, offset: 41482},
+									pos:   position{line: 1729, col: 10, offset: 41483},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1729, col: 12, offset: 41484},
+										pos:  position{line: 1729, col: 12, offset: 41485},
 										name: "EscapeSequence",
 									},
 								},
@@ -12426,28 +12426,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1731, col: 1, offset: 41518},
+			pos:  position{line: 1731, col: 1, offset: 41519},
 			expr: &actionExpr{
-				pos: position{line: 1732, col: 5, offset: 41530},
+				pos: position{line: 1732, col: 5, offset: 41531},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1732, col: 5, offset: 41530},
+					pos: position{line: 1732, col: 5, offset: 41531},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1732, col: 5, offset: 41530},
+							pos:   position{line: 1732, col: 5, offset: 41531},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1732, col: 10, offset: 41535},
+								pos:  position{line: 1732, col: 10, offset: 41536},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1732, col: 23, offset: 41548},
+							pos:   position{line: 1732, col: 23, offset: 41549},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1732, col: 28, offset: 41553},
+								pos: position{line: 1732, col: 28, offset: 41554},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1732, col: 28, offset: 41553},
+									pos:  position{line: 1732, col: 28, offset: 41554},
 									name: "KeyWordRest",
 								},
 							},
@@ -12460,16 +12460,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1734, col: 1, offset: 41615},
+			pos:  position{line: 1734, col: 1, offset: 41616},
 			expr: &choiceExpr{
-				pos: position{line: 1735, col: 5, offset: 41632},
+				pos: position{line: 1735, col: 5, offset: 41633},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1735, col: 5, offset: 41632},
+						pos:  position{line: 1735, col: 5, offset: 41633},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1736, col: 5, offset: 41649},
+						pos:  position{line: 1736, col: 5, offset: 41650},
 						name: "KeyWordEsc",
 					},
 				},
@@ -12479,16 +12479,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1738, col: 1, offset: 41661},
+			pos:  position{line: 1738, col: 1, offset: 41662},
 			expr: &choiceExpr{
-				pos: position{line: 1739, col: 5, offset: 41677},
+				pos: position{line: 1739, col: 5, offset: 41678},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1739, col: 5, offset: 41677},
+						pos:  position{line: 1739, col: 5, offset: 41678},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1740, col: 5, offset: 41694},
+						pos:        position{line: 1740, col: 5, offset: 41695},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12501,19 +12501,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1742, col: 1, offset: 41701},
+			pos:  position{line: 1742, col: 1, offset: 41702},
 			expr: &actionExpr{
-				pos: position{line: 1742, col: 16, offset: 41716},
+				pos: position{line: 1742, col: 16, offset: 41717},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1742, col: 17, offset: 41717},
+					pos: position{line: 1742, col: 17, offset: 41718},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1742, col: 17, offset: 41717},
+							pos:  position{line: 1742, col: 17, offset: 41718},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1742, col: 33, offset: 41733},
+							pos:        position{line: 1742, col: 33, offset: 41734},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12527,31 +12527,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1744, col: 1, offset: 41777},
+			pos:  position{line: 1744, col: 1, offset: 41778},
 			expr: &actionExpr{
-				pos: position{line: 1744, col: 14, offset: 41790},
+				pos: position{line: 1744, col: 14, offset: 41791},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1744, col: 14, offset: 41790},
+					pos: position{line: 1744, col: 14, offset: 41791},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1744, col: 14, offset: 41790},
+							pos:        position{line: 1744, col: 14, offset: 41791},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1744, col: 19, offset: 41795},
+							pos:   position{line: 1744, col: 19, offset: 41796},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1744, col: 22, offset: 41798},
+								pos: position{line: 1744, col: 22, offset: 41799},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1744, col: 22, offset: 41798},
+										pos:  position{line: 1744, col: 22, offset: 41799},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1744, col: 38, offset: 41814},
+										pos:  position{line: 1744, col: 38, offset: 41815},
 										name: "EscapeSequence",
 									},
 								},
@@ -12565,42 +12565,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1746, col: 1, offset: 41849},
+			pos:  position{line: 1746, col: 1, offset: 41850},
 			expr: &actionExpr{
-				pos: position{line: 1747, col: 5, offset: 41865},
+				pos: position{line: 1747, col: 5, offset: 41866},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1747, col: 5, offset: 41865},
+					pos: position{line: 1747, col: 5, offset: 41866},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1747, col: 5, offset: 41865},
+							pos: position{line: 1747, col: 5, offset: 41866},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1747, col: 6, offset: 41866},
+								pos:  position{line: 1747, col: 6, offset: 41867},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1747, col: 22, offset: 41882},
+							pos: position{line: 1747, col: 22, offset: 41883},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1747, col: 23, offset: 41883},
+								pos:  position{line: 1747, col: 23, offset: 41884},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1747, col: 35, offset: 41895},
+							pos:   position{line: 1747, col: 35, offset: 41896},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1747, col: 40, offset: 41900},
+								pos:  position{line: 1747, col: 40, offset: 41901},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1747, col: 50, offset: 41910},
+							pos:   position{line: 1747, col: 50, offset: 41911},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1747, col: 55, offset: 41915},
+								pos: position{line: 1747, col: 55, offset: 41916},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1747, col: 55, offset: 41915},
+									pos:  position{line: 1747, col: 55, offset: 41916},
 									name: "GlobRest",
 								},
 							},
@@ -12613,28 +12613,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1751, col: 1, offset: 41984},
+			pos:  position{line: 1751, col: 1, offset: 41985},
 			expr: &choiceExpr{
-				pos: position{line: 1751, col: 19, offset: 42002},
+				pos: position{line: 1751, col: 19, offset: 42003},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1751, col: 19, offset: 42002},
+						pos:  position{line: 1751, col: 19, offset: 42003},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1751, col: 34, offset: 42017},
+						pos: position{line: 1751, col: 34, offset: 42018},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1751, col: 34, offset: 42017},
+								pos: position{line: 1751, col: 34, offset: 42018},
 								expr: &litMatcher{
-									pos:        position{line: 1751, col: 34, offset: 42017},
+									pos:        position{line: 1751, col: 34, offset: 42018},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1751, col: 39, offset: 42022},
+								pos:  position{line: 1751, col: 39, offset: 42023},
 								name: "KeyWordRest",
 							},
 						},
@@ -12646,19 +12646,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1752, col: 1, offset: 42034},
+			pos:  position{line: 1752, col: 1, offset: 42035},
 			expr: &seqExpr{
-				pos: position{line: 1752, col: 15, offset: 42048},
+				pos: position{line: 1752, col: 15, offset: 42049},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1752, col: 15, offset: 42048},
+						pos: position{line: 1752, col: 15, offset: 42049},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1752, col: 15, offset: 42048},
+							pos:  position{line: 1752, col: 15, offset: 42049},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1752, col: 28, offset: 42061},
+						pos:        position{line: 1752, col: 28, offset: 42062},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12670,23 +12670,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1754, col: 1, offset: 42066},
+			pos:  position{line: 1754, col: 1, offset: 42067},
 			expr: &choiceExpr{
-				pos: position{line: 1755, col: 5, offset: 42080},
+				pos: position{line: 1755, col: 5, offset: 42081},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1755, col: 5, offset: 42080},
+						pos:  position{line: 1755, col: 5, offset: 42081},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1756, col: 5, offset: 42097},
+						pos:  position{line: 1756, col: 5, offset: 42098},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1757, col: 5, offset: 42109},
+						pos: position{line: 1757, col: 5, offset: 42110},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1757, col: 5, offset: 42109},
+							pos:        position{line: 1757, col: 5, offset: 42110},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12699,16 +12699,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1759, col: 1, offset: 42134},
+			pos:  position{line: 1759, col: 1, offset: 42135},
 			expr: &choiceExpr{
-				pos: position{line: 1760, col: 5, offset: 42147},
+				pos: position{line: 1760, col: 5, offset: 42148},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1760, col: 5, offset: 42147},
+						pos:  position{line: 1760, col: 5, offset: 42148},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1761, col: 5, offset: 42161},
+						pos:        position{line: 1761, col: 5, offset: 42162},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12721,31 +12721,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1763, col: 1, offset: 42168},
+			pos:  position{line: 1763, col: 1, offset: 42169},
 			expr: &actionExpr{
-				pos: position{line: 1763, col: 11, offset: 42178},
+				pos: position{line: 1763, col: 11, offset: 42179},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1763, col: 11, offset: 42178},
+					pos: position{line: 1763, col: 11, offset: 42179},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1763, col: 11, offset: 42178},
+							pos:        position{line: 1763, col: 11, offset: 42179},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1763, col: 16, offset: 42183},
+							pos:   position{line: 1763, col: 16, offset: 42184},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1763, col: 19, offset: 42186},
+								pos: position{line: 1763, col: 19, offset: 42187},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1763, col: 19, offset: 42186},
+										pos:  position{line: 1763, col: 19, offset: 42187},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1763, col: 32, offset: 42199},
+										pos:  position{line: 1763, col: 32, offset: 42200},
 										name: "EscapeSequence",
 									},
 								},
@@ -12759,32 +12759,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1765, col: 1, offset: 42234},
+			pos:  position{line: 1765, col: 1, offset: 42235},
 			expr: &choiceExpr{
-				pos: position{line: 1766, col: 5, offset: 42249},
+				pos: position{line: 1766, col: 5, offset: 42250},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1766, col: 5, offset: 42249},
+						pos: position{line: 1766, col: 5, offset: 42250},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1766, col: 5, offset: 42249},
+							pos:        position{line: 1766, col: 5, offset: 42250},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1767, col: 5, offset: 42277},
+						pos: position{line: 1767, col: 5, offset: 42278},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1767, col: 5, offset: 42277},
+							pos:        position{line: 1767, col: 5, offset: 42278},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1768, col: 5, offset: 42307},
+						pos:        position{line: 1768, col: 5, offset: 42308},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12797,57 +12797,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1770, col: 1, offset: 42313},
+			pos:  position{line: 1770, col: 1, offset: 42314},
 			expr: &choiceExpr{
-				pos: position{line: 1771, col: 5, offset: 42334},
+				pos: position{line: 1771, col: 5, offset: 42335},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1771, col: 5, offset: 42334},
+						pos: position{line: 1771, col: 5, offset: 42335},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1771, col: 5, offset: 42334},
+							pos: position{line: 1771, col: 5, offset: 42335},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1771, col: 5, offset: 42334},
+									pos: position{line: 1771, col: 5, offset: 42335},
 									expr: &choiceExpr{
-										pos: position{line: 1771, col: 7, offset: 42336},
+										pos: position{line: 1771, col: 7, offset: 42337},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1771, col: 7, offset: 42336},
+												pos:        position{line: 1771, col: 7, offset: 42337},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1771, col: 13, offset: 42342},
+												pos:  position{line: 1771, col: 13, offset: 42343},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1771, col: 26, offset: 42355,
+									line: 1771, col: 26, offset: 42356,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1772, col: 5, offset: 42392},
+						pos: position{line: 1772, col: 5, offset: 42393},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1772, col: 5, offset: 42392},
+							pos: position{line: 1772, col: 5, offset: 42393},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1772, col: 5, offset: 42392},
+									pos:        position{line: 1772, col: 5, offset: 42393},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1772, col: 10, offset: 42397},
+									pos:   position{line: 1772, col: 10, offset: 42398},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1772, col: 12, offset: 42399},
+										pos:  position{line: 1772, col: 12, offset: 42400},
 										name: "EscapeSequence",
 									},
 								},
@@ -12861,16 +12861,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1774, col: 1, offset: 42433},
+			pos:  position{line: 1774, col: 1, offset: 42434},
 			expr: &choiceExpr{
-				pos: position{line: 1775, col: 5, offset: 42452},
+				pos: position{line: 1775, col: 5, offset: 42453},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1775, col: 5, offset: 42452},
+						pos:  position{line: 1775, col: 5, offset: 42453},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1776, col: 5, offset: 42473},
+						pos:  position{line: 1776, col: 5, offset: 42474},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12880,87 +12880,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1778, col: 1, offset: 42488},
+			pos:  position{line: 1778, col: 1, offset: 42489},
 			expr: &choiceExpr{
-				pos: position{line: 1779, col: 5, offset: 42509},
+				pos: position{line: 1779, col: 5, offset: 42510},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1779, col: 5, offset: 42509},
+						pos:        position{line: 1779, col: 5, offset: 42510},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1780, col: 5, offset: 42517},
+						pos: position{line: 1780, col: 5, offset: 42518},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1780, col: 5, offset: 42517},
+							pos:        position{line: 1780, col: 5, offset: 42518},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1781, col: 5, offset: 42557},
+						pos:        position{line: 1781, col: 5, offset: 42558},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1782, col: 5, offset: 42566},
+						pos: position{line: 1782, col: 5, offset: 42567},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1782, col: 5, offset: 42566},
+							pos:        position{line: 1782, col: 5, offset: 42567},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1783, col: 5, offset: 42595},
+						pos: position{line: 1783, col: 5, offset: 42596},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1783, col: 5, offset: 42595},
+							pos:        position{line: 1783, col: 5, offset: 42596},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1784, col: 5, offset: 42624},
+						pos: position{line: 1784, col: 5, offset: 42625},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1784, col: 5, offset: 42624},
+							pos:        position{line: 1784, col: 5, offset: 42625},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1785, col: 5, offset: 42653},
+						pos: position{line: 1785, col: 5, offset: 42654},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1785, col: 5, offset: 42653},
+							pos:        position{line: 1785, col: 5, offset: 42654},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1786, col: 5, offset: 42682},
+						pos: position{line: 1786, col: 5, offset: 42683},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1786, col: 5, offset: 42682},
+							pos:        position{line: 1786, col: 5, offset: 42683},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1787, col: 5, offset: 42711},
+						pos: position{line: 1787, col: 5, offset: 42712},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1787, col: 5, offset: 42711},
+							pos:        position{line: 1787, col: 5, offset: 42712},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12973,32 +12973,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1789, col: 1, offset: 42737},
+			pos:  position{line: 1789, col: 1, offset: 42738},
 			expr: &choiceExpr{
-				pos: position{line: 1790, col: 5, offset: 42755},
+				pos: position{line: 1790, col: 5, offset: 42756},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1790, col: 5, offset: 42755},
+						pos: position{line: 1790, col: 5, offset: 42756},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1790, col: 5, offset: 42755},
+							pos:        position{line: 1790, col: 5, offset: 42756},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1791, col: 5, offset: 42783},
+						pos: position{line: 1791, col: 5, offset: 42784},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1791, col: 5, offset: 42783},
+							pos:        position{line: 1791, col: 5, offset: 42784},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1792, col: 5, offset: 42811},
+						pos:        position{line: 1792, col: 5, offset: 42812},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -13011,42 +13011,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1794, col: 1, offset: 42817},
+			pos:  position{line: 1794, col: 1, offset: 42818},
 			expr: &choiceExpr{
-				pos: position{line: 1795, col: 5, offset: 42835},
+				pos: position{line: 1795, col: 5, offset: 42836},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1795, col: 5, offset: 42835},
+						pos: position{line: 1795, col: 5, offset: 42836},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1795, col: 5, offset: 42835},
+							pos: position{line: 1795, col: 5, offset: 42836},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1795, col: 5, offset: 42835},
+									pos:        position{line: 1795, col: 5, offset: 42836},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1795, col: 9, offset: 42839},
+									pos:   position{line: 1795, col: 9, offset: 42840},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1795, col: 16, offset: 42846},
+										pos: position{line: 1795, col: 16, offset: 42847},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1795, col: 16, offset: 42846},
+												pos:  position{line: 1795, col: 16, offset: 42847},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1795, col: 25, offset: 42855},
+												pos:  position{line: 1795, col: 25, offset: 42856},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1795, col: 34, offset: 42864},
+												pos:  position{line: 1795, col: 34, offset: 42865},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1795, col: 43, offset: 42873},
+												pos:  position{line: 1795, col: 43, offset: 42874},
 												name: "HexDigit",
 											},
 										},
@@ -13056,65 +13056,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1798, col: 5, offset: 42936},
+						pos: position{line: 1798, col: 5, offset: 42937},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1798, col: 5, offset: 42936},
+							pos: position{line: 1798, col: 5, offset: 42937},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1798, col: 5, offset: 42936},
+									pos:        position{line: 1798, col: 5, offset: 42937},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1798, col: 9, offset: 42940},
+									pos:        position{line: 1798, col: 9, offset: 42941},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1798, col: 13, offset: 42944},
+									pos:   position{line: 1798, col: 13, offset: 42945},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1798, col: 20, offset: 42951},
+										pos: position{line: 1798, col: 20, offset: 42952},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1798, col: 20, offset: 42951},
+												pos:  position{line: 1798, col: 20, offset: 42952},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1798, col: 29, offset: 42960},
+												pos: position{line: 1798, col: 29, offset: 42961},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1798, col: 29, offset: 42960},
+													pos:  position{line: 1798, col: 29, offset: 42961},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1798, col: 39, offset: 42970},
+												pos: position{line: 1798, col: 39, offset: 42971},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1798, col: 39, offset: 42970},
+													pos:  position{line: 1798, col: 39, offset: 42971},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1798, col: 49, offset: 42980},
+												pos: position{line: 1798, col: 49, offset: 42981},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1798, col: 49, offset: 42980},
+													pos:  position{line: 1798, col: 49, offset: 42981},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1798, col: 59, offset: 42990},
+												pos: position{line: 1798, col: 59, offset: 42991},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1798, col: 59, offset: 42990},
+													pos:  position{line: 1798, col: 59, offset: 42991},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1798, col: 69, offset: 43000},
+												pos: position{line: 1798, col: 69, offset: 43001},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1798, col: 69, offset: 43000},
+													pos:  position{line: 1798, col: 69, offset: 43001},
 													name: "HexDigit",
 												},
 											},
@@ -13122,7 +13122,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1798, col: 80, offset: 43011},
+									pos:        position{line: 1798, col: 80, offset: 43012},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -13137,37 +13137,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1802, col: 1, offset: 43065},
+			pos:  position{line: 1802, col: 1, offset: 43066},
 			expr: &actionExpr{
-				pos: position{line: 1803, col: 5, offset: 43083},
+				pos: position{line: 1803, col: 5, offset: 43084},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1803, col: 5, offset: 43083},
+					pos: position{line: 1803, col: 5, offset: 43084},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1803, col: 5, offset: 43083},
+							pos:        position{line: 1803, col: 5, offset: 43084},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1803, col: 9, offset: 43087},
+							pos:   position{line: 1803, col: 9, offset: 43088},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1803, col: 14, offset: 43092},
+								pos:  position{line: 1803, col: 14, offset: 43093},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1803, col: 25, offset: 43103},
+							pos:        position{line: 1803, col: 25, offset: 43104},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1803, col: 29, offset: 43107},
+							pos: position{line: 1803, col: 29, offset: 43108},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1803, col: 30, offset: 43108},
+								pos:  position{line: 1803, col: 30, offset: 43109},
 								name: "KeyWordStart",
 							},
 						},
@@ -13179,33 +13179,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1805, col: 1, offset: 43143},
+			pos:  position{line: 1805, col: 1, offset: 43144},
 			expr: &actionExpr{
-				pos: position{line: 1806, col: 5, offset: 43158},
+				pos: position{line: 1806, col: 5, offset: 43159},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1806, col: 5, offset: 43158},
+					pos: position{line: 1806, col: 5, offset: 43159},
 					expr: &choiceExpr{
-						pos: position{line: 1806, col: 6, offset: 43159},
+						pos: position{line: 1806, col: 6, offset: 43160},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1806, col: 6, offset: 43159},
+								pos:        position{line: 1806, col: 6, offset: 43160},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1806, col: 15, offset: 43168},
+								pos: position{line: 1806, col: 15, offset: 43169},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1806, col: 15, offset: 43168},
+										pos:        position{line: 1806, col: 15, offset: 43169},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1806, col: 20, offset: 43173,
+										line: 1806, col: 20, offset: 43174,
 									},
 								},
 							},
@@ -13218,9 +13218,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1808, col: 1, offset: 43209},
+			pos:  position{line: 1808, col: 1, offset: 43210},
 			expr: &charClassMatcher{
-				pos:        position{line: 1809, col: 5, offset: 43225},
+				pos:        position{line: 1809, col: 5, offset: 43226},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -13232,11 +13232,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1811, col: 1, offset: 43240},
+			pos:  position{line: 1811, col: 1, offset: 43241},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1811, col: 5, offset: 43244},
+				pos: position{line: 1811, col: 5, offset: 43245},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1811, col: 5, offset: 43244},
+					pos:  position{line: 1811, col: 5, offset: 43245},
 					name: "AnySpace",
 				},
 			},
@@ -13245,11 +13245,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1813, col: 1, offset: 43255},
+			pos:  position{line: 1813, col: 1, offset: 43256},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1813, col: 6, offset: 43260},
+				pos: position{line: 1813, col: 6, offset: 43261},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1813, col: 6, offset: 43260},
+					pos:  position{line: 1813, col: 6, offset: 43261},
 					name: "AnySpace",
 				},
 			},
@@ -13258,20 +13258,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1815, col: 1, offset: 43271},
+			pos:  position{line: 1815, col: 1, offset: 43272},
 			expr: &choiceExpr{
-				pos: position{line: 1816, col: 5, offset: 43284},
+				pos: position{line: 1816, col: 5, offset: 43285},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1816, col: 5, offset: 43284},
+						pos:  position{line: 1816, col: 5, offset: 43285},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1817, col: 5, offset: 43299},
+						pos:  position{line: 1817, col: 5, offset: 43300},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1818, col: 5, offset: 43318},
+						pos:  position{line: 1818, col: 5, offset: 43319},
 						name: "Comment",
 					},
 				},
@@ -13281,32 +13281,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1820, col: 1, offset: 43327},
+			pos:  position{line: 1820, col: 1, offset: 43328},
 			expr: &choiceExpr{
-				pos: position{line: 1821, col: 5, offset: 43345},
+				pos: position{line: 1821, col: 5, offset: 43346},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1821, col: 5, offset: 43345},
+						pos:  position{line: 1821, col: 5, offset: 43346},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1822, col: 5, offset: 43352},
+						pos:  position{line: 1822, col: 5, offset: 43353},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1823, col: 5, offset: 43359},
+						pos:  position{line: 1823, col: 5, offset: 43360},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1824, col: 5, offset: 43366},
+						pos:  position{line: 1824, col: 5, offset: 43367},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1825, col: 5, offset: 43373},
+						pos:  position{line: 1825, col: 5, offset: 43374},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1826, col: 5, offset: 43380},
+						pos:  position{line: 1826, col: 5, offset: 43381},
 						name: "Nl",
 					},
 				},
@@ -13316,16 +13316,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1828, col: 1, offset: 43384},
+			pos:  position{line: 1828, col: 1, offset: 43385},
 			expr: &choiceExpr{
-				pos: position{line: 1829, col: 5, offset: 43409},
+				pos: position{line: 1829, col: 5, offset: 43410},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1829, col: 5, offset: 43409},
+						pos:  position{line: 1829, col: 5, offset: 43410},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1830, col: 5, offset: 43416},
+						pos:  position{line: 1830, col: 5, offset: 43417},
 						name: "Mc",
 					},
 				},
@@ -13335,9 +13335,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1832, col: 1, offset: 43420},
+			pos:  position{line: 1832, col: 1, offset: 43421},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1833, col: 5, offset: 43437},
+				pos:  position{line: 1833, col: 5, offset: 43438},
 				name: "Nd",
 			},
 			leader:        false,
@@ -13345,9 +13345,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1835, col: 1, offset: 43441},
+			pos:  position{line: 1835, col: 1, offset: 43442},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1836, col: 5, offset: 43473},
+				pos:  position{line: 1836, col: 5, offset: 43474},
 				name: "Pc",
 			},
 			leader:        false,
@@ -13355,9 +13355,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1842, col: 1, offset: 43654},
+			pos:  position{line: 1842, col: 1, offset: 43655},
 			expr: &charClassMatcher{
-				pos:        position{line: 1842, col: 6, offset: 43659},
+				pos:        position{line: 1842, col: 6, offset: 43660},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -13369,9 +13369,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1845, col: 1, offset: 47811},
+			pos:  position{line: 1845, col: 1, offset: 47812},
 			expr: &charClassMatcher{
-				pos:        position{line: 1845, col: 6, offset: 47816},
+				pos:        position{line: 1845, col: 6, offset: 47817},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -13383,9 +13383,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1848, col: 1, offset: 48301},
+			pos:  position{line: 1848, col: 1, offset: 48302},
 			expr: &charClassMatcher{
-				pos:        position{line: 1848, col: 6, offset: 48306},
+				pos:        position{line: 1848, col: 6, offset: 48307},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -13397,9 +13397,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1851, col: 1, offset: 51753},
+			pos:  position{line: 1851, col: 1, offset: 51754},
 			expr: &charClassMatcher{
-				pos:        position{line: 1851, col: 6, offset: 51758},
+				pos:        position{line: 1851, col: 6, offset: 51759},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -13411,9 +13411,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1854, col: 1, offset: 51864},
+			pos:  position{line: 1854, col: 1, offset: 51865},
 			expr: &charClassMatcher{
-				pos:        position{line: 1854, col: 6, offset: 51869},
+				pos:        position{line: 1854, col: 6, offset: 51870},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -13425,9 +13425,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1857, col: 1, offset: 55870},
+			pos:  position{line: 1857, col: 1, offset: 55871},
 			expr: &charClassMatcher{
-				pos:        position{line: 1857, col: 6, offset: 55875},
+				pos:        position{line: 1857, col: 6, offset: 55876},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -13439,9 +13439,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1860, col: 1, offset: 57063},
+			pos:  position{line: 1860, col: 1, offset: 57064},
 			expr: &charClassMatcher{
-				pos:        position{line: 1860, col: 6, offset: 57068},
+				pos:        position{line: 1860, col: 6, offset: 57069},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -13453,9 +13453,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1863, col: 1, offset: 59248},
+			pos:  position{line: 1863, col: 1, offset: 59249},
 			expr: &charClassMatcher{
-				pos:        position{line: 1863, col: 6, offset: 59253},
+				pos:        position{line: 1863, col: 6, offset: 59254},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -13466,9 +13466,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1866, col: 1, offset: 59756},
+			pos:  position{line: 1866, col: 1, offset: 59757},
 			expr: &charClassMatcher{
-				pos:        position{line: 1866, col: 6, offset: 59761},
+				pos:        position{line: 1866, col: 6, offset: 59762},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -13480,9 +13480,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1869, col: 1, offset: 59875},
+			pos:  position{line: 1869, col: 1, offset: 59876},
 			expr: &charClassMatcher{
-				pos:        position{line: 1869, col: 6, offset: 59880},
+				pos:        position{line: 1869, col: 6, offset: 59881},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -13494,9 +13494,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1872, col: 1, offset: 59961},
+			pos:  position{line: 1872, col: 1, offset: 59962},
 			expr: &charClassMatcher{
-				pos:        position{line: 1872, col: 6, offset: 59966},
+				pos:        position{line: 1872, col: 6, offset: 59967},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13508,9 +13508,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1874, col: 1, offset: 60019},
+			pos:  position{line: 1874, col: 1, offset: 60020},
 			expr: &anyMatcher{
-				line: 1875, col: 5, offset: 60039,
+				line: 1875, col: 5, offset: 60040,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13518,48 +13518,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1877, col: 1, offset: 60042},
+			pos:         position{line: 1877, col: 1, offset: 60043},
 			expr: &choiceExpr{
-				pos: position{line: 1878, col: 5, offset: 60070},
+				pos: position{line: 1878, col: 5, offset: 60071},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1878, col: 5, offset: 60070},
+						pos:        position{line: 1878, col: 5, offset: 60071},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1879, col: 5, offset: 60079},
+						pos:        position{line: 1879, col: 5, offset: 60080},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1880, col: 5, offset: 60088},
+						pos:        position{line: 1880, col: 5, offset: 60089},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1881, col: 5, offset: 60097},
+						pos:        position{line: 1881, col: 5, offset: 60098},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1882, col: 5, offset: 60105},
+						pos:        position{line: 1882, col: 5, offset: 60106},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1883, col: 5, offset: 60118},
+						pos:        position{line: 1883, col: 5, offset: 60119},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1884, col: 5, offset: 60131},
+						pos:  position{line: 1884, col: 5, offset: 60132},
 						name: "Zs",
 					},
 				},
@@ -13569,9 +13569,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1886, col: 1, offset: 60135},
+			pos:  position{line: 1886, col: 1, offset: 60136},
 			expr: &charClassMatcher{
-				pos:        position{line: 1887, col: 5, offset: 60154},
+				pos:        position{line: 1887, col: 5, offset: 60155},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13583,9 +13583,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1893, col: 1, offset: 60484},
+			pos:         position{line: 1893, col: 1, offset: 60485},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1896, col: 5, offset: 60555},
+				pos:  position{line: 1896, col: 5, offset: 60556},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -13593,39 +13593,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1898, col: 1, offset: 60574},
+			pos:  position{line: 1898, col: 1, offset: 60575},
 			expr: &seqExpr{
-				pos: position{line: 1899, col: 5, offset: 60595},
+				pos: position{line: 1899, col: 5, offset: 60596},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1899, col: 5, offset: 60595},
+						pos:        position{line: 1899, col: 5, offset: 60596},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1899, col: 10, offset: 60600},
+						pos: position{line: 1899, col: 10, offset: 60601},
 						expr: &seqExpr{
-							pos: position{line: 1899, col: 11, offset: 60601},
+							pos: position{line: 1899, col: 11, offset: 60602},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1899, col: 11, offset: 60601},
+									pos: position{line: 1899, col: 11, offset: 60602},
 									expr: &litMatcher{
-										pos:        position{line: 1899, col: 12, offset: 60602},
+										pos:        position{line: 1899, col: 12, offset: 60603},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1899, col: 17, offset: 60607},
+									pos:  position{line: 1899, col: 17, offset: 60608},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1899, col: 35, offset: 60625},
+						pos:        position{line: 1899, col: 35, offset: 60626},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13637,33 +13637,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1901, col: 1, offset: 60631},
+			pos:  position{line: 1901, col: 1, offset: 60632},
 			expr: &choiceExpr{
-				pos: position{line: 1902, col: 5, offset: 60653},
+				pos: position{line: 1902, col: 5, offset: 60654},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1902, col: 5, offset: 60653},
+						pos: position{line: 1902, col: 5, offset: 60654},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1902, col: 5, offset: 60653},
+								pos:        position{line: 1902, col: 5, offset: 60654},
 								val:        "//",
 								ignoreCase: false,
 								want:       "\"//\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1902, col: 10, offset: 60658},
+								pos: position{line: 1902, col: 10, offset: 60659},
 								expr: &seqExpr{
-									pos: position{line: 1902, col: 11, offset: 60659},
+									pos: position{line: 1902, col: 11, offset: 60660},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1902, col: 11, offset: 60659},
+											pos: position{line: 1902, col: 11, offset: 60660},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1902, col: 12, offset: 60660},
+												pos:  position{line: 1902, col: 12, offset: 60661},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1902, col: 27, offset: 60675},
+											pos:  position{line: 1902, col: 27, offset: 60676},
 											name: "SourceCharacter",
 										},
 									},
@@ -13672,28 +13672,28 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1903, col: 5, offset: 60697},
+						pos: position{line: 1903, col: 5, offset: 60698},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1903, col: 5, offset: 60697},
+								pos:        position{line: 1903, col: 5, offset: 60698},
 								val:        "--",
 								ignoreCase: false,
 								want:       "\"--\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1903, col: 10, offset: 60702},
+								pos: position{line: 1903, col: 10, offset: 60703},
 								expr: &seqExpr{
-									pos: position{line: 1903, col: 11, offset: 60703},
+									pos: position{line: 1903, col: 11, offset: 60704},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1903, col: 11, offset: 60703},
+											pos: position{line: 1903, col: 11, offset: 60704},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1903, col: 12, offset: 60704},
+												pos:  position{line: 1903, col: 12, offset: 60705},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1903, col: 27, offset: 60719},
+											pos:  position{line: 1903, col: 27, offset: 60720},
 											name: "SourceCharacter",
 										},
 									},
@@ -13708,19 +13708,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1905, col: 1, offset: 60738},
+			pos:  position{line: 1905, col: 1, offset: 60739},
 			expr: &seqExpr{
-				pos: position{line: 1905, col: 7, offset: 60744},
+				pos: position{line: 1905, col: 7, offset: 60745},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1905, col: 7, offset: 60744},
+						pos: position{line: 1905, col: 7, offset: 60745},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1905, col: 7, offset: 60744},
+							pos:  position{line: 1905, col: 7, offset: 60745},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1905, col: 19, offset: 60756},
+						pos:  position{line: 1905, col: 19, offset: 60757},
 						name: "LineTerminator",
 					},
 				},
@@ -13730,16 +13730,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1907, col: 1, offset: 60772},
+			pos:  position{line: 1907, col: 1, offset: 60773},
 			expr: &choiceExpr{
-				pos: position{line: 1907, col: 7, offset: 60778},
+				pos: position{line: 1907, col: 7, offset: 60779},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1907, col: 7, offset: 60778},
+						pos:  position{line: 1907, col: 7, offset: 60779},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1907, col: 11, offset: 60782},
+						pos:  position{line: 1907, col: 11, offset: 60783},
 						name: "EOF",
 					},
 				},
@@ -13749,11 +13749,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1909, col: 1, offset: 60787},
+			pos:  position{line: 1909, col: 1, offset: 60788},
 			expr: &notExpr{
-				pos: position{line: 1909, col: 7, offset: 60793},
+				pos: position{line: 1909, col: 7, offset: 60794},
 				expr: &anyMatcher{
-					line: 1909, col: 8, offset: 60794,
+					line: 1909, col: 8, offset: 60795,
 				},
 			},
 			leader:        false,
@@ -13761,11 +13761,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1911, col: 1, offset: 60797},
+			pos:  position{line: 1911, col: 1, offset: 60798},
 			expr: &notExpr{
-				pos: position{line: 1911, col: 8, offset: 60804},
+				pos: position{line: 1911, col: 8, offset: 60805},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1911, col: 9, offset: 60805},
+					pos:  position{line: 1911, col: 9, offset: 60806},
 					name: "KeyWordChars",
 				},
 			},
@@ -13774,15 +13774,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1915, col: 1, offset: 60841},
+			pos:  position{line: 1915, col: 1, offset: 60842},
 			expr: &actionExpr{
-				pos: position{line: 1916, col: 5, offset: 60854},
+				pos: position{line: 1916, col: 5, offset: 60855},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1916, col: 5, offset: 60854},
+					pos:   position{line: 1916, col: 5, offset: 60855},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1916, col: 7, offset: 60856},
+						pos:  position{line: 1916, col: 7, offset: 60857},
 						name: "Seq",
 					},
 				},
@@ -13792,27 +13792,27 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1924, col: 1, offset: 61002},
+			pos:  position{line: 1924, col: 1, offset: 61003},
 			expr: &actionExpr{
-				pos: position{line: 1924, col: 12, offset: 61013},
+				pos: position{line: 1924, col: 12, offset: 61014},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1924, col: 12, offset: 61013},
+					pos: position{line: 1924, col: 12, offset: 61014},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1924, col: 12, offset: 61013},
+							pos: position{line: 1924, col: 12, offset: 61014},
 							expr: &litMatcher{
-								pos:        position{line: 1924, col: 13, offset: 61014},
+								pos:        position{line: 1924, col: 13, offset: 61015},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1924, col: 17, offset: 61018},
+							pos:   position{line: 1924, col: 17, offset: 61019},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1924, col: 20, offset: 61021},
+								pos:  position{line: 1924, col: 20, offset: 61022},
 								name: "SelectExpr",
 							},
 						},
@@ -13824,65 +13824,65 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1926, col: 1, offset: 61051},
+			pos:  position{line: 1926, col: 1, offset: 61052},
 			expr: &actionExpr{
-				pos: position{line: 1927, col: 5, offset: 61067},
+				pos: position{line: 1927, col: 5, offset: 61068},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1927, col: 5, offset: 61067},
+					pos: position{line: 1927, col: 5, offset: 61068},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1927, col: 5, offset: 61067},
+							pos:   position{line: 1927, col: 5, offset: 61068},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1927, col: 10, offset: 61072},
+								pos:  position{line: 1927, col: 10, offset: 61073},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1928, col: 5, offset: 61090},
+							pos:   position{line: 1928, col: 5, offset: 61091},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1929, col: 9, offset: 61105},
+								pos: position{line: 1929, col: 9, offset: 61106},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1929, col: 9, offset: 61105},
+										pos:  position{line: 1929, col: 9, offset: 61106},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1930, col: 9, offset: 61126},
+										pos:  position{line: 1930, col: 9, offset: 61127},
 										name: "Select",
 									},
 									&actionExpr{
-										pos: position{line: 1931, col: 9, offset: 61141},
+										pos: position{line: 1931, col: 9, offset: 61142},
 										run: (*parser).callonSelectExpr9,
 										expr: &seqExpr{
-											pos: position{line: 1931, col: 9, offset: 61141},
+											pos: position{line: 1931, col: 9, offset: 61142},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1931, col: 9, offset: 61141},
+													pos:        position{line: 1931, col: 9, offset: 61142},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1931, col: 13, offset: 61145},
+													pos:  position{line: 1931, col: 13, offset: 61146},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1931, col: 16, offset: 61148},
+													pos:   position{line: 1931, col: 16, offset: 61149},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1931, col: 18, offset: 61150},
+														pos:  position{line: 1931, col: 18, offset: 61151},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1931, col: 26, offset: 61158},
+													pos:  position{line: 1931, col: 26, offset: 61159},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1931, col: 28, offset: 61160},
+													pos:        position{line: 1931, col: 28, offset: 61161},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13894,97 +13894,97 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1933, col: 5, offset: 61197},
+							pos:   position{line: 1933, col: 5, offset: 61198},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1933, col: 13, offset: 61205},
+								pos:  position{line: 1933, col: 13, offset: 61206},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1934, col: 5, offset: 61226},
+							pos:   position{line: 1934, col: 5, offset: 61227},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1934, col: 11, offset: 61232},
+								pos:  position{line: 1934, col: 11, offset: 61233},
 								name: "OptLimitClause",
 							},
 						},
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1954, col: 1, offset: 61618},
+			pos:  position{line: 1954, col: 1, offset: 61619},
 			expr: &actionExpr{
-				pos: position{line: 1955, col: 5, offset: 61630},
+				pos: position{line: 1955, col: 5, offset: 61631},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1955, col: 5, offset: 61630},
+					pos: position{line: 1955, col: 5, offset: 61631},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1955, col: 5, offset: 61630},
+							pos:  position{line: 1955, col: 5, offset: 61631},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1956, col: 5, offset: 61642},
+							pos:   position{line: 1956, col: 5, offset: 61643},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1956, col: 14, offset: 61651},
+								pos:  position{line: 1956, col: 14, offset: 61652},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1957, col: 5, offset: 61667},
+							pos:   position{line: 1957, col: 5, offset: 61668},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1957, col: 11, offset: 61673},
+								pos:  position{line: 1957, col: 11, offset: 61674},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1960, col: 5, offset: 61813},
+							pos:  position{line: 1960, col: 5, offset: 61814},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1960, col: 7, offset: 61815},
+							pos:   position{line: 1960, col: 7, offset: 61816},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1960, col: 17, offset: 61825},
+								pos:  position{line: 1960, col: 17, offset: 61826},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1961, col: 5, offset: 61839},
+							pos:   position{line: 1961, col: 5, offset: 61840},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1961, col: 10, offset: 61844},
+								pos:  position{line: 1961, col: 10, offset: 61845},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1962, col: 5, offset: 61862},
+							pos:   position{line: 1962, col: 5, offset: 61863},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1962, col: 11, offset: 61868},
+								pos:  position{line: 1962, col: 11, offset: 61869},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1963, col: 5, offset: 61887},
+							pos:   position{line: 1963, col: 5, offset: 61888},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1963, col: 11, offset: 61893},
+								pos:  position{line: 1963, col: 11, offset: 61894},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1964, col: 5, offset: 61912},
+							pos:   position{line: 1964, col: 5, offset: 61913},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1964, col: 12, offset: 61919},
+								pos:  position{line: 1964, col: 12, offset: 61920},
 								name: "OptHavingClause",
 							},
 						},
@@ -13996,49 +13996,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 1990, col: 1, offset: 62525},
+			pos:  position{line: 1990, col: 1, offset: 62526},
 			expr: &choiceExpr{
-				pos: position{line: 1991, col: 5, offset: 62541},
+				pos: position{line: 1991, col: 5, offset: 62542},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1991, col: 5, offset: 62541},
+						pos: position{line: 1991, col: 5, offset: 62542},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 1991, col: 5, offset: 62541},
+							pos: position{line: 1991, col: 5, offset: 62542},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1991, col: 5, offset: 62541},
+									pos:  position{line: 1991, col: 5, offset: 62542},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1991, col: 7, offset: 62543},
+									pos:  position{line: 1991, col: 7, offset: 62544},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1992, col: 5, offset: 62580},
+						pos: position{line: 1992, col: 5, offset: 62581},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 1992, col: 5, offset: 62580},
+							pos: position{line: 1992, col: 5, offset: 62581},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1992, col: 5, offset: 62580},
+									pos:  position{line: 1992, col: 5, offset: 62581},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1992, col: 7, offset: 62582},
+									pos:  position{line: 1992, col: 7, offset: 62583},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1993, col: 5, offset: 62618},
+						pos: position{line: 1993, col: 5, offset: 62619},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 1993, col: 5, offset: 62618},
+							pos:        position{line: 1993, col: 5, offset: 62619},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14051,57 +14051,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 1995, col: 1, offset: 62657},
+			pos:  position{line: 1995, col: 1, offset: 62658},
 			expr: &choiceExpr{
-				pos: position{line: 1996, col: 5, offset: 62676},
+				pos: position{line: 1996, col: 5, offset: 62677},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1996, col: 5, offset: 62676},
+						pos: position{line: 1996, col: 5, offset: 62677},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 1996, col: 5, offset: 62676},
+							pos: position{line: 1996, col: 5, offset: 62677},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1996, col: 5, offset: 62676},
+									pos:  position{line: 1996, col: 5, offset: 62677},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1996, col: 7, offset: 62678},
+									pos:  position{line: 1996, col: 7, offset: 62679},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1996, col: 10, offset: 62681},
+									pos:  position{line: 1996, col: 10, offset: 62682},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1996, col: 12, offset: 62683},
+									pos:  position{line: 1996, col: 12, offset: 62684},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1997, col: 5, offset: 62715},
+						pos: position{line: 1997, col: 5, offset: 62716},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 1997, col: 5, offset: 62715},
+							pos: position{line: 1997, col: 5, offset: 62716},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1997, col: 5, offset: 62715},
+									pos:  position{line: 1997, col: 5, offset: 62716},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1997, col: 7, offset: 62717},
+									pos:  position{line: 1997, col: 7, offset: 62718},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1998, col: 5, offset: 62788},
+						pos: position{line: 1998, col: 5, offset: 62789},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 1998, col: 5, offset: 62788},
+							pos:        position{line: 1998, col: 5, offset: 62789},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14114,19 +14114,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2000, col: 1, offset: 62831},
+			pos:  position{line: 2000, col: 1, offset: 62832},
 			expr: &choiceExpr{
-				pos: position{line: 2001, col: 5, offset: 62850},
+				pos: position{line: 2001, col: 5, offset: 62851},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2001, col: 5, offset: 62850},
+						pos:  position{line: 2001, col: 5, offset: 62851},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2002, col: 5, offset: 62866},
+						pos: position{line: 2002, col: 5, offset: 62867},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2002, col: 5, offset: 62866},
+							pos:        position{line: 2002, col: 5, offset: 62867},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14139,38 +14139,38 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2004, col: 1, offset: 62899},
+			pos:  position{line: 2004, col: 1, offset: 62900},
 			expr: &actionExpr{
-				pos: position{line: 2005, col: 5, offset: 62915},
+				pos: position{line: 2005, col: 5, offset: 62916},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2005, col: 5, offset: 62915},
+					pos: position{line: 2005, col: 5, offset: 62916},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2005, col: 5, offset: 62915},
+							pos:  position{line: 2005, col: 5, offset: 62916},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2005, col: 7, offset: 62917},
+							pos:  position{line: 2005, col: 7, offset: 62918},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2005, col: 12, offset: 62922},
+							pos:   position{line: 2005, col: 12, offset: 62923},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2005, col: 14, offset: 62924},
+								pos:  position{line: 2005, col: 14, offset: 62925},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2005, col: 27, offset: 62937},
+							pos:  position{line: 2005, col: 27, offset: 62938},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2005, col: 29, offset: 62939},
+							pos:   position{line: 2005, col: 29, offset: 62940},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2005, col: 34, offset: 62944},
+								pos:  position{line: 2005, col: 34, offset: 62945},
 								name: "CteList",
 							},
 						},
@@ -14182,32 +14182,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2014, col: 1, offset: 63129},
+			pos:  position{line: 2014, col: 1, offset: 63130},
 			expr: &choiceExpr{
-				pos: position{line: 2015, col: 5, offset: 63147},
+				pos: position{line: 2015, col: 5, offset: 63148},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2015, col: 5, offset: 63147},
+						pos: position{line: 2015, col: 5, offset: 63148},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2015, col: 5, offset: 63147},
+							pos: position{line: 2015, col: 5, offset: 63148},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2015, col: 5, offset: 63147},
+									pos:  position{line: 2015, col: 5, offset: 63148},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2015, col: 7, offset: 63149},
+									pos:  position{line: 2015, col: 7, offset: 63150},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2016, col: 5, offset: 63185},
+						pos: position{line: 2016, col: 5, offset: 63186},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2016, col: 5, offset: 63185},
+							pos:        position{line: 2016, col: 5, offset: 63186},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14220,51 +14220,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2018, col: 1, offset: 63224},
+			pos:  position{line: 2018, col: 1, offset: 63225},
 			expr: &actionExpr{
-				pos: position{line: 2018, col: 11, offset: 63234},
+				pos: position{line: 2018, col: 11, offset: 63235},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2018, col: 11, offset: 63234},
+					pos: position{line: 2018, col: 11, offset: 63235},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2018, col: 11, offset: 63234},
+							pos:   position{line: 2018, col: 11, offset: 63235},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2018, col: 17, offset: 63240},
+								pos:  position{line: 2018, col: 17, offset: 63241},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2018, col: 21, offset: 63244},
+							pos:   position{line: 2018, col: 21, offset: 63245},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2018, col: 26, offset: 63249},
+								pos: position{line: 2018, col: 26, offset: 63250},
 								expr: &actionExpr{
-									pos: position{line: 2018, col: 28, offset: 63251},
+									pos: position{line: 2018, col: 28, offset: 63252},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2018, col: 28, offset: 63251},
+										pos: position{line: 2018, col: 28, offset: 63252},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2018, col: 28, offset: 63251},
+												pos:  position{line: 2018, col: 28, offset: 63252},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2018, col: 31, offset: 63254},
+												pos:        position{line: 2018, col: 31, offset: 63255},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2018, col: 35, offset: 63258},
+												pos:  position{line: 2018, col: 35, offset: 63259},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2018, col: 38, offset: 63261},
+												pos:   position{line: 2018, col: 38, offset: 63262},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2018, col: 42, offset: 63265},
+													pos:  position{line: 2018, col: 42, offset: 63266},
 													name: "Cte",
 												},
 											},
@@ -14281,65 +14281,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2022, col: 1, offset: 63334},
+			pos:  position{line: 2022, col: 1, offset: 63335},
 			expr: &actionExpr{
-				pos: position{line: 2023, col: 5, offset: 63342},
+				pos: position{line: 2023, col: 5, offset: 63343},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2023, col: 5, offset: 63342},
+					pos: position{line: 2023, col: 5, offset: 63343},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2023, col: 5, offset: 63342},
+							pos:   position{line: 2023, col: 5, offset: 63343},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2023, col: 10, offset: 63347},
+								pos:  position{line: 2023, col: 10, offset: 63348},
 								name: "AliasName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 20, offset: 63357},
+							pos:  position{line: 2023, col: 20, offset: 63358},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 22, offset: 63359},
+							pos:  position{line: 2023, col: 22, offset: 63360},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2023, col: 25, offset: 63362},
+							pos:   position{line: 2023, col: 25, offset: 63363},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2023, col: 27, offset: 63364},
+								pos:  position{line: 2023, col: 27, offset: 63365},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 43, offset: 63380},
+							pos:  position{line: 2023, col: 43, offset: 63381},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2023, col: 46, offset: 63383},
+							pos:        position{line: 2023, col: 46, offset: 63384},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 50, offset: 63387},
+							pos:  position{line: 2023, col: 50, offset: 63388},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2023, col: 53, offset: 63390},
+							pos:   position{line: 2023, col: 53, offset: 63391},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2023, col: 55, offset: 63392},
+								pos:  position{line: 2023, col: 55, offset: 63393},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 63, offset: 63400},
+							pos:  position{line: 2023, col: 63, offset: 63401},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2023, col: 66, offset: 63403},
+							pos:        position{line: 2023, col: 66, offset: 63404},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14352,9 +14352,9 @@ var g = &grammar{
 		},
 		{
 			name: "AliasName",
-			pos:  position{line: 2032, col: 1, offset: 63578},
+			pos:  position{line: 2032, col: 1, offset: 63579},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2032, col: 13, offset: 63590},
+				pos:  position{line: 2032, col: 13, offset: 63591},
 				name: "Identifier",
 			},
 			leader:        false,
@@ -14362,65 +14362,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2034, col: 1, offset: 63602},
+			pos:  position{line: 2034, col: 1, offset: 63603},
 			expr: &choiceExpr{
-				pos: position{line: 2035, col: 5, offset: 63623},
+				pos: position{line: 2035, col: 5, offset: 63624},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2035, col: 5, offset: 63623},
+						pos: position{line: 2035, col: 5, offset: 63624},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2035, col: 5, offset: 63623},
+							pos: position{line: 2035, col: 5, offset: 63624},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 5, offset: 63623},
+									pos:  position{line: 2035, col: 5, offset: 63624},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 7, offset: 63625},
+									pos:  position{line: 2035, col: 7, offset: 63626},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2035, col: 20, offset: 63638},
+									pos:  position{line: 2035, col: 20, offset: 63639},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2036, col: 5, offset: 63677},
+						pos: position{line: 2036, col: 5, offset: 63678},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2036, col: 5, offset: 63677},
+							pos: position{line: 2036, col: 5, offset: 63678},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2036, col: 5, offset: 63677},
+									pos:  position{line: 2036, col: 5, offset: 63678},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2036, col: 7, offset: 63679},
+									pos:  position{line: 2036, col: 7, offset: 63680},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2036, col: 11, offset: 63683},
+									pos:  position{line: 2036, col: 11, offset: 63684},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2036, col: 13, offset: 63685},
+									pos:  position{line: 2036, col: 13, offset: 63686},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2036, col: 26, offset: 63698},
+									pos:  position{line: 2036, col: 26, offset: 63699},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2037, col: 5, offset: 63729},
+						pos: position{line: 2037, col: 5, offset: 63730},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2037, col: 5, offset: 63729},
+							pos:        position{line: 2037, col: 5, offset: 63730},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14433,25 +14433,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2039, col: 1, offset: 63784},
+			pos:  position{line: 2039, col: 1, offset: 63785},
 			expr: &choiceExpr{
-				pos: position{line: 2040, col: 5, offset: 63801},
+				pos: position{line: 2040, col: 5, offset: 63802},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2040, col: 5, offset: 63801},
+						pos: position{line: 2040, col: 5, offset: 63802},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2040, col: 5, offset: 63801},
+								pos:  position{line: 2040, col: 5, offset: 63802},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2040, col: 7, offset: 63803},
+								pos:  position{line: 2040, col: 7, offset: 63804},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2041, col: 5, offset: 63812},
+						pos:        position{line: 2041, col: 5, offset: 63813},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14463,25 +14463,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2043, col: 1, offset: 63816},
+			pos:  position{line: 2043, col: 1, offset: 63817},
 			expr: &choiceExpr{
-				pos: position{line: 2044, col: 5, offset: 63834},
+				pos: position{line: 2044, col: 5, offset: 63835},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2044, col: 5, offset: 63834},
+						pos: position{line: 2044, col: 5, offset: 63835},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2044, col: 5, offset: 63834},
+							pos: position{line: 2044, col: 5, offset: 63835},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2044, col: 5, offset: 63834},
+									pos:  position{line: 2044, col: 5, offset: 63835},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2044, col: 7, offset: 63836},
+									pos:   position{line: 2044, col: 7, offset: 63837},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2044, col: 12, offset: 63841},
+										pos:  position{line: 2044, col: 12, offset: 63842},
 										name: "FromOp",
 									},
 								},
@@ -14489,10 +14489,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2047, col: 5, offset: 63883},
+						pos: position{line: 2047, col: 5, offset: 63884},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2047, col: 5, offset: 63883},
+							pos:        position{line: 2047, col: 5, offset: 63884},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14505,27 +14505,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2049, col: 1, offset: 63924},
+			pos:  position{line: 2049, col: 1, offset: 63925},
 			expr: &choiceExpr{
-				pos: position{line: 2050, col: 5, offset: 63943},
+				pos: position{line: 2050, col: 5, offset: 63944},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2050, col: 5, offset: 63943},
+						pos: position{line: 2050, col: 5, offset: 63944},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2050, col: 5, offset: 63943},
+							pos:   position{line: 2050, col: 5, offset: 63944},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2050, col: 11, offset: 63949},
+								pos:  position{line: 2050, col: 11, offset: 63950},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2051, col: 5, offset: 63991},
+						pos: position{line: 2051, col: 5, offset: 63992},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2051, col: 5, offset: 63991},
+							pos:        position{line: 2051, col: 5, offset: 63992},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14538,25 +14538,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2053, col: 1, offset: 64036},
+			pos:  position{line: 2053, col: 1, offset: 64037},
 			expr: &choiceExpr{
-				pos: position{line: 2054, col: 5, offset: 64055},
+				pos: position{line: 2054, col: 5, offset: 64056},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2054, col: 5, offset: 64055},
+						pos: position{line: 2054, col: 5, offset: 64056},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2054, col: 5, offset: 64055},
+							pos: position{line: 2054, col: 5, offset: 64056},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2054, col: 5, offset: 64055},
+									pos:  position{line: 2054, col: 5, offset: 64056},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2054, col: 7, offset: 64057},
+									pos:   position{line: 2054, col: 7, offset: 64058},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2054, col: 13, offset: 64063},
+										pos:  position{line: 2054, col: 13, offset: 64064},
 										name: "GroupClause",
 									},
 								},
@@ -14564,10 +14564,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2055, col: 5, offset: 64101},
+						pos: position{line: 2055, col: 5, offset: 64102},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2055, col: 5, offset: 64101},
+							pos:        position{line: 2055, col: 5, offset: 64102},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14580,34 +14580,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2057, col: 1, offset: 64142},
+			pos:  position{line: 2057, col: 1, offset: 64143},
 			expr: &actionExpr{
-				pos: position{line: 2058, col: 5, offset: 64158},
+				pos: position{line: 2058, col: 5, offset: 64159},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2058, col: 5, offset: 64158},
+					pos: position{line: 2058, col: 5, offset: 64159},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2058, col: 5, offset: 64158},
+							pos:  position{line: 2058, col: 5, offset: 64159},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2058, col: 11, offset: 64164},
+							pos:  position{line: 2058, col: 11, offset: 64165},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2058, col: 13, offset: 64166},
+							pos:  position{line: 2058, col: 13, offset: 64167},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2058, col: 16, offset: 64169},
+							pos:  position{line: 2058, col: 16, offset: 64170},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2058, col: 18, offset: 64171},
+							pos:   position{line: 2058, col: 18, offset: 64172},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2058, col: 23, offset: 64176},
+								pos:  position{line: 2058, col: 23, offset: 64177},
 								name: "GroupByList",
 							},
 						},
@@ -14619,51 +14619,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2060, col: 1, offset: 64210},
+			pos:  position{line: 2060, col: 1, offset: 64211},
 			expr: &actionExpr{
-				pos: position{line: 2061, col: 5, offset: 64227},
+				pos: position{line: 2061, col: 5, offset: 64228},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2061, col: 5, offset: 64227},
+					pos: position{line: 2061, col: 5, offset: 64228},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2061, col: 5, offset: 64227},
+							pos:   position{line: 2061, col: 5, offset: 64228},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2061, col: 11, offset: 64233},
+								pos:  position{line: 2061, col: 11, offset: 64234},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2061, col: 23, offset: 64245},
+							pos:   position{line: 2061, col: 23, offset: 64246},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2061, col: 28, offset: 64250},
+								pos: position{line: 2061, col: 28, offset: 64251},
 								expr: &actionExpr{
-									pos: position{line: 2061, col: 30, offset: 64252},
+									pos: position{line: 2061, col: 30, offset: 64253},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2061, col: 30, offset: 64252},
+										pos: position{line: 2061, col: 30, offset: 64253},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2061, col: 30, offset: 64252},
+												pos:  position{line: 2061, col: 30, offset: 64253},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2061, col: 33, offset: 64255},
+												pos:        position{line: 2061, col: 33, offset: 64256},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2061, col: 37, offset: 64259},
+												pos:  position{line: 2061, col: 37, offset: 64260},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2061, col: 40, offset: 64262},
+												pos:   position{line: 2061, col: 40, offset: 64263},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2061, col: 42, offset: 64264},
+													pos:  position{line: 2061, col: 42, offset: 64265},
 													name: "GroupByItem",
 												},
 											},
@@ -14680,9 +14680,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2065, col: 1, offset: 64345},
+			pos:  position{line: 2065, col: 1, offset: 64346},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2065, col: 15, offset: 64359},
+				pos:  position{line: 2065, col: 15, offset: 64360},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14690,25 +14690,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2067, col: 1, offset: 64365},
+			pos:  position{line: 2067, col: 1, offset: 64366},
 			expr: &choiceExpr{
-				pos: position{line: 2068, col: 5, offset: 64385},
+				pos: position{line: 2068, col: 5, offset: 64386},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2068, col: 5, offset: 64385},
+						pos: position{line: 2068, col: 5, offset: 64386},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2068, col: 5, offset: 64385},
+							pos: position{line: 2068, col: 5, offset: 64386},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2068, col: 5, offset: 64385},
+									pos:  position{line: 2068, col: 5, offset: 64386},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2068, col: 7, offset: 64387},
+									pos:   position{line: 2068, col: 7, offset: 64388},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2068, col: 9, offset: 64389},
+										pos:  position{line: 2068, col: 9, offset: 64390},
 										name: "HavingClause",
 									},
 								},
@@ -14716,10 +14716,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2069, col: 5, offset: 64424},
+						pos: position{line: 2069, col: 5, offset: 64425},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2069, col: 5, offset: 64424},
+							pos:        position{line: 2069, col: 5, offset: 64425},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14732,26 +14732,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2071, col: 1, offset: 64448},
+			pos:  position{line: 2071, col: 1, offset: 64449},
 			expr: &actionExpr{
-				pos: position{line: 2072, col: 5, offset: 64465},
+				pos: position{line: 2072, col: 5, offset: 64466},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2072, col: 5, offset: 64465},
+					pos: position{line: 2072, col: 5, offset: 64466},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2072, col: 5, offset: 64465},
+							pos:  position{line: 2072, col: 5, offset: 64466},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2072, col: 12, offset: 64472},
+							pos:  position{line: 2072, col: 12, offset: 64473},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2072, col: 14, offset: 64474},
+							pos:   position{line: 2072, col: 14, offset: 64475},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2072, col: 16, offset: 64476},
+								pos:  position{line: 2072, col: 16, offset: 64477},
 								name: "Expr",
 							},
 						},
@@ -14763,16 +14763,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2074, col: 1, offset: 64500},
+			pos:  position{line: 2074, col: 1, offset: 64501},
 			expr: &choiceExpr{
-				pos: position{line: 2075, col: 5, offset: 64518},
+				pos: position{line: 2075, col: 5, offset: 64519},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2075, col: 5, offset: 64518},
+						pos:  position{line: 2075, col: 5, offset: 64519},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2076, col: 5, offset: 64532},
+						pos:  position{line: 2076, col: 5, offset: 64533},
 						name: "ConditionJoin",
 					},
 				},
@@ -14782,30 +14782,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2078, col: 1, offset: 64547},
+			pos:  position{line: 2078, col: 1, offset: 64548},
 			expr: &actionExpr{
-				pos: position{line: 2079, col: 5, offset: 64561},
+				pos: position{line: 2079, col: 5, offset: 64562},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2079, col: 5, offset: 64561},
+					pos: position{line: 2079, col: 5, offset: 64562},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2079, col: 5, offset: 64561},
+							pos:   position{line: 2079, col: 5, offset: 64562},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2079, col: 10, offset: 64566},
+								pos:  position{line: 2079, col: 10, offset: 64567},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 19, offset: 64575},
+							pos:  position{line: 2079, col: 19, offset: 64576},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2079, col: 31, offset: 64587},
+							pos:   position{line: 2079, col: 31, offset: 64588},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2079, col: 37, offset: 64593},
+								pos:  position{line: 2079, col: 37, offset: 64594},
 								name: "FromElem",
 							},
 						},
@@ -14817,50 +14817,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2088, col: 1, offset: 64795},
+			pos:  position{line: 2088, col: 1, offset: 64796},
 			expr: &choiceExpr{
-				pos: position{line: 2089, col: 5, offset: 64812},
+				pos: position{line: 2089, col: 5, offset: 64813},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2089, col: 5, offset: 64812},
+						pos: position{line: 2089, col: 5, offset: 64813},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2089, col: 5, offset: 64812},
+								pos:  position{line: 2089, col: 5, offset: 64813},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2089, col: 8, offset: 64815},
+								pos:        position{line: 2089, col: 8, offset: 64816},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2089, col: 12, offset: 64819},
+								pos:  position{line: 2089, col: 12, offset: 64820},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2090, col: 5, offset: 64827},
+						pos: position{line: 2090, col: 5, offset: 64828},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2090, col: 5, offset: 64827},
+								pos:  position{line: 2090, col: 5, offset: 64828},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2090, col: 7, offset: 64829},
+								pos:  position{line: 2090, col: 7, offset: 64830},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2090, col: 13, offset: 64835},
+								pos:  position{line: 2090, col: 13, offset: 64836},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2090, col: 15, offset: 64837},
+								pos:  position{line: 2090, col: 15, offset: 64838},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2090, col: 20, offset: 64842},
+								pos:  position{line: 2090, col: 20, offset: 64843},
 								name: "_",
 							},
 						},
@@ -14872,46 +14872,46 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2092, col: 1, offset: 64846},
+			pos:  position{line: 2092, col: 1, offset: 64847},
 			expr: &actionExpr{
-				pos: position{line: 2093, col: 5, offset: 64864},
+				pos: position{line: 2093, col: 5, offset: 64865},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2093, col: 5, offset: 64864},
+					pos: position{line: 2093, col: 5, offset: 64865},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2093, col: 5, offset: 64864},
+							pos:   position{line: 2093, col: 5, offset: 64865},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2093, col: 10, offset: 64869},
+								pos:  position{line: 2093, col: 10, offset: 64870},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2093, col: 19, offset: 64878},
+							pos:   position{line: 2093, col: 19, offset: 64879},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2093, col: 25, offset: 64884},
+								pos:  position{line: 2093, col: 25, offset: 64885},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2093, col: 38, offset: 64897},
+							pos:  position{line: 2093, col: 38, offset: 64898},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2093, col: 40, offset: 64899},
+							pos:   position{line: 2093, col: 40, offset: 64900},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2093, col: 46, offset: 64905},
+								pos:  position{line: 2093, col: 46, offset: 64906},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2093, col: 55, offset: 64914},
+							pos:   position{line: 2093, col: 55, offset: 64915},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2093, col: 57, offset: 64916},
+								pos:  position{line: 2093, col: 57, offset: 64917},
 								name: "JoinExpr",
 							},
 						},
@@ -14923,161 +14923,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2104, col: 1, offset: 65185},
+			pos:  position{line: 2104, col: 1, offset: 65186},
 			expr: &choiceExpr{
-				pos: position{line: 2105, col: 5, offset: 65203},
+				pos: position{line: 2105, col: 5, offset: 65204},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2105, col: 5, offset: 65203},
+						pos: position{line: 2105, col: 5, offset: 65204},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2105, col: 5, offset: 65203},
+							pos: position{line: 2105, col: 5, offset: 65204},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2105, col: 5, offset: 65203},
+									pos: position{line: 2105, col: 5, offset: 65204},
 									expr: &seqExpr{
-										pos: position{line: 2105, col: 6, offset: 65204},
+										pos: position{line: 2105, col: 6, offset: 65205},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2105, col: 6, offset: 65204},
+												pos:  position{line: 2105, col: 6, offset: 65205},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2105, col: 8, offset: 65206},
+												pos:  position{line: 2105, col: 8, offset: 65207},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 16, offset: 65214},
+									pos:  position{line: 2105, col: 16, offset: 65215},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 18, offset: 65216},
+									pos:  position{line: 2105, col: 18, offset: 65217},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2106, col: 5, offset: 65261},
+						pos: position{line: 2106, col: 5, offset: 65262},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2106, col: 5, offset: 65261},
+							pos: position{line: 2106, col: 5, offset: 65262},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 5, offset: 65261},
+									pos:  position{line: 2106, col: 5, offset: 65262},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 7, offset: 65263},
+									pos:  position{line: 2106, col: 7, offset: 65264},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2106, col: 12, offset: 65268},
+									pos: position{line: 2106, col: 12, offset: 65269},
 									expr: &seqExpr{
-										pos: position{line: 2106, col: 13, offset: 65269},
+										pos: position{line: 2106, col: 13, offset: 65270},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2106, col: 13, offset: 65269},
+												pos:  position{line: 2106, col: 13, offset: 65270},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2106, col: 15, offset: 65271},
+												pos:  position{line: 2106, col: 15, offset: 65272},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 23, offset: 65279},
+									pos:  position{line: 2106, col: 23, offset: 65280},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 25, offset: 65281},
+									pos:  position{line: 2106, col: 25, offset: 65282},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2107, col: 5, offset: 65315},
+						pos: position{line: 2107, col: 5, offset: 65316},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2107, col: 5, offset: 65315},
+							pos: position{line: 2107, col: 5, offset: 65316},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2107, col: 5, offset: 65315},
+									pos:  position{line: 2107, col: 5, offset: 65316},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2107, col: 7, offset: 65317},
+									pos:  position{line: 2107, col: 7, offset: 65318},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2107, col: 12, offset: 65322},
+									pos: position{line: 2107, col: 12, offset: 65323},
 									expr: &seqExpr{
-										pos: position{line: 2107, col: 13, offset: 65323},
+										pos: position{line: 2107, col: 13, offset: 65324},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2107, col: 13, offset: 65323},
+												pos:  position{line: 2107, col: 13, offset: 65324},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2107, col: 15, offset: 65325},
+												pos:  position{line: 2107, col: 15, offset: 65326},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2107, col: 23, offset: 65333},
+									pos:  position{line: 2107, col: 23, offset: 65334},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2107, col: 25, offset: 65335},
+									pos:  position{line: 2107, col: 25, offset: 65336},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2108, col: 5, offset: 65369},
+						pos: position{line: 2108, col: 5, offset: 65370},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2108, col: 5, offset: 65369},
+							pos: position{line: 2108, col: 5, offset: 65370},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2108, col: 5, offset: 65369},
+									pos:  position{line: 2108, col: 5, offset: 65370},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2108, col: 7, offset: 65371},
+									pos:  position{line: 2108, col: 7, offset: 65372},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2108, col: 13, offset: 65377},
+									pos: position{line: 2108, col: 13, offset: 65378},
 									expr: &seqExpr{
-										pos: position{line: 2108, col: 14, offset: 65378},
+										pos: position{line: 2108, col: 14, offset: 65379},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2108, col: 14, offset: 65378},
+												pos:  position{line: 2108, col: 14, offset: 65379},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2108, col: 16, offset: 65380},
+												pos:  position{line: 2108, col: 16, offset: 65381},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2108, col: 24, offset: 65388},
+									pos:  position{line: 2108, col: 24, offset: 65389},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2108, col: 26, offset: 65390},
+									pos:  position{line: 2108, col: 26, offset: 65391},
 									name: "JOIN",
 								},
 							},
@@ -15090,33 +15090,33 @@ var g = &grammar{
 		},
 		{
 			name: "JoinExpr",
-			pos:  position{line: 2110, col: 1, offset: 65422},
+			pos:  position{line: 2110, col: 1, offset: 65423},
 			expr: &choiceExpr{
-				pos: position{line: 2111, col: 5, offset: 65436},
+				pos: position{line: 2111, col: 5, offset: 65437},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2111, col: 5, offset: 65436},
+						pos: position{line: 2111, col: 5, offset: 65437},
 						run: (*parser).callonJoinExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2111, col: 5, offset: 65436},
+							pos: position{line: 2111, col: 5, offset: 65437},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2111, col: 5, offset: 65436},
+									pos:  position{line: 2111, col: 5, offset: 65437},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2111, col: 7, offset: 65438},
+									pos:  position{line: 2111, col: 7, offset: 65439},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2111, col: 10, offset: 65441},
+									pos:  position{line: 2111, col: 10, offset: 65442},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2111, col: 12, offset: 65443},
+									pos:   position{line: 2111, col: 12, offset: 65444},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2111, col: 14, offset: 65445},
+										pos:  position{line: 2111, col: 14, offset: 65446},
 										name: "Expr",
 									},
 								},
@@ -15124,47 +15124,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2118, col: 5, offset: 65600},
+						pos: position{line: 2118, col: 5, offset: 65601},
 						run: (*parser).callonJoinExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2118, col: 5, offset: 65600},
+							pos: position{line: 2118, col: 5, offset: 65601},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2118, col: 5, offset: 65600},
+									pos:  position{line: 2118, col: 5, offset: 65601},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2118, col: 7, offset: 65602},
+									pos:  position{line: 2118, col: 7, offset: 65603},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2118, col: 13, offset: 65608},
+									pos:  position{line: 2118, col: 13, offset: 65609},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2118, col: 16, offset: 65611},
+									pos:        position{line: 2118, col: 16, offset: 65612},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2118, col: 20, offset: 65615},
+									pos:  position{line: 2118, col: 20, offset: 65616},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2118, col: 23, offset: 65618},
+									pos:   position{line: 2118, col: 23, offset: 65619},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2118, col: 30, offset: 65625},
+										pos:  position{line: 2118, col: 30, offset: 65626},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2118, col: 36, offset: 65631},
+									pos:  position{line: 2118, col: 36, offset: 65632},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2118, col: 39, offset: 65634},
+									pos:        position{line: 2118, col: 39, offset: 65635},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -15179,40 +15179,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2126, col: 1, offset: 65804},
+			pos:  position{line: 2126, col: 1, offset: 65805},
 			expr: &choiceExpr{
-				pos: position{line: 2127, col: 5, offset: 65823},
+				pos: position{line: 2127, col: 5, offset: 65824},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2127, col: 5, offset: 65823},
+						pos: position{line: 2127, col: 5, offset: 65824},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2127, col: 5, offset: 65823},
+							pos: position{line: 2127, col: 5, offset: 65824},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 5, offset: 65823},
+									pos:  position{line: 2127, col: 5, offset: 65824},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 7, offset: 65825},
+									pos:  position{line: 2127, col: 7, offset: 65826},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 12, offset: 65830},
+									pos:  position{line: 2127, col: 12, offset: 65831},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 14, offset: 65832},
+									pos:  position{line: 2127, col: 14, offset: 65833},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2133, col: 5, offset: 65961},
+						pos: position{line: 2133, col: 5, offset: 65962},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2133, col: 5, offset: 65961},
+							pos:        position{line: 2133, col: 5, offset: 65962},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15225,25 +15225,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2135, col: 1, offset: 66010},
+			pos:  position{line: 2135, col: 1, offset: 66011},
 			expr: &choiceExpr{
-				pos: position{line: 2136, col: 5, offset: 66023},
+				pos: position{line: 2136, col: 5, offset: 66024},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2136, col: 5, offset: 66023},
+						pos: position{line: 2136, col: 5, offset: 66024},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2136, col: 5, offset: 66023},
+							pos: position{line: 2136, col: 5, offset: 66024},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2136, col: 5, offset: 66023},
+									pos:  position{line: 2136, col: 5, offset: 66024},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2136, col: 7, offset: 66025},
+									pos:   position{line: 2136, col: 7, offset: 66026},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2136, col: 9, offset: 66027},
+										pos:  position{line: 2136, col: 9, offset: 66028},
 										name: "AliasClause",
 									},
 								},
@@ -15251,10 +15251,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2137, col: 5, offset: 66061},
+						pos: position{line: 2137, col: 5, offset: 66062},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2137, col: 5, offset: 66061},
+							pos:        position{line: 2137, col: 5, offset: 66062},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15267,50 +15267,50 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2139, col: 1, offset: 66098},
+			pos:  position{line: 2139, col: 1, offset: 66099},
 			expr: &actionExpr{
-				pos: position{line: 2140, col: 5, offset: 66115},
+				pos: position{line: 2140, col: 5, offset: 66116},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2140, col: 5, offset: 66115},
+					pos: position{line: 2140, col: 5, offset: 66116},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2140, col: 5, offset: 66115},
+							pos: position{line: 2140, col: 5, offset: 66116},
 							expr: &seqExpr{
-								pos: position{line: 2140, col: 6, offset: 66116},
+								pos: position{line: 2140, col: 6, offset: 66117},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2140, col: 6, offset: 66116},
+										pos:  position{line: 2140, col: 6, offset: 66117},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2140, col: 9, offset: 66119},
+										pos:  position{line: 2140, col: 9, offset: 66120},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2140, col: 13, offset: 66123},
+							pos: position{line: 2140, col: 13, offset: 66124},
 							expr: &choiceExpr{
-								pos: position{line: 2140, col: 15, offset: 66125},
+								pos: position{line: 2140, col: 15, offset: 66126},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2140, col: 15, offset: 66125},
+										pos:  position{line: 2140, col: 15, offset: 66126},
 										name: "SQLGuard",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2140, col: 26, offset: 66136},
+										pos:  position{line: 2140, col: 26, offset: 66137},
 										name: "DeprecatedFroms",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2140, col: 43, offset: 66153},
+							pos:   position{line: 2140, col: 43, offset: 66154},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2140, col: 48, offset: 66158},
+								pos:  position{line: 2140, col: 48, offset: 66159},
 								name: "IdentifierName",
 							},
 						},
@@ -15322,51 +15322,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2144, col: 1, offset: 66291},
+			pos:  position{line: 2144, col: 1, offset: 66292},
 			expr: &actionExpr{
-				pos: position{line: 2145, col: 5, offset: 66305},
+				pos: position{line: 2145, col: 5, offset: 66306},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2145, col: 5, offset: 66305},
+					pos: position{line: 2145, col: 5, offset: 66306},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2145, col: 5, offset: 66305},
+							pos:   position{line: 2145, col: 5, offset: 66306},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2145, col: 11, offset: 66311},
+								pos:  position{line: 2145, col: 11, offset: 66312},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2145, col: 22, offset: 66322},
+							pos:   position{line: 2145, col: 22, offset: 66323},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2145, col: 27, offset: 66327},
+								pos: position{line: 2145, col: 27, offset: 66328},
 								expr: &actionExpr{
-									pos: position{line: 2145, col: 29, offset: 66329},
+									pos: position{line: 2145, col: 29, offset: 66330},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2145, col: 29, offset: 66329},
+										pos: position{line: 2145, col: 29, offset: 66330},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2145, col: 29, offset: 66329},
+												pos:  position{line: 2145, col: 29, offset: 66330},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2145, col: 32, offset: 66332},
+												pos:        position{line: 2145, col: 32, offset: 66333},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2145, col: 36, offset: 66336},
+												pos:  position{line: 2145, col: 36, offset: 66337},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2145, col: 39, offset: 66339},
+												pos:   position{line: 2145, col: 39, offset: 66340},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2145, col: 41, offset: 66341},
+													pos:  position{line: 2145, col: 41, offset: 66342},
 													name: "SelectElem",
 												},
 											},
@@ -15383,38 +15383,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2154, col: 1, offset: 66567},
+			pos:  position{line: 2154, col: 1, offset: 66568},
 			expr: &choiceExpr{
-				pos: position{line: 2155, col: 5, offset: 66583},
+				pos: position{line: 2155, col: 5, offset: 66584},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2155, col: 5, offset: 66583},
+						pos: position{line: 2155, col: 5, offset: 66584},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2155, col: 5, offset: 66583},
+							pos: position{line: 2155, col: 5, offset: 66584},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2155, col: 5, offset: 66583},
+									pos:   position{line: 2155, col: 5, offset: 66584},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2155, col: 11, offset: 66589},
+										pos: position{line: 2155, col: 11, offset: 66590},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2155, col: 11, offset: 66589},
+												pos:  position{line: 2155, col: 11, offset: 66590},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2155, col: 25, offset: 66603},
+												pos:  position{line: 2155, col: 25, offset: 66604},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2155, col: 31, offset: 66609},
+									pos:   position{line: 2155, col: 31, offset: 66610},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2155, col: 34, offset: 66612},
+										pos:  position{line: 2155, col: 34, offset: 66613},
 										name: "OptAsClause",
 									},
 								},
@@ -15422,10 +15422,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2166, col: 5, offset: 66831},
+						pos: position{line: 2166, col: 5, offset: 66832},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2166, col: 5, offset: 66831},
+							pos:        position{line: 2166, col: 5, offset: 66832},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15438,33 +15438,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2171, col: 1, offset: 66933},
+			pos:  position{line: 2171, col: 1, offset: 66934},
 			expr: &choiceExpr{
-				pos: position{line: 2172, col: 5, offset: 66950},
+				pos: position{line: 2172, col: 5, offset: 66951},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2172, col: 5, offset: 66950},
+						pos: position{line: 2172, col: 5, offset: 66951},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2172, col: 5, offset: 66950},
+							pos: position{line: 2172, col: 5, offset: 66951},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 5, offset: 66950},
+									pos:  position{line: 2172, col: 5, offset: 66951},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 7, offset: 66952},
+									pos:  position{line: 2172, col: 7, offset: 66953},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 10, offset: 66955},
+									pos:  position{line: 2172, col: 10, offset: 66956},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2172, col: 12, offset: 66957},
+									pos:   position{line: 2172, col: 12, offset: 66958},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2172, col: 15, offset: 66960},
+										pos:  position{line: 2172, col: 15, offset: 66961},
 										name: "Identifier",
 									},
 								},
@@ -15472,27 +15472,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2173, col: 5, offset: 66994},
+						pos: position{line: 2173, col: 5, offset: 66995},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2173, col: 5, offset: 66994},
+							pos: position{line: 2173, col: 5, offset: 66995},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 5, offset: 66994},
+									pos:  position{line: 2173, col: 5, offset: 66995},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2173, col: 7, offset: 66996},
+									pos: position{line: 2173, col: 7, offset: 66997},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2173, col: 8, offset: 66997},
+										pos:  position{line: 2173, col: 8, offset: 66998},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2173, col: 17, offset: 67006},
+									pos:   position{line: 2173, col: 17, offset: 67007},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2173, col: 20, offset: 67009},
+										pos:  position{line: 2173, col: 20, offset: 67010},
 										name: "Identifier",
 									},
 								},
@@ -15500,10 +15500,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2174, col: 5, offset: 67043},
+						pos: position{line: 2174, col: 5, offset: 67044},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2174, col: 5, offset: 67043},
+							pos:        position{line: 2174, col: 5, offset: 67044},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15516,41 +15516,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2176, col: 1, offset: 67068},
+			pos:  position{line: 2176, col: 1, offset: 67069},
 			expr: &choiceExpr{
-				pos: position{line: 2177, col: 5, offset: 67090},
+				pos: position{line: 2177, col: 5, offset: 67091},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2177, col: 5, offset: 67090},
+						pos: position{line: 2177, col: 5, offset: 67091},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2177, col: 5, offset: 67090},
+							pos: position{line: 2177, col: 5, offset: 67091},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 5, offset: 67090},
+									pos:  position{line: 2177, col: 5, offset: 67091},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 7, offset: 67092},
+									pos:  position{line: 2177, col: 7, offset: 67093},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 13, offset: 67098},
+									pos:  position{line: 2177, col: 13, offset: 67099},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 15, offset: 67100},
+									pos:  position{line: 2177, col: 15, offset: 67101},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 18, offset: 67103},
+									pos:  position{line: 2177, col: 18, offset: 67104},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2177, col: 20, offset: 67105},
+									pos:   position{line: 2177, col: 20, offset: 67106},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2177, col: 25, offset: 67110},
+										pos:  position{line: 2177, col: 25, offset: 67111},
 										name: "OrderByList",
 									},
 								},
@@ -15558,10 +15558,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2184, col: 5, offset: 67269},
+						pos: position{line: 2184, col: 5, offset: 67270},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2184, col: 5, offset: 67269},
+							pos:        position{line: 2184, col: 5, offset: 67270},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15574,51 +15574,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2186, col: 1, offset: 67302},
+			pos:  position{line: 2186, col: 1, offset: 67303},
 			expr: &actionExpr{
-				pos: position{line: 2187, col: 5, offset: 67319},
+				pos: position{line: 2187, col: 5, offset: 67320},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2187, col: 5, offset: 67319},
+					pos: position{line: 2187, col: 5, offset: 67320},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2187, col: 5, offset: 67319},
+							pos:   position{line: 2187, col: 5, offset: 67320},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2187, col: 11, offset: 67325},
+								pos:  position{line: 2187, col: 11, offset: 67326},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2187, col: 23, offset: 67337},
+							pos:   position{line: 2187, col: 23, offset: 67338},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2187, col: 28, offset: 67342},
+								pos: position{line: 2187, col: 28, offset: 67343},
 								expr: &actionExpr{
-									pos: position{line: 2187, col: 30, offset: 67344},
+									pos: position{line: 2187, col: 30, offset: 67345},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2187, col: 30, offset: 67344},
+										pos: position{line: 2187, col: 30, offset: 67345},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2187, col: 30, offset: 67344},
+												pos:  position{line: 2187, col: 30, offset: 67345},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2187, col: 33, offset: 67347},
+												pos:        position{line: 2187, col: 33, offset: 67348},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2187, col: 37, offset: 67351},
+												pos:  position{line: 2187, col: 37, offset: 67352},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2187, col: 40, offset: 67354},
+												pos:   position{line: 2187, col: 40, offset: 67355},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2187, col: 42, offset: 67356},
+													pos:  position{line: 2187, col: 42, offset: 67357},
 													name: "OrderByItem",
 												},
 											},
@@ -15635,34 +15635,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2191, col: 1, offset: 67457},
+			pos:  position{line: 2191, col: 1, offset: 67458},
 			expr: &actionExpr{
-				pos: position{line: 2192, col: 5, offset: 67473},
+				pos: position{line: 2192, col: 5, offset: 67474},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2192, col: 5, offset: 67473},
+					pos: position{line: 2192, col: 5, offset: 67474},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2192, col: 5, offset: 67473},
+							pos:   position{line: 2192, col: 5, offset: 67474},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2192, col: 7, offset: 67475},
+								pos:  position{line: 2192, col: 7, offset: 67476},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2192, col: 12, offset: 67480},
+							pos:   position{line: 2192, col: 12, offset: 67481},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2192, col: 18, offset: 67486},
+								pos:  position{line: 2192, col: 18, offset: 67487},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2192, col: 29, offset: 67497},
+							pos:   position{line: 2192, col: 29, offset: 67498},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2192, col: 35, offset: 67503},
+								pos:  position{line: 2192, col: 35, offset: 67504},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15674,49 +15674,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2203, col: 1, offset: 67753},
+			pos:  position{line: 2203, col: 1, offset: 67754},
 			expr: &choiceExpr{
-				pos: position{line: 2204, col: 5, offset: 67768},
+				pos: position{line: 2204, col: 5, offset: 67769},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2204, col: 5, offset: 67768},
+						pos: position{line: 2204, col: 5, offset: 67769},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2204, col: 5, offset: 67768},
+							pos: position{line: 2204, col: 5, offset: 67769},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2204, col: 5, offset: 67768},
+									pos:  position{line: 2204, col: 5, offset: 67769},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2204, col: 7, offset: 67770},
+									pos:  position{line: 2204, col: 7, offset: 67771},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2205, col: 5, offset: 67842},
+						pos: position{line: 2205, col: 5, offset: 67843},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2205, col: 5, offset: 67842},
+							pos: position{line: 2205, col: 5, offset: 67843},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 5, offset: 67842},
+									pos:  position{line: 2205, col: 5, offset: 67843},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 7, offset: 67844},
+									pos:  position{line: 2205, col: 7, offset: 67845},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2206, col: 5, offset: 67916},
+						pos: position{line: 2206, col: 5, offset: 67917},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2206, col: 5, offset: 67916},
+							pos:        position{line: 2206, col: 5, offset: 67917},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15729,65 +15729,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2208, col: 1, offset: 67948},
+			pos:  position{line: 2208, col: 1, offset: 67949},
 			expr: &choiceExpr{
-				pos: position{line: 2209, col: 5, offset: 67966},
+				pos: position{line: 2209, col: 5, offset: 67967},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2209, col: 5, offset: 67966},
+						pos: position{line: 2209, col: 5, offset: 67967},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2209, col: 5, offset: 67966},
+							pos: position{line: 2209, col: 5, offset: 67967},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2209, col: 5, offset: 67966},
+									pos:  position{line: 2209, col: 5, offset: 67967},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2209, col: 7, offset: 67968},
+									pos:  position{line: 2209, col: 7, offset: 67969},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2209, col: 13, offset: 67974},
+									pos:  position{line: 2209, col: 13, offset: 67975},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2209, col: 15, offset: 67976},
+									pos:  position{line: 2209, col: 15, offset: 67977},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2210, col: 5, offset: 68052},
+						pos: position{line: 2210, col: 5, offset: 68053},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2210, col: 5, offset: 68052},
+							pos: position{line: 2210, col: 5, offset: 68053},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2210, col: 5, offset: 68052},
+									pos:  position{line: 2210, col: 5, offset: 68053},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2210, col: 7, offset: 68054},
+									pos:  position{line: 2210, col: 7, offset: 68055},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2210, col: 13, offset: 68060},
+									pos:  position{line: 2210, col: 13, offset: 68061},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2210, col: 15, offset: 68062},
+									pos:  position{line: 2210, col: 15, offset: 68063},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2211, col: 5, offset: 68137},
+						pos: position{line: 2211, col: 5, offset: 68138},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2211, col: 5, offset: 68137},
+							pos:        position{line: 2211, col: 5, offset: 68138},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15800,29 +15800,29 @@ var g = &grammar{
 		},
 		{
 			name: "SelectLimit",
-			pos:  position{line: 2213, col: 1, offset: 68182},
+			pos:  position{line: 2213, col: 1, offset: 68183},
 			expr: &choiceExpr{
-				pos: position{line: 2214, col: 5, offset: 68198},
+				pos: position{line: 2214, col: 5, offset: 68199},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2214, col: 5, offset: 68198},
+						pos: position{line: 2214, col: 5, offset: 68199},
 						run: (*parser).callonSelectLimit2,
 						expr: &seqExpr{
-							pos: position{line: 2214, col: 5, offset: 68198},
+							pos: position{line: 2214, col: 5, offset: 68199},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2214, col: 5, offset: 68198},
+									pos:   position{line: 2214, col: 5, offset: 68199},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2214, col: 7, offset: 68200},
+										pos:  position{line: 2214, col: 7, offset: 68201},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2214, col: 19, offset: 68212},
+									pos:   position{line: 2214, col: 19, offset: 68213},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2214, col: 21, offset: 68214},
+										pos:  position{line: 2214, col: 21, offset: 68215},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15830,24 +15830,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2221, col: 5, offset: 68360},
+						pos: position{line: 2221, col: 5, offset: 68361},
 						run: (*parser).callonSelectLimit8,
 						expr: &seqExpr{
-							pos: position{line: 2221, col: 5, offset: 68360},
+							pos: position{line: 2221, col: 5, offset: 68361},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2221, col: 5, offset: 68360},
+									pos:   position{line: 2221, col: 5, offset: 68361},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2221, col: 7, offset: 68362},
+										pos:  position{line: 2221, col: 7, offset: 68363},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2221, col: 20, offset: 68375},
+									pos:   position{line: 2221, col: 20, offset: 68376},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2221, col: 22, offset: 68377},
+										pos:  position{line: 2221, col: 22, offset: 68378},
 										name: "OptLimitClause",
 									},
 								},
@@ -15861,25 +15861,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2234, col: 1, offset: 68649},
+			pos:  position{line: 2234, col: 1, offset: 68650},
 			expr: &choiceExpr{
-				pos: position{line: 2235, col: 5, offset: 68669},
+				pos: position{line: 2235, col: 5, offset: 68670},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2235, col: 5, offset: 68669},
+						pos: position{line: 2235, col: 5, offset: 68670},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2235, col: 5, offset: 68669},
+							pos: position{line: 2235, col: 5, offset: 68670},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2235, col: 5, offset: 68669},
+									pos:  position{line: 2235, col: 5, offset: 68670},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2235, col: 7, offset: 68671},
+									pos:   position{line: 2235, col: 7, offset: 68672},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2235, col: 9, offset: 68673},
+										pos:  position{line: 2235, col: 9, offset: 68674},
 										name: "LimitClause",
 									},
 								},
@@ -15887,10 +15887,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2236, col: 5, offset: 68707},
+						pos: position{line: 2236, col: 5, offset: 68708},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2236, col: 5, offset: 68707},
+							pos:        position{line: 2236, col: 5, offset: 68708},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15903,50 +15903,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2238, col: 1, offset: 68744},
+			pos:  position{line: 2238, col: 1, offset: 68745},
 			expr: &choiceExpr{
-				pos: position{line: 2239, col: 5, offset: 68761},
+				pos: position{line: 2239, col: 5, offset: 68762},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2239, col: 5, offset: 68761},
+						pos: position{line: 2239, col: 5, offset: 68762},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2239, col: 5, offset: 68761},
+							pos: position{line: 2239, col: 5, offset: 68762},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2239, col: 5, offset: 68761},
+									pos:  position{line: 2239, col: 5, offset: 68762},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2239, col: 11, offset: 68767},
+									pos:  position{line: 2239, col: 11, offset: 68768},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2239, col: 13, offset: 68769},
+									pos:  position{line: 2239, col: 13, offset: 68770},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2240, col: 5, offset: 68831},
+						pos: position{line: 2240, col: 5, offset: 68832},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2240, col: 5, offset: 68831},
+							pos: position{line: 2240, col: 5, offset: 68832},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 5, offset: 68831},
+									pos:  position{line: 2240, col: 5, offset: 68832},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 11, offset: 68837},
+									pos:  position{line: 2240, col: 11, offset: 68838},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2240, col: 13, offset: 68839},
+									pos:   position{line: 2240, col: 13, offset: 68840},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2240, col: 15, offset: 68841},
+										pos:  position{line: 2240, col: 15, offset: 68842},
 										name: "Expr",
 									},
 								},
@@ -15960,25 +15960,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2248, col: 1, offset: 68966},
+			pos:  position{line: 2248, col: 1, offset: 68967},
 			expr: &choiceExpr{
-				pos: position{line: 2249, col: 5, offset: 68987},
+				pos: position{line: 2249, col: 5, offset: 68988},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2249, col: 5, offset: 68987},
+						pos: position{line: 2249, col: 5, offset: 68988},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2249, col: 5, offset: 68987},
+							pos: position{line: 2249, col: 5, offset: 68988},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 5, offset: 68987},
+									pos:  position{line: 2249, col: 5, offset: 68988},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2249, col: 7, offset: 68989},
+									pos:   position{line: 2249, col: 7, offset: 68990},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2249, col: 9, offset: 68991},
+										pos:  position{line: 2249, col: 9, offset: 68992},
 										name: "OffsetClause",
 									},
 								},
@@ -15986,10 +15986,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2250, col: 5, offset: 69027},
+						pos: position{line: 2250, col: 5, offset: 69028},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2250, col: 5, offset: 69027},
+							pos:        position{line: 2250, col: 5, offset: 69028},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16002,26 +16002,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2252, col: 1, offset: 69052},
+			pos:  position{line: 2252, col: 1, offset: 69053},
 			expr: &actionExpr{
-				pos: position{line: 2253, col: 5, offset: 69070},
+				pos: position{line: 2253, col: 5, offset: 69071},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2253, col: 5, offset: 69070},
+					pos: position{line: 2253, col: 5, offset: 69071},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2253, col: 5, offset: 69070},
+							pos:  position{line: 2253, col: 5, offset: 69071},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2253, col: 12, offset: 69077},
+							pos:  position{line: 2253, col: 12, offset: 69078},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2253, col: 14, offset: 69079},
+							pos:   position{line: 2253, col: 14, offset: 69080},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2253, col: 16, offset: 69081},
+								pos:  position{line: 2253, col: 16, offset: 69082},
 								name: "Expr",
 							},
 						},
@@ -16033,103 +16033,103 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2255, col: 1, offset: 69106},
+			pos:  position{line: 2255, col: 1, offset: 69107},
 			expr: &actionExpr{
-				pos: position{line: 2256, col: 5, offset: 69123},
+				pos: position{line: 2256, col: 5, offset: 69124},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2256, col: 5, offset: 69123},
+					pos: position{line: 2256, col: 5, offset: 69124},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2256, col: 5, offset: 69123},
+							pos:   position{line: 2256, col: 5, offset: 69124},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2256, col: 10, offset: 69128},
+								pos:  position{line: 2256, col: 10, offset: 69129},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2256, col: 21, offset: 69139},
+							pos:   position{line: 2256, col: 21, offset: 69140},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2256, col: 30, offset: 69148},
+								pos:  position{line: 2256, col: 30, offset: 69149},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2256, col: 36, offset: 69154},
+							pos:  position{line: 2256, col: 36, offset: 69155},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2256, col: 38, offset: 69156},
+							pos:   position{line: 2256, col: 38, offset: 69157},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2256, col: 44, offset: 69162},
+								pos:  position{line: 2256, col: 44, offset: 69163},
 								name: "SelectExpr",
 							},
 						},
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2266, col: 1, offset: 69383},
+			pos:  position{line: 2266, col: 1, offset: 69384},
 			expr: &choiceExpr{
-				pos: position{line: 2267, col: 5, offset: 69394},
+				pos: position{line: 2267, col: 5, offset: 69395},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2267, col: 5, offset: 69394},
+						pos: position{line: 2267, col: 5, offset: 69395},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2267, col: 5, offset: 69394},
+							pos: position{line: 2267, col: 5, offset: 69395},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 5, offset: 69394},
+									pos:  position{line: 2267, col: 5, offset: 69395},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 7, offset: 69396},
+									pos:  position{line: 2267, col: 7, offset: 69397},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 13, offset: 69402},
+									pos:  position{line: 2267, col: 13, offset: 69403},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 15, offset: 69404},
+									pos:  position{line: 2267, col: 15, offset: 69405},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2268, col: 5, offset: 69440},
+						pos: position{line: 2268, col: 5, offset: 69441},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2268, col: 5, offset: 69440},
+							pos: position{line: 2268, col: 5, offset: 69441},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2268, col: 5, offset: 69440},
+									pos:  position{line: 2268, col: 5, offset: 69441},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2268, col: 7, offset: 69442},
+									pos:  position{line: 2268, col: 7, offset: 69443},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2268, col: 13, offset: 69448},
+									pos: position{line: 2268, col: 13, offset: 69449},
 									expr: &seqExpr{
-										pos: position{line: 2268, col: 14, offset: 69449},
+										pos: position{line: 2268, col: 14, offset: 69450},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2268, col: 14, offset: 69449},
+												pos:  position{line: 2268, col: 14, offset: 69450},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2268, col: 16, offset: 69451},
+												pos:  position{line: 2268, col: 16, offset: 69452},
 												name: "DISTINCT",
 											},
 										},
@@ -16145,80 +16145,80 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2271, col: 1, offset: 69503},
+			pos:  position{line: 2271, col: 1, offset: 69504},
 			expr: &choiceExpr{
-				pos: position{line: 2272, col: 5, offset: 69518},
+				pos: position{line: 2272, col: 5, offset: 69519},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 5, offset: 69518},
+						pos:  position{line: 2272, col: 5, offset: 69519},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 12, offset: 69525},
+						pos:  position{line: 2272, col: 12, offset: 69526},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 20, offset: 69533},
+						pos:  position{line: 2272, col: 20, offset: 69534},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 29, offset: 69542},
+						pos:  position{line: 2272, col: 29, offset: 69543},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 38, offset: 69551},
+						pos:  position{line: 2272, col: 38, offset: 69552},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2273, col: 5, offset: 69565},
+						pos:  position{line: 2273, col: 5, offset: 69566},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2273, col: 13, offset: 69573},
+						pos:  position{line: 2273, col: 13, offset: 69574},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2273, col: 20, offset: 69580},
+						pos:  position{line: 2273, col: 20, offset: 69581},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2273, col: 28, offset: 69588},
+						pos:  position{line: 2273, col: 28, offset: 69589},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2273, col: 36, offset: 69596},
+						pos:  position{line: 2273, col: 36, offset: 69597},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2273, col: 44, offset: 69604},
+						pos:  position{line: 2273, col: 44, offset: 69605},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2274, col: 5, offset: 69613},
+						pos:  position{line: 2274, col: 5, offset: 69614},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2275, col: 5, offset: 69623},
+						pos:  position{line: 2275, col: 5, offset: 69624},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2276, col: 5, offset: 69633},
+						pos:  position{line: 2276, col: 5, offset: 69634},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2277, col: 5, offset: 69643},
+						pos:  position{line: 2277, col: 5, offset: 69644},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2278, col: 5, offset: 69654},
+						pos:  position{line: 2278, col: 5, offset: 69655},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2279, col: 5, offset: 69663},
+						pos:  position{line: 2279, col: 5, offset: 69664},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2280, col: 5, offset: 69673},
+						pos:  position{line: 2280, col: 5, offset: 69674},
 						name: "ON",
 					},
 				},
@@ -16228,20 +16228,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2282, col: 1, offset: 69677},
+			pos:  position{line: 2282, col: 1, offset: 69678},
 			expr: &seqExpr{
-				pos: position{line: 2282, col: 14, offset: 69690},
+				pos: position{line: 2282, col: 14, offset: 69691},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2282, col: 14, offset: 69690},
+						pos:        position{line: 2282, col: 14, offset: 69691},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2282, col: 33, offset: 69709},
+						pos: position{line: 2282, col: 33, offset: 69710},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2282, col: 34, offset: 69710},
+							pos:  position{line: 2282, col: 34, offset: 69711},
 							name: "IdentifierRest",
 						},
 					},
@@ -16252,20 +16252,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2283, col: 1, offset: 69725},
+			pos:  position{line: 2283, col: 1, offset: 69726},
 			expr: &seqExpr{
-				pos: position{line: 2283, col: 14, offset: 69738},
+				pos: position{line: 2283, col: 14, offset: 69739},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2283, col: 14, offset: 69738},
+						pos:        position{line: 2283, col: 14, offset: 69739},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2283, col: 33, offset: 69757},
+						pos: position{line: 2283, col: 33, offset: 69758},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2283, col: 34, offset: 69758},
+							pos:  position{line: 2283, col: 34, offset: 69759},
 							name: "IdentifierRest",
 						},
 					},
@@ -16276,23 +16276,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2284, col: 1, offset: 69773},
+			pos:  position{line: 2284, col: 1, offset: 69774},
 			expr: &actionExpr{
-				pos: position{line: 2284, col: 14, offset: 69786},
+				pos: position{line: 2284, col: 14, offset: 69787},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2284, col: 14, offset: 69786},
+					pos: position{line: 2284, col: 14, offset: 69787},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2284, col: 14, offset: 69786},
+							pos:        position{line: 2284, col: 14, offset: 69787},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2284, col: 33, offset: 69805},
+							pos: position{line: 2284, col: 33, offset: 69806},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2284, col: 34, offset: 69806},
+								pos:  position{line: 2284, col: 34, offset: 69807},
 								name: "IdentifierRest",
 							},
 						},
@@ -16304,20 +16304,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2285, col: 1, offset: 69843},
+			pos:  position{line: 2285, col: 1, offset: 69844},
 			expr: &seqExpr{
-				pos: position{line: 2285, col: 14, offset: 69856},
+				pos: position{line: 2285, col: 14, offset: 69857},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2285, col: 14, offset: 69856},
+						pos:        position{line: 2285, col: 14, offset: 69857},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2285, col: 33, offset: 69875},
+						pos: position{line: 2285, col: 33, offset: 69876},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2285, col: 34, offset: 69876},
+							pos:  position{line: 2285, col: 34, offset: 69877},
 							name: "IdentifierRest",
 						},
 					},
@@ -16328,20 +16328,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2286, col: 1, offset: 69891},
+			pos:  position{line: 2286, col: 1, offset: 69892},
 			expr: &seqExpr{
-				pos: position{line: 2286, col: 14, offset: 69904},
+				pos: position{line: 2286, col: 14, offset: 69905},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2286, col: 14, offset: 69904},
+						pos:        position{line: 2286, col: 14, offset: 69905},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2286, col: 33, offset: 69923},
+						pos: position{line: 2286, col: 33, offset: 69924},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2286, col: 34, offset: 69924},
+							pos:  position{line: 2286, col: 34, offset: 69925},
 							name: "IdentifierRest",
 						},
 					},
@@ -16352,23 +16352,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2287, col: 1, offset: 69939},
+			pos:  position{line: 2287, col: 1, offset: 69940},
 			expr: &actionExpr{
-				pos: position{line: 2287, col: 14, offset: 69952},
+				pos: position{line: 2287, col: 14, offset: 69953},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2287, col: 14, offset: 69952},
+					pos: position{line: 2287, col: 14, offset: 69953},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2287, col: 14, offset: 69952},
+							pos:        position{line: 2287, col: 14, offset: 69953},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2287, col: 33, offset: 69971},
+							pos: position{line: 2287, col: 33, offset: 69972},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2287, col: 34, offset: 69972},
+								pos:  position{line: 2287, col: 34, offset: 69973},
 								name: "IdentifierRest",
 							},
 						},
@@ -16380,20 +16380,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2288, col: 1, offset: 70009},
+			pos:  position{line: 2288, col: 1, offset: 70010},
 			expr: &seqExpr{
-				pos: position{line: 2288, col: 14, offset: 70022},
+				pos: position{line: 2288, col: 14, offset: 70023},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2288, col: 14, offset: 70022},
+						pos:        position{line: 2288, col: 14, offset: 70023},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2288, col: 33, offset: 70041},
+						pos: position{line: 2288, col: 33, offset: 70042},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2288, col: 34, offset: 70042},
+							pos:  position{line: 2288, col: 34, offset: 70043},
 							name: "IdentifierRest",
 						},
 					},
@@ -16404,20 +16404,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2289, col: 1, offset: 70057},
+			pos:  position{line: 2289, col: 1, offset: 70058},
 			expr: &seqExpr{
-				pos: position{line: 2289, col: 14, offset: 70070},
+				pos: position{line: 2289, col: 14, offset: 70071},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2289, col: 14, offset: 70070},
+						pos:        position{line: 2289, col: 14, offset: 70071},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2289, col: 33, offset: 70089},
+						pos: position{line: 2289, col: 33, offset: 70090},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2289, col: 34, offset: 70090},
+							pos:  position{line: 2289, col: 34, offset: 70091},
 							name: "IdentifierRest",
 						},
 					},
@@ -16428,20 +16428,20 @@ var g = &grammar{
 		},
 		{
 			name: "AUTHOR",
-			pos:  position{line: 2290, col: 1, offset: 70105},
+			pos:  position{line: 2290, col: 1, offset: 70106},
 			expr: &seqExpr{
-				pos: position{line: 2290, col: 14, offset: 70118},
+				pos: position{line: 2290, col: 14, offset: 70119},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2290, col: 14, offset: 70118},
+						pos:        position{line: 2290, col: 14, offset: 70119},
 						val:        "author",
 						ignoreCase: true,
 						want:       "\"AUTHOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2290, col: 33, offset: 70137},
+						pos: position{line: 2290, col: 33, offset: 70138},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2290, col: 34, offset: 70138},
+							pos:  position{line: 2290, col: 34, offset: 70139},
 							name: "IdentifierRest",
 						},
 					},
@@ -16452,20 +16452,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2291, col: 1, offset: 70153},
+			pos:  position{line: 2291, col: 1, offset: 70154},
 			expr: &seqExpr{
-				pos: position{line: 2291, col: 14, offset: 70166},
+				pos: position{line: 2291, col: 14, offset: 70167},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2291, col: 14, offset: 70166},
+						pos:        position{line: 2291, col: 14, offset: 70167},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2291, col: 33, offset: 70185},
+						pos: position{line: 2291, col: 33, offset: 70186},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2291, col: 34, offset: 70186},
+							pos:  position{line: 2291, col: 34, offset: 70187},
 							name: "IdentifierRest",
 						},
 					},
@@ -16476,20 +16476,20 @@ var g = &grammar{
 		},
 		{
 			name: "BODY",
-			pos:  position{line: 2292, col: 1, offset: 70201},
+			pos:  position{line: 2292, col: 1, offset: 70202},
 			expr: &seqExpr{
-				pos: position{line: 2292, col: 14, offset: 70214},
+				pos: position{line: 2292, col: 14, offset: 70215},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2292, col: 14, offset: 70214},
+						pos:        position{line: 2292, col: 14, offset: 70215},
 						val:        "body",
 						ignoreCase: true,
 						want:       "\"BODY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2292, col: 33, offset: 70233},
+						pos: position{line: 2292, col: 33, offset: 70234},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2292, col: 34, offset: 70234},
+							pos:  position{line: 2292, col: 34, offset: 70235},
 							name: "IdentifierRest",
 						},
 					},
@@ -16500,20 +16500,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2293, col: 1, offset: 70249},
+			pos:  position{line: 2293, col: 1, offset: 70250},
 			expr: &seqExpr{
-				pos: position{line: 2293, col: 14, offset: 70262},
+				pos: position{line: 2293, col: 14, offset: 70263},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2293, col: 14, offset: 70262},
+						pos:        position{line: 2293, col: 14, offset: 70263},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2293, col: 33, offset: 70281},
+						pos: position{line: 2293, col: 33, offset: 70282},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2293, col: 34, offset: 70282},
+							pos:  position{line: 2293, col: 34, offset: 70283},
 							name: "IdentifierRest",
 						},
 					},
@@ -16524,20 +16524,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2294, col: 1, offset: 70297},
+			pos:  position{line: 2294, col: 1, offset: 70298},
 			expr: &seqExpr{
-				pos: position{line: 2294, col: 14, offset: 70310},
+				pos: position{line: 2294, col: 14, offset: 70311},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2294, col: 14, offset: 70310},
+						pos:        position{line: 2294, col: 14, offset: 70311},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2294, col: 33, offset: 70329},
+						pos: position{line: 2294, col: 33, offset: 70330},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2294, col: 34, offset: 70330},
+							pos:  position{line: 2294, col: 34, offset: 70331},
 							name: "IdentifierRest",
 						},
 					},
@@ -16548,20 +16548,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2295, col: 1, offset: 70345},
+			pos:  position{line: 2295, col: 1, offset: 70346},
 			expr: &seqExpr{
-				pos: position{line: 2295, col: 14, offset: 70358},
+				pos: position{line: 2295, col: 14, offset: 70359},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2295, col: 14, offset: 70358},
+						pos:        position{line: 2295, col: 14, offset: 70359},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2295, col: 33, offset: 70377},
+						pos: position{line: 2295, col: 33, offset: 70378},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2295, col: 34, offset: 70378},
+							pos:  position{line: 2295, col: 34, offset: 70379},
 							name: "IdentifierRest",
 						},
 					},
@@ -16572,20 +16572,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2296, col: 1, offset: 70393},
+			pos:  position{line: 2296, col: 1, offset: 70394},
 			expr: &seqExpr{
-				pos: position{line: 2296, col: 14, offset: 70406},
+				pos: position{line: 2296, col: 14, offset: 70407},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2296, col: 14, offset: 70406},
+						pos:        position{line: 2296, col: 14, offset: 70407},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2296, col: 33, offset: 70425},
+						pos: position{line: 2296, col: 33, offset: 70426},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2296, col: 34, offset: 70426},
+							pos:  position{line: 2296, col: 34, offset: 70427},
 							name: "IdentifierRest",
 						},
 					},
@@ -16596,20 +16596,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2297, col: 1, offset: 70441},
+			pos:  position{line: 2297, col: 1, offset: 70442},
 			expr: &seqExpr{
-				pos: position{line: 2297, col: 14, offset: 70454},
+				pos: position{line: 2297, col: 14, offset: 70455},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2297, col: 14, offset: 70454},
+						pos:        position{line: 2297, col: 14, offset: 70455},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2297, col: 33, offset: 70473},
+						pos: position{line: 2297, col: 33, offset: 70474},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2297, col: 34, offset: 70474},
+							pos:  position{line: 2297, col: 34, offset: 70475},
 							name: "IdentifierRest",
 						},
 					},
@@ -16620,20 +16620,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2298, col: 1, offset: 70489},
+			pos:  position{line: 2298, col: 1, offset: 70490},
 			expr: &seqExpr{
-				pos: position{line: 2298, col: 14, offset: 70502},
+				pos: position{line: 2298, col: 14, offset: 70503},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2298, col: 14, offset: 70502},
+						pos:        position{line: 2298, col: 14, offset: 70503},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2298, col: 33, offset: 70521},
+						pos: position{line: 2298, col: 33, offset: 70522},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2298, col: 34, offset: 70522},
+							pos:  position{line: 2298, col: 34, offset: 70523},
 							name: "IdentifierRest",
 						},
 					},
@@ -16644,20 +16644,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2299, col: 1, offset: 70537},
+			pos:  position{line: 2299, col: 1, offset: 70538},
 			expr: &seqExpr{
-				pos: position{line: 2299, col: 14, offset: 70550},
+				pos: position{line: 2299, col: 14, offset: 70551},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2299, col: 14, offset: 70550},
+						pos:        position{line: 2299, col: 14, offset: 70551},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2299, col: 33, offset: 70569},
+						pos: position{line: 2299, col: 33, offset: 70570},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2299, col: 34, offset: 70570},
+							pos:  position{line: 2299, col: 34, offset: 70571},
 							name: "IdentifierRest",
 						},
 					},
@@ -16668,23 +16668,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2300, col: 1, offset: 70585},
+			pos:  position{line: 2300, col: 1, offset: 70586},
 			expr: &actionExpr{
-				pos: position{line: 2300, col: 14, offset: 70598},
+				pos: position{line: 2300, col: 14, offset: 70599},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2300, col: 14, offset: 70598},
+					pos: position{line: 2300, col: 14, offset: 70599},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2300, col: 14, offset: 70598},
+							pos:        position{line: 2300, col: 14, offset: 70599},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2300, col: 33, offset: 70617},
+							pos: position{line: 2300, col: 33, offset: 70618},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2300, col: 34, offset: 70618},
+								pos:  position{line: 2300, col: 34, offset: 70619},
 								name: "IdentifierRest",
 							},
 						},
@@ -16696,20 +16696,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2301, col: 1, offset: 70656},
+			pos:  position{line: 2301, col: 1, offset: 70657},
 			expr: &seqExpr{
-				pos: position{line: 2301, col: 14, offset: 70669},
+				pos: position{line: 2301, col: 14, offset: 70670},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2301, col: 14, offset: 70669},
+						pos:        position{line: 2301, col: 14, offset: 70670},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2301, col: 33, offset: 70688},
+						pos: position{line: 2301, col: 33, offset: 70689},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2301, col: 34, offset: 70689},
+							pos:  position{line: 2301, col: 34, offset: 70690},
 							name: "IdentifierRest",
 						},
 					},
@@ -16720,20 +16720,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2302, col: 1, offset: 70704},
+			pos:  position{line: 2302, col: 1, offset: 70705},
 			expr: &seqExpr{
-				pos: position{line: 2302, col: 14, offset: 70717},
+				pos: position{line: 2302, col: 14, offset: 70718},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2302, col: 14, offset: 70717},
+						pos:        position{line: 2302, col: 14, offset: 70718},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2302, col: 33, offset: 70736},
+						pos: position{line: 2302, col: 33, offset: 70737},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2302, col: 34, offset: 70737},
+							pos:  position{line: 2302, col: 34, offset: 70738},
 							name: "IdentifierRest",
 						},
 					},
@@ -16744,23 +16744,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2303, col: 1, offset: 70752},
+			pos:  position{line: 2303, col: 1, offset: 70753},
 			expr: &actionExpr{
-				pos: position{line: 2303, col: 14, offset: 70765},
+				pos: position{line: 2303, col: 14, offset: 70766},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2303, col: 14, offset: 70765},
+					pos: position{line: 2303, col: 14, offset: 70766},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2303, col: 14, offset: 70765},
+							pos:        position{line: 2303, col: 14, offset: 70766},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2303, col: 33, offset: 70784},
+							pos: position{line: 2303, col: 33, offset: 70785},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2303, col: 34, offset: 70785},
+								pos:  position{line: 2303, col: 34, offset: 70786},
 								name: "IdentifierRest",
 							},
 						},
@@ -16772,20 +16772,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2304, col: 1, offset: 70823},
+			pos:  position{line: 2304, col: 1, offset: 70824},
 			expr: &seqExpr{
-				pos: position{line: 2304, col: 14, offset: 70836},
+				pos: position{line: 2304, col: 14, offset: 70837},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2304, col: 14, offset: 70836},
+						pos:        position{line: 2304, col: 14, offset: 70837},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2304, col: 33, offset: 70855},
+						pos: position{line: 2304, col: 33, offset: 70856},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2304, col: 34, offset: 70856},
+							pos:  position{line: 2304, col: 34, offset: 70857},
 							name: "IdentifierRest",
 						},
 					},
@@ -16796,20 +16796,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2305, col: 1, offset: 70871},
+			pos:  position{line: 2305, col: 1, offset: 70872},
 			expr: &seqExpr{
-				pos: position{line: 2305, col: 14, offset: 70884},
+				pos: position{line: 2305, col: 14, offset: 70885},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2305, col: 14, offset: 70884},
+						pos:        position{line: 2305, col: 14, offset: 70885},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2305, col: 33, offset: 70903},
+						pos: position{line: 2305, col: 33, offset: 70904},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2305, col: 34, offset: 70904},
+							pos:  position{line: 2305, col: 34, offset: 70905},
 							name: "IdentifierRest",
 						},
 					},
@@ -16820,20 +16820,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2306, col: 1, offset: 70920},
+			pos:  position{line: 2306, col: 1, offset: 70921},
 			expr: &seqExpr{
-				pos: position{line: 2306, col: 14, offset: 70933},
+				pos: position{line: 2306, col: 14, offset: 70934},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2306, col: 14, offset: 70933},
+						pos:        position{line: 2306, col: 14, offset: 70934},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2306, col: 33, offset: 70952},
+						pos: position{line: 2306, col: 33, offset: 70953},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2306, col: 34, offset: 70953},
+							pos:  position{line: 2306, col: 34, offset: 70954},
 							name: "IdentifierRest",
 						},
 					},
@@ -16844,20 +16844,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2307, col: 1, offset: 70968},
+			pos:  position{line: 2307, col: 1, offset: 70969},
 			expr: &seqExpr{
-				pos: position{line: 2307, col: 14, offset: 70981},
+				pos: position{line: 2307, col: 14, offset: 70982},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2307, col: 14, offset: 70981},
+						pos:        position{line: 2307, col: 14, offset: 70982},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2307, col: 33, offset: 71000},
+						pos: position{line: 2307, col: 33, offset: 71001},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2307, col: 34, offset: 71001},
+							pos:  position{line: 2307, col: 34, offset: 71002},
 							name: "IdentifierRest",
 						},
 					},
@@ -16868,20 +16868,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2308, col: 1, offset: 71016},
+			pos:  position{line: 2308, col: 1, offset: 71017},
 			expr: &seqExpr{
-				pos: position{line: 2308, col: 14, offset: 71029},
+				pos: position{line: 2308, col: 14, offset: 71030},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2308, col: 14, offset: 71029},
+						pos:        position{line: 2308, col: 14, offset: 71030},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2308, col: 33, offset: 71048},
+						pos: position{line: 2308, col: 33, offset: 71049},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2308, col: 34, offset: 71049},
+							pos:  position{line: 2308, col: 34, offset: 71050},
 							name: "IdentifierRest",
 						},
 					},
@@ -16892,20 +16892,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2309, col: 1, offset: 71064},
+			pos:  position{line: 2309, col: 1, offset: 71065},
 			expr: &seqExpr{
-				pos: position{line: 2309, col: 14, offset: 71077},
+				pos: position{line: 2309, col: 14, offset: 71078},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2309, col: 14, offset: 71077},
+						pos:        position{line: 2309, col: 14, offset: 71078},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2309, col: 33, offset: 71096},
+						pos: position{line: 2309, col: 33, offset: 71097},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2309, col: 34, offset: 71097},
+							pos:  position{line: 2309, col: 34, offset: 71098},
 							name: "IdentifierRest",
 						},
 					},
@@ -16916,20 +16916,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2310, col: 1, offset: 71112},
+			pos:  position{line: 2310, col: 1, offset: 71113},
 			expr: &seqExpr{
-				pos: position{line: 2310, col: 14, offset: 71125},
+				pos: position{line: 2310, col: 14, offset: 71126},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2310, col: 14, offset: 71125},
+						pos:        position{line: 2310, col: 14, offset: 71126},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2310, col: 33, offset: 71144},
+						pos: position{line: 2310, col: 33, offset: 71145},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2310, col: 34, offset: 71145},
+							pos:  position{line: 2310, col: 34, offset: 71146},
 							name: "IdentifierRest",
 						},
 					},
@@ -16940,20 +16940,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2311, col: 1, offset: 71160},
+			pos:  position{line: 2311, col: 1, offset: 71161},
 			expr: &seqExpr{
-				pos: position{line: 2311, col: 14, offset: 71173},
+				pos: position{line: 2311, col: 14, offset: 71174},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2311, col: 14, offset: 71173},
+						pos:        position{line: 2311, col: 14, offset: 71174},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2311, col: 33, offset: 71192},
+						pos: position{line: 2311, col: 33, offset: 71193},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2311, col: 34, offset: 71193},
+							pos:  position{line: 2311, col: 34, offset: 71194},
 							name: "IdentifierRest",
 						},
 					},
@@ -16964,20 +16964,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2312, col: 1, offset: 71208},
+			pos:  position{line: 2312, col: 1, offset: 71209},
 			expr: &seqExpr{
-				pos: position{line: 2312, col: 14, offset: 71221},
+				pos: position{line: 2312, col: 14, offset: 71222},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2312, col: 14, offset: 71221},
+						pos:        position{line: 2312, col: 14, offset: 71222},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2312, col: 33, offset: 71240},
+						pos: position{line: 2312, col: 33, offset: 71241},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2312, col: 34, offset: 71241},
+							pos:  position{line: 2312, col: 34, offset: 71242},
 							name: "IdentifierRest",
 						},
 					},
@@ -16988,20 +16988,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2313, col: 1, offset: 71256},
+			pos:  position{line: 2313, col: 1, offset: 71257},
 			expr: &seqExpr{
-				pos: position{line: 2313, col: 14, offset: 71269},
+				pos: position{line: 2313, col: 14, offset: 71270},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2313, col: 14, offset: 71269},
+						pos:        position{line: 2313, col: 14, offset: 71270},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2313, col: 33, offset: 71288},
+						pos: position{line: 2313, col: 33, offset: 71289},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2313, col: 34, offset: 71289},
+							pos:  position{line: 2313, col: 34, offset: 71290},
 							name: "IdentifierRest",
 						},
 					},
@@ -17012,20 +17012,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2314, col: 1, offset: 71304},
+			pos:  position{line: 2314, col: 1, offset: 71305},
 			expr: &seqExpr{
-				pos: position{line: 2314, col: 14, offset: 71317},
+				pos: position{line: 2314, col: 14, offset: 71318},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2314, col: 14, offset: 71317},
+						pos:        position{line: 2314, col: 14, offset: 71318},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2314, col: 33, offset: 71336},
+						pos: position{line: 2314, col: 33, offset: 71337},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2314, col: 34, offset: 71337},
+							pos:  position{line: 2314, col: 34, offset: 71338},
 							name: "IdentifierRest",
 						},
 					},
@@ -17036,20 +17036,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2315, col: 1, offset: 71352},
+			pos:  position{line: 2315, col: 1, offset: 71353},
 			expr: &seqExpr{
-				pos: position{line: 2315, col: 14, offset: 71365},
+				pos: position{line: 2315, col: 14, offset: 71366},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2315, col: 14, offset: 71365},
+						pos:        position{line: 2315, col: 14, offset: 71366},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2315, col: 33, offset: 71384},
+						pos: position{line: 2315, col: 33, offset: 71385},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2315, col: 34, offset: 71385},
+							pos:  position{line: 2315, col: 34, offset: 71386},
 							name: "IdentifierRest",
 						},
 					},
@@ -17060,20 +17060,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORMAT",
-			pos:  position{line: 2316, col: 1, offset: 71400},
+			pos:  position{line: 2316, col: 1, offset: 71401},
 			expr: &seqExpr{
-				pos: position{line: 2316, col: 14, offset: 71413},
+				pos: position{line: 2316, col: 14, offset: 71414},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2316, col: 14, offset: 71413},
+						pos:        position{line: 2316, col: 14, offset: 71414},
 						val:        "format",
 						ignoreCase: true,
 						want:       "\"FORMAT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2316, col: 33, offset: 71432},
+						pos: position{line: 2316, col: 33, offset: 71433},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2316, col: 34, offset: 71433},
+							pos:  position{line: 2316, col: 34, offset: 71434},
 							name: "IdentifierRest",
 						},
 					},
@@ -17084,20 +17084,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2317, col: 1, offset: 71448},
+			pos:  position{line: 2317, col: 1, offset: 71449},
 			expr: &seqExpr{
-				pos: position{line: 2317, col: 14, offset: 71461},
+				pos: position{line: 2317, col: 14, offset: 71462},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2317, col: 14, offset: 71461},
+						pos:        position{line: 2317, col: 14, offset: 71462},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2317, col: 33, offset: 71480},
+						pos: position{line: 2317, col: 33, offset: 71481},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2317, col: 34, offset: 71481},
+							pos:  position{line: 2317, col: 34, offset: 71482},
 							name: "IdentifierRest",
 						},
 					},
@@ -17108,20 +17108,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2318, col: 1, offset: 71496},
+			pos:  position{line: 2318, col: 1, offset: 71497},
 			expr: &seqExpr{
-				pos: position{line: 2318, col: 14, offset: 71509},
+				pos: position{line: 2318, col: 14, offset: 71510},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2318, col: 14, offset: 71509},
+						pos:        position{line: 2318, col: 14, offset: 71510},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2318, col: 33, offset: 71528},
+						pos: position{line: 2318, col: 33, offset: 71529},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2318, col: 34, offset: 71529},
+							pos:  position{line: 2318, col: 34, offset: 71530},
 							name: "IdentifierRest",
 						},
 					},
@@ -17132,20 +17132,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2319, col: 1, offset: 71544},
+			pos:  position{line: 2319, col: 1, offset: 71545},
 			expr: &seqExpr{
-				pos: position{line: 2319, col: 14, offset: 71557},
+				pos: position{line: 2319, col: 14, offset: 71558},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2319, col: 14, offset: 71557},
+						pos:        position{line: 2319, col: 14, offset: 71558},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2319, col: 33, offset: 71576},
+						pos: position{line: 2319, col: 33, offset: 71577},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2319, col: 34, offset: 71577},
+							pos:  position{line: 2319, col: 34, offset: 71578},
 							name: "IdentifierRest",
 						},
 					},
@@ -17156,20 +17156,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2320, col: 1, offset: 71592},
+			pos:  position{line: 2320, col: 1, offset: 71593},
 			expr: &seqExpr{
-				pos: position{line: 2320, col: 14, offset: 71605},
+				pos: position{line: 2320, col: 14, offset: 71606},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2320, col: 14, offset: 71605},
+						pos:        position{line: 2320, col: 14, offset: 71606},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2320, col: 33, offset: 71624},
+						pos: position{line: 2320, col: 33, offset: 71625},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2320, col: 34, offset: 71625},
+							pos:  position{line: 2320, col: 34, offset: 71626},
 							name: "IdentifierRest",
 						},
 					},
@@ -17180,20 +17180,20 @@ var g = &grammar{
 		},
 		{
 			name: "GREP",
-			pos:  position{line: 2321, col: 1, offset: 71640},
+			pos:  position{line: 2321, col: 1, offset: 71641},
 			expr: &seqExpr{
-				pos: position{line: 2321, col: 14, offset: 71653},
+				pos: position{line: 2321, col: 14, offset: 71654},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2321, col: 14, offset: 71653},
+						pos:        position{line: 2321, col: 14, offset: 71654},
 						val:        "grep",
 						ignoreCase: true,
 						want:       "\"GREP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2321, col: 33, offset: 71672},
+						pos: position{line: 2321, col: 33, offset: 71673},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2321, col: 34, offset: 71673},
+							pos:  position{line: 2321, col: 34, offset: 71674},
 							name: "IdentifierRest",
 						},
 					},
@@ -17204,20 +17204,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2322, col: 1, offset: 71688},
+			pos:  position{line: 2322, col: 1, offset: 71689},
 			expr: &seqExpr{
-				pos: position{line: 2322, col: 14, offset: 71701},
+				pos: position{line: 2322, col: 14, offset: 71702},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2322, col: 14, offset: 71701},
+						pos:        position{line: 2322, col: 14, offset: 71702},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2322, col: 33, offset: 71720},
+						pos: position{line: 2322, col: 33, offset: 71721},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2322, col: 34, offset: 71721},
+							pos:  position{line: 2322, col: 34, offset: 71722},
 							name: "IdentifierRest",
 						},
 					},
@@ -17228,20 +17228,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2323, col: 1, offset: 71736},
+			pos:  position{line: 2323, col: 1, offset: 71737},
 			expr: &seqExpr{
-				pos: position{line: 2323, col: 14, offset: 71749},
+				pos: position{line: 2323, col: 14, offset: 71750},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2323, col: 14, offset: 71749},
+						pos:        position{line: 2323, col: 14, offset: 71750},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2323, col: 33, offset: 71768},
+						pos: position{line: 2323, col: 33, offset: 71769},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2323, col: 34, offset: 71769},
+							pos:  position{line: 2323, col: 34, offset: 71770},
 							name: "IdentifierRest",
 						},
 					},
@@ -17252,20 +17252,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2324, col: 1, offset: 71784},
+			pos:  position{line: 2324, col: 1, offset: 71785},
 			expr: &seqExpr{
-				pos: position{line: 2324, col: 14, offset: 71797},
+				pos: position{line: 2324, col: 14, offset: 71798},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2324, col: 14, offset: 71797},
+						pos:        position{line: 2324, col: 14, offset: 71798},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2324, col: 33, offset: 71816},
+						pos: position{line: 2324, col: 33, offset: 71817},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2324, col: 34, offset: 71817},
+							pos:  position{line: 2324, col: 34, offset: 71818},
 							name: "IdentifierRest",
 						},
 					},
@@ -17276,20 +17276,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEADERS",
-			pos:  position{line: 2325, col: 1, offset: 71833},
+			pos:  position{line: 2325, col: 1, offset: 71834},
 			expr: &seqExpr{
-				pos: position{line: 2325, col: 14, offset: 71846},
+				pos: position{line: 2325, col: 14, offset: 71847},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2325, col: 14, offset: 71846},
+						pos:        position{line: 2325, col: 14, offset: 71847},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"HEADERS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2325, col: 33, offset: 71865},
+						pos: position{line: 2325, col: 33, offset: 71866},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2325, col: 34, offset: 71866},
+							pos:  position{line: 2325, col: 34, offset: 71867},
 							name: "IdentifierRest",
 						},
 					},
@@ -17300,20 +17300,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2326, col: 1, offset: 71881},
+			pos:  position{line: 2326, col: 1, offset: 71882},
 			expr: &seqExpr{
-				pos: position{line: 2326, col: 14, offset: 71894},
+				pos: position{line: 2326, col: 14, offset: 71895},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2326, col: 14, offset: 71894},
+						pos:        position{line: 2326, col: 14, offset: 71895},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2326, col: 33, offset: 71913},
+						pos: position{line: 2326, col: 33, offset: 71914},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2326, col: 34, offset: 71914},
+							pos:  position{line: 2326, col: 34, offset: 71915},
 							name: "IdentifierRest",
 						},
 					},
@@ -17324,20 +17324,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2327, col: 1, offset: 71929},
+			pos:  position{line: 2327, col: 1, offset: 71930},
 			expr: &seqExpr{
-				pos: position{line: 2327, col: 14, offset: 71942},
+				pos: position{line: 2327, col: 14, offset: 71943},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2327, col: 14, offset: 71942},
+						pos:        position{line: 2327, col: 14, offset: 71943},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2327, col: 33, offset: 71961},
+						pos: position{line: 2327, col: 33, offset: 71962},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2327, col: 34, offset: 71962},
+							pos:  position{line: 2327, col: 34, offset: 71963},
 							name: "IdentifierRest",
 						},
 					},
@@ -17348,20 +17348,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2328, col: 1, offset: 71977},
+			pos:  position{line: 2328, col: 1, offset: 71978},
 			expr: &seqExpr{
-				pos: position{line: 2328, col: 14, offset: 71990},
+				pos: position{line: 2328, col: 14, offset: 71991},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2328, col: 14, offset: 71990},
+						pos:        position{line: 2328, col: 14, offset: 71991},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2328, col: 33, offset: 72009},
+						pos: position{line: 2328, col: 33, offset: 72010},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2328, col: 34, offset: 72010},
+							pos:  position{line: 2328, col: 34, offset: 72011},
 							name: "IdentifierRest",
 						},
 					},
@@ -17372,20 +17372,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2329, col: 1, offset: 72025},
+			pos:  position{line: 2329, col: 1, offset: 72026},
 			expr: &seqExpr{
-				pos: position{line: 2329, col: 14, offset: 72038},
+				pos: position{line: 2329, col: 14, offset: 72039},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2329, col: 14, offset: 72038},
+						pos:        position{line: 2329, col: 14, offset: 72039},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2329, col: 33, offset: 72057},
+						pos: position{line: 2329, col: 33, offset: 72058},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2329, col: 34, offset: 72058},
+							pos:  position{line: 2329, col: 34, offset: 72059},
 							name: "IdentifierRest",
 						},
 					},
@@ -17396,20 +17396,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2330, col: 1, offset: 72073},
+			pos:  position{line: 2330, col: 1, offset: 72074},
 			expr: &seqExpr{
-				pos: position{line: 2330, col: 14, offset: 72086},
+				pos: position{line: 2330, col: 14, offset: 72087},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2330, col: 14, offset: 72086},
+						pos:        position{line: 2330, col: 14, offset: 72087},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2330, col: 33, offset: 72105},
+						pos: position{line: 2330, col: 33, offset: 72106},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2330, col: 34, offset: 72106},
+							pos:  position{line: 2330, col: 34, offset: 72107},
 							name: "IdentifierRest",
 						},
 					},
@@ -17420,20 +17420,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2331, col: 1, offset: 72121},
+			pos:  position{line: 2331, col: 1, offset: 72122},
 			expr: &seqExpr{
-				pos: position{line: 2331, col: 14, offset: 72134},
+				pos: position{line: 2331, col: 14, offset: 72135},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2331, col: 14, offset: 72134},
+						pos:        position{line: 2331, col: 14, offset: 72135},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2331, col: 33, offset: 72153},
+						pos: position{line: 2331, col: 33, offset: 72154},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2331, col: 34, offset: 72154},
+							pos:  position{line: 2331, col: 34, offset: 72155},
 							name: "IdentifierRest",
 						},
 					},
@@ -17444,20 +17444,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2332, col: 1, offset: 72169},
+			pos:  position{line: 2332, col: 1, offset: 72170},
 			expr: &seqExpr{
-				pos: position{line: 2332, col: 14, offset: 72182},
+				pos: position{line: 2332, col: 14, offset: 72183},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2332, col: 14, offset: 72182},
+						pos:        position{line: 2332, col: 14, offset: 72183},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2332, col: 32, offset: 72200},
+						pos: position{line: 2332, col: 32, offset: 72201},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2332, col: 33, offset: 72201},
+							pos:  position{line: 2332, col: 33, offset: 72202},
 							name: "IdentifierRest",
 						},
 					},
@@ -17468,20 +17468,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2333, col: 1, offset: 72216},
+			pos:  position{line: 2333, col: 1, offset: 72217},
 			expr: &seqExpr{
-				pos: position{line: 2333, col: 14, offset: 72229},
+				pos: position{line: 2333, col: 14, offset: 72230},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2333, col: 14, offset: 72229},
+						pos:        position{line: 2333, col: 14, offset: 72230},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2333, col: 33, offset: 72248},
+						pos: position{line: 2333, col: 33, offset: 72249},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2333, col: 34, offset: 72249},
+							pos:  position{line: 2333, col: 34, offset: 72250},
 							name: "IdentifierRest",
 						},
 					},
@@ -17492,20 +17492,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2334, col: 1, offset: 72264},
+			pos:  position{line: 2334, col: 1, offset: 72265},
 			expr: &seqExpr{
-				pos: position{line: 2334, col: 14, offset: 72277},
+				pos: position{line: 2334, col: 14, offset: 72278},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2334, col: 14, offset: 72277},
+						pos:        position{line: 2334, col: 14, offset: 72278},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2334, col: 33, offset: 72296},
+						pos: position{line: 2334, col: 33, offset: 72297},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2334, col: 34, offset: 72297},
+							pos:  position{line: 2334, col: 34, offset: 72298},
 							name: "IdentifierRest",
 						},
 					},
@@ -17516,20 +17516,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2335, col: 1, offset: 72312},
+			pos:  position{line: 2335, col: 1, offset: 72313},
 			expr: &seqExpr{
-				pos: position{line: 2335, col: 16, offset: 72327},
+				pos: position{line: 2335, col: 16, offset: 72328},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2335, col: 16, offset: 72327},
+						pos:        position{line: 2335, col: 16, offset: 72328},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2335, col: 33, offset: 72344},
+						pos: position{line: 2335, col: 33, offset: 72345},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2335, col: 34, offset: 72345},
+							pos:  position{line: 2335, col: 34, offset: 72346},
 							name: "IdentifierRest",
 						},
 					},
@@ -17540,20 +17540,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2336, col: 1, offset: 72360},
+			pos:  position{line: 2336, col: 1, offset: 72361},
 			expr: &seqExpr{
-				pos: position{line: 2336, col: 14, offset: 72373},
+				pos: position{line: 2336, col: 14, offset: 72374},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2336, col: 14, offset: 72373},
+						pos:        position{line: 2336, col: 14, offset: 72374},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2336, col: 33, offset: 72392},
+						pos: position{line: 2336, col: 33, offset: 72393},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2336, col: 34, offset: 72393},
+							pos:  position{line: 2336, col: 34, offset: 72394},
 							name: "IdentifierRest",
 						},
 					},
@@ -17564,20 +17564,20 @@ var g = &grammar{
 		},
 		{
 			name: "MESSAGE",
-			pos:  position{line: 2337, col: 1, offset: 72408},
+			pos:  position{line: 2337, col: 1, offset: 72409},
 			expr: &seqExpr{
-				pos: position{line: 2337, col: 14, offset: 72421},
+				pos: position{line: 2337, col: 14, offset: 72422},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2337, col: 14, offset: 72421},
+						pos:        position{line: 2337, col: 14, offset: 72422},
 						val:        "message",
 						ignoreCase: true,
 						want:       "\"MESSAGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2337, col: 33, offset: 72440},
+						pos: position{line: 2337, col: 33, offset: 72441},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2337, col: 34, offset: 72441},
+							pos:  position{line: 2337, col: 34, offset: 72442},
 							name: "IdentifierRest",
 						},
 					},
@@ -17588,20 +17588,20 @@ var g = &grammar{
 		},
 		{
 			name: "META",
-			pos:  position{line: 2338, col: 1, offset: 72456},
+			pos:  position{line: 2338, col: 1, offset: 72457},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 72469},
+				pos: position{line: 2338, col: 14, offset: 72470},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 72469},
+						pos:        position{line: 2338, col: 14, offset: 72470},
 						val:        "meta",
 						ignoreCase: true,
 						want:       "\"META\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 72488},
+						pos: position{line: 2338, col: 33, offset: 72489},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 72489},
+							pos:  position{line: 2338, col: 34, offset: 72490},
 							name: "IdentifierRest",
 						},
 					},
@@ -17612,20 +17612,20 @@ var g = &grammar{
 		},
 		{
 			name: "METHOD",
-			pos:  position{line: 2339, col: 1, offset: 72504},
+			pos:  position{line: 2339, col: 1, offset: 72505},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 72517},
+				pos: position{line: 2339, col: 14, offset: 72518},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 72517},
+						pos:        position{line: 2339, col: 14, offset: 72518},
 						val:        "method",
 						ignoreCase: true,
 						want:       "\"METHOD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 72536},
+						pos: position{line: 2339, col: 33, offset: 72537},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 72537},
+							pos:  position{line: 2339, col: 34, offset: 72538},
 							name: "IdentifierRest",
 						},
 					},
@@ -17636,20 +17636,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2340, col: 1, offset: 72552},
+			pos:  position{line: 2340, col: 1, offset: 72553},
 			expr: &seqExpr{
-				pos: position{line: 2340, col: 14, offset: 72565},
+				pos: position{line: 2340, col: 14, offset: 72566},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2340, col: 14, offset: 72565},
+						pos:        position{line: 2340, col: 14, offset: 72566},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2340, col: 33, offset: 72584},
+						pos: position{line: 2340, col: 33, offset: 72585},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2340, col: 34, offset: 72585},
+							pos:  position{line: 2340, col: 34, offset: 72586},
 							name: "IdentifierRest",
 						},
 					},
@@ -17660,20 +17660,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2341, col: 1, offset: 72600},
+			pos:  position{line: 2341, col: 1, offset: 72601},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 72613},
+				pos: position{line: 2341, col: 14, offset: 72614},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 72613},
+						pos:        position{line: 2341, col: 14, offset: 72614},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 72632},
+						pos: position{line: 2341, col: 33, offset: 72633},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 72633},
+							pos:  position{line: 2341, col: 34, offset: 72634},
 							name: "IdentifierRest",
 						},
 					},
@@ -17684,20 +17684,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2342, col: 1, offset: 72648},
+			pos:  position{line: 2342, col: 1, offset: 72649},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 72661},
+				pos: position{line: 2342, col: 14, offset: 72662},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 72661},
+						pos:        position{line: 2342, col: 14, offset: 72662},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 72680},
+						pos: position{line: 2342, col: 33, offset: 72681},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 72681},
+							pos:  position{line: 2342, col: 34, offset: 72682},
 							name: "IdentifierRest",
 						},
 					},
@@ -17708,20 +17708,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2343, col: 1, offset: 72696},
+			pos:  position{line: 2343, col: 1, offset: 72697},
 			expr: &seqExpr{
-				pos: position{line: 2343, col: 14, offset: 72709},
+				pos: position{line: 2343, col: 14, offset: 72710},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2343, col: 14, offset: 72709},
+						pos:        position{line: 2343, col: 14, offset: 72710},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2343, col: 33, offset: 72728},
+						pos: position{line: 2343, col: 33, offset: 72729},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2343, col: 34, offset: 72729},
+							pos:  position{line: 2343, col: 34, offset: 72730},
 							name: "IdentifierRest",
 						},
 					},
@@ -17732,20 +17732,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2344, col: 1, offset: 72744},
+			pos:  position{line: 2344, col: 1, offset: 72745},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 72757},
+				pos: position{line: 2344, col: 14, offset: 72758},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 72757},
+						pos:        position{line: 2344, col: 14, offset: 72758},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 72776},
+						pos: position{line: 2344, col: 33, offset: 72777},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 72777},
+							pos:  position{line: 2344, col: 34, offset: 72778},
 							name: "IdentifierRest",
 						},
 					},
@@ -17756,20 +17756,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2345, col: 1, offset: 72792},
+			pos:  position{line: 2345, col: 1, offset: 72793},
 			expr: &seqExpr{
-				pos: position{line: 2345, col: 14, offset: 72805},
+				pos: position{line: 2345, col: 14, offset: 72806},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2345, col: 14, offset: 72805},
+						pos:        position{line: 2345, col: 14, offset: 72806},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2345, col: 33, offset: 72824},
+						pos: position{line: 2345, col: 33, offset: 72825},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2345, col: 34, offset: 72825},
+							pos:  position{line: 2345, col: 34, offset: 72826},
 							name: "IdentifierRest",
 						},
 					},
@@ -17780,23 +17780,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2346, col: 1, offset: 72840},
+			pos:  position{line: 2346, col: 1, offset: 72841},
 			expr: &actionExpr{
-				pos: position{line: 2346, col: 14, offset: 72853},
+				pos: position{line: 2346, col: 14, offset: 72854},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2346, col: 14, offset: 72853},
+					pos: position{line: 2346, col: 14, offset: 72854},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2346, col: 14, offset: 72853},
+							pos:        position{line: 2346, col: 14, offset: 72854},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2346, col: 33, offset: 72872},
+							pos: position{line: 2346, col: 33, offset: 72873},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2346, col: 34, offset: 72873},
+								pos:  position{line: 2346, col: 34, offset: 72874},
 								name: "IdentifierRest",
 							},
 						},
@@ -17808,20 +17808,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2347, col: 1, offset: 72909},
+			pos:  position{line: 2347, col: 1, offset: 72910},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 72922},
+				pos: position{line: 2347, col: 14, offset: 72923},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 72922},
+						pos:        position{line: 2347, col: 14, offset: 72923},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 72941},
+						pos: position{line: 2347, col: 33, offset: 72942},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 72942},
+							pos:  position{line: 2347, col: 34, offset: 72943},
 							name: "IdentifierRest",
 						},
 					},
@@ -17832,20 +17832,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2348, col: 1, offset: 72957},
+			pos:  position{line: 2348, col: 1, offset: 72958},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 72970},
+				pos: position{line: 2348, col: 14, offset: 72971},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 72970},
+						pos:        position{line: 2348, col: 14, offset: 72971},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 72989},
+						pos: position{line: 2348, col: 33, offset: 72990},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 72990},
+							pos:  position{line: 2348, col: 34, offset: 72991},
 							name: "IdentifierRest",
 						},
 					},
@@ -17856,20 +17856,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2349, col: 1, offset: 73005},
+			pos:  position{line: 2349, col: 1, offset: 73006},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 73018},
+				pos: position{line: 2349, col: 14, offset: 73019},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 73018},
+						pos:        position{line: 2349, col: 14, offset: 73019},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 73037},
+						pos: position{line: 2349, col: 33, offset: 73038},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 73038},
+							pos:  position{line: 2349, col: 34, offset: 73039},
 							name: "IdentifierRest",
 						},
 					},
@@ -17880,20 +17880,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2350, col: 1, offset: 73053},
+			pos:  position{line: 2350, col: 1, offset: 73054},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 73066},
+				pos: position{line: 2350, col: 14, offset: 73067},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 73066},
+						pos:        position{line: 2350, col: 14, offset: 73067},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 73085},
+						pos: position{line: 2350, col: 33, offset: 73086},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 73086},
+							pos:  position{line: 2350, col: 34, offset: 73087},
 							name: "IdentifierRest",
 						},
 					},
@@ -17904,20 +17904,20 @@ var g = &grammar{
 		},
 		{
 			name: "OVER",
-			pos:  position{line: 2351, col: 1, offset: 73101},
+			pos:  position{line: 2351, col: 1, offset: 73102},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 73114},
+				pos: position{line: 2351, col: 14, offset: 73115},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 73114},
+						pos:        position{line: 2351, col: 14, offset: 73115},
 						val:        "over",
 						ignoreCase: true,
 						want:       "\"OVER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 73133},
+						pos: position{line: 2351, col: 33, offset: 73134},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 73134},
+							pos:  position{line: 2351, col: 34, offset: 73135},
 							name: "IdentifierRest",
 						},
 					},
@@ -17928,20 +17928,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2352, col: 1, offset: 73149},
+			pos:  position{line: 2352, col: 1, offset: 73150},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 73162},
+				pos: position{line: 2352, col: 14, offset: 73163},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 73162},
+						pos:        position{line: 2352, col: 14, offset: 73163},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 73181},
+						pos: position{line: 2352, col: 33, offset: 73182},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 73182},
+							pos:  position{line: 2352, col: 34, offset: 73183},
 							name: "IdentifierRest",
 						},
 					},
@@ -17952,20 +17952,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2353, col: 1, offset: 73197},
+			pos:  position{line: 2353, col: 1, offset: 73198},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 73210},
+				pos: position{line: 2353, col: 14, offset: 73211},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 73210},
+						pos:        position{line: 2353, col: 14, offset: 73211},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 73229},
+						pos: position{line: 2353, col: 33, offset: 73230},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 73230},
+							pos:  position{line: 2353, col: 34, offset: 73231},
 							name: "IdentifierRest",
 						},
 					},
@@ -17976,20 +17976,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2354, col: 1, offset: 73245},
+			pos:  position{line: 2354, col: 1, offset: 73246},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 73258},
+				pos: position{line: 2354, col: 14, offset: 73259},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 73258},
+						pos:        position{line: 2354, col: 14, offset: 73259},
 						val:        "RECURSIVE",
 						ignoreCase: false,
 						want:       "\"RECURSIVE\"",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 73277},
+						pos: position{line: 2354, col: 33, offset: 73278},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 73278},
+							pos:  position{line: 2354, col: 34, offset: 73279},
 							name: "IdentifierRest",
 						},
 					},
@@ -18000,20 +18000,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP",
-			pos:  position{line: 2355, col: 1, offset: 73293},
+			pos:  position{line: 2355, col: 1, offset: 73294},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 73306},
+				pos: position{line: 2355, col: 14, offset: 73307},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 73306},
+						pos:        position{line: 2355, col: 14, offset: 73307},
 						val:        "regexp",
 						ignoreCase: true,
 						want:       "\"REGEXP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 73325},
+						pos: position{line: 2355, col: 33, offset: 73326},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 73326},
+							pos:  position{line: 2355, col: 34, offset: 73327},
 							name: "IdentifierRest",
 						},
 					},
@@ -18024,20 +18024,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP_REPLACE",
-			pos:  position{line: 2356, col: 1, offset: 73341},
+			pos:  position{line: 2356, col: 1, offset: 73342},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 18, offset: 73358},
+				pos: position{line: 2356, col: 18, offset: 73359},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 18, offset: 73358},
+						pos:        position{line: 2356, col: 18, offset: 73359},
 						val:        "regexp_replace",
 						ignoreCase: true,
 						want:       "\"REGEXP_REPLACE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 36, offset: 73376},
+						pos: position{line: 2356, col: 36, offset: 73377},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 37, offset: 73377},
+							pos:  position{line: 2356, col: 37, offset: 73378},
 							name: "IdentifierRest",
 						},
 					},
@@ -18048,20 +18048,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2357, col: 1, offset: 73392},
+			pos:  position{line: 2357, col: 1, offset: 73393},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 73405},
+				pos: position{line: 2357, col: 14, offset: 73406},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 73405},
+						pos:        position{line: 2357, col: 14, offset: 73406},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 73424},
+						pos: position{line: 2357, col: 33, offset: 73425},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 73425},
+							pos:  position{line: 2357, col: 34, offset: 73426},
 							name: "IdentifierRest",
 						},
 					},
@@ -18072,20 +18072,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2358, col: 1, offset: 73440},
+			pos:  position{line: 2358, col: 1, offset: 73441},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 73453},
+				pos: position{line: 2358, col: 14, offset: 73454},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 73453},
+						pos:        position{line: 2358, col: 14, offset: 73454},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 73472},
+						pos: position{line: 2358, col: 33, offset: 73473},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 73473},
+							pos:  position{line: 2358, col: 34, offset: 73474},
 							name: "IdentifierRest",
 						},
 					},
@@ -18096,20 +18096,20 @@ var g = &grammar{
 		},
 		{
 			name: "SAMPLE",
-			pos:  position{line: 2359, col: 1, offset: 73488},
+			pos:  position{line: 2359, col: 1, offset: 73489},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 73501},
+				pos: position{line: 2359, col: 14, offset: 73502},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 73501},
+						pos:        position{line: 2359, col: 14, offset: 73502},
 						val:        "sample",
 						ignoreCase: true,
 						want:       "\"SAMPLE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 73520},
+						pos: position{line: 2359, col: 33, offset: 73521},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 73521},
+							pos:  position{line: 2359, col: 34, offset: 73522},
 							name: "IdentifierRest",
 						},
 					},
@@ -18120,20 +18120,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2360, col: 1, offset: 73536},
+			pos:  position{line: 2360, col: 1, offset: 73537},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 73549},
+				pos: position{line: 2360, col: 14, offset: 73550},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 73549},
+						pos:        position{line: 2360, col: 14, offset: 73550},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 73568},
+						pos: position{line: 2360, col: 33, offset: 73569},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 73569},
+							pos:  position{line: 2360, col: 34, offset: 73570},
 							name: "IdentifierRest",
 						},
 					},
@@ -18144,20 +18144,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2361, col: 1, offset: 73584},
+			pos:  position{line: 2361, col: 1, offset: 73585},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 73597},
+				pos: position{line: 2361, col: 14, offset: 73598},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 73597},
+						pos:        position{line: 2361, col: 14, offset: 73598},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 73616},
+						pos: position{line: 2361, col: 33, offset: 73617},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 73617},
+							pos:  position{line: 2361, col: 34, offset: 73618},
 							name: "IdentifierRest",
 						},
 					},
@@ -18168,20 +18168,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2362, col: 1, offset: 73632},
+			pos:  position{line: 2362, col: 1, offset: 73633},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 73645},
+				pos: position{line: 2362, col: 14, offset: 73646},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 73645},
+						pos:        position{line: 2362, col: 14, offset: 73646},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 73664},
+						pos: position{line: 2362, col: 33, offset: 73665},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 73665},
+							pos:  position{line: 2362, col: 34, offset: 73666},
 							name: "IdentifierRest",
 						},
 					},
@@ -18192,20 +18192,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2363, col: 1, offset: 73680},
+			pos:  position{line: 2363, col: 1, offset: 73681},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 73693},
+				pos: position{line: 2363, col: 14, offset: 73694},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 73693},
+						pos:        position{line: 2363, col: 14, offset: 73694},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 73712},
+						pos: position{line: 2363, col: 33, offset: 73713},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 73713},
+							pos:  position{line: 2363, col: 34, offset: 73714},
 							name: "IdentifierRest",
 						},
 					},
@@ -18216,20 +18216,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2364, col: 1, offset: 73728},
+			pos:  position{line: 2364, col: 1, offset: 73729},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 73741},
+				pos: position{line: 2364, col: 14, offset: 73742},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 73741},
+						pos:        position{line: 2364, col: 14, offset: 73742},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 73760},
+						pos: position{line: 2364, col: 33, offset: 73761},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 73761},
+							pos:  position{line: 2364, col: 34, offset: 73762},
 							name: "IdentifierRest",
 						},
 					},
@@ -18240,20 +18240,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2365, col: 1, offset: 73776},
+			pos:  position{line: 2365, col: 1, offset: 73777},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 73789},
+				pos: position{line: 2365, col: 14, offset: 73790},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 73789},
+						pos:        position{line: 2365, col: 14, offset: 73790},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 73808},
+						pos: position{line: 2365, col: 33, offset: 73809},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 73809},
+							pos:  position{line: 2365, col: 34, offset: 73810},
 							name: "IdentifierRest",
 						},
 					},
@@ -18264,20 +18264,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2366, col: 1, offset: 73824},
+			pos:  position{line: 2366, col: 1, offset: 73825},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 73837},
+				pos: position{line: 2366, col: 14, offset: 73838},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 73837},
+						pos:        position{line: 2366, col: 14, offset: 73838},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 73856},
+						pos: position{line: 2366, col: 33, offset: 73857},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 73857},
+							pos:  position{line: 2366, col: 34, offset: 73858},
 							name: "IdentifierRest",
 						},
 					},
@@ -18288,20 +18288,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2367, col: 1, offset: 73872},
+			pos:  position{line: 2367, col: 1, offset: 73873},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 73885},
+				pos: position{line: 2367, col: 14, offset: 73886},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 73885},
+						pos:        position{line: 2367, col: 14, offset: 73886},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 73904},
+						pos: position{line: 2367, col: 33, offset: 73905},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 73905},
+							pos:  position{line: 2367, col: 34, offset: 73906},
 							name: "IdentifierRest",
 						},
 					},
@@ -18312,20 +18312,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAP",
-			pos:  position{line: 2368, col: 1, offset: 73921},
+			pos:  position{line: 2368, col: 1, offset: 73922},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 73934},
+				pos: position{line: 2368, col: 14, offset: 73935},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 73934},
+						pos:        position{line: 2368, col: 14, offset: 73935},
 						val:        "tap",
 						ignoreCase: true,
 						want:       "\"TAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 73953},
+						pos: position{line: 2368, col: 33, offset: 73954},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 73954},
+							pos:  position{line: 2368, col: 34, offset: 73955},
 							name: "IdentifierRest",
 						},
 					},
@@ -18336,20 +18336,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2369, col: 1, offset: 73969},
+			pos:  position{line: 2369, col: 1, offset: 73970},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 73982},
+				pos: position{line: 2369, col: 14, offset: 73983},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 73982},
+						pos:        position{line: 2369, col: 14, offset: 73983},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 74001},
+						pos: position{line: 2369, col: 33, offset: 74002},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 74002},
+							pos:  position{line: 2369, col: 34, offset: 74003},
 							name: "IdentifierRest",
 						},
 					},
@@ -18360,23 +18360,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2370, col: 1, offset: 74017},
+			pos:  position{line: 2370, col: 1, offset: 74018},
 			expr: &actionExpr{
-				pos: position{line: 2370, col: 14, offset: 74030},
+				pos: position{line: 2370, col: 14, offset: 74031},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2370, col: 14, offset: 74030},
+					pos: position{line: 2370, col: 14, offset: 74031},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2370, col: 14, offset: 74030},
+							pos:        position{line: 2370, col: 14, offset: 74031},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2370, col: 33, offset: 74049},
+							pos: position{line: 2370, col: 33, offset: 74050},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2370, col: 34, offset: 74050},
+								pos:  position{line: 2370, col: 34, offset: 74051},
 								name: "IdentifierRest",
 							},
 						},
@@ -18388,20 +18388,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2371, col: 1, offset: 74093},
+			pos:  position{line: 2371, col: 1, offset: 74094},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 74106},
+				pos: position{line: 2371, col: 14, offset: 74107},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 74106},
+						pos:        position{line: 2371, col: 14, offset: 74107},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 74125},
+						pos: position{line: 2371, col: 33, offset: 74126},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 74126},
+							pos:  position{line: 2371, col: 34, offset: 74127},
 							name: "IdentifierRest",
 						},
 					},
@@ -18412,20 +18412,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2372, col: 1, offset: 74141},
+			pos:  position{line: 2372, col: 1, offset: 74142},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 74154},
+				pos: position{line: 2372, col: 14, offset: 74155},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 74154},
+						pos:        position{line: 2372, col: 14, offset: 74155},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 74173},
+						pos: position{line: 2372, col: 33, offset: 74174},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 74174},
+							pos:  position{line: 2372, col: 34, offset: 74175},
 							name: "IdentifierRest",
 						},
 					},
@@ -18436,20 +18436,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2373, col: 1, offset: 74189},
+			pos:  position{line: 2373, col: 1, offset: 74190},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 74202},
+				pos: position{line: 2373, col: 14, offset: 74203},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 74202},
+						pos:        position{line: 2373, col: 14, offset: 74203},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 74221},
+						pos: position{line: 2373, col: 33, offset: 74222},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 74222},
+							pos:  position{line: 2373, col: 34, offset: 74223},
 							name: "IdentifierRest",
 						},
 					},
@@ -18460,20 +18460,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2374, col: 1, offset: 74237},
+			pos:  position{line: 2374, col: 1, offset: 74238},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 74250},
+				pos: position{line: 2374, col: 14, offset: 74251},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 74250},
+						pos:        position{line: 2374, col: 14, offset: 74251},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 74269},
+						pos: position{line: 2374, col: 33, offset: 74270},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 74270},
+							pos:  position{line: 2374, col: 34, offset: 74271},
 							name: "IdentifierRest",
 						},
 					},
@@ -18484,20 +18484,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2375, col: 1, offset: 74285},
+			pos:  position{line: 2375, col: 1, offset: 74286},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 74298},
+				pos: position{line: 2375, col: 14, offset: 74299},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 74298},
+						pos:        position{line: 2375, col: 14, offset: 74299},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 74317},
+						pos: position{line: 2375, col: 33, offset: 74318},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 74318},
+							pos:  position{line: 2375, col: 34, offset: 74319},
 							name: "IdentifierRest",
 						},
 					},
@@ -18508,20 +18508,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2376, col: 1, offset: 74334},
+			pos:  position{line: 2376, col: 1, offset: 74335},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 74347},
+				pos: position{line: 2376, col: 14, offset: 74348},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 74347},
+						pos:        position{line: 2376, col: 14, offset: 74348},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 74366},
+						pos: position{line: 2376, col: 33, offset: 74367},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 74367},
+							pos:  position{line: 2376, col: 34, offset: 74368},
 							name: "IdentifierRest",
 						},
 					},
@@ -18532,20 +18532,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2377, col: 1, offset: 74382},
+			pos:  position{line: 2377, col: 1, offset: 74383},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 74395},
+				pos: position{line: 2377, col: 14, offset: 74396},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 74395},
+						pos:        position{line: 2377, col: 14, offset: 74396},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 74414},
+						pos: position{line: 2377, col: 33, offset: 74415},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 74415},
+							pos:  position{line: 2377, col: 34, offset: 74416},
 							name: "IdentifierRest",
 						},
 					},
@@ -18556,20 +18556,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2378, col: 1, offset: 74430},
+			pos:  position{line: 2378, col: 1, offset: 74431},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 74443},
+				pos: position{line: 2378, col: 14, offset: 74444},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 74443},
+						pos:        position{line: 2378, col: 14, offset: 74444},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 74462},
+						pos: position{line: 2378, col: 33, offset: 74463},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 74463},
+							pos:  position{line: 2378, col: 34, offset: 74464},
 							name: "IdentifierRest",
 						},
 					},
@@ -18580,20 +18580,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2379, col: 1, offset: 74478},
+			pos:  position{line: 2379, col: 1, offset: 74479},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 74491},
+				pos: position{line: 2379, col: 14, offset: 74492},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 74491},
+						pos:        position{line: 2379, col: 14, offset: 74492},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 74510},
+						pos: position{line: 2379, col: 33, offset: 74511},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 74511},
+							pos:  position{line: 2379, col: 34, offset: 74512},
 							name: "IdentifierRest",
 						},
 					},
@@ -18604,20 +18604,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2380, col: 1, offset: 74526},
+			pos:  position{line: 2380, col: 1, offset: 74527},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 74539},
+				pos: position{line: 2380, col: 14, offset: 74540},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 74539},
+						pos:        position{line: 2380, col: 14, offset: 74540},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 74558},
+						pos: position{line: 2380, col: 33, offset: 74559},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 74559},
+							pos:  position{line: 2380, col: 34, offset: 74560},
 							name: "IdentifierRest",
 						},
 					},
@@ -18628,20 +18628,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2381, col: 1, offset: 74574},
+			pos:  position{line: 2381, col: 1, offset: 74575},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 74587},
+				pos: position{line: 2381, col: 14, offset: 74588},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 74587},
+						pos:        position{line: 2381, col: 14, offset: 74588},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 74606},
+						pos: position{line: 2381, col: 33, offset: 74607},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 74607},
+							pos:  position{line: 2381, col: 34, offset: 74608},
 							name: "IdentifierRest",
 						},
 					},
@@ -18652,20 +18652,20 @@ var g = &grammar{
 		},
 		{
 			name: "YIELD",
-			pos:  position{line: 2382, col: 1, offset: 74622},
+			pos:  position{line: 2382, col: 1, offset: 74623},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 74635},
+				pos: position{line: 2382, col: 14, offset: 74636},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 74635},
+						pos:        position{line: 2382, col: 14, offset: 74636},
 						val:        "yield",
 						ignoreCase: true,
 						want:       "\"YIELD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 74654},
+						pos: position{line: 2382, col: 33, offset: 74655},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 74655},
+							pos:  position{line: 2382, col: 34, offset: 74656},
 							name: "IdentifierRest",
 						},
 					},
@@ -19488,7 +19488,7 @@ func (c *current) onSortOp1(args, exprs any) (any, error) {
 		Loc:  loc(c),
 	}
 	if exprs != nil {
-		o.Args = exprs.([]ast.SortExpr)
+		o.Exprs = exprs.([]ast.SortExpr)
 	}
 	argm := args.(map[string]any)
 	if _, ok := argm["r"]; ok {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -427,7 +427,7 @@ SortOp
         Loc: loc(c),
       }
       if exprs != nil {
-        o.Args = exprs.([]ast.SortExpr)
+        o.Exprs = exprs.([]ast.SortExpr)
       }
       argm := args.(map[string]any)
       if _, ok := argm["r"]; ok {

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -669,12 +669,12 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) dag.Seq {
 		})
 	case *ast.Sort:
 		var sortExprs []dag.SortExpr
-		for _, arg := range o.Args {
-			sortExprs = append(sortExprs, a.semSortExpr(nil, arg, o.Reverse))
+		for _, e := range o.Exprs {
+			sortExprs = append(sortExprs, a.semSortExpr(nil, e, o.Reverse))
 		}
 		return append(seq, &dag.Sort{
 			Kind:    "Sort",
-			Args:    sortExprs,
+			Exprs:   sortExprs,
 			Reverse: o.Reverse && len(sortExprs) == 0,
 		})
 	case *ast.Head:

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -373,7 +373,7 @@ func (a *analyzer) semSQLOp(op ast.Op, seq dag.Seq) (dag.Seq, schema) {
 		for _, e := range op.Exprs {
 			exprs = append(exprs, a.semSortExpr(schema, e, false))
 		}
-		return append(out, &dag.Sort{Kind: "Sort", Args: exprs}), schema
+		return append(out, &dag.Sort{Kind: "Sort", Exprs: exprs}), schema
 	case *ast.Limit:
 		e := a.semExpr(op.Count)
 		var err error

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -512,7 +512,7 @@ func (c *canon) op(p ast.Op) {
 		if p.Reverse {
 			c.write(" -r")
 		}
-		c.sortExprs(p.Args)
+		c.sortExprs(p.Exprs)
 	case *ast.Load:
 		c.next()
 		c.write("load %s", sup.QuotedString(p.Pool.Text))

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -423,7 +423,7 @@ func (c *canonDAG) op(p dag.Op) {
 		if p.Reverse {
 			c.write(" -r")
 		}
-		c.sortExprs(p.Args)
+		c.sortExprs(p.Exprs)
 	case *dag.Load:
 		c.next()
 		c.write("load %s", p.Pool)


### PR DESCRIPTION
Exprs is consistent with the name of the corresponding field in ast.Merge, ast.Top, dag.Merge, and dag.Top.