### PR TITLE
Add min/max docs examples that use string values

### DIFF
--- a/docs/language/aggregates/max.md
+++ b/docs/language/aggregates/max.md
@@ -4,7 +4,7 @@
 
 ### Synopsis
 ```
-max(number) -> number
+max(number|string) -> number|string
 ```
 
 ### Description
@@ -13,17 +13,20 @@ The _max_ aggregate function computes the maximum value of its input.
 
 ### Examples
 
-Maximum value of simple sequence:
+Maximum value of simple numeric sequence:
 ```mdtest-spq
 # spq
 max(this)
 # input
-1 2 3 4
+1
+2
+3
+4
 # expected output
 4
 ```
 
-Continuous maximum of simple sequence:
+Continuous maximum of simple numeric sequence:
 ```mdtest-spq
 # spq
 yield max(this)
@@ -39,7 +42,31 @@ yield max(this)
 4
 ```
 
-Unrecognized types are ignored:
+Maximum of several string values:
+```mdtest-spq
+# spq
+max(this)
+# input
+"bar"
+"foo"
+"baz"
+# expected output
+"foo"
+```
+
+Determining a maximum among mixed numeric and string inputs is not yet possible:
+```mdtest-spq
+# spq
+max(this)
+# input
+1
+"foo"
+2
+# expected output
+error("mixture of string and numeric values")
+```
+
+Other unrecognized types in mixed input are ignored:
 ```mdtest-spq
 # spq
 max(this)

--- a/docs/language/aggregates/max.md
+++ b/docs/language/aggregates/max.md
@@ -54,7 +54,8 @@ max(this)
 "foo"
 ```
 
-Determining a maximum among mixed numeric and string inputs is not yet possible:
+A mix of string and numeric input values results in an error:
+
 ```mdtest-spq
 # spq
 max(this)

--- a/docs/language/aggregates/min.md
+++ b/docs/language/aggregates/min.md
@@ -4,7 +4,7 @@
 
 ### Synopsis
 ```
-min(number) -> number
+min(number|string) -> number|string
 ```
 
 ### Description
@@ -13,7 +13,7 @@ The _min_ aggregate function computes the minimum value of its input.
 
 ### Examples
 
-Minimum value of simple sequence:
+Minimum value of simple numeric sequence:
 ```mdtest-spq
 # spq
 min(this)
@@ -26,7 +26,7 @@ min(this)
 1
 ```
 
-Continuous minimum of simple sequence:
+Continuous minimum of simple numeric sequence:
 ```mdtest-spq
 # spq
 yield min(this)
@@ -42,7 +42,31 @@ yield min(this)
 1
 ```
 
-Unrecognized types are ignored:
+Minimum of several string values:
+```mdtest-spq
+# spq
+min(this)
+# input
+"foo"
+"bar"
+"baz"
+# expected output
+"bar"
+```
+
+Determining a minimum among mixed numeric and string inputs is not yet possible:
+```mdtest-spq
+# spq
+min(this)
+# input
+1
+"foo"
+2
+# expected output
+error("mixture of string and numeric values")
+```
+
+Other unrecognized types in mixed input are ignored:
 ```mdtest-spq
 # spq
 min(this)

--- a/docs/language/aggregates/min.md
+++ b/docs/language/aggregates/min.md
@@ -54,7 +54,7 @@ min(this)
 "bar"
 ```
 
-Determining a minimum among mixed numeric and string inputs is not yet possible:
+A mix of string and numeric input values results in an error:
 ```mdtest-spq
 # spq
 min(this)


### PR DESCRIPTION
To further show the capabilities and limitations of the enhancement added in #5886.
