### PR TITLE
Skip crawling a github.com link that has chronic HTTP 429 errors

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -3,3 +3,7 @@ dirs:
 useGitIgnore: true
 excludedDirs:
   - node_modules
+
+# Currently not crawling links matching the following pattern due to HTTP 429 errors
+ignorePatterns:
+  - pattern: '^https://github.com/brimdata/super/blob/main/scripts/super-cmd-perf.*$'

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -5,5 +5,6 @@ excludedDirs:
   - node_modules
 
 # Currently not crawling links matching the following pattern due to HTTP 429 errors
+# See https://github.com/brimdata/super/pull/5887
 ignorePatterns:
   - pattern: '^https://github.com/brimdata/super/blob/main/scripts/super-cmd-perf.*$'


### PR DESCRIPTION
In Actions runs like [this one](https://github.com/brimdata/super/actions/runs/14924491280), for a couple weeks now our link checker has been consistently hitting HTTP 429 errors when trying to crawl a couple absolute `https://github.com` links we have in our docs. There's a thread [here](https://github.com/orgs/community/discussions/157887#discussioncomment-13037133) where hordes of people are complaining about the same thing and I was hoping GitHub would notice and just fix it but it seems to be dragging on. It's now started slowing down our developers when they see the link checking portion of their Pull Request CI fail, so here I'm just proposing excluding the pattern for the troublesome links from our link checker config for now. [This job](https://github.com/brimdata/super/actions/runs/14937453462) was run on this branch and shows it now passing.

![image](https://github.com/user-attachments/assets/7ccb6af2-ed2b-4251-a5ab-6494d9e00ecb)
