### PR TITLE
Avoid allocation in vector.String.Serialize

### DIFF
--- a/vector/string.go
+++ b/vector/string.go
@@ -45,7 +45,7 @@ func (s *String) Serialize(b *zcode.Builder, slot uint32) {
 	if s.Nulls.IsSet(slot) {
 		b.Append(nil)
 	} else {
-		b.Append(super.EncodeString(s.Value(slot)))
+		b.Append(s.table.Bytes(slot))
 	}
 }
 


### PR DESCRIPTION
For the current implementation, the compiler emits a call to runtime.slicebytetostring, which allocates memory.  Replace String.Value with vector.BytesTable.Bytes to avoid that.