### PR TITLE
Fix predicate pushdown bug

### DIFF
--- a/compiler/optimizer/pruner.go
+++ b/compiler/optimizer/pruner.go
@@ -297,8 +297,8 @@ func literalsInArrayOrSet(elems []dag.VectorElem) []*dag.Literal {
 }
 
 func metadataPrunerPred(op string, this *dag.This, literal *dag.Literal) *dag.BinaryExpr {
-	min := &dag.This{Kind: "This", Path: append(this.Path, "min")}
-	max := &dag.This{Kind: "This", Path: append(this.Path, "max")}
+	min := &dag.This{Kind: "This", Path: append(slices.Clone(this.Path), "min")}
+	max := &dag.This{Kind: "This", Path: append(slices.Clone(this.Path), "max")}
 	switch op {
 	case "<":
 		return compare("<", min, literal)


### PR DESCRIPTION
Predicate pushdown sometimes breaks because
compiler/optimizer.metadataPrunerPred appends to this.Path twice to create min and max expressions, and the second append can overwrite the first, leaving a min expression that incorrectly accesses this's max field.  Fix this by appending to a copy of this.Path.

Fixes brimdata/challenges#12.