### PR TITLE
Document collation used with min/max on string inputs

### DIFF
--- a/docs/language/aggregates/max.md
+++ b/docs/language/aggregates/max.md
@@ -11,6 +11,11 @@ max(number|string) -> number|string
 
 The _max_ aggregate function computes the maximum value of its input.
 
+When determining the _max_ of string inputs, values are compared via byte
+order. This is equivalent to
+[C/POSIX collation](https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD)
+as found in other SQL databases such as Postgres.
+
 ### Examples
 
 Maximum value of simple numeric sequence:

--- a/docs/language/aggregates/min.md
+++ b/docs/language/aggregates/min.md
@@ -11,6 +11,11 @@ min(number|string) -> number|string
 
 The _min_ aggregate function computes the minimum value of its input.
 
+When determining the _min_ of string inputs, values are compared via byte
+order. This is equivalent to
+[C/POSIX collation](https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD)
+as found in other SQL databases such as Postgres.
+
 ### Examples
 
 Minimum value of simple numeric sequence:


### PR DESCRIPTION
To provide clarification per a recent [community Slack inquiry](https://super-db.slack.com/archives/CTSMAK6G7/p1747236636614269).
