### PR TITLE
csup: Parallelize reading of CSUP metadata

### DIFF
--- a/csup/header.go
+++ b/csup/header.go
@@ -53,6 +53,10 @@ func (h *Header) Deserialize(bytes []byte) error {
 	return nil
 }
 
+func (h *Header) ObjectSize() uint64 {
+	return HeaderSize + h.MetaSize + h.DataSize
+}
+
 func ReadHeader(r io.ReaderAt) (Header, error) {
 	var bytes [HeaderSize]byte
 	cc, err := r.ReadAt(bytes[:], 0)

--- a/csup/object.go
+++ b/csup/object.go
@@ -44,6 +44,10 @@ func NewObject(r io.ReaderAt) (*Object, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewObjectFromHeader(r, hdr)
+}
+
+func NewObjectFromHeader(r io.ReaderAt, hdr Header) (*Object, error) {
 	cctx := NewContext()
 	if err := cctx.readMeta(io.NewSectionReader(r, HeaderSize, int64(hdr.MetaSize))); err != nil {
 		return nil, err
@@ -78,7 +82,7 @@ func (o *Object) DataReader() io.ReaderAt {
 }
 
 func (o *Object) Size() uint64 {
-	return HeaderSize + o.header.MetaSize + o.header.DataSize
+	return o.header.ObjectSize()
 }
 
 func (o *Object) ProjectMetadata(sctx *super.Context, projection field.Projection) []super.Value {

--- a/zio/csupio/stream.go
+++ b/zio/csupio/stream.go
@@ -1,33 +1,60 @@
 package csupio
 
 import (
+	"context"
 	"io"
 	"math"
+	"runtime"
 	"sync"
 
 	"github.com/brimdata/super/csup"
 )
 
 type stream struct {
-	mu  sync.Mutex
-	r   io.ReaderAt
-	off int64
+	r    io.ReaderAt
+	ch   chan result
+	once sync.Once
+	ctx  context.Context
 }
 
-func (s *stream) next() (*csup.Object, error) {
+type result struct {
+	off    int64
+	header csup.Header
+	err    error
+}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// We read the next object by creating a section reader that starts
-	// at the end of the previous object without an upper bound.  The csup
-	// package won't read off the end of the object so this is not a problem.
-	o, err := csup.NewObject(io.NewSectionReader(s.r, s.off, math.MaxInt64))
-	if err != nil {
-		if err == io.EOF {
-			err = nil
+func (s *stream) next() (*csup.Header, int64, error) {
+	s.once.Do(func() {
+		s.ch = make(chan result, runtime.GOMAXPROCS(0))
+		go s.run()
+	})
+	select {
+	case r, ok := <-s.ch:
+		if !ok || r.err != nil {
+			if r.err == io.EOF {
+				return nil, -1, nil
+			}
+			return nil, -1, r.err
 		}
-		return nil, err
+		return &r.header, r.off, nil
+	case <-s.ctx.Done():
+		return nil, -1, s.ctx.Err()
 	}
-	s.off += int64(o.Size())
-	return o, nil
+}
+
+func (s *stream) run() {
+	var off int64
+	for {
+		hdr, err := csup.ReadHeader(io.NewSectionReader(s.r, off, math.MaxInt64))
+		select {
+		case s.ch <- result{off, hdr, err}:
+		case <-s.ctx.Done():
+			return
+		}
+		if err != nil {
+			close(s.ch)
+			break
+		}
+		off += int64(hdr.ObjectSize())
+	}
 }


### PR DESCRIPTION
This commit improves the speed of reading CSUP file metadata by changing the single threaded csup.stream to only read the header of CSUP frames and instead have individual VectorReader threads read and serialize the frame's metadata.