### PR TITLE
Clarify that comparisons are via byte order

### DIFF
--- a/docs/language/aggregates/max.md
+++ b/docs/language/aggregates/max.md
@@ -11,6 +11,11 @@ max(number|string) -> number|string
 
 The _max_ aggregate function computes the maximum value of its input.
 
+When determining the _max_ of string inputs, values are compared via byte
+order. This is equivalent to
+[C/POSIX collation](https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD)
+as found in other SQL databases such as Postgres.
+
 ### Examples
 
 Maximum value of simple numeric sequence:

--- a/docs/language/aggregates/min.md
+++ b/docs/language/aggregates/min.md
@@ -11,6 +11,11 @@ min(number|string) -> number|string
 
 The _min_ aggregate function computes the minimum value of its input.
 
+When determining the _min_ of string inputs, values are compared via byte
+order. This is equivalent to
+[C/POSIX collation](https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD)
+as found in other SQL databases such as Postgres.
+
 ### Examples
 
 Minimum value of simple numeric sequence:

--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -34,13 +34,18 @@ error("divide by zero")
 
 ## Comparisons
 
-Comparison operations (`<`, `<=`, `==`, `!=`, `>`, `>=`) follow customary syntax
+Comparison operations (`<`, `<=`, `==`, `=`, `!=`, `>`, `>=`) follow customary syntax
 and semantics and result in a truth value of type `bool` or an [error](data-types.md#first-class-errors).
 A comparison expression is any valid expression compared to any other
 valid expression using a comparison operator.
 
+Values are compared via byte order.  Between values of type `string`, this is
+equivalent to [C/POSIX collation](https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD)
+as found in other SQL databases such as Postgres.
+
 When the operands are coercible to like types, the result is the truth value
-of the comparison.  Otherwise, the result is `false`.
+of the comparison.  Otherwise, the result is `false`.  To compare values of
+different types, consider the [`compare` function](functions/compare.md).
 
 If either operand to a comparison
 is `error("missing")`, then the result is `error("missing")`.

--- a/docs/language/functions/compare.md
+++ b/docs/language/functions/compare.md
@@ -12,8 +12,12 @@ compare(a: any, b: any [, nullsMax: bool]) -> int64
 
 The _compare_ function returns an integer comparing two values. The result will
 be 0 if a is equal to b, +1 if a is greater than b, and -1 if a is less than b.
-_compare_ differs from `<`, `>`, `<=`, `>=`, `==`, and `!=` in that it will
+_compare_ differs from [comparison expressions](../expressions.md#comparisons) in that it will
 work for any type (e.g., `compare(1, "1")`).
+
+Values are compared via byte order.  Between values of type `string`, this is
+equivalent to [C/POSIX collation](https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD)
+as found in other SQL databases such as Postgres.
 
 `nullsMax` is an optional value (true by default) that determines whether `null`
 is treated as the minimum or maximum value.

--- a/docs/language/operators/sort.md
+++ b/docs/language/operators/sort.md
@@ -48,6 +48,11 @@ such that values with identical sort keys always have the same relative order
 in the output as they had in the input, such as provided by the `-s` option in
 Unix's "sort" command-line utility.
 
+During sorting, values are compared via byte order.  Between values of type
+`string`, this is equivalent to
+[C/POSIX collation](https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD)
+as found in other SQL databases such as Postgres.
+
 Note that a total order is defined over the space of all values even
 between values of different types so sort order is always well-defined even
 when comparing heterogeneously typed values.


### PR DESCRIPTION
## tl;dr

This adds clarity to the docs that comparison between values for things like `min`, `max`, `sort`, `compare`, and comparison expressions are done via byte order.

## Details

After the merge of #5886, a community user [asked on Slack](https://super-db.slack.com/archives/CTSMAK6G7/p1747236636614269):

>will y’all have docs (or maybe you do already) on specifics when it comes to unicode / collation issues like i’m semi-used to in postgres?

The Dev team confirmed that it's done via byte order similar to the C/POSIX collation in Postgres, so I've added text to that effect.

While a user may assume that all of these order-centric operations rely on the same underlying mechanism, I can tell there's some differing code between them, so if there's subtle differences in their behaviors that I'm not picking up on, please do chime in.

I waffled a bit in terms of how much redundancy to have here, e.g., if maybe the topic should be covered in one place and then linked from everywhere else, but I landed on the side of "one-stop shopping" in the different pages with some repetition. That said, I chose not to paste the text yet again on the `top` page since that operator is already framed as a special kind of `sort`, so I figured we can lean on the existing linkage there.