### PR TITLE
Limit concurrency across multiple DAG entry points

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -222,7 +222,6 @@ func (o *Optimizer) optimizeSourcePaths(seq dag.Seq) (dag.Seq, error) {
 		if len(seq) == 0 {
 			return nil, errors.New("internal error: optimizer encountered empty sequential operator")
 		}
-		o.nent++
 		chain := seq[1:]
 		if len(chain) == 0 {
 			// Nothing to push down.
@@ -235,6 +234,7 @@ func (o *Optimizer) optimizeSourcePaths(seq dag.Seq) (dag.Seq, error) {
 		filter, chain := matchFilter(chain)
 		switch op := seq[0].(type) {
 		case *dag.PoolScan:
+			o.nent++
 			// Here we transform a PoolScan into a Lister followed by one or more chains
 			// of slicers and sequence scanners.  We'll eventually choose other configurations
 			// here based on metadata and availability of CSUP.
@@ -267,6 +267,7 @@ func (o *Optimizer) optimizeSourcePaths(seq dag.Seq) (dag.Seq, error) {
 			})
 			seq = append(seq, chain...)
 		case *dag.FileScan:
+			o.nent++
 			if o.env.UseVAM() {
 				// Here, we install the filter without a projection.
 				// The demand pass comes subsequently and will add
@@ -283,6 +284,7 @@ func (o *Optimizer) optimizeSourcePaths(seq dag.Seq) (dag.Seq, error) {
 			}
 			seq = append(dag.Seq{op}, chain...)
 		case *dag.CommitMetaScan:
+			o.nent++
 			if op.Tap {
 				sortKeys, err := o.sortKeysOfSource(op)
 				if err != nil {
@@ -299,6 +301,7 @@ func (o *Optimizer) optimizeSourcePaths(seq dag.Seq) (dag.Seq, error) {
 				seq = dag.Seq{op, o}
 			}
 		case *dag.DefaultScan:
+			o.nent++
 			op.Filter = filter
 			seq = append(dag.Seq{op}, chain...)
 		}

--- a/compiler/ztests/par-concurrency.yaml
+++ b/compiler/ztests/par-concurrency.yaml
@@ -1,0 +1,85 @@
+script: |
+  export SUPER_VAM=1
+  echo === -P 2
+  super compile -C -P 2 'fork (=> from a.csup | sort b => from c.csup | sort d)'
+  echo === -P 5
+  super compile -C -P 5 'fork (=> from a.csup | sort b => from c.csup | sort d)'
+  echo === -P 6
+  super compile -C -P 6 'fork (=> from a.csup | sort b => from c.csup | sort d)'
+
+outputs:
+  - name: stdout
+    data: |
+      === -P 2
+      fork (
+        =>
+          file a.csup format csup unordered
+          | scatter (
+            =>
+              sort b asc nulls last
+            =>
+              sort b asc nulls last
+          )
+          | merge b asc nulls last
+          | output main
+        =>
+          file c.csup format csup unordered
+          | scatter (
+            =>
+              sort d asc nulls last
+            =>
+              sort d asc nulls last
+          )
+          | merge d asc nulls last
+          | output main
+      )
+      === -P 5
+      fork (
+        =>
+          file a.csup format csup unordered
+          | scatter (
+            =>
+              sort b asc nulls last
+            =>
+              sort b asc nulls last
+          )
+          | merge b asc nulls last
+          | output main
+        =>
+          file c.csup format csup unordered
+          | scatter (
+            =>
+              sort d asc nulls last
+            =>
+              sort d asc nulls last
+          )
+          | merge d asc nulls last
+          | output main
+      )
+      === -P 6
+      fork (
+        =>
+          file a.csup format csup unordered
+          | scatter (
+            =>
+              sort b asc nulls last
+            =>
+              sort b asc nulls last
+            =>
+              sort b asc nulls last
+          )
+          | merge b asc nulls last
+          | output main
+        =>
+          file c.csup format csup unordered
+          | scatter (
+            =>
+              sort d asc nulls last
+            =>
+              sort d asc nulls last
+            =>
+              sort d asc nulls last
+          )
+          | merge d asc nulls last
+          | output main
+      )


### PR DESCRIPTION
compiler/optimizer.Optimizer.Parallelize is meant to limit concurrency by dividing its concurrency parameter by the number of DAG entry points. While the divided value is computed, it goes unused, and it is incorrect because entry points are overcounted by Optimizer.optimitzeSourcePaths. Fix both issues.