### PR TITLE
add SQL VALUES clause and column aliases

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -217,13 +217,20 @@ type FromElem struct {
 	Entity     FromEntity  `json:"entity"`
 	Args       FromArgs    `json:"args"`
 	Ordinality *Ordinality `json:"ordinality"`
-	Alias      *Name       `json:"alias"`
+	Alias      *TableAlias `json:"alias"`
 	Loc        `json:"loc"`
 }
 
 type Ordinality struct {
 	Kind string `json:"kind" unpack:""`
 	Loc  `json:"loc"`
+}
+
+type TableAlias struct {
+	Kind    string `json:"kind" unpack:""`
+	Name    string `json:"name"`
+	Columns []*ID  `json:"columns"`
+	Loc     `json:"loc"`
 }
 
 type RecordExpr struct {

--- a/compiler/ast/sql.go
+++ b/compiler/ast/sql.go
@@ -113,7 +113,7 @@ func (*JoinUsingExpr) joinExpr() {}
 
 func (*SQLPipe) OpAST()        {}
 func (*Select) OpAST()         {}
-func (*Values) OpAST()    {}
+func (*Values) OpAST()         {}
 func (*CrossJoin) OpAST()      {}
 func (*SQLJoin) OpAST()        {}
 func (*Union) OpAST()          {}

--- a/compiler/ast/sql.go
+++ b/compiler/ast/sql.go
@@ -18,6 +18,12 @@ type Selection struct {
 	Loc  `json:"loc"`
 }
 
+type Values struct {
+	Kind  string `json:"kind" unpack:""`
+	Exprs []Expr `json:"exprs"`
+	Loc   `json:"loc"`
+}
+
 // SQLPipe turns a Seq into an Op.  We need this to put pipes inside
 // of SQL expressions.
 type SQLPipe struct {
@@ -107,6 +113,7 @@ func (*JoinUsingExpr) joinExpr() {}
 
 func (*SQLPipe) OpAST()        {}
 func (*Select) OpAST()         {}
+func (*Values) OpAST()    {}
 func (*CrossJoin) OpAST()      {}
 func (*SQLJoin) OpAST()        {}
 func (*Union) OpAST()          {}

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -15380,57 +15380,60 @@ var g = &grammar{
 			name: "AliasClause",
 			pos:  position{line: 2170, col: 1, offset: 67005},
 			expr: &actionExpr{
-				pos: position{line: 2171, col: 5, offset: 67022},
+				pos: position{line: 2171, col: 4, offset: 67020},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2171, col: 5, offset: 67022},
+					pos: position{line: 2171, col: 4, offset: 67020},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2171, col: 5, offset: 67022},
+							pos: position{line: 2171, col: 4, offset: 67020},
 							expr: &seqExpr{
-								pos: position{line: 2171, col: 6, offset: 67023},
+								pos: position{line: 2171, col: 5, offset: 67021},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2171, col: 6, offset: 67023},
+										pos:  position{line: 2171, col: 5, offset: 67021},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2171, col: 9, offset: 67026},
+										pos:  position{line: 2171, col: 8, offset: 67024},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2171, col: 13, offset: 67030},
+							pos: position{line: 2171, col: 12, offset: 67028},
 							expr: &choiceExpr{
-								pos: position{line: 2171, col: 15, offset: 67032},
+								pos: position{line: 2171, col: 14, offset: 67030},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2171, col: 15, offset: 67032},
+										pos:  position{line: 2171, col: 14, offset: 67030},
 										name: "SQLGuard",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2171, col: 26, offset: 67043},
+										pos:  position{line: 2171, col: 25, offset: 67041},
 										name: "DeprecatedFroms",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2171, col: 43, offset: 67060},
+							pos:   position{line: 2171, col: 42, offset: 67058},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2171, col: 48, offset: 67065},
+								pos:  position{line: 2171, col: 47, offset: 67063},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2171, col: 63, offset: 67080},
+							pos:   position{line: 2171, col: 62, offset: 67078},
 							label: "cols",
-							expr: &ruleRefExpr{
-								pos:  position{line: 2171, col: 68, offset: 67085},
-								name: "OptColumns",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 2171, col: 67, offset: 67083},
+								expr: &ruleRefExpr{
+									pos:  position{line: 2171, col: 67, offset: 67083},
+									name: "Columns",
+								},
 							},
 						},
 					},
@@ -15440,94 +15443,83 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "OptColumns",
-			pos:  position{line: 2179, col: 1, offset: 67287},
-			expr: &choiceExpr{
-				pos: position{line: 2180, col: 5, offset: 67303},
-				alternatives: []any{
-					&actionExpr{
-						pos: position{line: 2180, col: 5, offset: 67303},
-						run: (*parser).callonOptColumns2,
-						expr: &seqExpr{
-							pos: position{line: 2180, col: 5, offset: 67303},
-							exprs: []any{
-								&litMatcher{
-									pos:        position{line: 2180, col: 5, offset: 67303},
-									val:        "(",
-									ignoreCase: false,
-									want:       "\"(\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 2180, col: 9, offset: 67307},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 2180, col: 12, offset: 67310},
-									label: "first",
-									expr: &ruleRefExpr{
-										pos:  position{line: 2180, col: 18, offset: 67316},
-										name: "SQLIdentifier",
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 2180, col: 32, offset: 67330},
-									label: "rest",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 2180, col: 37, offset: 67335},
-										expr: &actionExpr{
-											pos: position{line: 2180, col: 39, offset: 67337},
-											run: (*parser).callonOptColumns10,
-											expr: &seqExpr{
-												pos: position{line: 2180, col: 39, offset: 67337},
-												exprs: []any{
-													&ruleRefExpr{
-														pos:  position{line: 2180, col: 39, offset: 67337},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 2180, col: 42, offset: 67340},
-														val:        ",",
-														ignoreCase: false,
-														want:       "\",\"",
-													},
-													&ruleRefExpr{
-														pos:  position{line: 2180, col: 46, offset: 67344},
-														name: "__",
-													},
-													&labeledExpr{
-														pos:   position{line: 2180, col: 49, offset: 67347},
-														label: "s",
-														expr: &ruleRefExpr{
-															pos:  position{line: 2180, col: 51, offset: 67349},
-															name: "SQLIdentifier",
-														},
-													},
+			name: "Columns",
+			pos:  position{line: 2179, col: 1, offset: 67282},
+			expr: &actionExpr{
+				pos: position{line: 2180, col: 5, offset: 67294},
+				run: (*parser).callonColumns1,
+				expr: &seqExpr{
+					pos: position{line: 2180, col: 5, offset: 67294},
+					exprs: []any{
+						&ruleRefExpr{
+							pos:  position{line: 2180, col: 5, offset: 67294},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 2180, col: 8, offset: 67297},
+							val:        "(",
+							ignoreCase: false,
+							want:       "\"(\"",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 2180, col: 12, offset: 67301},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 2180, col: 15, offset: 67304},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 2180, col: 21, offset: 67310},
+								name: "SQLIdentifier",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 2180, col: 35, offset: 67324},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 2180, col: 40, offset: 67329},
+								expr: &actionExpr{
+									pos: position{line: 2180, col: 42, offset: 67331},
+									run: (*parser).callonColumns10,
+									expr: &seqExpr{
+										pos: position{line: 2180, col: 42, offset: 67331},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 2180, col: 42, offset: 67331},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 2180, col: 45, offset: 67334},
+												val:        ",",
+												ignoreCase: false,
+												want:       "\",\"",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 2180, col: 49, offset: 67338},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 2180, col: 52, offset: 67341},
+												label: "s",
+												expr: &ruleRefExpr{
+													pos:  position{line: 2180, col: 54, offset: 67343},
+													name: "SQLIdentifier",
 												},
 											},
 										},
 									},
 								},
-								&ruleRefExpr{
-									pos:  position{line: 2180, col: 84, offset: 67382},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 2180, col: 87, offset: 67385},
-									val:        ")",
-									ignoreCase: false,
-									want:       "\")\"",
-								},
 							},
 						},
-					},
-					&actionExpr{
-						pos: position{line: 2183, col: 5, offset: 67460},
-						run: (*parser).callonOptColumns19,
-						expr: &litMatcher{
-							pos:        position{line: 2183, col: 5, offset: 67460},
-							val:        "",
+						&ruleRefExpr{
+							pos:  position{line: 2180, col: 87, offset: 67376},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 2180, col: 90, offset: 67379},
+							val:        ")",
 							ignoreCase: false,
-							want:       "\"\"",
+							want:       "\")\"",
 						},
 					},
 				},
@@ -15537,51 +15529,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2185, col: 1, offset: 67484},
+			pos:  position{line: 2184, col: 1, offset: 67451},
 			expr: &actionExpr{
-				pos: position{line: 2186, col: 5, offset: 67498},
+				pos: position{line: 2185, col: 5, offset: 67465},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2186, col: 5, offset: 67498},
+					pos: position{line: 2185, col: 5, offset: 67465},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2186, col: 5, offset: 67498},
+							pos:   position{line: 2185, col: 5, offset: 67465},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2186, col: 11, offset: 67504},
+								pos:  position{line: 2185, col: 11, offset: 67471},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2186, col: 22, offset: 67515},
+							pos:   position{line: 2185, col: 22, offset: 67482},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2186, col: 27, offset: 67520},
+								pos: position{line: 2185, col: 27, offset: 67487},
 								expr: &actionExpr{
-									pos: position{line: 2186, col: 29, offset: 67522},
+									pos: position{line: 2185, col: 29, offset: 67489},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2186, col: 29, offset: 67522},
+										pos: position{line: 2185, col: 29, offset: 67489},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2186, col: 29, offset: 67522},
+												pos:  position{line: 2185, col: 29, offset: 67489},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2186, col: 32, offset: 67525},
+												pos:        position{line: 2185, col: 32, offset: 67492},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2186, col: 36, offset: 67529},
+												pos:  position{line: 2185, col: 36, offset: 67496},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2186, col: 39, offset: 67532},
+												pos:   position{line: 2185, col: 39, offset: 67499},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2186, col: 41, offset: 67534},
+													pos:  position{line: 2185, col: 41, offset: 67501},
 													name: "SelectElem",
 												},
 											},
@@ -15598,38 +15590,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2195, col: 1, offset: 67760},
+			pos:  position{line: 2194, col: 1, offset: 67727},
 			expr: &choiceExpr{
-				pos: position{line: 2196, col: 5, offset: 67776},
+				pos: position{line: 2195, col: 5, offset: 67743},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2196, col: 5, offset: 67776},
+						pos: position{line: 2195, col: 5, offset: 67743},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2196, col: 5, offset: 67776},
+							pos: position{line: 2195, col: 5, offset: 67743},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2196, col: 5, offset: 67776},
+									pos:   position{line: 2195, col: 5, offset: 67743},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2196, col: 11, offset: 67782},
+										pos: position{line: 2195, col: 11, offset: 67749},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2196, col: 11, offset: 67782},
+												pos:  position{line: 2195, col: 11, offset: 67749},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2196, col: 25, offset: 67796},
+												pos:  position{line: 2195, col: 25, offset: 67763},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2196, col: 31, offset: 67802},
+									pos:   position{line: 2195, col: 31, offset: 67769},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2196, col: 34, offset: 67805},
+										pos:  position{line: 2195, col: 34, offset: 67772},
 										name: "OptAsClause",
 									},
 								},
@@ -15637,10 +15629,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2207, col: 5, offset: 68027},
+						pos: position{line: 2206, col: 5, offset: 67994},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2207, col: 5, offset: 68027},
+							pos:        position{line: 2206, col: 5, offset: 67994},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15653,33 +15645,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2212, col: 1, offset: 68129},
+			pos:  position{line: 2211, col: 1, offset: 68096},
 			expr: &choiceExpr{
-				pos: position{line: 2213, col: 5, offset: 68146},
+				pos: position{line: 2212, col: 5, offset: 68113},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2213, col: 5, offset: 68146},
+						pos: position{line: 2212, col: 5, offset: 68113},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2213, col: 5, offset: 68146},
+							pos: position{line: 2212, col: 5, offset: 68113},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2213, col: 5, offset: 68146},
+									pos:  position{line: 2212, col: 5, offset: 68113},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2213, col: 7, offset: 68148},
+									pos:  position{line: 2212, col: 7, offset: 68115},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2213, col: 10, offset: 68151},
+									pos:  position{line: 2212, col: 10, offset: 68118},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2213, col: 12, offset: 68153},
+									pos:   position{line: 2212, col: 12, offset: 68120},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2213, col: 15, offset: 68156},
+										pos:  position{line: 2212, col: 15, offset: 68123},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15687,27 +15679,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2214, col: 5, offset: 68193},
+						pos: position{line: 2213, col: 5, offset: 68160},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2214, col: 5, offset: 68193},
+							pos: position{line: 2213, col: 5, offset: 68160},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2214, col: 5, offset: 68193},
+									pos:  position{line: 2213, col: 5, offset: 68160},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2214, col: 7, offset: 68195},
+									pos: position{line: 2213, col: 7, offset: 68162},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2214, col: 8, offset: 68196},
+										pos:  position{line: 2213, col: 8, offset: 68163},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2214, col: 17, offset: 68205},
+									pos:   position{line: 2213, col: 17, offset: 68172},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2214, col: 20, offset: 68208},
+										pos:  position{line: 2213, col: 20, offset: 68175},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15715,10 +15707,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2215, col: 5, offset: 68245},
+						pos: position{line: 2214, col: 5, offset: 68212},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2215, col: 5, offset: 68245},
+							pos:        position{line: 2214, col: 5, offset: 68212},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15731,41 +15723,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2217, col: 1, offset: 68270},
+			pos:  position{line: 2216, col: 1, offset: 68237},
 			expr: &choiceExpr{
-				pos: position{line: 2218, col: 5, offset: 68292},
+				pos: position{line: 2217, col: 5, offset: 68259},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2218, col: 5, offset: 68292},
+						pos: position{line: 2217, col: 5, offset: 68259},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2218, col: 5, offset: 68292},
+							pos: position{line: 2217, col: 5, offset: 68259},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2218, col: 5, offset: 68292},
+									pos:  position{line: 2217, col: 5, offset: 68259},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2218, col: 7, offset: 68294},
+									pos:  position{line: 2217, col: 7, offset: 68261},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2218, col: 13, offset: 68300},
+									pos:  position{line: 2217, col: 13, offset: 68267},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2218, col: 15, offset: 68302},
+									pos:  position{line: 2217, col: 15, offset: 68269},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2218, col: 18, offset: 68305},
+									pos:  position{line: 2217, col: 18, offset: 68272},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2218, col: 20, offset: 68307},
+									pos:   position{line: 2217, col: 20, offset: 68274},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2218, col: 25, offset: 68312},
+										pos:  position{line: 2217, col: 25, offset: 68279},
 										name: "OrderByList",
 									},
 								},
@@ -15773,10 +15765,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2225, col: 5, offset: 68471},
+						pos: position{line: 2224, col: 5, offset: 68438},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2225, col: 5, offset: 68471},
+							pos:        position{line: 2224, col: 5, offset: 68438},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15789,51 +15781,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2227, col: 1, offset: 68504},
+			pos:  position{line: 2226, col: 1, offset: 68471},
 			expr: &actionExpr{
-				pos: position{line: 2228, col: 5, offset: 68521},
+				pos: position{line: 2227, col: 5, offset: 68488},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2228, col: 5, offset: 68521},
+					pos: position{line: 2227, col: 5, offset: 68488},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2228, col: 5, offset: 68521},
+							pos:   position{line: 2227, col: 5, offset: 68488},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2228, col: 11, offset: 68527},
+								pos:  position{line: 2227, col: 11, offset: 68494},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2228, col: 23, offset: 68539},
+							pos:   position{line: 2227, col: 23, offset: 68506},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2228, col: 28, offset: 68544},
+								pos: position{line: 2227, col: 28, offset: 68511},
 								expr: &actionExpr{
-									pos: position{line: 2228, col: 30, offset: 68546},
+									pos: position{line: 2227, col: 30, offset: 68513},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2228, col: 30, offset: 68546},
+										pos: position{line: 2227, col: 30, offset: 68513},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2228, col: 30, offset: 68546},
+												pos:  position{line: 2227, col: 30, offset: 68513},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2228, col: 33, offset: 68549},
+												pos:        position{line: 2227, col: 33, offset: 68516},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2228, col: 37, offset: 68553},
+												pos:  position{line: 2227, col: 37, offset: 68520},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2228, col: 40, offset: 68556},
+												pos:   position{line: 2227, col: 40, offset: 68523},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2228, col: 42, offset: 68558},
+													pos:  position{line: 2227, col: 42, offset: 68525},
 													name: "OrderByItem",
 												},
 											},
@@ -15850,34 +15842,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2232, col: 1, offset: 68659},
+			pos:  position{line: 2231, col: 1, offset: 68626},
 			expr: &actionExpr{
-				pos: position{line: 2233, col: 5, offset: 68675},
+				pos: position{line: 2232, col: 5, offset: 68642},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2233, col: 5, offset: 68675},
+					pos: position{line: 2232, col: 5, offset: 68642},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2233, col: 5, offset: 68675},
+							pos:   position{line: 2232, col: 5, offset: 68642},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2233, col: 7, offset: 68677},
+								pos:  position{line: 2232, col: 7, offset: 68644},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2233, col: 12, offset: 68682},
+							pos:   position{line: 2232, col: 12, offset: 68649},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2233, col: 18, offset: 68688},
+								pos:  position{line: 2232, col: 18, offset: 68655},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2233, col: 29, offset: 68699},
+							pos:   position{line: 2232, col: 29, offset: 68666},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2233, col: 35, offset: 68705},
+								pos:  position{line: 2232, col: 35, offset: 68672},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15889,49 +15881,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2244, col: 1, offset: 68955},
+			pos:  position{line: 2243, col: 1, offset: 68922},
 			expr: &choiceExpr{
-				pos: position{line: 2245, col: 5, offset: 68970},
+				pos: position{line: 2244, col: 5, offset: 68937},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2245, col: 5, offset: 68970},
+						pos: position{line: 2244, col: 5, offset: 68937},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2245, col: 5, offset: 68970},
+							pos: position{line: 2244, col: 5, offset: 68937},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2245, col: 5, offset: 68970},
+									pos:  position{line: 2244, col: 5, offset: 68937},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2245, col: 7, offset: 68972},
+									pos:  position{line: 2244, col: 7, offset: 68939},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2246, col: 5, offset: 69044},
+						pos: position{line: 2245, col: 5, offset: 69011},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2246, col: 5, offset: 69044},
+							pos: position{line: 2245, col: 5, offset: 69011},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2246, col: 5, offset: 69044},
+									pos:  position{line: 2245, col: 5, offset: 69011},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2246, col: 7, offset: 69046},
+									pos:  position{line: 2245, col: 7, offset: 69013},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2247, col: 5, offset: 69118},
+						pos: position{line: 2246, col: 5, offset: 69085},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2247, col: 5, offset: 69118},
+							pos:        position{line: 2246, col: 5, offset: 69085},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15944,65 +15936,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2249, col: 1, offset: 69150},
+			pos:  position{line: 2248, col: 1, offset: 69117},
 			expr: &choiceExpr{
-				pos: position{line: 2250, col: 5, offset: 69168},
+				pos: position{line: 2249, col: 5, offset: 69135},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2250, col: 5, offset: 69168},
+						pos: position{line: 2249, col: 5, offset: 69135},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2250, col: 5, offset: 69168},
+							pos: position{line: 2249, col: 5, offset: 69135},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2250, col: 5, offset: 69168},
+									pos:  position{line: 2249, col: 5, offset: 69135},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2250, col: 7, offset: 69170},
+									pos:  position{line: 2249, col: 7, offset: 69137},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2250, col: 13, offset: 69176},
+									pos:  position{line: 2249, col: 13, offset: 69143},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2250, col: 15, offset: 69178},
+									pos:  position{line: 2249, col: 15, offset: 69145},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2251, col: 5, offset: 69254},
+						pos: position{line: 2250, col: 5, offset: 69221},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2251, col: 5, offset: 69254},
+							pos: position{line: 2250, col: 5, offset: 69221},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2251, col: 5, offset: 69254},
+									pos:  position{line: 2250, col: 5, offset: 69221},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2251, col: 7, offset: 69256},
+									pos:  position{line: 2250, col: 7, offset: 69223},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2251, col: 13, offset: 69262},
+									pos:  position{line: 2250, col: 13, offset: 69229},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2251, col: 15, offset: 69264},
+									pos:  position{line: 2250, col: 15, offset: 69231},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2252, col: 5, offset: 69339},
+						pos: position{line: 2251, col: 5, offset: 69306},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2252, col: 5, offset: 69339},
+							pos:        position{line: 2251, col: 5, offset: 69306},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16015,25 +16007,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2254, col: 1, offset: 69384},
+			pos:  position{line: 2253, col: 1, offset: 69351},
 			expr: &choiceExpr{
-				pos: position{line: 2255, col: 5, offset: 69406},
+				pos: position{line: 2254, col: 5, offset: 69373},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2255, col: 5, offset: 69406},
+						pos: position{line: 2254, col: 5, offset: 69373},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2255, col: 5, offset: 69406},
+							pos: position{line: 2254, col: 5, offset: 69373},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2255, col: 5, offset: 69406},
+									pos:  position{line: 2254, col: 5, offset: 69373},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2255, col: 7, offset: 69408},
+									pos:   position{line: 2254, col: 7, offset: 69375},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2255, col: 10, offset: 69411},
+										pos:  position{line: 2254, col: 10, offset: 69378},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -16041,10 +16033,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2256, col: 5, offset: 69450},
+						pos: position{line: 2255, col: 5, offset: 69417},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2256, col: 5, offset: 69450},
+							pos:        position{line: 2255, col: 5, offset: 69417},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16057,29 +16049,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2258, col: 1, offset: 69491},
+			pos:  position{line: 2257, col: 1, offset: 69458},
 			expr: &choiceExpr{
-				pos: position{line: 2259, col: 5, offset: 69510},
+				pos: position{line: 2258, col: 5, offset: 69477},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2259, col: 5, offset: 69510},
+						pos: position{line: 2258, col: 5, offset: 69477},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2259, col: 5, offset: 69510},
+							pos: position{line: 2258, col: 5, offset: 69477},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2259, col: 5, offset: 69510},
+									pos:   position{line: 2258, col: 5, offset: 69477},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2259, col: 7, offset: 69512},
+										pos:  position{line: 2258, col: 7, offset: 69479},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2259, col: 19, offset: 69524},
+									pos:   position{line: 2258, col: 19, offset: 69491},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2259, col: 21, offset: 69526},
+										pos:  position{line: 2258, col: 21, offset: 69493},
 										name: "OptOffsetClause",
 									},
 								},
@@ -16087,24 +16079,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2272, col: 5, offset: 69790},
+						pos: position{line: 2271, col: 5, offset: 69757},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2272, col: 5, offset: 69790},
+							pos: position{line: 2271, col: 5, offset: 69757},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2272, col: 5, offset: 69790},
+									pos:   position{line: 2271, col: 5, offset: 69757},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2272, col: 7, offset: 69792},
+										pos:  position{line: 2271, col: 7, offset: 69759},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2272, col: 20, offset: 69805},
+									pos:   position{line: 2271, col: 20, offset: 69772},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2272, col: 22, offset: 69807},
+										pos:  position{line: 2271, col: 22, offset: 69774},
 										name: "OptLimitClause",
 									},
 								},
@@ -16118,25 +16110,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2284, col: 1, offset: 70036},
+			pos:  position{line: 2283, col: 1, offset: 70003},
 			expr: &choiceExpr{
-				pos: position{line: 2285, col: 5, offset: 70056},
+				pos: position{line: 2284, col: 5, offset: 70023},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2285, col: 5, offset: 70056},
+						pos: position{line: 2284, col: 5, offset: 70023},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2285, col: 5, offset: 70056},
+							pos: position{line: 2284, col: 5, offset: 70023},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2285, col: 5, offset: 70056},
+									pos:  position{line: 2284, col: 5, offset: 70023},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2285, col: 7, offset: 70058},
+									pos:   position{line: 2284, col: 7, offset: 70025},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2285, col: 9, offset: 70060},
+										pos:  position{line: 2284, col: 9, offset: 70027},
 										name: "LimitClause",
 									},
 								},
@@ -16144,10 +16136,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2286, col: 5, offset: 70094},
+						pos: position{line: 2285, col: 5, offset: 70061},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2286, col: 5, offset: 70094},
+							pos:        position{line: 2285, col: 5, offset: 70061},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16160,50 +16152,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2288, col: 1, offset: 70131},
+			pos:  position{line: 2287, col: 1, offset: 70098},
 			expr: &choiceExpr{
-				pos: position{line: 2289, col: 5, offset: 70148},
+				pos: position{line: 2288, col: 5, offset: 70115},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2289, col: 5, offset: 70148},
+						pos: position{line: 2288, col: 5, offset: 70115},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2289, col: 5, offset: 70148},
+							pos: position{line: 2288, col: 5, offset: 70115},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 5, offset: 70148},
+									pos:  position{line: 2288, col: 5, offset: 70115},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 11, offset: 70154},
+									pos:  position{line: 2288, col: 11, offset: 70121},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 13, offset: 70156},
+									pos:  position{line: 2288, col: 13, offset: 70123},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2290, col: 5, offset: 70184},
+						pos: position{line: 2289, col: 5, offset: 70151},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2290, col: 5, offset: 70184},
+							pos: position{line: 2289, col: 5, offset: 70151},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2290, col: 5, offset: 70184},
+									pos:  position{line: 2289, col: 5, offset: 70151},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2290, col: 11, offset: 70190},
+									pos:  position{line: 2289, col: 11, offset: 70157},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2290, col: 13, offset: 70192},
+									pos:   position{line: 2289, col: 13, offset: 70159},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 15, offset: 70194},
+										pos:  position{line: 2289, col: 15, offset: 70161},
 										name: "Expr",
 									},
 								},
@@ -16217,25 +16209,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2292, col: 1, offset: 70218},
+			pos:  position{line: 2291, col: 1, offset: 70185},
 			expr: &choiceExpr{
-				pos: position{line: 2293, col: 5, offset: 70239},
+				pos: position{line: 2292, col: 5, offset: 70206},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2293, col: 5, offset: 70239},
+						pos: position{line: 2292, col: 5, offset: 70206},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2293, col: 5, offset: 70239},
+							pos: position{line: 2292, col: 5, offset: 70206},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2293, col: 5, offset: 70239},
+									pos:  position{line: 2292, col: 5, offset: 70206},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2293, col: 7, offset: 70241},
+									pos:   position{line: 2292, col: 7, offset: 70208},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2293, col: 9, offset: 70243},
+										pos:  position{line: 2292, col: 9, offset: 70210},
 										name: "OffsetClause",
 									},
 								},
@@ -16243,10 +16235,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2294, col: 5, offset: 70279},
+						pos: position{line: 2293, col: 5, offset: 70246},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2294, col: 5, offset: 70279},
+							pos:        position{line: 2293, col: 5, offset: 70246},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16259,26 +16251,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2296, col: 1, offset: 70304},
+			pos:  position{line: 2295, col: 1, offset: 70271},
 			expr: &actionExpr{
-				pos: position{line: 2297, col: 5, offset: 70322},
+				pos: position{line: 2296, col: 5, offset: 70289},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2297, col: 5, offset: 70322},
+					pos: position{line: 2296, col: 5, offset: 70289},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2297, col: 5, offset: 70322},
+							pos:  position{line: 2296, col: 5, offset: 70289},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2297, col: 12, offset: 70329},
+							pos:  position{line: 2296, col: 12, offset: 70296},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2297, col: 14, offset: 70331},
+							pos:   position{line: 2296, col: 14, offset: 70298},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2297, col: 16, offset: 70333},
+								pos:  position{line: 2296, col: 16, offset: 70300},
 								name: "Expr",
 							},
 						},
@@ -16290,38 +16282,38 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2299, col: 1, offset: 70358},
+			pos:  position{line: 2298, col: 1, offset: 70325},
 			expr: &actionExpr{
-				pos: position{line: 2300, col: 5, offset: 70375},
+				pos: position{line: 2299, col: 5, offset: 70342},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2300, col: 5, offset: 70375},
+					pos: position{line: 2299, col: 5, offset: 70342},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2300, col: 5, offset: 70375},
+							pos:   position{line: 2299, col: 5, offset: 70342},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2300, col: 10, offset: 70380},
+								pos:  position{line: 2299, col: 10, offset: 70347},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2300, col: 21, offset: 70391},
+							pos:   position{line: 2299, col: 21, offset: 70358},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2300, col: 30, offset: 70400},
+								pos:  position{line: 2299, col: 30, offset: 70367},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2300, col: 36, offset: 70406},
+							pos:  position{line: 2299, col: 36, offset: 70373},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2300, col: 38, offset: 70408},
+							pos:   position{line: 2299, col: 38, offset: 70375},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2300, col: 44, offset: 70414},
+								pos:  position{line: 2299, col: 44, offset: 70381},
 								name: "SelectExpr",
 							},
 						},
@@ -16333,60 +16325,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2310, col: 1, offset: 70635},
+			pos:  position{line: 2309, col: 1, offset: 70602},
 			expr: &choiceExpr{
-				pos: position{line: 2311, col: 5, offset: 70646},
+				pos: position{line: 2310, col: 5, offset: 70613},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2311, col: 5, offset: 70646},
+						pos: position{line: 2310, col: 5, offset: 70613},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2311, col: 5, offset: 70646},
+							pos: position{line: 2310, col: 5, offset: 70613},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2311, col: 5, offset: 70646},
+									pos:  position{line: 2310, col: 5, offset: 70613},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2311, col: 7, offset: 70648},
+									pos:  position{line: 2310, col: 7, offset: 70615},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2311, col: 13, offset: 70654},
+									pos:  position{line: 2310, col: 13, offset: 70621},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2311, col: 15, offset: 70656},
+									pos:  position{line: 2310, col: 15, offset: 70623},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2312, col: 5, offset: 70692},
+						pos: position{line: 2311, col: 5, offset: 70659},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2312, col: 5, offset: 70692},
+							pos: position{line: 2311, col: 5, offset: 70659},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2312, col: 5, offset: 70692},
+									pos:  position{line: 2311, col: 5, offset: 70659},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2312, col: 7, offset: 70694},
+									pos:  position{line: 2311, col: 7, offset: 70661},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2312, col: 13, offset: 70700},
+									pos: position{line: 2311, col: 13, offset: 70667},
 									expr: &seqExpr{
-										pos: position{line: 2312, col: 14, offset: 70701},
+										pos: position{line: 2311, col: 14, offset: 70668},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2312, col: 14, offset: 70701},
+												pos:  position{line: 2311, col: 14, offset: 70668},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2312, col: 16, offset: 70703},
+												pos:  position{line: 2311, col: 16, offset: 70670},
 												name: "DISTINCT",
 											},
 										},
@@ -16402,84 +16394,84 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2315, col: 1, offset: 70755},
+			pos:  position{line: 2314, col: 1, offset: 70722},
 			expr: &choiceExpr{
-				pos: position{line: 2316, col: 5, offset: 70770},
+				pos: position{line: 2315, col: 5, offset: 70737},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2316, col: 5, offset: 70770},
+						pos:  position{line: 2315, col: 5, offset: 70737},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2316, col: 12, offset: 70777},
+						pos:  position{line: 2315, col: 12, offset: 70744},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2316, col: 20, offset: 70785},
+						pos:  position{line: 2315, col: 20, offset: 70752},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2316, col: 29, offset: 70794},
+						pos:  position{line: 2315, col: 29, offset: 70761},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2316, col: 38, offset: 70803},
+						pos:  position{line: 2315, col: 38, offset: 70770},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2317, col: 5, offset: 70817},
+						pos:  position{line: 2316, col: 5, offset: 70784},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2317, col: 13, offset: 70825},
+						pos:  position{line: 2316, col: 13, offset: 70792},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2317, col: 20, offset: 70832},
+						pos:  position{line: 2316, col: 20, offset: 70799},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2317, col: 28, offset: 70840},
+						pos:  position{line: 2316, col: 28, offset: 70807},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2317, col: 36, offset: 70848},
+						pos:  position{line: 2316, col: 36, offset: 70815},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2317, col: 44, offset: 70856},
+						pos:  position{line: 2316, col: 44, offset: 70823},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2318, col: 5, offset: 70865},
+						pos:  position{line: 2317, col: 5, offset: 70832},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2319, col: 5, offset: 70875},
+						pos:  position{line: 2318, col: 5, offset: 70842},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2320, col: 5, offset: 70885},
+						pos:  position{line: 2319, col: 5, offset: 70852},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2321, col: 5, offset: 70896},
+						pos:  position{line: 2320, col: 5, offset: 70863},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2322, col: 5, offset: 70906},
+						pos:  position{line: 2321, col: 5, offset: 70873},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2323, col: 5, offset: 70917},
+						pos:  position{line: 2322, col: 5, offset: 70884},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2324, col: 5, offset: 70926},
+						pos:  position{line: 2323, col: 5, offset: 70893},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2325, col: 5, offset: 70936},
+						pos:  position{line: 2324, col: 5, offset: 70903},
 						name: "ON",
 					},
 				},
@@ -16489,20 +16481,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2327, col: 1, offset: 70940},
+			pos:  position{line: 2326, col: 1, offset: 70907},
 			expr: &seqExpr{
-				pos: position{line: 2327, col: 14, offset: 70953},
+				pos: position{line: 2326, col: 14, offset: 70920},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2327, col: 14, offset: 70953},
+						pos:        position{line: 2326, col: 14, offset: 70920},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2327, col: 33, offset: 70972},
+						pos: position{line: 2326, col: 33, offset: 70939},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2327, col: 34, offset: 70973},
+							pos:  position{line: 2326, col: 34, offset: 70940},
 							name: "IdentifierRest",
 						},
 					},
@@ -16513,20 +16505,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2328, col: 1, offset: 70988},
+			pos:  position{line: 2327, col: 1, offset: 70955},
 			expr: &seqExpr{
-				pos: position{line: 2328, col: 14, offset: 71001},
+				pos: position{line: 2327, col: 14, offset: 70968},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2328, col: 14, offset: 71001},
+						pos:        position{line: 2327, col: 14, offset: 70968},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2328, col: 33, offset: 71020},
+						pos: position{line: 2327, col: 33, offset: 70987},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2328, col: 34, offset: 71021},
+							pos:  position{line: 2327, col: 34, offset: 70988},
 							name: "IdentifierRest",
 						},
 					},
@@ -16537,23 +16529,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2329, col: 1, offset: 71036},
+			pos:  position{line: 2328, col: 1, offset: 71003},
 			expr: &actionExpr{
-				pos: position{line: 2329, col: 14, offset: 71049},
+				pos: position{line: 2328, col: 14, offset: 71016},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2329, col: 14, offset: 71049},
+					pos: position{line: 2328, col: 14, offset: 71016},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2329, col: 14, offset: 71049},
+							pos:        position{line: 2328, col: 14, offset: 71016},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2329, col: 33, offset: 71068},
+							pos: position{line: 2328, col: 33, offset: 71035},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2329, col: 34, offset: 71069},
+								pos:  position{line: 2328, col: 34, offset: 71036},
 								name: "IdentifierRest",
 							},
 						},
@@ -16565,20 +16557,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2330, col: 1, offset: 71106},
+			pos:  position{line: 2329, col: 1, offset: 71073},
 			expr: &seqExpr{
-				pos: position{line: 2330, col: 14, offset: 71119},
+				pos: position{line: 2329, col: 14, offset: 71086},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2330, col: 14, offset: 71119},
+						pos:        position{line: 2329, col: 14, offset: 71086},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2330, col: 33, offset: 71138},
+						pos: position{line: 2329, col: 33, offset: 71105},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2330, col: 34, offset: 71139},
+							pos:  position{line: 2329, col: 34, offset: 71106},
 							name: "IdentifierRest",
 						},
 					},
@@ -16589,20 +16581,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2331, col: 1, offset: 71154},
+			pos:  position{line: 2330, col: 1, offset: 71121},
 			expr: &seqExpr{
-				pos: position{line: 2331, col: 14, offset: 71167},
+				pos: position{line: 2330, col: 14, offset: 71134},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2331, col: 14, offset: 71167},
+						pos:        position{line: 2330, col: 14, offset: 71134},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2331, col: 33, offset: 71186},
+						pos: position{line: 2330, col: 33, offset: 71153},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2331, col: 34, offset: 71187},
+							pos:  position{line: 2330, col: 34, offset: 71154},
 							name: "IdentifierRest",
 						},
 					},
@@ -16613,23 +16605,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2332, col: 1, offset: 71202},
+			pos:  position{line: 2331, col: 1, offset: 71169},
 			expr: &actionExpr{
-				pos: position{line: 2332, col: 14, offset: 71215},
+				pos: position{line: 2331, col: 14, offset: 71182},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2332, col: 14, offset: 71215},
+					pos: position{line: 2331, col: 14, offset: 71182},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2332, col: 14, offset: 71215},
+							pos:        position{line: 2331, col: 14, offset: 71182},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2332, col: 33, offset: 71234},
+							pos: position{line: 2331, col: 33, offset: 71201},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2332, col: 34, offset: 71235},
+								pos:  position{line: 2331, col: 34, offset: 71202},
 								name: "IdentifierRest",
 							},
 						},
@@ -16641,20 +16633,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2333, col: 1, offset: 71272},
+			pos:  position{line: 2332, col: 1, offset: 71239},
 			expr: &seqExpr{
-				pos: position{line: 2333, col: 14, offset: 71285},
+				pos: position{line: 2332, col: 14, offset: 71252},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2333, col: 14, offset: 71285},
+						pos:        position{line: 2332, col: 14, offset: 71252},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2333, col: 33, offset: 71304},
+						pos: position{line: 2332, col: 33, offset: 71271},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2333, col: 34, offset: 71305},
+							pos:  position{line: 2332, col: 34, offset: 71272},
 							name: "IdentifierRest",
 						},
 					},
@@ -16665,20 +16657,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2334, col: 1, offset: 71320},
+			pos:  position{line: 2333, col: 1, offset: 71287},
 			expr: &seqExpr{
-				pos: position{line: 2334, col: 14, offset: 71333},
+				pos: position{line: 2333, col: 14, offset: 71300},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2334, col: 14, offset: 71333},
+						pos:        position{line: 2333, col: 14, offset: 71300},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2334, col: 33, offset: 71352},
+						pos: position{line: 2333, col: 33, offset: 71319},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2334, col: 34, offset: 71353},
+							pos:  position{line: 2333, col: 34, offset: 71320},
 							name: "IdentifierRest",
 						},
 					},
@@ -16689,20 +16681,20 @@ var g = &grammar{
 		},
 		{
 			name: "AUTHOR",
-			pos:  position{line: 2335, col: 1, offset: 71368},
+			pos:  position{line: 2334, col: 1, offset: 71335},
 			expr: &seqExpr{
-				pos: position{line: 2335, col: 14, offset: 71381},
+				pos: position{line: 2334, col: 14, offset: 71348},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2335, col: 14, offset: 71381},
+						pos:        position{line: 2334, col: 14, offset: 71348},
 						val:        "author",
 						ignoreCase: true,
 						want:       "\"AUTHOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2335, col: 33, offset: 71400},
+						pos: position{line: 2334, col: 33, offset: 71367},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2335, col: 34, offset: 71401},
+							pos:  position{line: 2334, col: 34, offset: 71368},
 							name: "IdentifierRest",
 						},
 					},
@@ -16713,20 +16705,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2336, col: 1, offset: 71416},
+			pos:  position{line: 2335, col: 1, offset: 71383},
 			expr: &seqExpr{
-				pos: position{line: 2336, col: 14, offset: 71429},
+				pos: position{line: 2335, col: 14, offset: 71396},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2336, col: 14, offset: 71429},
+						pos:        position{line: 2335, col: 14, offset: 71396},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2336, col: 33, offset: 71448},
+						pos: position{line: 2335, col: 33, offset: 71415},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2336, col: 34, offset: 71449},
+							pos:  position{line: 2335, col: 34, offset: 71416},
 							name: "IdentifierRest",
 						},
 					},
@@ -16737,20 +16729,20 @@ var g = &grammar{
 		},
 		{
 			name: "BODY",
-			pos:  position{line: 2337, col: 1, offset: 71464},
+			pos:  position{line: 2336, col: 1, offset: 71431},
 			expr: &seqExpr{
-				pos: position{line: 2337, col: 14, offset: 71477},
+				pos: position{line: 2336, col: 14, offset: 71444},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2337, col: 14, offset: 71477},
+						pos:        position{line: 2336, col: 14, offset: 71444},
 						val:        "body",
 						ignoreCase: true,
 						want:       "\"BODY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2337, col: 33, offset: 71496},
+						pos: position{line: 2336, col: 33, offset: 71463},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2337, col: 34, offset: 71497},
+							pos:  position{line: 2336, col: 34, offset: 71464},
 							name: "IdentifierRest",
 						},
 					},
@@ -16761,20 +16753,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2338, col: 1, offset: 71512},
+			pos:  position{line: 2337, col: 1, offset: 71479},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 71525},
+				pos: position{line: 2337, col: 14, offset: 71492},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 71525},
+						pos:        position{line: 2337, col: 14, offset: 71492},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 71544},
+						pos: position{line: 2337, col: 33, offset: 71511},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 71545},
+							pos:  position{line: 2337, col: 34, offset: 71512},
 							name: "IdentifierRest",
 						},
 					},
@@ -16785,20 +16777,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2339, col: 1, offset: 71560},
+			pos:  position{line: 2338, col: 1, offset: 71527},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 71573},
+				pos: position{line: 2338, col: 14, offset: 71540},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 71573},
+						pos:        position{line: 2338, col: 14, offset: 71540},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 71592},
+						pos: position{line: 2338, col: 33, offset: 71559},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 71593},
+							pos:  position{line: 2338, col: 34, offset: 71560},
 							name: "IdentifierRest",
 						},
 					},
@@ -16809,20 +16801,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2340, col: 1, offset: 71608},
+			pos:  position{line: 2339, col: 1, offset: 71575},
 			expr: &seqExpr{
-				pos: position{line: 2340, col: 14, offset: 71621},
+				pos: position{line: 2339, col: 14, offset: 71588},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2340, col: 14, offset: 71621},
+						pos:        position{line: 2339, col: 14, offset: 71588},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2340, col: 33, offset: 71640},
+						pos: position{line: 2339, col: 33, offset: 71607},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2340, col: 34, offset: 71641},
+							pos:  position{line: 2339, col: 34, offset: 71608},
 							name: "IdentifierRest",
 						},
 					},
@@ -16833,20 +16825,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2341, col: 1, offset: 71656},
+			pos:  position{line: 2340, col: 1, offset: 71623},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 71669},
+				pos: position{line: 2340, col: 14, offset: 71636},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 71669},
+						pos:        position{line: 2340, col: 14, offset: 71636},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 71688},
+						pos: position{line: 2340, col: 33, offset: 71655},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 71689},
+							pos:  position{line: 2340, col: 34, offset: 71656},
 							name: "IdentifierRest",
 						},
 					},
@@ -16857,20 +16849,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2342, col: 1, offset: 71704},
+			pos:  position{line: 2341, col: 1, offset: 71671},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 71717},
+				pos: position{line: 2341, col: 14, offset: 71684},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 71717},
+						pos:        position{line: 2341, col: 14, offset: 71684},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 71736},
+						pos: position{line: 2341, col: 33, offset: 71703},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 71737},
+							pos:  position{line: 2341, col: 34, offset: 71704},
 							name: "IdentifierRest",
 						},
 					},
@@ -16881,20 +16873,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2343, col: 1, offset: 71752},
+			pos:  position{line: 2342, col: 1, offset: 71719},
 			expr: &seqExpr{
-				pos: position{line: 2343, col: 14, offset: 71765},
+				pos: position{line: 2342, col: 14, offset: 71732},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2343, col: 14, offset: 71765},
+						pos:        position{line: 2342, col: 14, offset: 71732},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2343, col: 33, offset: 71784},
+						pos: position{line: 2342, col: 33, offset: 71751},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2343, col: 34, offset: 71785},
+							pos:  position{line: 2342, col: 34, offset: 71752},
 							name: "IdentifierRest",
 						},
 					},
@@ -16905,20 +16897,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2344, col: 1, offset: 71800},
+			pos:  position{line: 2343, col: 1, offset: 71767},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 71813},
+				pos: position{line: 2343, col: 14, offset: 71780},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 71813},
+						pos:        position{line: 2343, col: 14, offset: 71780},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 71832},
+						pos: position{line: 2343, col: 33, offset: 71799},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 71833},
+							pos:  position{line: 2343, col: 34, offset: 71800},
 							name: "IdentifierRest",
 						},
 					},
@@ -16929,23 +16921,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2345, col: 1, offset: 71848},
+			pos:  position{line: 2344, col: 1, offset: 71815},
 			expr: &actionExpr{
-				pos: position{line: 2345, col: 14, offset: 71861},
+				pos: position{line: 2344, col: 14, offset: 71828},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2345, col: 14, offset: 71861},
+					pos: position{line: 2344, col: 14, offset: 71828},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2345, col: 14, offset: 71861},
+							pos:        position{line: 2344, col: 14, offset: 71828},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2345, col: 33, offset: 71880},
+							pos: position{line: 2344, col: 33, offset: 71847},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2345, col: 34, offset: 71881},
+								pos:  position{line: 2344, col: 34, offset: 71848},
 								name: "IdentifierRest",
 							},
 						},
@@ -16957,20 +16949,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2346, col: 1, offset: 71919},
+			pos:  position{line: 2345, col: 1, offset: 71886},
 			expr: &seqExpr{
-				pos: position{line: 2346, col: 14, offset: 71932},
+				pos: position{line: 2345, col: 14, offset: 71899},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2346, col: 14, offset: 71932},
+						pos:        position{line: 2345, col: 14, offset: 71899},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2346, col: 33, offset: 71951},
+						pos: position{line: 2345, col: 33, offset: 71918},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2346, col: 34, offset: 71952},
+							pos:  position{line: 2345, col: 34, offset: 71919},
 							name: "IdentifierRest",
 						},
 					},
@@ -16981,20 +16973,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2347, col: 1, offset: 71967},
+			pos:  position{line: 2346, col: 1, offset: 71934},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 71980},
+				pos: position{line: 2346, col: 14, offset: 71947},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 71980},
+						pos:        position{line: 2346, col: 14, offset: 71947},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 71999},
+						pos: position{line: 2346, col: 33, offset: 71966},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 72000},
+							pos:  position{line: 2346, col: 34, offset: 71967},
 							name: "IdentifierRest",
 						},
 					},
@@ -17005,23 +16997,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2348, col: 1, offset: 72015},
+			pos:  position{line: 2347, col: 1, offset: 71982},
 			expr: &actionExpr{
-				pos: position{line: 2348, col: 14, offset: 72028},
+				pos: position{line: 2347, col: 14, offset: 71995},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2348, col: 14, offset: 72028},
+					pos: position{line: 2347, col: 14, offset: 71995},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2348, col: 14, offset: 72028},
+							pos:        position{line: 2347, col: 14, offset: 71995},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2348, col: 33, offset: 72047},
+							pos: position{line: 2347, col: 33, offset: 72014},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2348, col: 34, offset: 72048},
+								pos:  position{line: 2347, col: 34, offset: 72015},
 								name: "IdentifierRest",
 							},
 						},
@@ -17033,20 +17025,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2349, col: 1, offset: 72086},
+			pos:  position{line: 2348, col: 1, offset: 72053},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 72099},
+				pos: position{line: 2348, col: 14, offset: 72066},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 72099},
+						pos:        position{line: 2348, col: 14, offset: 72066},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 72118},
+						pos: position{line: 2348, col: 33, offset: 72085},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 72119},
+							pos:  position{line: 2348, col: 34, offset: 72086},
 							name: "IdentifierRest",
 						},
 					},
@@ -17057,20 +17049,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2350, col: 1, offset: 72134},
+			pos:  position{line: 2349, col: 1, offset: 72101},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 72147},
+				pos: position{line: 2349, col: 14, offset: 72114},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 72147},
+						pos:        position{line: 2349, col: 14, offset: 72114},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 72166},
+						pos: position{line: 2349, col: 33, offset: 72133},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 72167},
+							pos:  position{line: 2349, col: 34, offset: 72134},
 							name: "IdentifierRest",
 						},
 					},
@@ -17081,20 +17073,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2351, col: 1, offset: 72183},
+			pos:  position{line: 2350, col: 1, offset: 72150},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 72196},
+				pos: position{line: 2350, col: 14, offset: 72163},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 72196},
+						pos:        position{line: 2350, col: 14, offset: 72163},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 72215},
+						pos: position{line: 2350, col: 33, offset: 72182},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 72216},
+							pos:  position{line: 2350, col: 34, offset: 72183},
 							name: "IdentifierRest",
 						},
 					},
@@ -17105,20 +17097,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2352, col: 1, offset: 72231},
+			pos:  position{line: 2351, col: 1, offset: 72198},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 72244},
+				pos: position{line: 2351, col: 14, offset: 72211},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 72244},
+						pos:        position{line: 2351, col: 14, offset: 72211},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 72263},
+						pos: position{line: 2351, col: 33, offset: 72230},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 72264},
+							pos:  position{line: 2351, col: 34, offset: 72231},
 							name: "IdentifierRest",
 						},
 					},
@@ -17129,20 +17121,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2353, col: 1, offset: 72279},
+			pos:  position{line: 2352, col: 1, offset: 72246},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 72292},
+				pos: position{line: 2352, col: 14, offset: 72259},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 72292},
+						pos:        position{line: 2352, col: 14, offset: 72259},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 72311},
+						pos: position{line: 2352, col: 33, offset: 72278},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 72312},
+							pos:  position{line: 2352, col: 34, offset: 72279},
 							name: "IdentifierRest",
 						},
 					},
@@ -17153,20 +17145,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2354, col: 1, offset: 72327},
+			pos:  position{line: 2353, col: 1, offset: 72294},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 72340},
+				pos: position{line: 2353, col: 14, offset: 72307},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 72340},
+						pos:        position{line: 2353, col: 14, offset: 72307},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 72359},
+						pos: position{line: 2353, col: 33, offset: 72326},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 72360},
+							pos:  position{line: 2353, col: 34, offset: 72327},
 							name: "IdentifierRest",
 						},
 					},
@@ -17177,20 +17169,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2355, col: 1, offset: 72375},
+			pos:  position{line: 2354, col: 1, offset: 72342},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 72388},
+				pos: position{line: 2354, col: 14, offset: 72355},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 72388},
+						pos:        position{line: 2354, col: 14, offset: 72355},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 72407},
+						pos: position{line: 2354, col: 33, offset: 72374},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 72408},
+							pos:  position{line: 2354, col: 34, offset: 72375},
 							name: "IdentifierRest",
 						},
 					},
@@ -17201,20 +17193,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2356, col: 1, offset: 72423},
+			pos:  position{line: 2355, col: 1, offset: 72390},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 72436},
+				pos: position{line: 2355, col: 14, offset: 72403},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 72436},
+						pos:        position{line: 2355, col: 14, offset: 72403},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 72455},
+						pos: position{line: 2355, col: 33, offset: 72422},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 72456},
+							pos:  position{line: 2355, col: 34, offset: 72423},
 							name: "IdentifierRest",
 						},
 					},
@@ -17225,20 +17217,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2357, col: 1, offset: 72471},
+			pos:  position{line: 2356, col: 1, offset: 72438},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 72484},
+				pos: position{line: 2356, col: 14, offset: 72451},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 72484},
+						pos:        position{line: 2356, col: 14, offset: 72451},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 72503},
+						pos: position{line: 2356, col: 33, offset: 72470},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 72504},
+							pos:  position{line: 2356, col: 34, offset: 72471},
 							name: "IdentifierRest",
 						},
 					},
@@ -17249,20 +17241,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2358, col: 1, offset: 72519},
+			pos:  position{line: 2357, col: 1, offset: 72486},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 72532},
+				pos: position{line: 2357, col: 14, offset: 72499},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 72532},
+						pos:        position{line: 2357, col: 14, offset: 72499},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 72551},
+						pos: position{line: 2357, col: 33, offset: 72518},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 72552},
+							pos:  position{line: 2357, col: 34, offset: 72519},
 							name: "IdentifierRest",
 						},
 					},
@@ -17273,20 +17265,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2359, col: 1, offset: 72567},
+			pos:  position{line: 2358, col: 1, offset: 72534},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 72580},
+				pos: position{line: 2358, col: 14, offset: 72547},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 72580},
+						pos:        position{line: 2358, col: 14, offset: 72547},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 72599},
+						pos: position{line: 2358, col: 33, offset: 72566},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 72600},
+							pos:  position{line: 2358, col: 34, offset: 72567},
 							name: "IdentifierRest",
 						},
 					},
@@ -17297,20 +17289,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2360, col: 1, offset: 72615},
+			pos:  position{line: 2359, col: 1, offset: 72582},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 72628},
+				pos: position{line: 2359, col: 14, offset: 72595},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 72628},
+						pos:        position{line: 2359, col: 14, offset: 72595},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 72647},
+						pos: position{line: 2359, col: 33, offset: 72614},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 72648},
+							pos:  position{line: 2359, col: 34, offset: 72615},
 							name: "IdentifierRest",
 						},
 					},
@@ -17321,20 +17313,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORMAT",
-			pos:  position{line: 2361, col: 1, offset: 72663},
+			pos:  position{line: 2360, col: 1, offset: 72630},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 72676},
+				pos: position{line: 2360, col: 14, offset: 72643},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 72676},
+						pos:        position{line: 2360, col: 14, offset: 72643},
 						val:        "format",
 						ignoreCase: true,
 						want:       "\"FORMAT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 72695},
+						pos: position{line: 2360, col: 33, offset: 72662},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 72696},
+							pos:  position{line: 2360, col: 34, offset: 72663},
 							name: "IdentifierRest",
 						},
 					},
@@ -17345,20 +17337,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2362, col: 1, offset: 72711},
+			pos:  position{line: 2361, col: 1, offset: 72678},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 72724},
+				pos: position{line: 2361, col: 14, offset: 72691},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 72724},
+						pos:        position{line: 2361, col: 14, offset: 72691},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 72743},
+						pos: position{line: 2361, col: 33, offset: 72710},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 72744},
+							pos:  position{line: 2361, col: 34, offset: 72711},
 							name: "IdentifierRest",
 						},
 					},
@@ -17369,20 +17361,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2363, col: 1, offset: 72759},
+			pos:  position{line: 2362, col: 1, offset: 72726},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 72772},
+				pos: position{line: 2362, col: 14, offset: 72739},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 72772},
+						pos:        position{line: 2362, col: 14, offset: 72739},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 72791},
+						pos: position{line: 2362, col: 33, offset: 72758},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 72792},
+							pos:  position{line: 2362, col: 34, offset: 72759},
 							name: "IdentifierRest",
 						},
 					},
@@ -17393,20 +17385,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2364, col: 1, offset: 72807},
+			pos:  position{line: 2363, col: 1, offset: 72774},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 72820},
+				pos: position{line: 2363, col: 14, offset: 72787},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 72820},
+						pos:        position{line: 2363, col: 14, offset: 72787},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 72839},
+						pos: position{line: 2363, col: 33, offset: 72806},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 72840},
+							pos:  position{line: 2363, col: 34, offset: 72807},
 							name: "IdentifierRest",
 						},
 					},
@@ -17417,20 +17409,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2365, col: 1, offset: 72855},
+			pos:  position{line: 2364, col: 1, offset: 72822},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 72868},
+				pos: position{line: 2364, col: 14, offset: 72835},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 72868},
+						pos:        position{line: 2364, col: 14, offset: 72835},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 72887},
+						pos: position{line: 2364, col: 33, offset: 72854},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 72888},
+							pos:  position{line: 2364, col: 34, offset: 72855},
 							name: "IdentifierRest",
 						},
 					},
@@ -17441,20 +17433,20 @@ var g = &grammar{
 		},
 		{
 			name: "GREP",
-			pos:  position{line: 2366, col: 1, offset: 72903},
+			pos:  position{line: 2365, col: 1, offset: 72870},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 72916},
+				pos: position{line: 2365, col: 14, offset: 72883},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 72916},
+						pos:        position{line: 2365, col: 14, offset: 72883},
 						val:        "grep",
 						ignoreCase: true,
 						want:       "\"GREP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 72935},
+						pos: position{line: 2365, col: 33, offset: 72902},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 72936},
+							pos:  position{line: 2365, col: 34, offset: 72903},
 							name: "IdentifierRest",
 						},
 					},
@@ -17465,20 +17457,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2367, col: 1, offset: 72951},
+			pos:  position{line: 2366, col: 1, offset: 72918},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 72964},
+				pos: position{line: 2366, col: 14, offset: 72931},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 72964},
+						pos:        position{line: 2366, col: 14, offset: 72931},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 72983},
+						pos: position{line: 2366, col: 33, offset: 72950},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 72984},
+							pos:  position{line: 2366, col: 34, offset: 72951},
 							name: "IdentifierRest",
 						},
 					},
@@ -17489,20 +17481,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2368, col: 1, offset: 72999},
+			pos:  position{line: 2367, col: 1, offset: 72966},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 73012},
+				pos: position{line: 2367, col: 14, offset: 72979},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 73012},
+						pos:        position{line: 2367, col: 14, offset: 72979},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 73031},
+						pos: position{line: 2367, col: 33, offset: 72998},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 73032},
+							pos:  position{line: 2367, col: 34, offset: 72999},
 							name: "IdentifierRest",
 						},
 					},
@@ -17513,20 +17505,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2369, col: 1, offset: 73047},
+			pos:  position{line: 2368, col: 1, offset: 73014},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 73060},
+				pos: position{line: 2368, col: 14, offset: 73027},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 73060},
+						pos:        position{line: 2368, col: 14, offset: 73027},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 73079},
+						pos: position{line: 2368, col: 33, offset: 73046},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 73080},
+							pos:  position{line: 2368, col: 34, offset: 73047},
 							name: "IdentifierRest",
 						},
 					},
@@ -17537,20 +17529,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEADERS",
-			pos:  position{line: 2370, col: 1, offset: 73096},
+			pos:  position{line: 2369, col: 1, offset: 73063},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 73109},
+				pos: position{line: 2369, col: 14, offset: 73076},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 73109},
+						pos:        position{line: 2369, col: 14, offset: 73076},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"HEADERS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 73128},
+						pos: position{line: 2369, col: 33, offset: 73095},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 73129},
+							pos:  position{line: 2369, col: 34, offset: 73096},
 							name: "IdentifierRest",
 						},
 					},
@@ -17561,20 +17553,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2371, col: 1, offset: 73144},
+			pos:  position{line: 2370, col: 1, offset: 73111},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 73157},
+				pos: position{line: 2370, col: 14, offset: 73124},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 73157},
+						pos:        position{line: 2370, col: 14, offset: 73124},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 73176},
+						pos: position{line: 2370, col: 33, offset: 73143},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 73177},
+							pos:  position{line: 2370, col: 34, offset: 73144},
 							name: "IdentifierRest",
 						},
 					},
@@ -17585,20 +17577,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2372, col: 1, offset: 73192},
+			pos:  position{line: 2371, col: 1, offset: 73159},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 73205},
+				pos: position{line: 2371, col: 14, offset: 73172},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 73205},
+						pos:        position{line: 2371, col: 14, offset: 73172},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 73224},
+						pos: position{line: 2371, col: 33, offset: 73191},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 73225},
+							pos:  position{line: 2371, col: 34, offset: 73192},
 							name: "IdentifierRest",
 						},
 					},
@@ -17609,20 +17601,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2373, col: 1, offset: 73240},
+			pos:  position{line: 2372, col: 1, offset: 73207},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 73253},
+				pos: position{line: 2372, col: 14, offset: 73220},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 73253},
+						pos:        position{line: 2372, col: 14, offset: 73220},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 73272},
+						pos: position{line: 2372, col: 33, offset: 73239},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 73273},
+							pos:  position{line: 2372, col: 34, offset: 73240},
 							name: "IdentifierRest",
 						},
 					},
@@ -17633,20 +17625,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2374, col: 1, offset: 73288},
+			pos:  position{line: 2373, col: 1, offset: 73255},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 73301},
+				pos: position{line: 2373, col: 14, offset: 73268},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 73301},
+						pos:        position{line: 2373, col: 14, offset: 73268},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 73320},
+						pos: position{line: 2373, col: 33, offset: 73287},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 73321},
+							pos:  position{line: 2373, col: 34, offset: 73288},
 							name: "IdentifierRest",
 						},
 					},
@@ -17657,20 +17649,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2375, col: 1, offset: 73336},
+			pos:  position{line: 2374, col: 1, offset: 73303},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 73349},
+				pos: position{line: 2374, col: 14, offset: 73316},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 73349},
+						pos:        position{line: 2374, col: 14, offset: 73316},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 73368},
+						pos: position{line: 2374, col: 33, offset: 73335},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 73369},
+							pos:  position{line: 2374, col: 34, offset: 73336},
 							name: "IdentifierRest",
 						},
 					},
@@ -17681,20 +17673,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2376, col: 1, offset: 73384},
+			pos:  position{line: 2375, col: 1, offset: 73351},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 73397},
+				pos: position{line: 2375, col: 14, offset: 73364},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 73397},
+						pos:        position{line: 2375, col: 14, offset: 73364},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 73416},
+						pos: position{line: 2375, col: 33, offset: 73383},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 73417},
+							pos:  position{line: 2375, col: 34, offset: 73384},
 							name: "IdentifierRest",
 						},
 					},
@@ -17705,20 +17697,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2377, col: 1, offset: 73432},
+			pos:  position{line: 2376, col: 1, offset: 73399},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 73445},
+				pos: position{line: 2376, col: 14, offset: 73412},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 73445},
+						pos:        position{line: 2376, col: 14, offset: 73412},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 32, offset: 73463},
+						pos: position{line: 2376, col: 32, offset: 73430},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 33, offset: 73464},
+							pos:  position{line: 2376, col: 33, offset: 73431},
 							name: "IdentifierRest",
 						},
 					},
@@ -17729,20 +17721,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2378, col: 1, offset: 73479},
+			pos:  position{line: 2377, col: 1, offset: 73446},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 73492},
+				pos: position{line: 2377, col: 14, offset: 73459},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 73492},
+						pos:        position{line: 2377, col: 14, offset: 73459},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 73511},
+						pos: position{line: 2377, col: 33, offset: 73478},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 73512},
+							pos:  position{line: 2377, col: 34, offset: 73479},
 							name: "IdentifierRest",
 						},
 					},
@@ -17753,20 +17745,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2379, col: 1, offset: 73527},
+			pos:  position{line: 2378, col: 1, offset: 73494},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 73540},
+				pos: position{line: 2378, col: 14, offset: 73507},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 73540},
+						pos:        position{line: 2378, col: 14, offset: 73507},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 73559},
+						pos: position{line: 2378, col: 33, offset: 73526},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 73560},
+							pos:  position{line: 2378, col: 34, offset: 73527},
 							name: "IdentifierRest",
 						},
 					},
@@ -17777,20 +17769,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2380, col: 1, offset: 73575},
+			pos:  position{line: 2379, col: 1, offset: 73542},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 16, offset: 73590},
+				pos: position{line: 2379, col: 16, offset: 73557},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 16, offset: 73590},
+						pos:        position{line: 2379, col: 16, offset: 73557},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 73607},
+						pos: position{line: 2379, col: 33, offset: 73574},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 73608},
+							pos:  position{line: 2379, col: 34, offset: 73575},
 							name: "IdentifierRest",
 						},
 					},
@@ -17801,20 +17793,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2381, col: 1, offset: 73623},
+			pos:  position{line: 2380, col: 1, offset: 73590},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 73636},
+				pos: position{line: 2380, col: 14, offset: 73603},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 73636},
+						pos:        position{line: 2380, col: 14, offset: 73603},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 73655},
+						pos: position{line: 2380, col: 33, offset: 73622},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 73656},
+							pos:  position{line: 2380, col: 34, offset: 73623},
 							name: "IdentifierRest",
 						},
 					},
@@ -17825,20 +17817,20 @@ var g = &grammar{
 		},
 		{
 			name: "MESSAGE",
-			pos:  position{line: 2382, col: 1, offset: 73671},
+			pos:  position{line: 2381, col: 1, offset: 73638},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 73684},
+				pos: position{line: 2381, col: 14, offset: 73651},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 73684},
+						pos:        position{line: 2381, col: 14, offset: 73651},
 						val:        "message",
 						ignoreCase: true,
 						want:       "\"MESSAGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 73703},
+						pos: position{line: 2381, col: 33, offset: 73670},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 73704},
+							pos:  position{line: 2381, col: 34, offset: 73671},
 							name: "IdentifierRest",
 						},
 					},
@@ -17849,20 +17841,20 @@ var g = &grammar{
 		},
 		{
 			name: "META",
-			pos:  position{line: 2383, col: 1, offset: 73719},
+			pos:  position{line: 2382, col: 1, offset: 73686},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 73732},
+				pos: position{line: 2382, col: 14, offset: 73699},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 73732},
+						pos:        position{line: 2382, col: 14, offset: 73699},
 						val:        "meta",
 						ignoreCase: true,
 						want:       "\"META\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 73751},
+						pos: position{line: 2382, col: 33, offset: 73718},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 73752},
+							pos:  position{line: 2382, col: 34, offset: 73719},
 							name: "IdentifierRest",
 						},
 					},
@@ -17873,20 +17865,20 @@ var g = &grammar{
 		},
 		{
 			name: "METHOD",
-			pos:  position{line: 2384, col: 1, offset: 73767},
+			pos:  position{line: 2383, col: 1, offset: 73734},
 			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 73780},
+				pos: position{line: 2383, col: 14, offset: 73747},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 73780},
+						pos:        position{line: 2383, col: 14, offset: 73747},
 						val:        "method",
 						ignoreCase: true,
 						want:       "\"METHOD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 73799},
+						pos: position{line: 2383, col: 33, offset: 73766},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 73800},
+							pos:  position{line: 2383, col: 34, offset: 73767},
 							name: "IdentifierRest",
 						},
 					},
@@ -17897,20 +17889,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2385, col: 1, offset: 73815},
+			pos:  position{line: 2384, col: 1, offset: 73782},
 			expr: &seqExpr{
-				pos: position{line: 2385, col: 14, offset: 73828},
+				pos: position{line: 2384, col: 14, offset: 73795},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2385, col: 14, offset: 73828},
+						pos:        position{line: 2384, col: 14, offset: 73795},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2385, col: 33, offset: 73847},
+						pos: position{line: 2384, col: 33, offset: 73814},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 34, offset: 73848},
+							pos:  position{line: 2384, col: 34, offset: 73815},
 							name: "IdentifierRest",
 						},
 					},
@@ -17921,20 +17913,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2386, col: 1, offset: 73863},
+			pos:  position{line: 2385, col: 1, offset: 73830},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 73876},
+				pos: position{line: 2385, col: 14, offset: 73843},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 73876},
+						pos:        position{line: 2385, col: 14, offset: 73843},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 73895},
+						pos: position{line: 2385, col: 33, offset: 73862},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 73896},
+							pos:  position{line: 2385, col: 34, offset: 73863},
 							name: "IdentifierRest",
 						},
 					},
@@ -17945,20 +17937,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2387, col: 1, offset: 73911},
+			pos:  position{line: 2386, col: 1, offset: 73878},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 73924},
+				pos: position{line: 2386, col: 14, offset: 73891},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 73924},
+						pos:        position{line: 2386, col: 14, offset: 73891},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 73943},
+						pos: position{line: 2386, col: 33, offset: 73910},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 73944},
+							pos:  position{line: 2386, col: 34, offset: 73911},
 							name: "IdentifierRest",
 						},
 					},
@@ -17969,20 +17961,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2388, col: 1, offset: 73959},
+			pos:  position{line: 2387, col: 1, offset: 73926},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 73972},
+				pos: position{line: 2387, col: 14, offset: 73939},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 73972},
+						pos:        position{line: 2387, col: 14, offset: 73939},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 73991},
+						pos: position{line: 2387, col: 33, offset: 73958},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 73992},
+							pos:  position{line: 2387, col: 34, offset: 73959},
 							name: "IdentifierRest",
 						},
 					},
@@ -17993,20 +17985,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2389, col: 1, offset: 74007},
+			pos:  position{line: 2388, col: 1, offset: 73974},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 74020},
+				pos: position{line: 2388, col: 14, offset: 73987},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 74020},
+						pos:        position{line: 2388, col: 14, offset: 73987},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 74039},
+						pos: position{line: 2388, col: 33, offset: 74006},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 74040},
+							pos:  position{line: 2388, col: 34, offset: 74007},
 							name: "IdentifierRest",
 						},
 					},
@@ -18017,20 +18009,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2390, col: 1, offset: 74055},
+			pos:  position{line: 2389, col: 1, offset: 74022},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 14, offset: 74068},
+				pos: position{line: 2389, col: 14, offset: 74035},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 14, offset: 74068},
+						pos:        position{line: 2389, col: 14, offset: 74035},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 74087},
+						pos: position{line: 2389, col: 33, offset: 74054},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 74088},
+							pos:  position{line: 2389, col: 34, offset: 74055},
 							name: "IdentifierRest",
 						},
 					},
@@ -18041,23 +18033,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2391, col: 1, offset: 74103},
+			pos:  position{line: 2390, col: 1, offset: 74070},
 			expr: &actionExpr{
-				pos: position{line: 2391, col: 14, offset: 74116},
+				pos: position{line: 2390, col: 14, offset: 74083},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2391, col: 14, offset: 74116},
+					pos: position{line: 2390, col: 14, offset: 74083},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2391, col: 14, offset: 74116},
+							pos:        position{line: 2390, col: 14, offset: 74083},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2391, col: 33, offset: 74135},
+							pos: position{line: 2390, col: 33, offset: 74102},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2391, col: 34, offset: 74136},
+								pos:  position{line: 2390, col: 34, offset: 74103},
 								name: "IdentifierRest",
 							},
 						},
@@ -18069,20 +18061,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2392, col: 1, offset: 74172},
+			pos:  position{line: 2391, col: 1, offset: 74139},
 			expr: &seqExpr{
-				pos: position{line: 2392, col: 14, offset: 74185},
+				pos: position{line: 2391, col: 14, offset: 74152},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2392, col: 14, offset: 74185},
+						pos:        position{line: 2391, col: 14, offset: 74152},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2392, col: 33, offset: 74204},
+						pos: position{line: 2391, col: 33, offset: 74171},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2392, col: 34, offset: 74205},
+							pos:  position{line: 2391, col: 34, offset: 74172},
 							name: "IdentifierRest",
 						},
 					},
@@ -18093,20 +18085,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2393, col: 1, offset: 74220},
+			pos:  position{line: 2392, col: 1, offset: 74187},
 			expr: &seqExpr{
-				pos: position{line: 2393, col: 14, offset: 74233},
+				pos: position{line: 2392, col: 14, offset: 74200},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2393, col: 14, offset: 74233},
+						pos:        position{line: 2392, col: 14, offset: 74200},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2393, col: 33, offset: 74252},
+						pos: position{line: 2392, col: 33, offset: 74219},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2393, col: 34, offset: 74253},
+							pos:  position{line: 2392, col: 34, offset: 74220},
 							name: "IdentifierRest",
 						},
 					},
@@ -18117,20 +18109,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2394, col: 1, offset: 74268},
+			pos:  position{line: 2393, col: 1, offset: 74235},
 			expr: &seqExpr{
-				pos: position{line: 2394, col: 14, offset: 74281},
+				pos: position{line: 2393, col: 14, offset: 74248},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2394, col: 14, offset: 74281},
+						pos:        position{line: 2393, col: 14, offset: 74248},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2394, col: 33, offset: 74300},
+						pos: position{line: 2393, col: 33, offset: 74267},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2394, col: 34, offset: 74301},
+							pos:  position{line: 2393, col: 34, offset: 74268},
 							name: "IdentifierRest",
 						},
 					},
@@ -18141,20 +18133,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2395, col: 1, offset: 74316},
+			pos:  position{line: 2394, col: 1, offset: 74283},
 			expr: &seqExpr{
-				pos: position{line: 2395, col: 14, offset: 74329},
+				pos: position{line: 2394, col: 14, offset: 74296},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2395, col: 14, offset: 74329},
+						pos:        position{line: 2394, col: 14, offset: 74296},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2395, col: 33, offset: 74348},
+						pos: position{line: 2394, col: 33, offset: 74315},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2395, col: 34, offset: 74349},
+							pos:  position{line: 2394, col: 34, offset: 74316},
 							name: "IdentifierRest",
 						},
 					},
@@ -18165,20 +18157,20 @@ var g = &grammar{
 		},
 		{
 			name: "OVER",
-			pos:  position{line: 2396, col: 1, offset: 74364},
+			pos:  position{line: 2395, col: 1, offset: 74331},
 			expr: &seqExpr{
-				pos: position{line: 2396, col: 14, offset: 74377},
+				pos: position{line: 2395, col: 14, offset: 74344},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2396, col: 14, offset: 74377},
+						pos:        position{line: 2395, col: 14, offset: 74344},
 						val:        "over",
 						ignoreCase: true,
 						want:       "\"OVER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2396, col: 33, offset: 74396},
+						pos: position{line: 2395, col: 33, offset: 74363},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2396, col: 34, offset: 74397},
+							pos:  position{line: 2395, col: 34, offset: 74364},
 							name: "IdentifierRest",
 						},
 					},
@@ -18189,20 +18181,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2397, col: 1, offset: 74412},
+			pos:  position{line: 2396, col: 1, offset: 74379},
 			expr: &seqExpr{
-				pos: position{line: 2397, col: 14, offset: 74425},
+				pos: position{line: 2396, col: 14, offset: 74392},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2397, col: 14, offset: 74425},
+						pos:        position{line: 2396, col: 14, offset: 74392},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2397, col: 33, offset: 74444},
+						pos: position{line: 2396, col: 33, offset: 74411},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2397, col: 34, offset: 74445},
+							pos:  position{line: 2396, col: 34, offset: 74412},
 							name: "IdentifierRest",
 						},
 					},
@@ -18213,20 +18205,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2398, col: 1, offset: 74460},
+			pos:  position{line: 2397, col: 1, offset: 74427},
 			expr: &seqExpr{
-				pos: position{line: 2398, col: 14, offset: 74473},
+				pos: position{line: 2397, col: 14, offset: 74440},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2398, col: 14, offset: 74473},
+						pos:        position{line: 2397, col: 14, offset: 74440},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2398, col: 33, offset: 74492},
+						pos: position{line: 2397, col: 33, offset: 74459},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2398, col: 34, offset: 74493},
+							pos:  position{line: 2397, col: 34, offset: 74460},
 							name: "IdentifierRest",
 						},
 					},
@@ -18237,20 +18229,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2399, col: 1, offset: 74508},
+			pos:  position{line: 2398, col: 1, offset: 74475},
 			expr: &seqExpr{
-				pos: position{line: 2399, col: 14, offset: 74521},
+				pos: position{line: 2398, col: 14, offset: 74488},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2399, col: 14, offset: 74521},
+						pos:        position{line: 2398, col: 14, offset: 74488},
 						val:        "RECURSIVE",
 						ignoreCase: false,
 						want:       "\"RECURSIVE\"",
 					},
 					&notExpr{
-						pos: position{line: 2399, col: 33, offset: 74540},
+						pos: position{line: 2398, col: 33, offset: 74507},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2399, col: 34, offset: 74541},
+							pos:  position{line: 2398, col: 34, offset: 74508},
 							name: "IdentifierRest",
 						},
 					},
@@ -18261,20 +18253,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP",
-			pos:  position{line: 2400, col: 1, offset: 74556},
+			pos:  position{line: 2399, col: 1, offset: 74523},
 			expr: &seqExpr{
-				pos: position{line: 2400, col: 14, offset: 74569},
+				pos: position{line: 2399, col: 14, offset: 74536},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2400, col: 14, offset: 74569},
+						pos:        position{line: 2399, col: 14, offset: 74536},
 						val:        "regexp",
 						ignoreCase: true,
 						want:       "\"REGEXP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2400, col: 33, offset: 74588},
+						pos: position{line: 2399, col: 33, offset: 74555},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2400, col: 34, offset: 74589},
+							pos:  position{line: 2399, col: 34, offset: 74556},
 							name: "IdentifierRest",
 						},
 					},
@@ -18285,20 +18277,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP_REPLACE",
-			pos:  position{line: 2401, col: 1, offset: 74604},
+			pos:  position{line: 2400, col: 1, offset: 74571},
 			expr: &seqExpr{
-				pos: position{line: 2401, col: 18, offset: 74621},
+				pos: position{line: 2400, col: 18, offset: 74588},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2401, col: 18, offset: 74621},
+						pos:        position{line: 2400, col: 18, offset: 74588},
 						val:        "regexp_replace",
 						ignoreCase: true,
 						want:       "\"REGEXP_REPLACE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2401, col: 36, offset: 74639},
+						pos: position{line: 2400, col: 36, offset: 74606},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2401, col: 37, offset: 74640},
+							pos:  position{line: 2400, col: 37, offset: 74607},
 							name: "IdentifierRest",
 						},
 					},
@@ -18309,20 +18301,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2402, col: 1, offset: 74655},
+			pos:  position{line: 2401, col: 1, offset: 74622},
 			expr: &seqExpr{
-				pos: position{line: 2402, col: 14, offset: 74668},
+				pos: position{line: 2401, col: 14, offset: 74635},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2402, col: 14, offset: 74668},
+						pos:        position{line: 2401, col: 14, offset: 74635},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2402, col: 33, offset: 74687},
+						pos: position{line: 2401, col: 33, offset: 74654},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2402, col: 34, offset: 74688},
+							pos:  position{line: 2401, col: 34, offset: 74655},
 							name: "IdentifierRest",
 						},
 					},
@@ -18333,20 +18325,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2403, col: 1, offset: 74703},
+			pos:  position{line: 2402, col: 1, offset: 74670},
 			expr: &seqExpr{
-				pos: position{line: 2403, col: 14, offset: 74716},
+				pos: position{line: 2402, col: 14, offset: 74683},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2403, col: 14, offset: 74716},
+						pos:        position{line: 2402, col: 14, offset: 74683},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2403, col: 33, offset: 74735},
+						pos: position{line: 2402, col: 33, offset: 74702},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2403, col: 34, offset: 74736},
+							pos:  position{line: 2402, col: 34, offset: 74703},
 							name: "IdentifierRest",
 						},
 					},
@@ -18357,20 +18349,20 @@ var g = &grammar{
 		},
 		{
 			name: "SAMPLE",
-			pos:  position{line: 2404, col: 1, offset: 74751},
+			pos:  position{line: 2403, col: 1, offset: 74718},
 			expr: &seqExpr{
-				pos: position{line: 2404, col: 14, offset: 74764},
+				pos: position{line: 2403, col: 14, offset: 74731},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2404, col: 14, offset: 74764},
+						pos:        position{line: 2403, col: 14, offset: 74731},
 						val:        "sample",
 						ignoreCase: true,
 						want:       "\"SAMPLE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2404, col: 33, offset: 74783},
+						pos: position{line: 2403, col: 33, offset: 74750},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2404, col: 34, offset: 74784},
+							pos:  position{line: 2403, col: 34, offset: 74751},
 							name: "IdentifierRest",
 						},
 					},
@@ -18381,20 +18373,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2405, col: 1, offset: 74799},
+			pos:  position{line: 2404, col: 1, offset: 74766},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 74812},
+				pos: position{line: 2404, col: 14, offset: 74779},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 74812},
+						pos:        position{line: 2404, col: 14, offset: 74779},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 74831},
+						pos: position{line: 2404, col: 33, offset: 74798},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 74832},
+							pos:  position{line: 2404, col: 34, offset: 74799},
 							name: "IdentifierRest",
 						},
 					},
@@ -18405,20 +18397,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2406, col: 1, offset: 74847},
+			pos:  position{line: 2405, col: 1, offset: 74814},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 74860},
+				pos: position{line: 2405, col: 14, offset: 74827},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 74860},
+						pos:        position{line: 2405, col: 14, offset: 74827},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 74879},
+						pos: position{line: 2405, col: 33, offset: 74846},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 74880},
+							pos:  position{line: 2405, col: 34, offset: 74847},
 							name: "IdentifierRest",
 						},
 					},
@@ -18429,20 +18421,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2407, col: 1, offset: 74895},
+			pos:  position{line: 2406, col: 1, offset: 74862},
 			expr: &seqExpr{
-				pos: position{line: 2407, col: 14, offset: 74908},
+				pos: position{line: 2406, col: 14, offset: 74875},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2407, col: 14, offset: 74908},
+						pos:        position{line: 2406, col: 14, offset: 74875},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2407, col: 33, offset: 74927},
+						pos: position{line: 2406, col: 33, offset: 74894},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2407, col: 34, offset: 74928},
+							pos:  position{line: 2406, col: 34, offset: 74895},
 							name: "IdentifierRest",
 						},
 					},
@@ -18453,20 +18445,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2408, col: 1, offset: 74943},
+			pos:  position{line: 2407, col: 1, offset: 74910},
 			expr: &seqExpr{
-				pos: position{line: 2408, col: 14, offset: 74956},
+				pos: position{line: 2407, col: 14, offset: 74923},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2408, col: 14, offset: 74956},
+						pos:        position{line: 2407, col: 14, offset: 74923},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2408, col: 33, offset: 74975},
+						pos: position{line: 2407, col: 33, offset: 74942},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2408, col: 34, offset: 74976},
+							pos:  position{line: 2407, col: 34, offset: 74943},
 							name: "IdentifierRest",
 						},
 					},
@@ -18477,20 +18469,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2409, col: 1, offset: 74991},
+			pos:  position{line: 2408, col: 1, offset: 74958},
 			expr: &seqExpr{
-				pos: position{line: 2409, col: 14, offset: 75004},
+				pos: position{line: 2408, col: 14, offset: 74971},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2409, col: 14, offset: 75004},
+						pos:        position{line: 2408, col: 14, offset: 74971},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2409, col: 33, offset: 75023},
+						pos: position{line: 2408, col: 33, offset: 74990},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2409, col: 34, offset: 75024},
+							pos:  position{line: 2408, col: 34, offset: 74991},
 							name: "IdentifierRest",
 						},
 					},
@@ -18501,20 +18493,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2410, col: 1, offset: 75039},
+			pos:  position{line: 2409, col: 1, offset: 75006},
 			expr: &seqExpr{
-				pos: position{line: 2410, col: 14, offset: 75052},
+				pos: position{line: 2409, col: 14, offset: 75019},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2410, col: 14, offset: 75052},
+						pos:        position{line: 2409, col: 14, offset: 75019},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2410, col: 33, offset: 75071},
+						pos: position{line: 2409, col: 33, offset: 75038},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2410, col: 34, offset: 75072},
+							pos:  position{line: 2409, col: 34, offset: 75039},
 							name: "IdentifierRest",
 						},
 					},
@@ -18525,20 +18517,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2411, col: 1, offset: 75087},
+			pos:  position{line: 2410, col: 1, offset: 75054},
 			expr: &seqExpr{
-				pos: position{line: 2411, col: 14, offset: 75100},
+				pos: position{line: 2410, col: 14, offset: 75067},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2411, col: 14, offset: 75100},
+						pos:        position{line: 2410, col: 14, offset: 75067},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2411, col: 33, offset: 75119},
+						pos: position{line: 2410, col: 33, offset: 75086},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2411, col: 34, offset: 75120},
+							pos:  position{line: 2410, col: 34, offset: 75087},
 							name: "IdentifierRest",
 						},
 					},
@@ -18549,20 +18541,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2412, col: 1, offset: 75135},
+			pos:  position{line: 2411, col: 1, offset: 75102},
 			expr: &seqExpr{
-				pos: position{line: 2412, col: 14, offset: 75148},
+				pos: position{line: 2411, col: 14, offset: 75115},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2412, col: 14, offset: 75148},
+						pos:        position{line: 2411, col: 14, offset: 75115},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2412, col: 33, offset: 75167},
+						pos: position{line: 2411, col: 33, offset: 75134},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2412, col: 34, offset: 75168},
+							pos:  position{line: 2411, col: 34, offset: 75135},
 							name: "IdentifierRest",
 						},
 					},
@@ -18573,20 +18565,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2413, col: 1, offset: 75183},
+			pos:  position{line: 2412, col: 1, offset: 75150},
 			expr: &seqExpr{
-				pos: position{line: 2413, col: 14, offset: 75196},
+				pos: position{line: 2412, col: 14, offset: 75163},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2413, col: 14, offset: 75196},
+						pos:        position{line: 2412, col: 14, offset: 75163},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2413, col: 33, offset: 75215},
+						pos: position{line: 2412, col: 33, offset: 75182},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2413, col: 34, offset: 75216},
+							pos:  position{line: 2412, col: 34, offset: 75183},
 							name: "IdentifierRest",
 						},
 					},
@@ -18597,20 +18589,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAP",
-			pos:  position{line: 2414, col: 1, offset: 75232},
+			pos:  position{line: 2413, col: 1, offset: 75199},
 			expr: &seqExpr{
-				pos: position{line: 2414, col: 14, offset: 75245},
+				pos: position{line: 2413, col: 14, offset: 75212},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2414, col: 14, offset: 75245},
+						pos:        position{line: 2413, col: 14, offset: 75212},
 						val:        "tap",
 						ignoreCase: true,
 						want:       "\"TAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2414, col: 33, offset: 75264},
+						pos: position{line: 2413, col: 33, offset: 75231},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2414, col: 34, offset: 75265},
+							pos:  position{line: 2413, col: 34, offset: 75232},
 							name: "IdentifierRest",
 						},
 					},
@@ -18621,20 +18613,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2415, col: 1, offset: 75280},
+			pos:  position{line: 2414, col: 1, offset: 75247},
 			expr: &seqExpr{
-				pos: position{line: 2415, col: 14, offset: 75293},
+				pos: position{line: 2414, col: 14, offset: 75260},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2415, col: 14, offset: 75293},
+						pos:        position{line: 2414, col: 14, offset: 75260},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2415, col: 33, offset: 75312},
+						pos: position{line: 2414, col: 33, offset: 75279},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2415, col: 34, offset: 75313},
+							pos:  position{line: 2414, col: 34, offset: 75280},
 							name: "IdentifierRest",
 						},
 					},
@@ -18645,23 +18637,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2416, col: 1, offset: 75328},
+			pos:  position{line: 2415, col: 1, offset: 75295},
 			expr: &actionExpr{
-				pos: position{line: 2416, col: 14, offset: 75341},
+				pos: position{line: 2415, col: 14, offset: 75308},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2416, col: 14, offset: 75341},
+					pos: position{line: 2415, col: 14, offset: 75308},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2416, col: 14, offset: 75341},
+							pos:        position{line: 2415, col: 14, offset: 75308},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2416, col: 33, offset: 75360},
+							pos: position{line: 2415, col: 33, offset: 75327},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2416, col: 34, offset: 75361},
+								pos:  position{line: 2415, col: 34, offset: 75328},
 								name: "IdentifierRest",
 							},
 						},
@@ -18673,20 +18665,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2417, col: 1, offset: 75404},
+			pos:  position{line: 2416, col: 1, offset: 75371},
 			expr: &seqExpr{
-				pos: position{line: 2417, col: 14, offset: 75417},
+				pos: position{line: 2416, col: 14, offset: 75384},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2417, col: 14, offset: 75417},
+						pos:        position{line: 2416, col: 14, offset: 75384},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2417, col: 33, offset: 75436},
+						pos: position{line: 2416, col: 33, offset: 75403},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2417, col: 34, offset: 75437},
+							pos:  position{line: 2416, col: 34, offset: 75404},
 							name: "IdentifierRest",
 						},
 					},
@@ -18697,20 +18689,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2418, col: 1, offset: 75452},
+			pos:  position{line: 2417, col: 1, offset: 75419},
 			expr: &seqExpr{
-				pos: position{line: 2418, col: 14, offset: 75465},
+				pos: position{line: 2417, col: 14, offset: 75432},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2418, col: 14, offset: 75465},
+						pos:        position{line: 2417, col: 14, offset: 75432},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2418, col: 33, offset: 75484},
+						pos: position{line: 2417, col: 33, offset: 75451},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2418, col: 34, offset: 75485},
+							pos:  position{line: 2417, col: 34, offset: 75452},
 							name: "IdentifierRest",
 						},
 					},
@@ -18721,20 +18713,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2419, col: 1, offset: 75500},
+			pos:  position{line: 2418, col: 1, offset: 75467},
 			expr: &seqExpr{
-				pos: position{line: 2419, col: 14, offset: 75513},
+				pos: position{line: 2418, col: 14, offset: 75480},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2419, col: 14, offset: 75513},
+						pos:        position{line: 2418, col: 14, offset: 75480},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2419, col: 33, offset: 75532},
+						pos: position{line: 2418, col: 33, offset: 75499},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2419, col: 34, offset: 75533},
+							pos:  position{line: 2418, col: 34, offset: 75500},
 							name: "IdentifierRest",
 						},
 					},
@@ -18745,20 +18737,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2420, col: 1, offset: 75548},
+			pos:  position{line: 2419, col: 1, offset: 75515},
 			expr: &seqExpr{
-				pos: position{line: 2420, col: 14, offset: 75561},
+				pos: position{line: 2419, col: 14, offset: 75528},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2420, col: 14, offset: 75561},
+						pos:        position{line: 2419, col: 14, offset: 75528},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2420, col: 33, offset: 75580},
+						pos: position{line: 2419, col: 33, offset: 75547},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2420, col: 34, offset: 75581},
+							pos:  position{line: 2419, col: 34, offset: 75548},
 							name: "IdentifierRest",
 						},
 					},
@@ -18769,20 +18761,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2421, col: 1, offset: 75596},
+			pos:  position{line: 2420, col: 1, offset: 75563},
 			expr: &seqExpr{
-				pos: position{line: 2421, col: 14, offset: 75609},
+				pos: position{line: 2420, col: 14, offset: 75576},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2421, col: 14, offset: 75609},
+						pos:        position{line: 2420, col: 14, offset: 75576},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2421, col: 33, offset: 75628},
+						pos: position{line: 2420, col: 33, offset: 75595},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2421, col: 34, offset: 75629},
+							pos:  position{line: 2420, col: 34, offset: 75596},
 							name: "IdentifierRest",
 						},
 					},
@@ -18793,20 +18785,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2422, col: 1, offset: 75645},
+			pos:  position{line: 2421, col: 1, offset: 75612},
 			expr: &seqExpr{
-				pos: position{line: 2422, col: 14, offset: 75658},
+				pos: position{line: 2421, col: 14, offset: 75625},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2422, col: 14, offset: 75658},
+						pos:        position{line: 2421, col: 14, offset: 75625},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2422, col: 33, offset: 75677},
+						pos: position{line: 2421, col: 33, offset: 75644},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2422, col: 34, offset: 75678},
+							pos:  position{line: 2421, col: 34, offset: 75645},
 							name: "IdentifierRest",
 						},
 					},
@@ -18817,20 +18809,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2423, col: 1, offset: 75693},
+			pos:  position{line: 2422, col: 1, offset: 75660},
 			expr: &seqExpr{
-				pos: position{line: 2423, col: 14, offset: 75706},
+				pos: position{line: 2422, col: 14, offset: 75673},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2423, col: 14, offset: 75706},
+						pos:        position{line: 2422, col: 14, offset: 75673},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2423, col: 33, offset: 75725},
+						pos: position{line: 2422, col: 33, offset: 75692},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2423, col: 34, offset: 75726},
+							pos:  position{line: 2422, col: 34, offset: 75693},
 							name: "IdentifierRest",
 						},
 					},
@@ -18841,20 +18833,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2424, col: 1, offset: 75741},
+			pos:  position{line: 2423, col: 1, offset: 75708},
 			expr: &seqExpr{
-				pos: position{line: 2424, col: 14, offset: 75754},
+				pos: position{line: 2423, col: 14, offset: 75721},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2424, col: 14, offset: 75754},
+						pos:        position{line: 2423, col: 14, offset: 75721},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2424, col: 33, offset: 75773},
+						pos: position{line: 2423, col: 33, offset: 75740},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2424, col: 34, offset: 75774},
+							pos:  position{line: 2423, col: 34, offset: 75741},
 							name: "IdentifierRest",
 						},
 					},
@@ -18865,20 +18857,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2425, col: 1, offset: 75789},
+			pos:  position{line: 2424, col: 1, offset: 75756},
 			expr: &seqExpr{
-				pos: position{line: 2425, col: 14, offset: 75802},
+				pos: position{line: 2424, col: 14, offset: 75769},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2425, col: 14, offset: 75802},
+						pos:        position{line: 2424, col: 14, offset: 75769},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2425, col: 33, offset: 75821},
+						pos: position{line: 2424, col: 33, offset: 75788},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2425, col: 34, offset: 75822},
+							pos:  position{line: 2424, col: 34, offset: 75789},
 							name: "IdentifierRest",
 						},
 					},
@@ -18889,20 +18881,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2426, col: 1, offset: 75837},
+			pos:  position{line: 2425, col: 1, offset: 75804},
 			expr: &seqExpr{
-				pos: position{line: 2426, col: 14, offset: 75850},
+				pos: position{line: 2425, col: 14, offset: 75817},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2426, col: 14, offset: 75850},
+						pos:        position{line: 2425, col: 14, offset: 75817},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2426, col: 33, offset: 75869},
+						pos: position{line: 2425, col: 33, offset: 75836},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2426, col: 34, offset: 75870},
+							pos:  position{line: 2425, col: 34, offset: 75837},
 							name: "IdentifierRest",
 						},
 					},
@@ -18913,20 +18905,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2427, col: 1, offset: 75885},
+			pos:  position{line: 2426, col: 1, offset: 75852},
 			expr: &seqExpr{
-				pos: position{line: 2427, col: 14, offset: 75898},
+				pos: position{line: 2426, col: 14, offset: 75865},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2427, col: 14, offset: 75898},
+						pos:        position{line: 2426, col: 14, offset: 75865},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2427, col: 33, offset: 75917},
+						pos: position{line: 2426, col: 33, offset: 75884},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2427, col: 34, offset: 75918},
+							pos:  position{line: 2426, col: 34, offset: 75885},
 							name: "IdentifierRest",
 						},
 					},
@@ -18937,20 +18929,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2428, col: 1, offset: 75933},
+			pos:  position{line: 2427, col: 1, offset: 75900},
 			expr: &seqExpr{
-				pos: position{line: 2428, col: 14, offset: 75946},
+				pos: position{line: 2427, col: 14, offset: 75913},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2428, col: 14, offset: 75946},
+						pos:        position{line: 2427, col: 14, offset: 75913},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2428, col: 33, offset: 75965},
+						pos: position{line: 2427, col: 33, offset: 75932},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2428, col: 34, offset: 75966},
+							pos:  position{line: 2427, col: 34, offset: 75933},
 							name: "IdentifierRest",
 						},
 					},
@@ -18961,20 +18953,20 @@ var g = &grammar{
 		},
 		{
 			name: "YIELD",
-			pos:  position{line: 2429, col: 1, offset: 75981},
+			pos:  position{line: 2428, col: 1, offset: 75948},
 			expr: &seqExpr{
-				pos: position{line: 2429, col: 14, offset: 75994},
+				pos: position{line: 2428, col: 14, offset: 75961},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2429, col: 14, offset: 75994},
+						pos:        position{line: 2428, col: 14, offset: 75961},
 						val:        "yield",
 						ignoreCase: true,
 						want:       "\"YIELD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2429, col: 33, offset: 76013},
+						pos: position{line: 2428, col: 33, offset: 75980},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2429, col: 34, offset: 76014},
+							pos:  position{line: 2428, col: 34, offset: 75981},
 							name: "IdentifierRest",
 						},
 					},
@@ -23479,7 +23471,6 @@ func (p *parser) callonOptAlias7() (any, error) {
 }
 
 func (c *current) onAliasClause1(name, cols any) (any, error) {
-
 	alias := &ast.TableAlias{Kind: "TableAlias", Name: name.(string), Loc: loc(c)}
 	if cols != nil {
 		alias.Columns = cols.([]*ast.ID)
@@ -23494,35 +23485,25 @@ func (p *parser) callonAliasClause1() (any, error) {
 	return p.cur.onAliasClause1(stack["name"], stack["cols"])
 }
 
-func (c *current) onOptColumns10(s any) (any, error) {
+func (c *current) onColumns10(s any) (any, error) {
 	return s, nil
 }
 
-func (p *parser) callonOptColumns10() (any, error) {
+func (p *parser) callonColumns10() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOptColumns10(stack["s"])
+	return p.cur.onColumns10(stack["s"])
 }
 
-func (c *current) onOptColumns2(first, rest any) (any, error) {
+func (c *current) onColumns1(first, rest any) (any, error) {
 	return sliceOf[*ast.ID](prepend(first, rest)), nil
 
 }
 
-func (p *parser) callonOptColumns2() (any, error) {
+func (p *parser) callonColumns1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOptColumns2(stack["first"], stack["rest"])
-}
-
-func (c *current) onOptColumns19() (any, error) {
-	return nil, nil
-}
-
-func (p *parser) callonOptColumns19() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOptColumns19()
+	return p.cur.onColumns1(stack["first"], stack["rest"])
 }
 
 func (c *current) onSelection7(s any) (any, error) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -4795,46 +4795,46 @@ var g = &grammar{
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 720, col: 1, offset: 17033},
+			pos:  position{line: 720, col: 1, offset: 17039},
 			expr: &choiceExpr{
-				pos: position{line: 721, col: 5, offset: 17048},
+				pos: position{line: 721, col: 5, offset: 17054},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 721, col: 5, offset: 17048},
+						pos: position{line: 721, col: 5, offset: 17054},
 						run: (*parser).callonFromEntity2,
 						expr: &labeledExpr{
-							pos:   position{line: 721, col: 5, offset: 17048},
+							pos:   position{line: 721, col: 5, offset: 17054},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 721, col: 9, offset: 17052},
+								pos:  position{line: 721, col: 9, offset: 17058},
 								name: "UnquotedURL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 728, col: 5, offset: 17184},
+						pos:  position{line: 728, col: 5, offset: 17190},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 729, col: 5, offset: 17195},
+						pos:  position{line: 729, col: 5, offset: 17201},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 730, col: 5, offset: 17204},
+						pos: position{line: 730, col: 5, offset: 17210},
 						run: (*parser).callonFromEntity7,
 						expr: &seqExpr{
-							pos: position{line: 730, col: 5, offset: 17204},
+							pos: position{line: 730, col: 5, offset: 17210},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 730, col: 5, offset: 17204},
+									pos:        position{line: 730, col: 5, offset: 17210},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 730, col: 9, offset: 17208},
+									pos: position{line: 730, col: 9, offset: 17214},
 									expr: &ruleRefExpr{
-										pos:  position{line: 730, col: 10, offset: 17209},
+										pos:  position{line: 730, col: 10, offset: 17215},
 										name: "ExprGuard",
 									},
 								},
@@ -4842,43 +4842,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 731, col: 5, offset: 17290},
+						pos: position{line: 731, col: 5, offset: 17296},
 						run: (*parser).callonFromEntity12,
 						expr: &seqExpr{
-							pos: position{line: 731, col: 5, offset: 17290},
+							pos: position{line: 731, col: 5, offset: 17296},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 731, col: 5, offset: 17290},
+									pos:  position{line: 731, col: 5, offset: 17296},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 731, col: 10, offset: 17295},
+									pos:  position{line: 731, col: 10, offset: 17301},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 731, col: 13, offset: 17298},
+									pos:        position{line: 731, col: 13, offset: 17304},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 731, col: 17, offset: 17302},
+									pos:  position{line: 731, col: 17, offset: 17308},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 731, col: 20, offset: 17305},
+									pos:   position{line: 731, col: 20, offset: 17311},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 731, col: 22, offset: 17307},
+										pos:  position{line: 731, col: 22, offset: 17313},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 731, col: 27, offset: 17312},
+									pos:  position{line: 731, col: 27, offset: 17318},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 731, col: 30, offset: 17315},
+									pos:        position{line: 731, col: 30, offset: 17321},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4887,35 +4887,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 738, col: 5, offset: 17451},
+						pos: position{line: 738, col: 5, offset: 17457},
 						run: (*parser).callonFromEntity22,
 						expr: &labeledExpr{
-							pos:   position{line: 738, col: 5, offset: 17451},
+							pos:   position{line: 738, col: 5, offset: 17457},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 738, col: 10, offset: 17456},
+								pos:  position{line: 738, col: 10, offset: 17462},
 								name: "PoolMeta",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 745, col: 5, offset: 17599},
+						pos: position{line: 745, col: 5, offset: 17605},
 						run: (*parser).callonFromEntity25,
 						expr: &seqExpr{
-							pos: position{line: 745, col: 5, offset: 17599},
+							pos: position{line: 745, col: 5, offset: 17605},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 745, col: 5, offset: 17599},
+									pos:   position{line: 745, col: 5, offset: 17605},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 745, col: 10, offset: 17604},
+										pos:  position{line: 745, col: 10, offset: 17610},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 745, col: 24, offset: 17618},
+									pos: position{line: 745, col: 24, offset: 17624},
 									expr: &ruleRefExpr{
-										pos:  position{line: 745, col: 25, offset: 17619},
+										pos:  position{line: 745, col: 25, offset: 17625},
 										name: "AliasClause",
 									},
 								},
@@ -4923,35 +4923,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 746, col: 5, offset: 17654},
+						pos: position{line: 746, col: 5, offset: 17660},
 						run: (*parser).callonFromEntity31,
 						expr: &seqExpr{
-							pos: position{line: 746, col: 5, offset: 17654},
+							pos: position{line: 746, col: 5, offset: 17660},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 746, col: 5, offset: 17654},
+									pos:        position{line: 746, col: 5, offset: 17660},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 746, col: 9, offset: 17658},
+									pos:  position{line: 746, col: 9, offset: 17664},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 746, col: 12, offset: 17661},
+									pos:   position{line: 746, col: 12, offset: 17667},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 746, col: 17, offset: 17666},
+										pos:  position{line: 746, col: 17, offset: 17672},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 746, col: 31, offset: 17680},
+									pos:  position{line: 746, col: 31, offset: 17686},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 746, col: 34, offset: 17683},
+									pos:        position{line: 746, col: 34, offset: 17689},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4960,35 +4960,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 747, col: 5, offset: 17712},
+						pos: position{line: 747, col: 5, offset: 17718},
 						run: (*parser).callonFromEntity39,
 						expr: &seqExpr{
-							pos: position{line: 747, col: 5, offset: 17712},
+							pos: position{line: 747, col: 5, offset: 17718},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 747, col: 5, offset: 17712},
+									pos:        position{line: 747, col: 5, offset: 17718},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 747, col: 9, offset: 17716},
+									pos:  position{line: 747, col: 9, offset: 17722},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 747, col: 12, offset: 17719},
+									pos:   position{line: 747, col: 12, offset: 17725},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 747, col: 14, offset: 17721},
+										pos:  position{line: 747, col: 14, offset: 17727},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 747, col: 22, offset: 17729},
+									pos:  position{line: 747, col: 22, offset: 17735},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 747, col: 25, offset: 17732},
+									pos:        position{line: 747, col: 25, offset: 17738},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4997,13 +4997,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 750, col: 6, offset: 17769},
+						pos: position{line: 750, col: 6, offset: 17775},
 						run: (*parser).callonFromEntity47,
 						expr: &labeledExpr{
-							pos:   position{line: 750, col: 6, offset: 17769},
+							pos:   position{line: 750, col: 6, offset: 17775},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 750, col: 11, offset: 17774},
+								pos:  position{line: 750, col: 11, offset: 17780},
 								name: "Name",
 							},
 						},
@@ -5015,40 +5015,40 @@ var g = &grammar{
 		},
 		{
 			name: "FromArgs",
-			pos:  position{line: 753, col: 1, offset: 17872},
+			pos:  position{line: 753, col: 1, offset: 17878},
 			expr: &choiceExpr{
-				pos: position{line: 754, col: 5, offset: 17885},
+				pos: position{line: 754, col: 5, offset: 17891},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 754, col: 5, offset: 17885},
+						pos: position{line: 754, col: 5, offset: 17891},
 						run: (*parser).callonFromArgs2,
 						expr: &seqExpr{
-							pos: position{line: 754, col: 5, offset: 17885},
+							pos: position{line: 754, col: 5, offset: 17891},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 754, col: 5, offset: 17885},
+									pos:   position{line: 754, col: 5, offset: 17891},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 754, col: 12, offset: 17892},
+										pos:  position{line: 754, col: 12, offset: 17898},
 										name: "PoolCommit",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 754, col: 23, offset: 17903},
+									pos:   position{line: 754, col: 23, offset: 17909},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 754, col: 28, offset: 17908},
+										pos: position{line: 754, col: 28, offset: 17914},
 										expr: &ruleRefExpr{
-											pos:  position{line: 754, col: 28, offset: 17908},
+											pos:  position{line: 754, col: 28, offset: 17914},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 754, col: 38, offset: 17918},
+									pos:   position{line: 754, col: 38, offset: 17924},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 754, col: 42, offset: 17922},
+										pos:  position{line: 754, col: 42, offset: 17928},
 										name: "TapArg",
 									},
 								},
@@ -5056,24 +5056,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 763, col: 5, offset: 18126},
+						pos: position{line: 763, col: 5, offset: 18132},
 						run: (*parser).callonFromArgs11,
 						expr: &seqExpr{
-							pos: position{line: 763, col: 5, offset: 18126},
+							pos: position{line: 763, col: 5, offset: 18132},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 763, col: 5, offset: 18126},
+									pos:   position{line: 763, col: 5, offset: 18132},
 									label: "meta",
 									expr: &ruleRefExpr{
-										pos:  position{line: 763, col: 10, offset: 18131},
+										pos:  position{line: 763, col: 10, offset: 18137},
 										name: "PoolMeta",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 763, col: 19, offset: 18140},
+									pos:   position{line: 763, col: 19, offset: 18146},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 763, col: 23, offset: 18144},
+										pos:  position{line: 763, col: 23, offset: 18150},
 										name: "TapArg",
 									},
 								},
@@ -5081,41 +5081,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 771, col: 5, offset: 18310},
+						pos: position{line: 771, col: 5, offset: 18316},
 						run: (*parser).callonFromArgs17,
 						expr: &seqExpr{
-							pos: position{line: 771, col: 5, offset: 18310},
+							pos: position{line: 771, col: 5, offset: 18316},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 771, col: 5, offset: 18310},
+									pos:   position{line: 771, col: 5, offset: 18316},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 771, col: 12, offset: 18317},
+										pos:  position{line: 771, col: 12, offset: 18323},
 										name: "FormatArg",
 									},
 								},
 								&notExpr{
-									pos: position{line: 771, col: 22, offset: 18327},
+									pos: position{line: 771, col: 22, offset: 18333},
 									expr: &seqExpr{
-										pos: position{line: 771, col: 24, offset: 18329},
+										pos: position{line: 771, col: 24, offset: 18335},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 771, col: 24, offset: 18329},
+												pos:  position{line: 771, col: 24, offset: 18335},
 												name: "_",
 											},
 											&choiceExpr{
-												pos: position{line: 771, col: 27, offset: 18332},
+												pos: position{line: 771, col: 27, offset: 18338},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 771, col: 27, offset: 18332},
+														pos:  position{line: 771, col: 27, offset: 18338},
 														name: "METHOD",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 771, col: 36, offset: 18341},
+														pos:  position{line: 771, col: 36, offset: 18347},
 														name: "HEADERS",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 771, col: 46, offset: 18351},
+														pos:  position{line: 771, col: 46, offset: 18357},
 														name: "BODY",
 													},
 												},
@@ -5127,51 +5127,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 778, col: 5, offset: 18496},
+						pos: position{line: 778, col: 5, offset: 18502},
 						run: (*parser).callonFromArgs28,
 						expr: &seqExpr{
-							pos: position{line: 778, col: 5, offset: 18496},
+							pos: position{line: 778, col: 5, offset: 18502},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 778, col: 5, offset: 18496},
+									pos:   position{line: 778, col: 5, offset: 18502},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 12, offset: 18503},
+										pos: position{line: 778, col: 12, offset: 18509},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 12, offset: 18503},
+											pos:  position{line: 778, col: 12, offset: 18509},
 											name: "FormatArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 23, offset: 18514},
+									pos:   position{line: 778, col: 23, offset: 18520},
 									label: "method",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 30, offset: 18521},
+										pos: position{line: 778, col: 30, offset: 18527},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 30, offset: 18521},
+											pos:  position{line: 778, col: 30, offset: 18527},
 											name: "MethodArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 41, offset: 18532},
+									pos:   position{line: 778, col: 41, offset: 18538},
 									label: "headers",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 49, offset: 18540},
+										pos: position{line: 778, col: 49, offset: 18546},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 49, offset: 18540},
+											pos:  position{line: 778, col: 49, offset: 18546},
 											name: "HeadersArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 61, offset: 18552},
+									pos:   position{line: 778, col: 61, offset: 18558},
 									label: "body",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 66, offset: 18557},
+										pos: position{line: 778, col: 66, offset: 18563},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 66, offset: 18557},
+											pos:  position{line: 778, col: 66, offset: 18563},
 											name: "BodyArg",
 										},
 									},
@@ -5186,30 +5186,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 795, col: 1, offset: 18973},
+			pos:  position{line: 795, col: 1, offset: 18979},
 			expr: &actionExpr{
-				pos: position{line: 795, col: 13, offset: 18985},
+				pos: position{line: 795, col: 13, offset: 18991},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 795, col: 13, offset: 18985},
+					pos: position{line: 795, col: 13, offset: 18991},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 13, offset: 18985},
+							pos:  position{line: 795, col: 13, offset: 18991},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 15, offset: 18987},
+							pos:  position{line: 795, col: 15, offset: 18993},
 							name: "FORMAT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 22, offset: 18994},
+							pos:  position{line: 795, col: 22, offset: 19000},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 24, offset: 18996},
+							pos:   position{line: 795, col: 24, offset: 19002},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 26, offset: 18998},
+								pos:  position{line: 795, col: 26, offset: 19004},
 								name: "Name",
 							},
 						},
@@ -5221,30 +5221,30 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 797, col: 1, offset: 19022},
+			pos:  position{line: 797, col: 1, offset: 19028},
 			expr: &actionExpr{
-				pos: position{line: 797, col: 13, offset: 19034},
+				pos: position{line: 797, col: 13, offset: 19040},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 797, col: 13, offset: 19034},
+					pos: position{line: 797, col: 13, offset: 19040},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 797, col: 13, offset: 19034},
+							pos:  position{line: 797, col: 13, offset: 19040},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 797, col: 15, offset: 19036},
+							pos:  position{line: 797, col: 15, offset: 19042},
 							name: "METHOD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 797, col: 22, offset: 19043},
+							pos:  position{line: 797, col: 22, offset: 19049},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 797, col: 24, offset: 19045},
+							pos:   position{line: 797, col: 24, offset: 19051},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 797, col: 26, offset: 19047},
+								pos:  position{line: 797, col: 26, offset: 19053},
 								name: "Name",
 							},
 						},
@@ -5256,30 +5256,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 799, col: 1, offset: 19071},
+			pos:  position{line: 799, col: 1, offset: 19077},
 			expr: &actionExpr{
-				pos: position{line: 799, col: 14, offset: 19084},
+				pos: position{line: 799, col: 14, offset: 19090},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 799, col: 14, offset: 19084},
+					pos: position{line: 799, col: 14, offset: 19090},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 14, offset: 19084},
+							pos:  position{line: 799, col: 14, offset: 19090},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 16, offset: 19086},
+							pos:  position{line: 799, col: 16, offset: 19092},
 							name: "HEADERS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 24, offset: 19094},
+							pos:  position{line: 799, col: 24, offset: 19100},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 799, col: 26, offset: 19096},
+							pos:   position{line: 799, col: 26, offset: 19102},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 799, col: 28, offset: 19098},
+								pos:  position{line: 799, col: 28, offset: 19104},
 								name: "Record",
 							},
 						},
@@ -5291,30 +5291,30 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 801, col: 1, offset: 19124},
+			pos:  position{line: 801, col: 1, offset: 19130},
 			expr: &actionExpr{
-				pos: position{line: 801, col: 11, offset: 19134},
+				pos: position{line: 801, col: 11, offset: 19140},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 801, col: 11, offset: 19134},
+					pos: position{line: 801, col: 11, offset: 19140},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 11, offset: 19134},
+							pos:  position{line: 801, col: 11, offset: 19140},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 13, offset: 19136},
+							pos:  position{line: 801, col: 13, offset: 19142},
 							name: "BODY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 18, offset: 19141},
+							pos:  position{line: 801, col: 18, offset: 19147},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 20, offset: 19143},
+							pos:   position{line: 801, col: 20, offset: 19149},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 801, col: 22, offset: 19145},
+								pos:  position{line: 801, col: 22, offset: 19151},
 								name: "Name",
 							},
 						},
@@ -5326,24 +5326,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 803, col: 1, offset: 19169},
+			pos:  position{line: 803, col: 1, offset: 19175},
 			expr: &actionExpr{
-				pos: position{line: 803, col: 15, offset: 19183},
+				pos: position{line: 803, col: 15, offset: 19189},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 803, col: 15, offset: 19183},
+					pos: position{line: 803, col: 15, offset: 19189},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 803, col: 16, offset: 19184},
+							pos: position{line: 803, col: 16, offset: 19190},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 803, col: 16, offset: 19184},
+									pos:        position{line: 803, col: 16, offset: 19190},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 803, col: 28, offset: 19196},
+									pos:        position{line: 803, col: 28, offset: 19202},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
@@ -5351,9 +5351,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 803, col: 40, offset: 19208},
+							pos: position{line: 803, col: 40, offset: 19214},
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 40, offset: 19208},
+								pos:  position{line: 803, col: 40, offset: 19214},
 								name: "URLChar",
 							},
 						},
@@ -5365,9 +5365,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 805, col: 1, offset: 19249},
+			pos:  position{line: 805, col: 1, offset: 19255},
 			expr: &charClassMatcher{
-				pos:        position{line: 805, col: 11, offset: 19259},
+				pos:        position{line: 805, col: 11, offset: 19265},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -5379,30 +5379,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 808, col: 1, offset: 19323},
+			pos:  position{line: 808, col: 1, offset: 19329},
 			expr: &actionExpr{
-				pos: position{line: 809, col: 5, offset: 19334},
+				pos: position{line: 809, col: 5, offset: 19340},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 809, col: 5, offset: 19334},
+					pos: position{line: 809, col: 5, offset: 19340},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 5, offset: 19334},
+							pos:  position{line: 809, col: 5, offset: 19340},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 7, offset: 19336},
+							pos:  position{line: 809, col: 7, offset: 19342},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 10, offset: 19339},
+							pos:  position{line: 809, col: 10, offset: 19345},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 809, col: 12, offset: 19341},
+							pos:   position{line: 809, col: 12, offset: 19347},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 809, col: 15, offset: 19344},
+								pos:  position{line: 809, col: 15, offset: 19350},
 								name: "KSUID",
 							},
 						},
@@ -5414,14 +5414,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 812, col: 1, offset: 19410},
+			pos:  position{line: 812, col: 1, offset: 19416},
 			expr: &actionExpr{
-				pos: position{line: 812, col: 9, offset: 19418},
+				pos: position{line: 812, col: 9, offset: 19424},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 812, col: 9, offset: 19418},
+					pos: position{line: 812, col: 9, offset: 19424},
 					expr: &charClassMatcher{
-						pos:        position{line: 812, col: 10, offset: 19419},
+						pos:        position{line: 812, col: 10, offset: 19425},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -5434,24 +5434,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 814, col: 1, offset: 19465},
+			pos:  position{line: 814, col: 1, offset: 19471},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 19480},
+				pos: position{line: 815, col: 5, offset: 19486},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 19480},
+					pos: position{line: 815, col: 5, offset: 19486},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 815, col: 5, offset: 19480},
+							pos:        position{line: 815, col: 5, offset: 19486},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 9, offset: 19484},
+							pos:   position{line: 815, col: 9, offset: 19490},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 11, offset: 19486},
+								pos:  position{line: 815, col: 11, offset: 19492},
 								name: "Name",
 							},
 						},
@@ -5463,24 +5463,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 817, col: 1, offset: 19510},
+			pos:  position{line: 817, col: 1, offset: 19516},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 5, offset: 19523},
+				pos: position{line: 818, col: 5, offset: 19529},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 5, offset: 19523},
+					pos: position{line: 818, col: 5, offset: 19529},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 818, col: 5, offset: 19523},
+							pos:        position{line: 818, col: 5, offset: 19529},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 9, offset: 19527},
+							pos:   position{line: 818, col: 9, offset: 19533},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 11, offset: 19529},
+								pos:  position{line: 818, col: 11, offset: 19535},
 								name: "Name",
 							},
 						},
@@ -5492,32 +5492,32 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 820, col: 1, offset: 19553},
+			pos:  position{line: 820, col: 1, offset: 19559},
 			expr: &choiceExpr{
-				pos: position{line: 821, col: 5, offset: 19564},
+				pos: position{line: 821, col: 5, offset: 19570},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 821, col: 5, offset: 19564},
+						pos: position{line: 821, col: 5, offset: 19570},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 821, col: 5, offset: 19564},
+							pos: position{line: 821, col: 5, offset: 19570},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 821, col: 5, offset: 19564},
+									pos:  position{line: 821, col: 5, offset: 19570},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 821, col: 7, offset: 19566},
+									pos:  position{line: 821, col: 7, offset: 19572},
 									name: "TAP",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 822, col: 5, offset: 19595},
+						pos: position{line: 822, col: 5, offset: 19601},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 822, col: 5, offset: 19595},
+							pos:        position{line: 822, col: 5, offset: 19601},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -5530,28 +5530,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 824, col: 1, offset: 19621},
+			pos:  position{line: 824, col: 1, offset: 19627},
 			expr: &actionExpr{
-				pos: position{line: 825, col: 5, offset: 19632},
+				pos: position{line: 825, col: 5, offset: 19638},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 825, col: 5, offset: 19632},
+					pos: position{line: 825, col: 5, offset: 19638},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 825, col: 5, offset: 19632},
+							pos:  position{line: 825, col: 5, offset: 19638},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 825, col: 10, offset: 19637},
+							pos: position{line: 825, col: 10, offset: 19643},
 							expr: &seqExpr{
-								pos: position{line: 825, col: 12, offset: 19639},
+								pos: position{line: 825, col: 12, offset: 19645},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 825, col: 12, offset: 19639},
+										pos:  position{line: 825, col: 12, offset: 19645},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 825, col: 15, offset: 19642},
+										pos:        position{line: 825, col: 15, offset: 19648},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5560,9 +5560,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 825, col: 20, offset: 19647},
+							pos: position{line: 825, col: 20, offset: 19653},
 							expr: &ruleRefExpr{
-								pos:  position{line: 825, col: 21, offset: 19648},
+								pos:  position{line: 825, col: 21, offset: 19654},
 								name: "EOKW",
 							},
 						},
@@ -5574,44 +5574,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 831, col: 1, offset: 19839},
+			pos:  position{line: 831, col: 1, offset: 19845},
 			expr: &actionExpr{
-				pos: position{line: 832, col: 5, offset: 19853},
+				pos: position{line: 832, col: 5, offset: 19859},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 832, col: 5, offset: 19853},
+					pos: position{line: 832, col: 5, offset: 19859},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 832, col: 5, offset: 19853},
+							pos:  position{line: 832, col: 5, offset: 19859},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 832, col: 13, offset: 19861},
+							pos:  position{line: 832, col: 13, offset: 19867},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 15, offset: 19863},
+							pos:   position{line: 832, col: 15, offset: 19869},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 832, col: 20, offset: 19868},
+								pos:  position{line: 832, col: 20, offset: 19874},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 26, offset: 19874},
+							pos:   position{line: 832, col: 26, offset: 19880},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 832, col: 30, offset: 19878},
+								pos:  position{line: 832, col: 30, offset: 19884},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 38, offset: 19886},
+							pos:   position{line: 832, col: 38, offset: 19892},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 832, col: 41, offset: 19889},
+								pos: position{line: 832, col: 41, offset: 19895},
 								expr: &ruleRefExpr{
-									pos:  position{line: 832, col: 41, offset: 19889},
+									pos:  position{line: 832, col: 41, offset: 19895},
 									name: "AsArg",
 								},
 							},
@@ -5624,26 +5624,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 845, col: 1, offset: 20131},
+			pos:  position{line: 845, col: 1, offset: 20137},
 			expr: &actionExpr{
-				pos: position{line: 846, col: 5, offset: 20143},
+				pos: position{line: 846, col: 5, offset: 20149},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 846, col: 5, offset: 20143},
+					pos: position{line: 846, col: 5, offset: 20149},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 846, col: 5, offset: 20143},
+							pos:  position{line: 846, col: 5, offset: 20149},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 846, col: 11, offset: 20149},
+							pos:  position{line: 846, col: 11, offset: 20155},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 846, col: 13, offset: 20151},
+							pos:   position{line: 846, col: 13, offset: 20157},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 846, col: 19, offset: 20157},
+								pos:  position{line: 846, col: 19, offset: 20163},
 								name: "OrderByList",
 							},
 						},
@@ -5655,56 +5655,56 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 854, col: 1, offset: 20299},
+			pos:  position{line: 854, col: 1, offset: 20305},
 			expr: &actionExpr{
-				pos: position{line: 855, col: 5, offset: 20310},
+				pos: position{line: 855, col: 5, offset: 20316},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 855, col: 5, offset: 20310},
+					pos: position{line: 855, col: 5, offset: 20316},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 855, col: 6, offset: 20311},
+							pos: position{line: 855, col: 6, offset: 20317},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 855, col: 6, offset: 20311},
+									pos:  position{line: 855, col: 6, offset: 20317},
 									name: "OVER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 855, col: 13, offset: 20318},
+									pos:  position{line: 855, col: 13, offset: 20324},
 									name: "UNNEST",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 855, col: 21, offset: 20326},
+							pos:  position{line: 855, col: 21, offset: 20332},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 23, offset: 20328},
+							pos:   position{line: 855, col: 23, offset: 20334},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 29, offset: 20334},
+								pos:  position{line: 855, col: 29, offset: 20340},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 35, offset: 20340},
+							pos:   position{line: 855, col: 35, offset: 20346},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 855, col: 42, offset: 20347},
+								pos: position{line: 855, col: 42, offset: 20353},
 								expr: &ruleRefExpr{
-									pos:  position{line: 855, col: 42, offset: 20347},
+									pos:  position{line: 855, col: 42, offset: 20353},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 50, offset: 20355},
+							pos:   position{line: 855, col: 50, offset: 20361},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 855, col: 55, offset: 20360},
+								pos: position{line: 855, col: 55, offset: 20366},
 								expr: &ruleRefExpr{
-									pos:  position{line: 855, col: 55, offset: 20360},
+									pos:  position{line: 855, col: 55, offset: 20366},
 									name: "Lateral",
 								},
 							},
@@ -5717,54 +5717,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 870, col: 1, offset: 20685},
+			pos:  position{line: 870, col: 1, offset: 20691},
 			expr: &choiceExpr{
-				pos: position{line: 871, col: 5, offset: 20697},
+				pos: position{line: 871, col: 5, offset: 20703},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 871, col: 5, offset: 20697},
+						pos: position{line: 871, col: 5, offset: 20703},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 871, col: 5, offset: 20697},
+							pos: position{line: 871, col: 5, offset: 20703},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 871, col: 5, offset: 20697},
+									pos:  position{line: 871, col: 5, offset: 20703},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 871, col: 8, offset: 20700},
+									pos:        position{line: 871, col: 8, offset: 20706},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 871, col: 13, offset: 20705},
+									pos:  position{line: 871, col: 13, offset: 20711},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 871, col: 16, offset: 20708},
+									pos:        position{line: 871, col: 16, offset: 20714},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 871, col: 20, offset: 20712},
+									pos:  position{line: 871, col: 20, offset: 20718},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 871, col: 23, offset: 20715},
+									pos:   position{line: 871, col: 23, offset: 20721},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 871, col: 29, offset: 20721},
+										pos:  position{line: 871, col: 29, offset: 20727},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 871, col: 35, offset: 20727},
+									pos:  position{line: 871, col: 35, offset: 20733},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 871, col: 38, offset: 20730},
+									pos:        position{line: 871, col: 38, offset: 20736},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5773,49 +5773,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 874, col: 5, offset: 20811},
+						pos: position{line: 874, col: 5, offset: 20817},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 874, col: 5, offset: 20811},
+							pos: position{line: 874, col: 5, offset: 20817},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 874, col: 5, offset: 20811},
+									pos:  position{line: 874, col: 5, offset: 20817},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 874, col: 8, offset: 20814},
+									pos:        position{line: 874, col: 8, offset: 20820},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 874, col: 13, offset: 20819},
+									pos:  position{line: 874, col: 13, offset: 20825},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 874, col: 16, offset: 20822},
+									pos:        position{line: 874, col: 16, offset: 20828},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 874, col: 20, offset: 20826},
+									pos:  position{line: 874, col: 20, offset: 20832},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 874, col: 23, offset: 20829},
+									pos:   position{line: 874, col: 23, offset: 20835},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 874, col: 27, offset: 20833},
+										pos:  position{line: 874, col: 27, offset: 20839},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 874, col: 31, offset: 20837},
+									pos:  position{line: 874, col: 31, offset: 20843},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 874, col: 34, offset: 20840},
+									pos:        position{line: 874, col: 34, offset: 20846},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5830,63 +5830,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 878, col: 1, offset: 20896},
+			pos:  position{line: 878, col: 1, offset: 20902},
 			expr: &actionExpr{
-				pos: position{line: 879, col: 5, offset: 20907},
+				pos: position{line: 879, col: 5, offset: 20913},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 879, col: 5, offset: 20907},
+					pos: position{line: 879, col: 5, offset: 20913},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 5, offset: 20907},
+							pos:  position{line: 879, col: 5, offset: 20913},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 7, offset: 20909},
+							pos:  position{line: 879, col: 7, offset: 20915},
 							name: "WITH",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 12, offset: 20914},
+							pos:  position{line: 879, col: 12, offset: 20920},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 14, offset: 20916},
+							pos:   position{line: 879, col: 14, offset: 20922},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 20, offset: 20922},
+								pos:  position{line: 879, col: 20, offset: 20928},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 37, offset: 20939},
+							pos:   position{line: 879, col: 37, offset: 20945},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 879, col: 42, offset: 20944},
+								pos: position{line: 879, col: 42, offset: 20950},
 								expr: &actionExpr{
-									pos: position{line: 879, col: 43, offset: 20945},
+									pos: position{line: 879, col: 43, offset: 20951},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 879, col: 43, offset: 20945},
+										pos: position{line: 879, col: 43, offset: 20951},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 879, col: 43, offset: 20945},
+												pos:  position{line: 879, col: 43, offset: 20951},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 879, col: 46, offset: 20948},
+												pos:        position{line: 879, col: 46, offset: 20954},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 879, col: 50, offset: 20952},
+												pos:  position{line: 879, col: 50, offset: 20958},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 879, col: 53, offset: 20955},
+												pos:   position{line: 879, col: 53, offset: 20961},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 879, col: 55, offset: 20957},
+													pos:  position{line: 879, col: 55, offset: 20963},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5903,45 +5903,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 883, col: 1, offset: 21042},
+			pos:  position{line: 883, col: 1, offset: 21048},
 			expr: &actionExpr{
-				pos: position{line: 884, col: 5, offset: 21063},
+				pos: position{line: 884, col: 5, offset: 21069},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 884, col: 5, offset: 21063},
+					pos: position{line: 884, col: 5, offset: 21069},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 884, col: 5, offset: 21063},
+							pos:   position{line: 884, col: 5, offset: 21069},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 884, col: 10, offset: 21068},
+								pos:  position{line: 884, col: 10, offset: 21074},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 884, col: 21, offset: 21079},
+							pos:   position{line: 884, col: 21, offset: 21085},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 884, col: 25, offset: 21083},
+								pos: position{line: 884, col: 25, offset: 21089},
 								expr: &seqExpr{
-									pos: position{line: 884, col: 26, offset: 21084},
+									pos: position{line: 884, col: 26, offset: 21090},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 884, col: 26, offset: 21084},
+											pos:  position{line: 884, col: 26, offset: 21090},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 884, col: 29, offset: 21087},
+											pos:        position{line: 884, col: 29, offset: 21093},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 884, col: 33, offset: 21091},
+											pos:  position{line: 884, col: 33, offset: 21097},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 884, col: 36, offset: 21094},
+											pos:  position{line: 884, col: 36, offset: 21100},
 											name: "Expr",
 										},
 									},
@@ -5956,26 +5956,26 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 896, col: 1, offset: 21318},
+			pos:  position{line: 896, col: 1, offset: 21324},
 			expr: &actionExpr{
-				pos: position{line: 897, col: 5, offset: 21330},
+				pos: position{line: 897, col: 5, offset: 21336},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 897, col: 5, offset: 21330},
+					pos: position{line: 897, col: 5, offset: 21336},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 897, col: 5, offset: 21330},
+							pos:  position{line: 897, col: 5, offset: 21336},
 							name: "YIELD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 897, col: 11, offset: 21336},
+							pos:  position{line: 897, col: 11, offset: 21342},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 897, col: 13, offset: 21338},
+							pos:   position{line: 897, col: 13, offset: 21344},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 897, col: 19, offset: 21344},
+								pos:  position{line: 897, col: 19, offset: 21350},
 								name: "Exprs",
 							},
 						},
@@ -5987,30 +5987,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 905, col: 1, offset: 21488},
+			pos:  position{line: 905, col: 1, offset: 21494},
 			expr: &actionExpr{
-				pos: position{line: 906, col: 5, offset: 21500},
+				pos: position{line: 906, col: 5, offset: 21506},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 906, col: 5, offset: 21500},
+					pos: position{line: 906, col: 5, offset: 21506},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 5, offset: 21500},
+							pos:  position{line: 906, col: 5, offset: 21506},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 7, offset: 21502},
+							pos:  position{line: 906, col: 7, offset: 21508},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 10, offset: 21505},
+							pos:  position{line: 906, col: 10, offset: 21511},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 906, col: 12, offset: 21507},
+							pos:   position{line: 906, col: 12, offset: 21513},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 906, col: 16, offset: 21511},
+								pos:  position{line: 906, col: 16, offset: 21517},
 								name: "Type",
 							},
 						},
@@ -6022,30 +6022,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 908, col: 1, offset: 21537},
+			pos:  position{line: 908, col: 1, offset: 21543},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 5, offset: 21547},
+				pos: position{line: 909, col: 5, offset: 21553},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 909, col: 5, offset: 21547},
+					pos: position{line: 909, col: 5, offset: 21553},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 5, offset: 21547},
+							pos:  position{line: 909, col: 5, offset: 21553},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 7, offset: 21549},
+							pos:  position{line: 909, col: 7, offset: 21555},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 10, offset: 21552},
+							pos:  position{line: 909, col: 10, offset: 21558},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 12, offset: 21554},
+							pos:   position{line: 909, col: 12, offset: 21560},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 909, col: 16, offset: 21558},
+								pos:  position{line: 909, col: 16, offset: 21564},
 								name: "Lval",
 							},
 						},
@@ -6057,9 +6057,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 913, col: 1, offset: 21609},
+			pos:  position{line: 913, col: 1, offset: 21615},
 			expr: &ruleRefExpr{
-				pos:  position{line: 913, col: 8, offset: 21616},
+				pos:  position{line: 913, col: 8, offset: 21622},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -6067,51 +6067,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 915, col: 1, offset: 21627},
+			pos:  position{line: 915, col: 1, offset: 21633},
 			expr: &actionExpr{
-				pos: position{line: 916, col: 5, offset: 21637},
+				pos: position{line: 916, col: 5, offset: 21643},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 916, col: 5, offset: 21637},
+					pos: position{line: 916, col: 5, offset: 21643},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 916, col: 5, offset: 21637},
+							pos:   position{line: 916, col: 5, offset: 21643},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 916, col: 11, offset: 21643},
+								pos:  position{line: 916, col: 11, offset: 21649},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 916, col: 16, offset: 21648},
+							pos:   position{line: 916, col: 16, offset: 21654},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 916, col: 21, offset: 21653},
+								pos: position{line: 916, col: 21, offset: 21659},
 								expr: &actionExpr{
-									pos: position{line: 916, col: 22, offset: 21654},
+									pos: position{line: 916, col: 22, offset: 21660},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 916, col: 22, offset: 21654},
+										pos: position{line: 916, col: 22, offset: 21660},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 22, offset: 21654},
+												pos:  position{line: 916, col: 22, offset: 21660},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 916, col: 25, offset: 21657},
+												pos:        position{line: 916, col: 25, offset: 21663},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 29, offset: 21661},
+												pos:  position{line: 916, col: 29, offset: 21667},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 916, col: 32, offset: 21664},
+												pos:   position{line: 916, col: 32, offset: 21670},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 916, col: 37, offset: 21669},
+													pos:  position{line: 916, col: 37, offset: 21675},
 													name: "Lval",
 												},
 											},
@@ -6128,51 +6128,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 920, col: 1, offset: 21745},
+			pos:  position{line: 920, col: 1, offset: 21751},
 			expr: &actionExpr{
-				pos: position{line: 921, col: 5, offset: 21761},
+				pos: position{line: 921, col: 5, offset: 21767},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 921, col: 5, offset: 21761},
+					pos: position{line: 921, col: 5, offset: 21767},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 921, col: 5, offset: 21761},
+							pos:   position{line: 921, col: 5, offset: 21767},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 921, col: 11, offset: 21767},
+								pos:  position{line: 921, col: 11, offset: 21773},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 921, col: 22, offset: 21778},
+							pos:   position{line: 921, col: 22, offset: 21784},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 921, col: 27, offset: 21783},
+								pos: position{line: 921, col: 27, offset: 21789},
 								expr: &actionExpr{
-									pos: position{line: 921, col: 28, offset: 21784},
+									pos: position{line: 921, col: 28, offset: 21790},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 921, col: 28, offset: 21784},
+										pos: position{line: 921, col: 28, offset: 21790},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 921, col: 28, offset: 21784},
+												pos:  position{line: 921, col: 28, offset: 21790},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 921, col: 31, offset: 21787},
+												pos:        position{line: 921, col: 31, offset: 21793},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 921, col: 35, offset: 21791},
+												pos:  position{line: 921, col: 35, offset: 21797},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 921, col: 38, offset: 21794},
+												pos:   position{line: 921, col: 38, offset: 21800},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 921, col: 40, offset: 21796},
+													pos:  position{line: 921, col: 40, offset: 21802},
 													name: "Assignment",
 												},
 											},
@@ -6189,40 +6189,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 925, col: 1, offset: 21871},
+			pos:  position{line: 925, col: 1, offset: 21877},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 5, offset: 21886},
+				pos: position{line: 926, col: 5, offset: 21892},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 926, col: 5, offset: 21886},
+					pos: position{line: 926, col: 5, offset: 21892},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 926, col: 5, offset: 21886},
+							pos:   position{line: 926, col: 5, offset: 21892},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 9, offset: 21890},
+								pos:  position{line: 926, col: 9, offset: 21896},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 14, offset: 21895},
+							pos:  position{line: 926, col: 14, offset: 21901},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 926, col: 17, offset: 21898},
+							pos:        position{line: 926, col: 17, offset: 21904},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 22, offset: 21903},
+							pos:  position{line: 926, col: 22, offset: 21909},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 926, col: 25, offset: 21906},
+							pos:   position{line: 926, col: 25, offset: 21912},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 29, offset: 21910},
+								pos:  position{line: 926, col: 29, offset: 21916},
 								name: "Expr",
 							},
 						},
@@ -6234,9 +6234,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 935, col: 1, offset: 22081},
+			pos:  position{line: 935, col: 1, offset: 22087},
 			expr: &ruleRefExpr{
-				pos:  position{line: 935, col: 8, offset: 22088},
+				pos:  position{line: 935, col: 8, offset: 22094},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -6244,63 +6244,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 937, col: 1, offset: 22105},
+			pos:  position{line: 937, col: 1, offset: 22111},
 			expr: &actionExpr{
-				pos: position{line: 938, col: 5, offset: 22125},
+				pos: position{line: 938, col: 5, offset: 22131},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 938, col: 5, offset: 22125},
+					pos: position{line: 938, col: 5, offset: 22131},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 938, col: 5, offset: 22125},
+							pos:   position{line: 938, col: 5, offset: 22131},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 938, col: 10, offset: 22130},
+								pos:  position{line: 938, col: 10, offset: 22136},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 938, col: 24, offset: 22144},
+							pos:   position{line: 938, col: 24, offset: 22150},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 938, col: 28, offset: 22148},
+								pos: position{line: 938, col: 28, offset: 22154},
 								expr: &seqExpr{
-									pos: position{line: 938, col: 29, offset: 22149},
+									pos: position{line: 938, col: 29, offset: 22155},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 29, offset: 22149},
+											pos:  position{line: 938, col: 29, offset: 22155},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 938, col: 32, offset: 22152},
+											pos:        position{line: 938, col: 32, offset: 22158},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 36, offset: 22156},
+											pos:  position{line: 938, col: 36, offset: 22162},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 39, offset: 22159},
+											pos:  position{line: 938, col: 39, offset: 22165},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 44, offset: 22164},
+											pos:  position{line: 938, col: 44, offset: 22170},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 938, col: 47, offset: 22167},
+											pos:        position{line: 938, col: 47, offset: 22173},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 51, offset: 22171},
+											pos:  position{line: 938, col: 51, offset: 22177},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 54, offset: 22174},
+											pos:  position{line: 938, col: 54, offset: 22180},
 											name: "Expr",
 										},
 									},
@@ -6315,53 +6315,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 952, col: 1, offset: 22495},
+			pos:  position{line: 952, col: 1, offset: 22501},
 			expr: &actionExpr{
-				pos: position{line: 953, col: 5, offset: 22513},
+				pos: position{line: 953, col: 5, offset: 22519},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 953, col: 5, offset: 22513},
+					pos: position{line: 953, col: 5, offset: 22519},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 953, col: 5, offset: 22513},
+							pos:   position{line: 953, col: 5, offset: 22519},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 953, col: 11, offset: 22519},
+								pos:  position{line: 953, col: 11, offset: 22525},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 954, col: 5, offset: 22538},
+							pos:   position{line: 954, col: 5, offset: 22544},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 954, col: 10, offset: 22543},
+								pos: position{line: 954, col: 10, offset: 22549},
 								expr: &actionExpr{
-									pos: position{line: 954, col: 11, offset: 22544},
+									pos: position{line: 954, col: 11, offset: 22550},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 954, col: 11, offset: 22544},
+										pos: position{line: 954, col: 11, offset: 22550},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 954, col: 11, offset: 22544},
+												pos:  position{line: 954, col: 11, offset: 22550},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 954, col: 14, offset: 22547},
+												pos:   position{line: 954, col: 14, offset: 22553},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 954, col: 17, offset: 22550},
+													pos:  position{line: 954, col: 17, offset: 22556},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 954, col: 20, offset: 22553},
+												pos:  position{line: 954, col: 20, offset: 22559},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 954, col: 23, offset: 22556},
+												pos:   position{line: 954, col: 23, offset: 22562},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 954, col: 28, offset: 22561},
+													pos:  position{line: 954, col: 28, offset: 22567},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6378,53 +6378,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 958, col: 1, offset: 22675},
+			pos:  position{line: 958, col: 1, offset: 22681},
 			expr: &actionExpr{
-				pos: position{line: 959, col: 5, offset: 22694},
+				pos: position{line: 959, col: 5, offset: 22700},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 959, col: 5, offset: 22694},
+					pos: position{line: 959, col: 5, offset: 22700},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 959, col: 5, offset: 22694},
+							pos:   position{line: 959, col: 5, offset: 22700},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 959, col: 11, offset: 22700},
+								pos:  position{line: 959, col: 11, offset: 22706},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 960, col: 5, offset: 22712},
+							pos:   position{line: 960, col: 5, offset: 22718},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 960, col: 10, offset: 22717},
+								pos: position{line: 960, col: 10, offset: 22723},
 								expr: &actionExpr{
-									pos: position{line: 960, col: 11, offset: 22718},
+									pos: position{line: 960, col: 11, offset: 22724},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 960, col: 11, offset: 22718},
+										pos: position{line: 960, col: 11, offset: 22724},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 960, col: 11, offset: 22718},
+												pos:  position{line: 960, col: 11, offset: 22724},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 960, col: 14, offset: 22721},
+												pos:   position{line: 960, col: 14, offset: 22727},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 960, col: 17, offset: 22724},
+													pos:  position{line: 960, col: 17, offset: 22730},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 960, col: 21, offset: 22728},
+												pos:  position{line: 960, col: 21, offset: 22734},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 960, col: 24, offset: 22731},
+												pos:   position{line: 960, col: 24, offset: 22737},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 960, col: 29, offset: 22736},
+													pos:  position{line: 960, col: 29, offset: 22742},
 													name: "NotExpr",
 												},
 											},
@@ -6441,43 +6441,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 964, col: 1, offset: 22843},
+			pos:  position{line: 964, col: 1, offset: 22849},
 			expr: &choiceExpr{
-				pos: position{line: 965, col: 5, offset: 22855},
+				pos: position{line: 965, col: 5, offset: 22861},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 965, col: 5, offset: 22855},
+						pos: position{line: 965, col: 5, offset: 22861},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 965, col: 5, offset: 22855},
+							pos: position{line: 965, col: 5, offset: 22861},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 965, col: 6, offset: 22856},
+									pos: position{line: 965, col: 6, offset: 22862},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 965, col: 6, offset: 22856},
+											pos: position{line: 965, col: 6, offset: 22862},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 965, col: 6, offset: 22856},
+													pos:  position{line: 965, col: 6, offset: 22862},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 965, col: 10, offset: 22860},
+													pos:  position{line: 965, col: 10, offset: 22866},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 965, col: 14, offset: 22864},
+											pos: position{line: 965, col: 14, offset: 22870},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 965, col: 14, offset: 22864},
+													pos:        position{line: 965, col: 14, offset: 22870},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 965, col: 18, offset: 22868},
+													pos:  position{line: 965, col: 18, offset: 22874},
 													name: "__",
 												},
 											},
@@ -6485,10 +6485,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 965, col: 22, offset: 22872},
+									pos:   position{line: 965, col: 22, offset: 22878},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 965, col: 24, offset: 22874},
+										pos:  position{line: 965, col: 24, offset: 22880},
 										name: "NotExpr",
 									},
 								},
@@ -6496,7 +6496,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 973, col: 5, offset: 23040},
+						pos:  position{line: 973, col: 5, offset: 23046},
 						name: "BetweenExpr",
 					},
 				},
@@ -6506,42 +6506,42 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 975, col: 1, offset: 23055},
+			pos:  position{line: 975, col: 1, offset: 23061},
 			expr: &choiceExpr{
-				pos: position{line: 976, col: 5, offset: 23071},
+				pos: position{line: 976, col: 5, offset: 23077},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 976, col: 5, offset: 23071},
+						pos: position{line: 976, col: 5, offset: 23077},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 976, col: 5, offset: 23071},
+							pos: position{line: 976, col: 5, offset: 23077},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 976, col: 5, offset: 23071},
+									pos:   position{line: 976, col: 5, offset: 23077},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 10, offset: 23076},
+										pos:  position{line: 976, col: 10, offset: 23082},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 25, offset: 23091},
+									pos:  position{line: 976, col: 25, offset: 23097},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 27, offset: 23093},
+									pos:   position{line: 976, col: 27, offset: 23099},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 976, col: 31, offset: 23097},
+										pos: position{line: 976, col: 31, offset: 23103},
 										expr: &seqExpr{
-											pos: position{line: 976, col: 32, offset: 23098},
+											pos: position{line: 976, col: 32, offset: 23104},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 976, col: 32, offset: 23098},
+													pos:  position{line: 976, col: 32, offset: 23104},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 976, col: 36, offset: 23102},
+													pos:  position{line: 976, col: 36, offset: 23108},
 													name: "_",
 												},
 											},
@@ -6549,38 +6549,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 40, offset: 23106},
+									pos:  position{line: 976, col: 40, offset: 23112},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 48, offset: 23114},
+									pos:  position{line: 976, col: 48, offset: 23120},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 50, offset: 23116},
+									pos:   position{line: 976, col: 50, offset: 23122},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 56, offset: 23122},
+										pos:  position{line: 976, col: 56, offset: 23128},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 68, offset: 23134},
+									pos:  position{line: 976, col: 68, offset: 23140},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 70, offset: 23136},
+									pos:  position{line: 976, col: 70, offset: 23142},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 74, offset: 23140},
+									pos:  position{line: 976, col: 74, offset: 23146},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 76, offset: 23142},
+									pos:   position{line: 976, col: 76, offset: 23148},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 82, offset: 23148},
+										pos:  position{line: 976, col: 82, offset: 23154},
 										name: "BetweenExpr",
 									},
 								},
@@ -6588,7 +6588,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 986, col: 5, offset: 23380},
+						pos:  position{line: 986, col: 5, offset: 23386},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6598,46 +6598,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 988, col: 1, offset: 23396},
+			pos:  position{line: 988, col: 1, offset: 23402},
 			expr: &choiceExpr{
-				pos: position{line: 989, col: 5, offset: 23415},
+				pos: position{line: 989, col: 5, offset: 23421},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 989, col: 5, offset: 23415},
+						pos: position{line: 989, col: 5, offset: 23421},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 989, col: 5, offset: 23415},
+							pos: position{line: 989, col: 5, offset: 23421},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 989, col: 5, offset: 23415},
+									pos:   position{line: 989, col: 5, offset: 23421},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 989, col: 10, offset: 23420},
+										pos:  position{line: 989, col: 10, offset: 23426},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 23, offset: 23433},
+									pos:  position{line: 989, col: 23, offset: 23439},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 25, offset: 23435},
+									pos:  position{line: 989, col: 25, offset: 23441},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 989, col: 28, offset: 23438},
+									pos:   position{line: 989, col: 28, offset: 23444},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 989, col: 32, offset: 23442},
+										pos: position{line: 989, col: 32, offset: 23448},
 										expr: &seqExpr{
-											pos: position{line: 989, col: 33, offset: 23443},
+											pos: position{line: 989, col: 33, offset: 23449},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 989, col: 33, offset: 23443},
+													pos:  position{line: 989, col: 33, offset: 23449},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 989, col: 35, offset: 23445},
+													pos:  position{line: 989, col: 35, offset: 23451},
 													name: "NOT",
 												},
 											},
@@ -6645,82 +6645,82 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 41, offset: 23451},
+									pos:  position{line: 989, col: 41, offset: 23457},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 43, offset: 23453},
+									pos:  position{line: 989, col: 43, offset: 23459},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 997, col: 5, offset: 23621},
+						pos: position{line: 997, col: 5, offset: 23627},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 997, col: 5, offset: 23621},
+							pos: position{line: 997, col: 5, offset: 23627},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 997, col: 5, offset: 23621},
+									pos:   position{line: 997, col: 5, offset: 23627},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 997, col: 9, offset: 23625},
+										pos:  position{line: 997, col: 9, offset: 23631},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 997, col: 22, offset: 23638},
+									pos:   position{line: 997, col: 22, offset: 23644},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 997, col: 31, offset: 23647},
+										pos: position{line: 997, col: 31, offset: 23653},
 										expr: &choiceExpr{
-											pos: position{line: 997, col: 32, offset: 23648},
+											pos: position{line: 997, col: 32, offset: 23654},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 997, col: 32, offset: 23648},
+													pos: position{line: 997, col: 32, offset: 23654},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 32, offset: 23648},
+															pos:  position{line: 997, col: 32, offset: 23654},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 35, offset: 23651},
+															pos:  position{line: 997, col: 35, offset: 23657},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 46, offset: 23662},
+															pos:  position{line: 997, col: 46, offset: 23668},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 49, offset: 23665},
+															pos:  position{line: 997, col: 49, offset: 23671},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 997, col: 64, offset: 23680},
+													pos: position{line: 997, col: 64, offset: 23686},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 64, offset: 23680},
+															pos:  position{line: 997, col: 64, offset: 23686},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 997, col: 68, offset: 23684},
+															pos: position{line: 997, col: 68, offset: 23690},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 997, col: 68, offset: 23684},
+																pos:        position{line: 997, col: 68, offset: 23690},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 104, offset: 23720},
+															pos:  position{line: 997, col: 104, offset: 23726},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 107, offset: 23723},
+															pos:  position{line: 997, col: 107, offset: 23729},
 															name: "Regexp",
 														},
 													},
@@ -6739,53 +6739,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 1010, col: 1, offset: 24009},
+			pos:  position{line: 1010, col: 1, offset: 24015},
 			expr: &actionExpr{
-				pos: position{line: 1011, col: 5, offset: 24026},
+				pos: position{line: 1011, col: 5, offset: 24032},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1011, col: 5, offset: 24026},
+					pos: position{line: 1011, col: 5, offset: 24032},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1011, col: 5, offset: 24026},
+							pos:   position{line: 1011, col: 5, offset: 24032},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1011, col: 11, offset: 24032},
+								pos:  position{line: 1011, col: 11, offset: 24038},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1012, col: 5, offset: 24055},
+							pos:   position{line: 1012, col: 5, offset: 24061},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1012, col: 10, offset: 24060},
+								pos: position{line: 1012, col: 10, offset: 24066},
 								expr: &actionExpr{
-									pos: position{line: 1012, col: 11, offset: 24061},
+									pos: position{line: 1012, col: 11, offset: 24067},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1012, col: 11, offset: 24061},
+										pos: position{line: 1012, col: 11, offset: 24067},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1012, col: 11, offset: 24061},
+												pos:  position{line: 1012, col: 11, offset: 24067},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1012, col: 14, offset: 24064},
+												pos:   position{line: 1012, col: 14, offset: 24070},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1012, col: 17, offset: 24067},
+													pos:  position{line: 1012, col: 17, offset: 24073},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1012, col: 34, offset: 24084},
+												pos:  position{line: 1012, col: 34, offset: 24090},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1012, col: 37, offset: 24087},
+												pos:   position{line: 1012, col: 37, offset: 24093},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1012, col: 42, offset: 24092},
+													pos:  position{line: 1012, col: 42, offset: 24098},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6802,21 +6802,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 1016, col: 1, offset: 24210},
+			pos:  position{line: 1016, col: 1, offset: 24216},
 			expr: &actionExpr{
-				pos: position{line: 1016, col: 20, offset: 24229},
+				pos: position{line: 1016, col: 20, offset: 24235},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 1016, col: 21, offset: 24230},
+					pos: position{line: 1016, col: 21, offset: 24236},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1016, col: 21, offset: 24230},
+							pos:        position{line: 1016, col: 21, offset: 24236},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1016, col: 27, offset: 24236},
+							pos:        position{line: 1016, col: 27, offset: 24242},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6829,53 +6829,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 1018, col: 1, offset: 24273},
+			pos:  position{line: 1018, col: 1, offset: 24279},
 			expr: &actionExpr{
-				pos: position{line: 1019, col: 5, offset: 24296},
+				pos: position{line: 1019, col: 5, offset: 24302},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1019, col: 5, offset: 24296},
+					pos: position{line: 1019, col: 5, offset: 24302},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1019, col: 5, offset: 24296},
+							pos:   position{line: 1019, col: 5, offset: 24302},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1019, col: 11, offset: 24302},
+								pos:  position{line: 1019, col: 11, offset: 24308},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1020, col: 5, offset: 24317},
+							pos:   position{line: 1020, col: 5, offset: 24323},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1020, col: 10, offset: 24322},
+								pos: position{line: 1020, col: 10, offset: 24328},
 								expr: &actionExpr{
-									pos: position{line: 1020, col: 11, offset: 24323},
+									pos: position{line: 1020, col: 11, offset: 24329},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1020, col: 11, offset: 24323},
+										pos: position{line: 1020, col: 11, offset: 24329},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1020, col: 11, offset: 24323},
+												pos:  position{line: 1020, col: 11, offset: 24329},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1020, col: 14, offset: 24326},
+												pos:   position{line: 1020, col: 14, offset: 24332},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1020, col: 17, offset: 24329},
+													pos:  position{line: 1020, col: 17, offset: 24335},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1020, col: 40, offset: 24352},
+												pos:  position{line: 1020, col: 40, offset: 24358},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1020, col: 43, offset: 24355},
+												pos:   position{line: 1020, col: 43, offset: 24361},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1020, col: 48, offset: 24360},
+													pos:  position{line: 1020, col: 48, offset: 24366},
 													name: "ConcatExpr",
 												},
 											},
@@ -6892,27 +6892,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 1024, col: 1, offset: 24470},
+			pos:  position{line: 1024, col: 1, offset: 24476},
 			expr: &actionExpr{
-				pos: position{line: 1024, col: 26, offset: 24495},
+				pos: position{line: 1024, col: 26, offset: 24501},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 1024, col: 27, offset: 24496},
+					pos: position{line: 1024, col: 27, offset: 24502},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1024, col: 27, offset: 24496},
+							pos:        position{line: 1024, col: 27, offset: 24502},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1024, col: 33, offset: 24502},
+							pos:        position{line: 1024, col: 33, offset: 24508},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1024, col: 39, offset: 24508},
+							pos:        position{line: 1024, col: 39, offset: 24514},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6925,51 +6925,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 1026, col: 1, offset: 24545},
+			pos:  position{line: 1026, col: 1, offset: 24551},
 			expr: &actionExpr{
-				pos: position{line: 1027, col: 5, offset: 24561},
+				pos: position{line: 1027, col: 5, offset: 24567},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1027, col: 5, offset: 24561},
+					pos: position{line: 1027, col: 5, offset: 24567},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1027, col: 5, offset: 24561},
+							pos:   position{line: 1027, col: 5, offset: 24567},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1027, col: 11, offset: 24567},
+								pos:  position{line: 1027, col: 11, offset: 24573},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1028, col: 5, offset: 24588},
+							pos:   position{line: 1028, col: 5, offset: 24594},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1028, col: 10, offset: 24593},
+								pos: position{line: 1028, col: 10, offset: 24599},
 								expr: &actionExpr{
-									pos: position{line: 1028, col: 11, offset: 24594},
+									pos: position{line: 1028, col: 11, offset: 24600},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1028, col: 11, offset: 24594},
+										pos: position{line: 1028, col: 11, offset: 24600},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1028, col: 11, offset: 24594},
+												pos:  position{line: 1028, col: 11, offset: 24600},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1028, col: 14, offset: 24597},
+												pos:        position{line: 1028, col: 14, offset: 24603},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1028, col: 19, offset: 24602},
+												pos:  position{line: 1028, col: 19, offset: 24608},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1028, col: 22, offset: 24605},
+												pos:   position{line: 1028, col: 22, offset: 24611},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1028, col: 27, offset: 24610},
+													pos:  position{line: 1028, col: 27, offset: 24616},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6986,40 +6986,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 1032, col: 1, offset: 24728},
+			pos:  position{line: 1032, col: 1, offset: 24734},
 			expr: &choiceExpr{
-				pos: position{line: 1033, col: 5, offset: 24749},
+				pos: position{line: 1033, col: 5, offset: 24755},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1033, col: 5, offset: 24749},
+						pos: position{line: 1033, col: 5, offset: 24755},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 1033, col: 5, offset: 24749},
+							pos: position{line: 1033, col: 5, offset: 24755},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1033, col: 5, offset: 24749},
+									pos: position{line: 1033, col: 5, offset: 24755},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1033, col: 6, offset: 24750},
+										pos:  position{line: 1033, col: 6, offset: 24756},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1033, col: 14, offset: 24758},
+									pos:   position{line: 1033, col: 14, offset: 24764},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1033, col: 17, offset: 24761},
+										pos:  position{line: 1033, col: 17, offset: 24767},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1033, col: 31, offset: 24775},
+									pos:  position{line: 1033, col: 31, offset: 24781},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1033, col: 34, offset: 24778},
+									pos:   position{line: 1033, col: 34, offset: 24784},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1033, col: 36, offset: 24780},
+										pos:  position{line: 1033, col: 36, offset: 24786},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -7027,7 +7027,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1042, col: 5, offset: 24964},
+						pos:  position{line: 1042, col: 5, offset: 24970},
 						name: "DerefExpr",
 					},
 				},
@@ -7037,21 +7037,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 1044, col: 1, offset: 24975},
+			pos:  position{line: 1044, col: 1, offset: 24981},
 			expr: &actionExpr{
-				pos: position{line: 1044, col: 17, offset: 24991},
+				pos: position{line: 1044, col: 17, offset: 24997},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 1044, col: 18, offset: 24992},
+					pos: position{line: 1044, col: 18, offset: 24998},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1044, col: 18, offset: 24992},
+							pos:        position{line: 1044, col: 18, offset: 24998},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1044, col: 24, offset: 24998},
+							pos:        position{line: 1044, col: 24, offset: 25004},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -7064,73 +7064,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 1046, col: 1, offset: 25035},
+			pos:  position{line: 1046, col: 1, offset: 25041},
 			expr: &choiceExpr{
-				pos: position{line: 1047, col: 5, offset: 25049},
+				pos: position{line: 1047, col: 5, offset: 25055},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1047, col: 5, offset: 25049},
+						pos: position{line: 1047, col: 5, offset: 25055},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1047, col: 5, offset: 25049},
+							pos: position{line: 1047, col: 5, offset: 25055},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1047, col: 5, offset: 25049},
+									pos:   position{line: 1047, col: 5, offset: 25055},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1047, col: 10, offset: 25054},
+										pos:  position{line: 1047, col: 10, offset: 25060},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 20, offset: 25064},
+									pos:        position{line: 1047, col: 20, offset: 25070},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 24, offset: 25068},
+									pos:  position{line: 1047, col: 24, offset: 25074},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1047, col: 27, offset: 25071},
+									pos:   position{line: 1047, col: 27, offset: 25077},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1047, col: 32, offset: 25076},
+										pos:  position{line: 1047, col: 32, offset: 25082},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 45, offset: 25089},
+									pos:  position{line: 1047, col: 45, offset: 25095},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 48, offset: 25092},
+									pos:        position{line: 1047, col: 48, offset: 25098},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 52, offset: 25096},
+									pos:  position{line: 1047, col: 52, offset: 25102},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1047, col: 55, offset: 25099},
+									pos:   position{line: 1047, col: 55, offset: 25105},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1047, col: 58, offset: 25102},
+										pos: position{line: 1047, col: 58, offset: 25108},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1047, col: 58, offset: 25102},
+											pos:  position{line: 1047, col: 58, offset: 25108},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 72, offset: 25116},
+									pos:  position{line: 1047, col: 72, offset: 25122},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 75, offset: 25119},
+									pos:        position{line: 1047, col: 75, offset: 25125},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7139,49 +7139,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1059, col: 5, offset: 25358},
+						pos: position{line: 1059, col: 5, offset: 25364},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1059, col: 5, offset: 25358},
+							pos: position{line: 1059, col: 5, offset: 25364},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1059, col: 5, offset: 25358},
+									pos:   position{line: 1059, col: 5, offset: 25364},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1059, col: 10, offset: 25363},
+										pos:  position{line: 1059, col: 10, offset: 25369},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1059, col: 20, offset: 25373},
+									pos:        position{line: 1059, col: 20, offset: 25379},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1059, col: 24, offset: 25377},
+									pos:  position{line: 1059, col: 24, offset: 25383},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1059, col: 27, offset: 25380},
+									pos:        position{line: 1059, col: 27, offset: 25386},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1059, col: 31, offset: 25384},
+									pos:  position{line: 1059, col: 31, offset: 25390},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1059, col: 34, offset: 25387},
+									pos:   position{line: 1059, col: 34, offset: 25393},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1059, col: 37, offset: 25390},
+										pos:  position{line: 1059, col: 37, offset: 25396},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1059, col: 50, offset: 25403},
+									pos:        position{line: 1059, col: 50, offset: 25409},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7190,35 +7190,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 25567},
+						pos: position{line: 1067, col: 5, offset: 25573},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1067, col: 5, offset: 25567},
+							pos: position{line: 1067, col: 5, offset: 25573},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1067, col: 5, offset: 25567},
+									pos:   position{line: 1067, col: 5, offset: 25573},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1067, col: 10, offset: 25572},
+										pos:  position{line: 1067, col: 10, offset: 25578},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1067, col: 20, offset: 25582},
+									pos:        position{line: 1067, col: 20, offset: 25588},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1067, col: 24, offset: 25586},
+									pos:   position{line: 1067, col: 24, offset: 25592},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1067, col: 30, offset: 25592},
+										pos:  position{line: 1067, col: 30, offset: 25598},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1067, col: 35, offset: 25597},
+									pos:        position{line: 1067, col: 35, offset: 25603},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7227,30 +7227,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1075, col: 5, offset: 25767},
+						pos: position{line: 1075, col: 5, offset: 25773},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1075, col: 5, offset: 25767},
+							pos: position{line: 1075, col: 5, offset: 25773},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1075, col: 5, offset: 25767},
+									pos:   position{line: 1075, col: 5, offset: 25773},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1075, col: 10, offset: 25772},
+										pos:  position{line: 1075, col: 10, offset: 25778},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1075, col: 20, offset: 25782},
+									pos:        position{line: 1075, col: 20, offset: 25788},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1075, col: 24, offset: 25786},
+									pos:   position{line: 1075, col: 24, offset: 25792},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1075, col: 27, offset: 25789},
+										pos:  position{line: 1075, col: 27, offset: 25795},
 										name: "DerefKey",
 									},
 								},
@@ -7258,11 +7258,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1084, col: 5, offset: 25977},
+						pos:  position{line: 1084, col: 5, offset: 25983},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1085, col: 5, offset: 25990},
+						pos:  position{line: 1085, col: 5, offset: 25996},
 						name: "Primary",
 					},
 				},
@@ -7272,34 +7272,34 @@ var g = &grammar{
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 1087, col: 1, offset: 25999},
+			pos:  position{line: 1087, col: 1, offset: 26005},
 			expr: &choiceExpr{
-				pos: position{line: 1088, col: 5, offset: 26012},
+				pos: position{line: 1088, col: 5, offset: 26018},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1088, col: 5, offset: 26012},
+						pos:  position{line: 1088, col: 5, offset: 26018},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1089, col: 5, offset: 26028},
+						pos: position{line: 1089, col: 5, offset: 26034},
 						run: (*parser).callonDerefKey3,
 						expr: &labeledExpr{
-							pos:   position{line: 1089, col: 5, offset: 26028},
+							pos:   position{line: 1089, col: 5, offset: 26034},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1089, col: 7, offset: 26030},
+								pos:  position{line: 1089, col: 7, offset: 26036},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1090, col: 5, offset: 26122},
+						pos: position{line: 1090, col: 5, offset: 26128},
 						run: (*parser).callonDerefKey6,
 						expr: &labeledExpr{
-							pos:   position{line: 1090, col: 5, offset: 26122},
+							pos:   position{line: 1090, col: 5, offset: 26128},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 7, offset: 26124},
+								pos:  position{line: 1090, col: 7, offset: 26130},
 								name: "BacktickString",
 							},
 						},
@@ -7311,16 +7311,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 1092, col: 1, offset: 26213},
+			pos:  position{line: 1092, col: 1, offset: 26219},
 			expr: &choiceExpr{
-				pos: position{line: 1093, col: 5, offset: 26226},
+				pos: position{line: 1093, col: 5, offset: 26232},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1093, col: 5, offset: 26226},
+						pos:  position{line: 1093, col: 5, offset: 26232},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1094, col: 5, offset: 26235},
+						pos:  position{line: 1094, col: 5, offset: 26241},
 						name: "Function",
 					},
 				},
@@ -7330,20 +7330,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1096, col: 1, offset: 26245},
+			pos:  position{line: 1096, col: 1, offset: 26251},
 			expr: &seqExpr{
-				pos: position{line: 1096, col: 13, offset: 26257},
+				pos: position{line: 1096, col: 13, offset: 26263},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1096, col: 13, offset: 26257},
+						pos:  position{line: 1096, col: 13, offset: 26263},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1096, col: 22, offset: 26266},
+						pos:  position{line: 1096, col: 22, offset: 26272},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1096, col: 25, offset: 26269},
+						pos:        position{line: 1096, col: 25, offset: 26275},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -7355,16 +7355,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1098, col: 1, offset: 26274},
+			pos:  position{line: 1098, col: 1, offset: 26280},
 			expr: &choiceExpr{
-				pos: position{line: 1099, col: 5, offset: 26287},
+				pos: position{line: 1099, col: 5, offset: 26293},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1099, col: 5, offset: 26287},
+						pos:  position{line: 1099, col: 5, offset: 26293},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 26295},
+						pos:  position{line: 1100, col: 5, offset: 26301},
 						name: "SELECT",
 					},
 				},
@@ -7374,58 +7374,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1102, col: 1, offset: 26303},
+			pos:  position{line: 1102, col: 1, offset: 26309},
 			expr: &actionExpr{
-				pos: position{line: 1103, col: 5, offset: 26312},
+				pos: position{line: 1103, col: 5, offset: 26318},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1103, col: 5, offset: 26312},
+					pos: position{line: 1103, col: 5, offset: 26318},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1103, col: 5, offset: 26312},
+							pos:   position{line: 1103, col: 5, offset: 26318},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1103, col: 9, offset: 26316},
+								pos:  position{line: 1103, col: 9, offset: 26322},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 21, offset: 26328},
+							pos:  position{line: 1103, col: 21, offset: 26334},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 24, offset: 26331},
+							pos:        position{line: 1103, col: 24, offset: 26337},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 28, offset: 26335},
+							pos:  position{line: 1103, col: 28, offset: 26341},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1103, col: 31, offset: 26338},
+							pos:   position{line: 1103, col: 31, offset: 26344},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1103, col: 37, offset: 26344},
+								pos: position{line: 1103, col: 37, offset: 26350},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 37, offset: 26344},
+										pos:  position{line: 1103, col: 37, offset: 26350},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 48, offset: 26355},
+										pos:  position{line: 1103, col: 48, offset: 26361},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 54, offset: 26361},
+							pos:  position{line: 1103, col: 54, offset: 26367},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 57, offset: 26364},
+							pos:        position{line: 1103, col: 57, offset: 26370},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7438,85 +7438,85 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1107, col: 1, offset: 26477},
+			pos:  position{line: 1107, col: 1, offset: 26483},
 			expr: &choiceExpr{
-				pos: position{line: 1108, col: 5, offset: 26490},
+				pos: position{line: 1108, col: 5, offset: 26496},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1108, col: 5, offset: 26490},
+						pos:  position{line: 1108, col: 5, offset: 26496},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1110, col: 5, offset: 26577},
+						pos: position{line: 1110, col: 5, offset: 26583},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1110, col: 5, offset: 26577},
+							pos: position{line: 1110, col: 5, offset: 26583},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 5, offset: 26577},
+									pos:  position{line: 1110, col: 5, offset: 26583},
 									name: "REGEXP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 12, offset: 26584},
+									pos:  position{line: 1110, col: 12, offset: 26590},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 15, offset: 26587},
+									pos:        position{line: 1110, col: 15, offset: 26593},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 19, offset: 26591},
+									pos:  position{line: 1110, col: 19, offset: 26597},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 22, offset: 26594},
+									pos:   position{line: 1110, col: 22, offset: 26600},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 27, offset: 26599},
+										pos:  position{line: 1110, col: 27, offset: 26605},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 43, offset: 26615},
+									pos:  position{line: 1110, col: 43, offset: 26621},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 46, offset: 26618},
+									pos:        position{line: 1110, col: 46, offset: 26624},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 50, offset: 26622},
+									pos:  position{line: 1110, col: 50, offset: 26628},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 53, offset: 26625},
+									pos:   position{line: 1110, col: 53, offset: 26631},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 58, offset: 26630},
+										pos:  position{line: 1110, col: 58, offset: 26636},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 63, offset: 26635},
+									pos:  position{line: 1110, col: 63, offset: 26641},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 66, offset: 26638},
+									pos:        position{line: 1110, col: 66, offset: 26644},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 70, offset: 26642},
+									pos:   position{line: 1110, col: 70, offset: 26648},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1110, col: 76, offset: 26648},
+										pos: position{line: 1110, col: 76, offset: 26654},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1110, col: 76, offset: 26648},
+											pos:  position{line: 1110, col: 76, offset: 26654},
 											name: "WhereClause",
 										},
 									},
@@ -7525,98 +7525,98 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1114, col: 5, offset: 26827},
+						pos: position{line: 1114, col: 5, offset: 26833},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1114, col: 5, offset: 26827},
+							pos: position{line: 1114, col: 5, offset: 26833},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 5, offset: 26827},
+									pos:  position{line: 1114, col: 5, offset: 26833},
 									name: "REGEXP_REPLACE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 20, offset: 26842},
+									pos:  position{line: 1114, col: 20, offset: 26848},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 23, offset: 26845},
+									pos:        position{line: 1114, col: 23, offset: 26851},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 27, offset: 26849},
+									pos:  position{line: 1114, col: 27, offset: 26855},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 30, offset: 26852},
+									pos:   position{line: 1114, col: 30, offset: 26858},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1114, col: 35, offset: 26857},
+										pos:  position{line: 1114, col: 35, offset: 26863},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 40, offset: 26862},
+									pos:  position{line: 1114, col: 40, offset: 26868},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 43, offset: 26865},
+									pos:        position{line: 1114, col: 43, offset: 26871},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 47, offset: 26869},
+									pos:  position{line: 1114, col: 47, offset: 26875},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 50, offset: 26872},
+									pos:   position{line: 1114, col: 50, offset: 26878},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1114, col: 55, offset: 26877},
+										pos:  position{line: 1114, col: 55, offset: 26883},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 71, offset: 26893},
+									pos:  position{line: 1114, col: 71, offset: 26899},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 74, offset: 26896},
+									pos:        position{line: 1114, col: 74, offset: 26902},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 78, offset: 26900},
+									pos:  position{line: 1114, col: 78, offset: 26906},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 81, offset: 26903},
+									pos:   position{line: 1114, col: 81, offset: 26909},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1114, col: 86, offset: 26908},
+										pos:  position{line: 1114, col: 86, offset: 26914},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 91, offset: 26913},
+									pos:  position{line: 1114, col: 91, offset: 26919},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 94, offset: 26916},
+									pos:        position{line: 1114, col: 94, offset: 26922},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 98, offset: 26920},
+									pos:   position{line: 1114, col: 98, offset: 26926},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1114, col: 104, offset: 26926},
+										pos: position{line: 1114, col: 104, offset: 26932},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1114, col: 104, offset: 26926},
+											pos:  position{line: 1114, col: 104, offset: 26932},
 											name: "WhereClause",
 										},
 									},
@@ -7625,81 +7625,81 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1118, col: 5, offset: 27120},
+						pos: position{line: 1118, col: 5, offset: 27126},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1118, col: 5, offset: 27120},
+							pos: position{line: 1118, col: 5, offset: 27126},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1118, col: 5, offset: 27120},
+									pos: position{line: 1118, col: 5, offset: 27126},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 6, offset: 27121},
+										pos:  position{line: 1118, col: 6, offset: 27127},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 16, offset: 27131},
+									pos:  position{line: 1118, col: 16, offset: 27137},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 24, offset: 27139},
+									pos:  position{line: 1118, col: 24, offset: 27145},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1118, col: 27, offset: 27142},
+									pos:        position{line: 1118, col: 27, offset: 27148},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 31, offset: 27146},
+									pos:  position{line: 1118, col: 31, offset: 27152},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 34, offset: 27149},
+									pos:   position{line: 1118, col: 34, offset: 27155},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 39, offset: 27154},
+										pos:  position{line: 1118, col: 39, offset: 27160},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 44, offset: 27159},
+									pos:  position{line: 1118, col: 44, offset: 27165},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 46, offset: 27161},
+									pos:  position{line: 1118, col: 46, offset: 27167},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 51, offset: 27166},
+									pos:  position{line: 1118, col: 51, offset: 27172},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 53, offset: 27168},
+									pos:   position{line: 1118, col: 53, offset: 27174},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 55, offset: 27170},
+										pos:  position{line: 1118, col: 55, offset: 27176},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 60, offset: 27175},
+									pos:  position{line: 1118, col: 60, offset: 27181},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1118, col: 63, offset: 27178},
+									pos:        position{line: 1118, col: 63, offset: 27184},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 67, offset: 27182},
+									pos:   position{line: 1118, col: 67, offset: 27188},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1118, col: 73, offset: 27188},
+										pos: position{line: 1118, col: 73, offset: 27194},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1118, col: 73, offset: 27188},
+											pos:  position{line: 1118, col: 73, offset: 27194},
 											name: "WhereClause",
 										},
 									},
@@ -7708,70 +7708,70 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1126, col: 5, offset: 27367},
+						pos: position{line: 1126, col: 5, offset: 27373},
 						run: (*parser).callonFunction64,
 						expr: &seqExpr{
-							pos: position{line: 1126, col: 5, offset: 27367},
+							pos: position{line: 1126, col: 5, offset: 27373},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1126, col: 5, offset: 27367},
+									pos: position{line: 1126, col: 5, offset: 27373},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 6, offset: 27368},
+										pos:  position{line: 1126, col: 6, offset: 27374},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 16, offset: 27378},
+									pos:  position{line: 1126, col: 16, offset: 27384},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 21, offset: 27383},
+									pos:  position{line: 1126, col: 21, offset: 27389},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1126, col: 24, offset: 27386},
+									pos:        position{line: 1126, col: 24, offset: 27392},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 28, offset: 27390},
+									pos:  position{line: 1126, col: 28, offset: 27396},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 31, offset: 27393},
+									pos:   position{line: 1126, col: 31, offset: 27399},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 33, offset: 27395},
+										pos:  position{line: 1126, col: 33, offset: 27401},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 38, offset: 27400},
+									pos:  position{line: 1126, col: 38, offset: 27406},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 40, offset: 27402},
+									pos:  position{line: 1126, col: 40, offset: 27408},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 43, offset: 27405},
+									pos:  position{line: 1126, col: 43, offset: 27411},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 45, offset: 27407},
+									pos:   position{line: 1126, col: 45, offset: 27413},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 49, offset: 27411},
+										pos:  position{line: 1126, col: 49, offset: 27417},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 60, offset: 27422},
+									pos:  position{line: 1126, col: 60, offset: 27428},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1126, col: 63, offset: 27425},
+									pos:        position{line: 1126, col: 63, offset: 27431},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7780,72 +7780,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1134, col: 5, offset: 27584},
+						pos: position{line: 1134, col: 5, offset: 27590},
 						run: (*parser).callonFunction81,
 						expr: &seqExpr{
-							pos: position{line: 1134, col: 5, offset: 27584},
+							pos: position{line: 1134, col: 5, offset: 27590},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1134, col: 5, offset: 27584},
+									pos: position{line: 1134, col: 5, offset: 27590},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1134, col: 6, offset: 27585},
+										pos:  position{line: 1134, col: 6, offset: 27591},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 16, offset: 27595},
+									pos:  position{line: 1134, col: 16, offset: 27601},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 26, offset: 27605},
+									pos:  position{line: 1134, col: 26, offset: 27611},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1134, col: 29, offset: 27608},
+									pos:        position{line: 1134, col: 29, offset: 27614},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 33, offset: 27612},
+									pos:  position{line: 1134, col: 33, offset: 27618},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 36, offset: 27615},
+									pos:   position{line: 1134, col: 36, offset: 27621},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1134, col: 41, offset: 27620},
+										pos:  position{line: 1134, col: 41, offset: 27626},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 46, offset: 27625},
+									pos:   position{line: 1134, col: 46, offset: 27631},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1134, col: 51, offset: 27630},
+										pos: position{line: 1134, col: 51, offset: 27636},
 										expr: &actionExpr{
-											pos: position{line: 1134, col: 52, offset: 27631},
+											pos: position{line: 1134, col: 52, offset: 27637},
 											run: (*parser).callonFunction93,
 											expr: &seqExpr{
-												pos: position{line: 1134, col: 52, offset: 27631},
+												pos: position{line: 1134, col: 52, offset: 27637},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 52, offset: 27631},
+														pos:  position{line: 1134, col: 52, offset: 27637},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 54, offset: 27633},
+														pos:  position{line: 1134, col: 54, offset: 27639},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 59, offset: 27638},
+														pos:  position{line: 1134, col: 59, offset: 27644},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1134, col: 61, offset: 27640},
+														pos:   position{line: 1134, col: 61, offset: 27646},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1134, col: 63, offset: 27642},
+															pos:  position{line: 1134, col: 63, offset: 27648},
 															name: "Expr",
 														},
 													},
@@ -7855,33 +7855,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 88, offset: 27667},
+									pos:   position{line: 1134, col: 88, offset: 27673},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1134, col: 93, offset: 27672},
+										pos: position{line: 1134, col: 93, offset: 27678},
 										expr: &actionExpr{
-											pos: position{line: 1134, col: 94, offset: 27673},
+											pos: position{line: 1134, col: 94, offset: 27679},
 											run: (*parser).callonFunction102,
 											expr: &seqExpr{
-												pos: position{line: 1134, col: 94, offset: 27673},
+												pos: position{line: 1134, col: 94, offset: 27679},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 94, offset: 27673},
+														pos:  position{line: 1134, col: 94, offset: 27679},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 96, offset: 27675},
+														pos:  position{line: 1134, col: 96, offset: 27681},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 100, offset: 27679},
+														pos:  position{line: 1134, col: 100, offset: 27685},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1134, col: 102, offset: 27681},
+														pos:   position{line: 1134, col: 102, offset: 27687},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1134, col: 104, offset: 27683},
+															pos:  position{line: 1134, col: 104, offset: 27689},
 															name: "Expr",
 														},
 													},
@@ -7891,7 +7891,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1134, col: 129, offset: 27708},
+									pos:        position{line: 1134, col: 129, offset: 27714},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7900,65 +7900,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1148, col: 5, offset: 27991},
+						pos: position{line: 1148, col: 5, offset: 27997},
 						run: (*parser).callonFunction110,
 						expr: &seqExpr{
-							pos: position{line: 1148, col: 5, offset: 27991},
+							pos: position{line: 1148, col: 5, offset: 27997},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1148, col: 5, offset: 27991},
+									pos: position{line: 1148, col: 5, offset: 27997},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1148, col: 6, offset: 27992},
+										pos:  position{line: 1148, col: 6, offset: 27998},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1148, col: 16, offset: 28002},
+									pos:   position{line: 1148, col: 16, offset: 28008},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1148, col: 19, offset: 28005},
+										pos:  position{line: 1148, col: 19, offset: 28011},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1148, col: 30, offset: 28016},
+									pos:  position{line: 1148, col: 30, offset: 28022},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1148, col: 33, offset: 28019},
+									pos:        position{line: 1148, col: 33, offset: 28025},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1148, col: 37, offset: 28023},
+									pos:  position{line: 1148, col: 37, offset: 28029},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1148, col: 40, offset: 28026},
+									pos:   position{line: 1148, col: 40, offset: 28032},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1148, col: 45, offset: 28031},
+										pos:  position{line: 1148, col: 45, offset: 28037},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1148, col: 58, offset: 28044},
+									pos:  position{line: 1148, col: 58, offset: 28050},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1148, col: 61, offset: 28047},
+									pos:        position{line: 1148, col: 61, offset: 28053},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1148, col: 65, offset: 28051},
+									pos:   position{line: 1148, col: 65, offset: 28057},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1148, col: 71, offset: 28057},
+										pos: position{line: 1148, col: 71, offset: 28063},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1148, col: 71, offset: 28057},
+											pos:  position{line: 1148, col: 71, offset: 28063},
 											name: "WhereClause",
 										},
 									},
@@ -7967,7 +7967,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1151, col: 5, offset: 28128},
+						pos:  position{line: 1151, col: 5, offset: 28134},
 						name: "CountStar",
 					},
 				},
@@ -7977,15 +7977,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1153, col: 1, offset: 28139},
+			pos:  position{line: 1153, col: 1, offset: 28145},
 			expr: &actionExpr{
-				pos: position{line: 1154, col: 5, offset: 28159},
+				pos: position{line: 1154, col: 5, offset: 28165},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1154, col: 5, offset: 28159},
+					pos:   position{line: 1154, col: 5, offset: 28165},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1154, col: 9, offset: 28163},
+						pos:  position{line: 1154, col: 9, offset: 28169},
 						name: "RegexpPattern",
 					},
 				},
@@ -7995,24 +7995,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1156, col: 1, offset: 28234},
+			pos:  position{line: 1156, col: 1, offset: 28240},
 			expr: &choiceExpr{
-				pos: position{line: 1157, col: 5, offset: 28251},
+				pos: position{line: 1157, col: 5, offset: 28257},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1157, col: 5, offset: 28251},
+						pos: position{line: 1157, col: 5, offset: 28257},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1157, col: 5, offset: 28251},
+							pos:   position{line: 1157, col: 5, offset: 28257},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1157, col: 7, offset: 28253},
+								pos:  position{line: 1157, col: 7, offset: 28259},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1158, col: 5, offset: 28291},
+						pos:  position{line: 1158, col: 5, offset: 28297},
 						name: "OptionalExprs",
 					},
 				},
@@ -8022,96 +8022,96 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1160, col: 1, offset: 28306},
+			pos:  position{line: 1160, col: 1, offset: 28312},
 			expr: &actionExpr{
-				pos: position{line: 1161, col: 5, offset: 28315},
+				pos: position{line: 1161, col: 5, offset: 28321},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1161, col: 5, offset: 28315},
+					pos: position{line: 1161, col: 5, offset: 28321},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1161, col: 5, offset: 28315},
+							pos:  position{line: 1161, col: 5, offset: 28321},
 							name: "GREP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1161, col: 10, offset: 28320},
+							pos:  position{line: 1161, col: 10, offset: 28326},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 13, offset: 28323},
+							pos:        position{line: 1161, col: 13, offset: 28329},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1161, col: 17, offset: 28327},
+							pos:  position{line: 1161, col: 17, offset: 28333},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1161, col: 20, offset: 28330},
+							pos:   position{line: 1161, col: 20, offset: 28336},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1161, col: 29, offset: 28339},
+								pos: position{line: 1161, col: 29, offset: 28345},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1161, col: 29, offset: 28339},
+										pos:  position{line: 1161, col: 29, offset: 28345},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1161, col: 38, offset: 28348},
+										pos:  position{line: 1161, col: 38, offset: 28354},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1161, col: 45, offset: 28355},
+										pos:  position{line: 1161, col: 45, offset: 28361},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1161, col: 51, offset: 28361},
+							pos:  position{line: 1161, col: 51, offset: 28367},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1161, col: 54, offset: 28364},
+							pos:   position{line: 1161, col: 54, offset: 28370},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1161, col: 58, offset: 28368},
+								pos: position{line: 1161, col: 58, offset: 28374},
 								expr: &actionExpr{
-									pos: position{line: 1161, col: 59, offset: 28369},
+									pos: position{line: 1161, col: 59, offset: 28375},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1161, col: 59, offset: 28369},
+										pos: position{line: 1161, col: 59, offset: 28375},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1161, col: 59, offset: 28369},
+												pos:        position{line: 1161, col: 59, offset: 28375},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1161, col: 63, offset: 28373},
+												pos:  position{line: 1161, col: 63, offset: 28379},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1161, col: 66, offset: 28376},
+												pos:   position{line: 1161, col: 66, offset: 28382},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1161, col: 69, offset: 28379},
+													pos: position{line: 1161, col: 69, offset: 28385},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1161, col: 69, offset: 28379},
+															pos:  position{line: 1161, col: 69, offset: 28385},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1161, col: 80, offset: 28390},
+															pos:  position{line: 1161, col: 80, offset: 28396},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1161, col: 86, offset: 28396},
+												pos:  position{line: 1161, col: 86, offset: 28402},
 												name: "__",
 											},
 										},
@@ -8120,7 +8120,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 109, offset: 28419},
+							pos:        position{line: 1161, col: 109, offset: 28425},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8133,19 +8133,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1173, col: 1, offset: 28632},
+			pos:  position{line: 1173, col: 1, offset: 28638},
 			expr: &choiceExpr{
-				pos: position{line: 1174, col: 5, offset: 28650},
+				pos: position{line: 1174, col: 5, offset: 28656},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1174, col: 5, offset: 28650},
+						pos:  position{line: 1174, col: 5, offset: 28656},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1175, col: 5, offset: 28660},
+						pos: position{line: 1175, col: 5, offset: 28666},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1175, col: 5, offset: 28660},
+							pos:  position{line: 1175, col: 5, offset: 28666},
 							name: "__",
 						},
 					},
@@ -8156,51 +8156,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1177, col: 1, offset: 28688},
+			pos:  position{line: 1177, col: 1, offset: 28694},
 			expr: &actionExpr{
-				pos: position{line: 1178, col: 5, offset: 28698},
+				pos: position{line: 1178, col: 5, offset: 28704},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1178, col: 5, offset: 28698},
+					pos: position{line: 1178, col: 5, offset: 28704},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1178, col: 5, offset: 28698},
+							pos:   position{line: 1178, col: 5, offset: 28704},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1178, col: 11, offset: 28704},
+								pos:  position{line: 1178, col: 11, offset: 28710},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1178, col: 16, offset: 28709},
+							pos:   position{line: 1178, col: 16, offset: 28715},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1178, col: 21, offset: 28714},
+								pos: position{line: 1178, col: 21, offset: 28720},
 								expr: &actionExpr{
-									pos: position{line: 1178, col: 22, offset: 28715},
+									pos: position{line: 1178, col: 22, offset: 28721},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1178, col: 22, offset: 28715},
+										pos: position{line: 1178, col: 22, offset: 28721},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1178, col: 22, offset: 28715},
+												pos:  position{line: 1178, col: 22, offset: 28721},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1178, col: 25, offset: 28718},
+												pos:        position{line: 1178, col: 25, offset: 28724},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1178, col: 29, offset: 28722},
+												pos:  position{line: 1178, col: 29, offset: 28728},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1178, col: 32, offset: 28725},
+												pos:   position{line: 1178, col: 32, offset: 28731},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1178, col: 34, offset: 28727},
+													pos:  position{line: 1178, col: 34, offset: 28733},
 													name: "Expr",
 												},
 											},
@@ -8217,56 +8217,56 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1182, col: 1, offset: 28800},
+			pos:  position{line: 1182, col: 1, offset: 28806},
 			expr: &choiceExpr{
-				pos: position{line: 1183, col: 5, offset: 28812},
+				pos: position{line: 1183, col: 5, offset: 28818},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1183, col: 5, offset: 28812},
+						pos:  position{line: 1183, col: 5, offset: 28818},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 5, offset: 28825},
+						pos:  position{line: 1184, col: 5, offset: 28831},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1185, col: 5, offset: 28836},
+						pos:  position{line: 1185, col: 5, offset: 28842},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 5, offset: 28846},
+						pos:  position{line: 1186, col: 5, offset: 28852},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1187, col: 5, offset: 28854},
+						pos:  position{line: 1187, col: 5, offset: 28860},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1188, col: 5, offset: 28862},
+						pos:  position{line: 1188, col: 5, offset: 28868},
 						name: "SQLTimeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1189, col: 5, offset: 28879},
+						pos:  position{line: 1189, col: 5, offset: 28885},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1190, col: 5, offset: 28891},
+						pos: position{line: 1190, col: 5, offset: 28897},
 						run: (*parser).callonPrimary9,
 						expr: &seqExpr{
-							pos: position{line: 1190, col: 5, offset: 28891},
+							pos: position{line: 1190, col: 5, offset: 28897},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1190, col: 5, offset: 28891},
+									pos: position{line: 1190, col: 5, offset: 28897},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1190, col: 6, offset: 28892},
+										pos:  position{line: 1190, col: 6, offset: 28898},
 										name: "PipeKeyword",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1190, col: 18, offset: 28904},
+									pos:   position{line: 1190, col: 18, offset: 28910},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1190, col: 21, offset: 28907},
+										pos:  position{line: 1190, col: 21, offset: 28913},
 										name: "Identifier",
 									},
 								},
@@ -8274,39 +8274,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1191, col: 5, offset: 28941},
+						pos:  position{line: 1191, col: 5, offset: 28947},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1192, col: 5, offset: 28951},
+						pos: position{line: 1192, col: 5, offset: 28957},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 5, offset: 28951},
+							pos: position{line: 1192, col: 5, offset: 28957},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1192, col: 5, offset: 28951},
+									pos:        position{line: 1192, col: 5, offset: 28957},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1192, col: 9, offset: 28955},
+									pos:  position{line: 1192, col: 9, offset: 28961},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 12, offset: 28958},
+									pos:   position{line: 1192, col: 12, offset: 28964},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 17, offset: 28963},
+										pos:  position{line: 1192, col: 17, offset: 28969},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1192, col: 26, offset: 28972},
+									pos:  position{line: 1192, col: 26, offset: 28978},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1192, col: 29, offset: 28975},
+									pos:        position{line: 1192, col: 29, offset: 28981},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8315,35 +8315,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1193, col: 5, offset: 29004},
+						pos: position{line: 1193, col: 5, offset: 29010},
 						run: (*parser).callonPrimary24,
 						expr: &seqExpr{
-							pos: position{line: 1193, col: 5, offset: 29004},
+							pos: position{line: 1193, col: 5, offset: 29010},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1193, col: 5, offset: 29004},
+									pos:        position{line: 1193, col: 5, offset: 29010},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1193, col: 9, offset: 29008},
+									pos:  position{line: 1193, col: 9, offset: 29014},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1193, col: 12, offset: 29011},
+									pos:   position{line: 1193, col: 12, offset: 29017},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1193, col: 17, offset: 29016},
+										pos:  position{line: 1193, col: 17, offset: 29022},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1193, col: 22, offset: 29021},
+									pos:  position{line: 1193, col: 22, offset: 29027},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1193, col: 25, offset: 29024},
+									pos:        position{line: 1193, col: 25, offset: 29030},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8358,53 +8358,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1195, col: 1, offset: 29050},
+			pos:  position{line: 1195, col: 1, offset: 29056},
 			expr: &choiceExpr{
-				pos: position{line: 1196, col: 5, offset: 29063},
+				pos: position{line: 1196, col: 5, offset: 29069},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1196, col: 5, offset: 29063},
+						pos: position{line: 1196, col: 5, offset: 29069},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1196, col: 5, offset: 29063},
+							pos: position{line: 1196, col: 5, offset: 29069},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1196, col: 5, offset: 29063},
+									pos:  position{line: 1196, col: 5, offset: 29069},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1196, col: 10, offset: 29068},
+									pos:   position{line: 1196, col: 10, offset: 29074},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1196, col: 16, offset: 29074},
+										pos: position{line: 1196, col: 16, offset: 29080},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1196, col: 16, offset: 29074},
+											pos:  position{line: 1196, col: 16, offset: 29080},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1196, col: 22, offset: 29080},
+									pos:   position{line: 1196, col: 22, offset: 29086},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1196, col: 28, offset: 29086},
+										pos: position{line: 1196, col: 28, offset: 29092},
 										expr: &seqExpr{
-											pos: position{line: 1196, col: 29, offset: 29087},
+											pos: position{line: 1196, col: 29, offset: 29093},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1196, col: 29, offset: 29087},
+													pos:  position{line: 1196, col: 29, offset: 29093},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1196, col: 31, offset: 29089},
+													pos:  position{line: 1196, col: 31, offset: 29095},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1196, col: 36, offset: 29094},
+													pos:  position{line: 1196, col: 36, offset: 29100},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1196, col: 38, offset: 29096},
+													pos:  position{line: 1196, col: 38, offset: 29102},
 													name: "Expr",
 												},
 											},
@@ -8412,24 +8412,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1196, col: 45, offset: 29103},
+									pos:  position{line: 1196, col: 45, offset: 29109},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1196, col: 47, offset: 29105},
+									pos:  position{line: 1196, col: 47, offset: 29111},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1196, col: 51, offset: 29109},
+									pos: position{line: 1196, col: 51, offset: 29115},
 									expr: &seqExpr{
-										pos: position{line: 1196, col: 52, offset: 29110},
+										pos: position{line: 1196, col: 52, offset: 29116},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1196, col: 52, offset: 29110},
+												pos:  position{line: 1196, col: 52, offset: 29116},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1196, col: 54, offset: 29112},
+												pos:  position{line: 1196, col: 54, offset: 29118},
 												name: "CASE",
 											},
 										},
@@ -8439,60 +8439,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1220, col: 5, offset: 29761},
+						pos: position{line: 1220, col: 5, offset: 29767},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1220, col: 5, offset: 29761},
+							pos: position{line: 1220, col: 5, offset: 29767},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 5, offset: 29761},
+									pos:  position{line: 1220, col: 5, offset: 29767},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 10, offset: 29766},
+									pos:  position{line: 1220, col: 10, offset: 29772},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1220, col: 12, offset: 29768},
+									pos:   position{line: 1220, col: 12, offset: 29774},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1220, col: 17, offset: 29773},
+										pos:  position{line: 1220, col: 17, offset: 29779},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1220, col: 22, offset: 29778},
+									pos:   position{line: 1220, col: 22, offset: 29784},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1220, col: 28, offset: 29784},
+										pos: position{line: 1220, col: 28, offset: 29790},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1220, col: 28, offset: 29784},
+											pos:  position{line: 1220, col: 28, offset: 29790},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1220, col: 34, offset: 29790},
+									pos:   position{line: 1220, col: 34, offset: 29796},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1220, col: 40, offset: 29796},
+										pos: position{line: 1220, col: 40, offset: 29802},
 										expr: &seqExpr{
-											pos: position{line: 1220, col: 41, offset: 29797},
+											pos: position{line: 1220, col: 41, offset: 29803},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1220, col: 41, offset: 29797},
+													pos:  position{line: 1220, col: 41, offset: 29803},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1220, col: 43, offset: 29799},
+													pos:  position{line: 1220, col: 43, offset: 29805},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1220, col: 48, offset: 29804},
+													pos:  position{line: 1220, col: 48, offset: 29810},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1220, col: 50, offset: 29806},
+													pos:  position{line: 1220, col: 50, offset: 29812},
 													name: "Expr",
 												},
 											},
@@ -8500,24 +8500,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 57, offset: 29813},
+									pos:  position{line: 1220, col: 57, offset: 29819},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 59, offset: 29815},
+									pos:  position{line: 1220, col: 59, offset: 29821},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1220, col: 63, offset: 29819},
+									pos: position{line: 1220, col: 63, offset: 29825},
 									expr: &seqExpr{
-										pos: position{line: 1220, col: 64, offset: 29820},
+										pos: position{line: 1220, col: 64, offset: 29826},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1220, col: 64, offset: 29820},
+												pos:  position{line: 1220, col: 64, offset: 29826},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1220, col: 66, offset: 29822},
+												pos:  position{line: 1220, col: 66, offset: 29828},
 												name: "CASE",
 											},
 										},
@@ -8533,50 +8533,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1233, col: 1, offset: 30128},
+			pos:  position{line: 1233, col: 1, offset: 30134},
 			expr: &actionExpr{
-				pos: position{line: 1234, col: 5, offset: 30137},
+				pos: position{line: 1234, col: 5, offset: 30143},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1234, col: 5, offset: 30137},
+					pos: position{line: 1234, col: 5, offset: 30143},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 5, offset: 30137},
+							pos:  position{line: 1234, col: 5, offset: 30143},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 7, offset: 30139},
+							pos:  position{line: 1234, col: 7, offset: 30145},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 12, offset: 30144},
+							pos:  position{line: 1234, col: 12, offset: 30150},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1234, col: 14, offset: 30146},
+							pos:   position{line: 1234, col: 14, offset: 30152},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1234, col: 19, offset: 30151},
+								pos:  position{line: 1234, col: 19, offset: 30157},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 24, offset: 30156},
+							pos:  position{line: 1234, col: 24, offset: 30162},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 26, offset: 30158},
+							pos:  position{line: 1234, col: 26, offset: 30164},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 31, offset: 30163},
+							pos:  position{line: 1234, col: 31, offset: 30169},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1234, col: 33, offset: 30165},
+							pos:   position{line: 1234, col: 33, offset: 30171},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1234, col: 38, offset: 30170},
+								pos:  position{line: 1234, col: 38, offset: 30176},
 								name: "Expr",
 							},
 						},
@@ -8588,57 +8588,57 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1243, col: 1, offset: 30329},
+			pos:  position{line: 1243, col: 1, offset: 30335},
 			expr: &actionExpr{
-				pos: position{line: 1244, col: 5, offset: 30342},
+				pos: position{line: 1244, col: 5, offset: 30348},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1244, col: 5, offset: 30342},
+					pos: position{line: 1244, col: 5, offset: 30348},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 5, offset: 30342},
+							pos:  position{line: 1244, col: 5, offset: 30348},
 							name: "OVER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 10, offset: 30347},
+							pos:  position{line: 1244, col: 10, offset: 30353},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1244, col: 12, offset: 30349},
+							pos:   position{line: 1244, col: 12, offset: 30355},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1244, col: 18, offset: 30355},
+								pos:  position{line: 1244, col: 18, offset: 30361},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1244, col: 24, offset: 30361},
+							pos:   position{line: 1244, col: 24, offset: 30367},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1244, col: 31, offset: 30368},
+								pos: position{line: 1244, col: 31, offset: 30374},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1244, col: 31, offset: 30368},
+									pos:  position{line: 1244, col: 31, offset: 30374},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 39, offset: 30376},
+							pos:  position{line: 1244, col: 39, offset: 30382},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 42, offset: 30379},
+							pos:  position{line: 1244, col: 42, offset: 30385},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 47, offset: 30384},
+							pos:  position{line: 1244, col: 47, offset: 30390},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1244, col: 50, offset: 30387},
+							pos:   position{line: 1244, col: 50, offset: 30393},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1244, col: 55, offset: 30392},
+								pos:  position{line: 1244, col: 55, offset: 30398},
 								name: "Seq",
 							},
 						},
@@ -8650,37 +8650,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1254, col: 1, offset: 30623},
+			pos:  position{line: 1254, col: 1, offset: 30629},
 			expr: &actionExpr{
-				pos: position{line: 1255, col: 5, offset: 30634},
+				pos: position{line: 1255, col: 5, offset: 30640},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1255, col: 5, offset: 30634},
+					pos: position{line: 1255, col: 5, offset: 30640},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1255, col: 5, offset: 30634},
+							pos:        position{line: 1255, col: 5, offset: 30640},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1255, col: 9, offset: 30638},
+							pos:  position{line: 1255, col: 9, offset: 30644},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1255, col: 12, offset: 30641},
+							pos:   position{line: 1255, col: 12, offset: 30647},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1255, col: 18, offset: 30647},
+								pos:  position{line: 1255, col: 18, offset: 30653},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1255, col: 30, offset: 30659},
+							pos:  position{line: 1255, col: 30, offset: 30665},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1255, col: 33, offset: 30662},
+							pos:        position{line: 1255, col: 33, offset: 30668},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8693,31 +8693,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1263, col: 1, offset: 30820},
+			pos:  position{line: 1263, col: 1, offset: 30826},
 			expr: &choiceExpr{
-				pos: position{line: 1264, col: 5, offset: 30836},
+				pos: position{line: 1264, col: 5, offset: 30842},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1264, col: 5, offset: 30836},
+						pos: position{line: 1264, col: 5, offset: 30842},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 5, offset: 30836},
+							pos: position{line: 1264, col: 5, offset: 30842},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1264, col: 5, offset: 30836},
+									pos:   position{line: 1264, col: 5, offset: 30842},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1264, col: 11, offset: 30842},
+										pos:  position{line: 1264, col: 11, offset: 30848},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1264, col: 22, offset: 30853},
+									pos:   position{line: 1264, col: 22, offset: 30859},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1264, col: 27, offset: 30858},
+										pos: position{line: 1264, col: 27, offset: 30864},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1264, col: 27, offset: 30858},
+											pos:  position{line: 1264, col: 27, offset: 30864},
 											name: "RecordElemTail",
 										},
 									},
@@ -8726,10 +8726,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 30921},
+						pos: position{line: 1267, col: 5, offset: 30927},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1267, col: 5, offset: 30921},
+							pos:  position{line: 1267, col: 5, offset: 30927},
 							name: "__",
 						},
 					},
@@ -8740,32 +8740,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1269, col: 1, offset: 30945},
+			pos:  position{line: 1269, col: 1, offset: 30951},
 			expr: &actionExpr{
-				pos: position{line: 1269, col: 18, offset: 30962},
+				pos: position{line: 1269, col: 18, offset: 30968},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1269, col: 18, offset: 30962},
+					pos: position{line: 1269, col: 18, offset: 30968},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1269, col: 18, offset: 30962},
+							pos:  position{line: 1269, col: 18, offset: 30968},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1269, col: 21, offset: 30965},
+							pos:        position{line: 1269, col: 21, offset: 30971},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1269, col: 25, offset: 30969},
+							pos:  position{line: 1269, col: 25, offset: 30975},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1269, col: 28, offset: 30972},
+							pos:   position{line: 1269, col: 28, offset: 30978},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1269, col: 33, offset: 30977},
+								pos:  position{line: 1269, col: 33, offset: 30983},
 								name: "RecordElem",
 							},
 						},
@@ -8777,20 +8777,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1271, col: 1, offset: 31010},
+			pos:  position{line: 1271, col: 1, offset: 31016},
 			expr: &choiceExpr{
-				pos: position{line: 1272, col: 5, offset: 31025},
+				pos: position{line: 1272, col: 5, offset: 31031},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1272, col: 5, offset: 31025},
+						pos:  position{line: 1272, col: 5, offset: 31031},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 31036},
+						pos:  position{line: 1273, col: 5, offset: 31042},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1274, col: 5, offset: 31050},
+						pos:  position{line: 1274, col: 5, offset: 31056},
 						name: "Identifier",
 					},
 				},
@@ -8800,28 +8800,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1276, col: 1, offset: 31062},
+			pos:  position{line: 1276, col: 1, offset: 31068},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 5, offset: 31073},
+				pos: position{line: 1277, col: 5, offset: 31079},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1277, col: 5, offset: 31073},
+					pos: position{line: 1277, col: 5, offset: 31079},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1277, col: 5, offset: 31073},
+							pos:        position{line: 1277, col: 5, offset: 31079},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1277, col: 11, offset: 31079},
+							pos:  position{line: 1277, col: 11, offset: 31085},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1277, col: 14, offset: 31082},
+							pos:   position{line: 1277, col: 14, offset: 31088},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1277, col: 19, offset: 31087},
+								pos:  position{line: 1277, col: 19, offset: 31093},
 								name: "Expr",
 							},
 						},
@@ -8833,40 +8833,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1281, col: 1, offset: 31183},
+			pos:  position{line: 1281, col: 1, offset: 31189},
 			expr: &actionExpr{
-				pos: position{line: 1282, col: 5, offset: 31197},
+				pos: position{line: 1282, col: 5, offset: 31203},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1282, col: 5, offset: 31197},
+					pos: position{line: 1282, col: 5, offset: 31203},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1282, col: 5, offset: 31197},
+							pos:   position{line: 1282, col: 5, offset: 31203},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1282, col: 10, offset: 31202},
+								pos:  position{line: 1282, col: 10, offset: 31208},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1282, col: 15, offset: 31207},
+							pos:  position{line: 1282, col: 15, offset: 31213},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1282, col: 18, offset: 31210},
+							pos:        position{line: 1282, col: 18, offset: 31216},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1282, col: 22, offset: 31214},
+							pos:  position{line: 1282, col: 22, offset: 31220},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1282, col: 25, offset: 31217},
+							pos:   position{line: 1282, col: 25, offset: 31223},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1282, col: 31, offset: 31223},
+								pos:  position{line: 1282, col: 31, offset: 31229},
 								name: "Expr",
 							},
 						},
@@ -8878,37 +8878,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1291, col: 1, offset: 31392},
+			pos:  position{line: 1291, col: 1, offset: 31398},
 			expr: &actionExpr{
-				pos: position{line: 1292, col: 5, offset: 31402},
+				pos: position{line: 1292, col: 5, offset: 31408},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1292, col: 5, offset: 31402},
+					pos: position{line: 1292, col: 5, offset: 31408},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1292, col: 5, offset: 31402},
+							pos:        position{line: 1292, col: 5, offset: 31408},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1292, col: 9, offset: 31406},
+							pos:  position{line: 1292, col: 9, offset: 31412},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1292, col: 12, offset: 31409},
+							pos:   position{line: 1292, col: 12, offset: 31415},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1292, col: 18, offset: 31415},
+								pos:  position{line: 1292, col: 18, offset: 31421},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1292, col: 30, offset: 31427},
+							pos:  position{line: 1292, col: 30, offset: 31433},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1292, col: 33, offset: 31430},
+							pos:        position{line: 1292, col: 33, offset: 31436},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8921,37 +8921,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1300, col: 1, offset: 31586},
+			pos:  position{line: 1300, col: 1, offset: 31592},
 			expr: &actionExpr{
-				pos: position{line: 1301, col: 5, offset: 31594},
+				pos: position{line: 1301, col: 5, offset: 31600},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1301, col: 5, offset: 31594},
+					pos: position{line: 1301, col: 5, offset: 31600},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1301, col: 5, offset: 31594},
+							pos:        position{line: 1301, col: 5, offset: 31600},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1301, col: 10, offset: 31599},
+							pos:  position{line: 1301, col: 10, offset: 31605},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1301, col: 13, offset: 31602},
+							pos:   position{line: 1301, col: 13, offset: 31608},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1301, col: 19, offset: 31608},
+								pos:  position{line: 1301, col: 19, offset: 31614},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1301, col: 31, offset: 31620},
+							pos:  position{line: 1301, col: 31, offset: 31626},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1301, col: 34, offset: 31623},
+							pos:        position{line: 1301, col: 34, offset: 31629},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8964,54 +8964,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1309, col: 1, offset: 31776},
+			pos:  position{line: 1309, col: 1, offset: 31782},
 			expr: &choiceExpr{
-				pos: position{line: 1310, col: 5, offset: 31792},
+				pos: position{line: 1310, col: 5, offset: 31798},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 31792},
+						pos: position{line: 1310, col: 5, offset: 31798},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1310, col: 5, offset: 31792},
+							pos: position{line: 1310, col: 5, offset: 31798},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1310, col: 5, offset: 31792},
+									pos:   position{line: 1310, col: 5, offset: 31798},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1310, col: 11, offset: 31798},
+										pos:  position{line: 1310, col: 11, offset: 31804},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1310, col: 22, offset: 31809},
+									pos:   position{line: 1310, col: 22, offset: 31815},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1310, col: 27, offset: 31814},
+										pos: position{line: 1310, col: 27, offset: 31820},
 										expr: &actionExpr{
-											pos: position{line: 1310, col: 28, offset: 31815},
+											pos: position{line: 1310, col: 28, offset: 31821},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1310, col: 28, offset: 31815},
+												pos: position{line: 1310, col: 28, offset: 31821},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1310, col: 28, offset: 31815},
+														pos:  position{line: 1310, col: 28, offset: 31821},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1310, col: 31, offset: 31818},
+														pos:        position{line: 1310, col: 31, offset: 31824},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1310, col: 35, offset: 31822},
+														pos:  position{line: 1310, col: 35, offset: 31828},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1310, col: 38, offset: 31825},
+														pos:   position{line: 1310, col: 38, offset: 31831},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1310, col: 40, offset: 31827},
+															pos:  position{line: 1310, col: 40, offset: 31833},
 															name: "VectorElem",
 														},
 													},
@@ -9024,10 +9024,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 31909},
+						pos: position{line: 1313, col: 5, offset: 31915},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1313, col: 5, offset: 31909},
+							pos:  position{line: 1313, col: 5, offset: 31915},
 							name: "__",
 						},
 					},
@@ -9038,22 +9038,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1315, col: 1, offset: 31933},
+			pos:  position{line: 1315, col: 1, offset: 31939},
 			expr: &choiceExpr{
-				pos: position{line: 1316, col: 5, offset: 31948},
+				pos: position{line: 1316, col: 5, offset: 31954},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1316, col: 5, offset: 31948},
+						pos:  position{line: 1316, col: 5, offset: 31954},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 31959},
+						pos: position{line: 1317, col: 5, offset: 31965},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1317, col: 5, offset: 31959},
+							pos:   position{line: 1317, col: 5, offset: 31965},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1317, col: 7, offset: 31961},
+								pos:  position{line: 1317, col: 7, offset: 31967},
 								name: "Expr",
 							},
 						},
@@ -9065,37 +9065,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1319, col: 1, offset: 32052},
+			pos:  position{line: 1319, col: 1, offset: 32058},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 5, offset: 32060},
+				pos: position{line: 1320, col: 5, offset: 32066},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1320, col: 5, offset: 32060},
+					pos: position{line: 1320, col: 5, offset: 32066},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1320, col: 5, offset: 32060},
+							pos:        position{line: 1320, col: 5, offset: 32066},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1320, col: 10, offset: 32065},
+							pos:  position{line: 1320, col: 10, offset: 32071},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1320, col: 13, offset: 32068},
+							pos:   position{line: 1320, col: 13, offset: 32074},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1320, col: 19, offset: 32074},
+								pos:  position{line: 1320, col: 19, offset: 32080},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1320, col: 27, offset: 32082},
+							pos:  position{line: 1320, col: 27, offset: 32088},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1320, col: 30, offset: 32085},
+							pos:        position{line: 1320, col: 30, offset: 32091},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -9108,31 +9108,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1328, col: 1, offset: 32239},
+			pos:  position{line: 1328, col: 1, offset: 32245},
 			expr: &choiceExpr{
-				pos: position{line: 1329, col: 5, offset: 32251},
+				pos: position{line: 1329, col: 5, offset: 32257},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 32251},
+						pos: position{line: 1329, col: 5, offset: 32257},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1329, col: 5, offset: 32251},
+							pos: position{line: 1329, col: 5, offset: 32257},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1329, col: 5, offset: 32251},
+									pos:   position{line: 1329, col: 5, offset: 32257},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1329, col: 11, offset: 32257},
+										pos:  position{line: 1329, col: 11, offset: 32263},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1329, col: 17, offset: 32263},
+									pos:   position{line: 1329, col: 17, offset: 32269},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1329, col: 22, offset: 32268},
+										pos: position{line: 1329, col: 22, offset: 32274},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1329, col: 22, offset: 32268},
+											pos:  position{line: 1329, col: 22, offset: 32274},
 											name: "EntryTail",
 										},
 									},
@@ -9141,10 +9141,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1332, col: 5, offset: 32326},
+						pos: position{line: 1332, col: 5, offset: 32332},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1332, col: 5, offset: 32326},
+							pos:  position{line: 1332, col: 5, offset: 32332},
 							name: "__",
 						},
 					},
@@ -9155,32 +9155,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1335, col: 1, offset: 32351},
+			pos:  position{line: 1335, col: 1, offset: 32357},
 			expr: &actionExpr{
-				pos: position{line: 1335, col: 13, offset: 32363},
+				pos: position{line: 1335, col: 13, offset: 32369},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1335, col: 13, offset: 32363},
+					pos: position{line: 1335, col: 13, offset: 32369},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1335, col: 13, offset: 32363},
+							pos:  position{line: 1335, col: 13, offset: 32369},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1335, col: 16, offset: 32366},
+							pos:        position{line: 1335, col: 16, offset: 32372},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1335, col: 20, offset: 32370},
+							pos:  position{line: 1335, col: 20, offset: 32376},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1335, col: 23, offset: 32373},
+							pos:   position{line: 1335, col: 23, offset: 32379},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1335, col: 25, offset: 32375},
+								pos:  position{line: 1335, col: 25, offset: 32381},
 								name: "Entry",
 							},
 						},
@@ -9192,40 +9192,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1337, col: 1, offset: 32400},
+			pos:  position{line: 1337, col: 1, offset: 32406},
 			expr: &actionExpr{
-				pos: position{line: 1338, col: 5, offset: 32410},
+				pos: position{line: 1338, col: 5, offset: 32416},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1338, col: 5, offset: 32410},
+					pos: position{line: 1338, col: 5, offset: 32416},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1338, col: 5, offset: 32410},
+							pos:   position{line: 1338, col: 5, offset: 32416},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1338, col: 9, offset: 32414},
+								pos:  position{line: 1338, col: 9, offset: 32420},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1338, col: 14, offset: 32419},
+							pos:  position{line: 1338, col: 14, offset: 32425},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1338, col: 17, offset: 32422},
+							pos:        position{line: 1338, col: 17, offset: 32428},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1338, col: 21, offset: 32426},
+							pos:  position{line: 1338, col: 21, offset: 32432},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1338, col: 24, offset: 32429},
+							pos:   position{line: 1338, col: 24, offset: 32435},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1338, col: 30, offset: 32435},
+								pos:  position{line: 1338, col: 30, offset: 32441},
 								name: "Expr",
 							},
 						},
@@ -9237,61 +9237,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1342, col: 1, offset: 32538},
+			pos:  position{line: 1342, col: 1, offset: 32544},
 			expr: &actionExpr{
-				pos: position{line: 1343, col: 5, offset: 32548},
+				pos: position{line: 1343, col: 5, offset: 32554},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1343, col: 5, offset: 32548},
+					pos: position{line: 1343, col: 5, offset: 32554},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1343, col: 5, offset: 32548},
+							pos:        position{line: 1343, col: 5, offset: 32554},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1343, col: 9, offset: 32552},
+							pos:  position{line: 1343, col: 9, offset: 32558},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1343, col: 12, offset: 32555},
+							pos:   position{line: 1343, col: 12, offset: 32561},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1343, col: 18, offset: 32561},
+								pos:  position{line: 1343, col: 18, offset: 32567},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1343, col: 23, offset: 32566},
+							pos:   position{line: 1343, col: 23, offset: 32572},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1343, col: 28, offset: 32571},
+								pos: position{line: 1343, col: 28, offset: 32577},
 								expr: &actionExpr{
-									pos: position{line: 1343, col: 29, offset: 32572},
+									pos: position{line: 1343, col: 29, offset: 32578},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1343, col: 29, offset: 32572},
+										pos: position{line: 1343, col: 29, offset: 32578},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1343, col: 29, offset: 32572},
+												pos:  position{line: 1343, col: 29, offset: 32578},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1343, col: 32, offset: 32575},
+												pos:        position{line: 1343, col: 32, offset: 32581},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1343, col: 36, offset: 32579},
+												pos:  position{line: 1343, col: 36, offset: 32585},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1343, col: 39, offset: 32582},
+												pos:   position{line: 1343, col: 39, offset: 32588},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1343, col: 41, offset: 32584},
+													pos:  position{line: 1343, col: 41, offset: 32590},
 													name: "Expr",
 												},
 											},
@@ -9301,11 +9301,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1343, col: 66, offset: 32609},
+							pos:  position{line: 1343, col: 66, offset: 32615},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 69, offset: 32612},
+							pos:        position{line: 1343, col: 69, offset: 32618},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -9318,39 +9318,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1351, col: 1, offset: 32771},
+			pos:  position{line: 1351, col: 1, offset: 32777},
 			expr: &actionExpr{
-				pos: position{line: 1352, col: 5, offset: 32788},
+				pos: position{line: 1352, col: 5, offset: 32794},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1352, col: 5, offset: 32788},
+					pos: position{line: 1352, col: 5, offset: 32794},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1352, col: 5, offset: 32788},
+							pos:   position{line: 1352, col: 5, offset: 32794},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1352, col: 10, offset: 32793},
+								pos: position{line: 1352, col: 10, offset: 32799},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1352, col: 10, offset: 32793},
+										pos:  position{line: 1352, col: 10, offset: 32799},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1352, col: 17, offset: 32800},
+										pos:  position{line: 1352, col: 17, offset: 32806},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1352, col: 28, offset: 32811},
+							pos:  position{line: 1352, col: 28, offset: 32817},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1352, col: 30, offset: 32813},
+							pos:   position{line: 1352, col: 30, offset: 32819},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1352, col: 32, offset: 32815},
+								pos:  position{line: 1352, col: 32, offset: 32821},
 								name: "StringLiteral",
 							},
 						},
@@ -9362,56 +9362,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1363, col: 1, offset: 33032},
+			pos:  position{line: 1363, col: 1, offset: 33038},
 			expr: &choiceExpr{
-				pos: position{line: 1364, col: 5, offset: 33044},
+				pos: position{line: 1364, col: 5, offset: 33050},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1364, col: 5, offset: 33044},
+						pos:  position{line: 1364, col: 5, offset: 33050},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1365, col: 5, offset: 33060},
+						pos:  position{line: 1365, col: 5, offset: 33066},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1366, col: 5, offset: 33078},
+						pos:  position{line: 1366, col: 5, offset: 33084},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1367, col: 5, offset: 33090},
+						pos:  position{line: 1367, col: 5, offset: 33096},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 5, offset: 33108},
+						pos:  position{line: 1368, col: 5, offset: 33114},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1369, col: 5, offset: 33127},
+						pos:  position{line: 1369, col: 5, offset: 33133},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1370, col: 5, offset: 33144},
+						pos:  position{line: 1370, col: 5, offset: 33150},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1371, col: 5, offset: 33157},
+						pos:  position{line: 1371, col: 5, offset: 33163},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1372, col: 5, offset: 33166},
+						pos:  position{line: 1372, col: 5, offset: 33172},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1373, col: 5, offset: 33183},
+						pos:  position{line: 1373, col: 5, offset: 33189},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1374, col: 5, offset: 33202},
+						pos:  position{line: 1374, col: 5, offset: 33208},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 5, offset: 33221},
+						pos:  position{line: 1375, col: 5, offset: 33227},
 						name: "NullLiteral",
 					},
 				},
@@ -9421,28 +9421,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1377, col: 1, offset: 33234},
+			pos:  position{line: 1377, col: 1, offset: 33240},
 			expr: &choiceExpr{
-				pos: position{line: 1378, col: 5, offset: 33252},
+				pos: position{line: 1378, col: 5, offset: 33258},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1378, col: 5, offset: 33252},
+						pos: position{line: 1378, col: 5, offset: 33258},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1378, col: 5, offset: 33252},
+							pos: position{line: 1378, col: 5, offset: 33258},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1378, col: 5, offset: 33252},
+									pos:   position{line: 1378, col: 5, offset: 33258},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1378, col: 7, offset: 33254},
+										pos:  position{line: 1378, col: 7, offset: 33260},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1378, col: 14, offset: 33261},
+									pos: position{line: 1378, col: 14, offset: 33267},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1378, col: 15, offset: 33262},
+										pos:  position{line: 1378, col: 15, offset: 33268},
 										name: "IdentifierRest",
 									},
 								},
@@ -9450,13 +9450,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1381, col: 5, offset: 33342},
+						pos: position{line: 1381, col: 5, offset: 33348},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1381, col: 5, offset: 33342},
+							pos:   position{line: 1381, col: 5, offset: 33348},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1381, col: 7, offset: 33344},
+								pos:  position{line: 1381, col: 7, offset: 33350},
 								name: "IP4Net",
 							},
 						},
@@ -9468,28 +9468,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1385, col: 1, offset: 33413},
+			pos:  position{line: 1385, col: 1, offset: 33419},
 			expr: &choiceExpr{
-				pos: position{line: 1386, col: 5, offset: 33432},
+				pos: position{line: 1386, col: 5, offset: 33438},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1386, col: 5, offset: 33432},
+						pos: position{line: 1386, col: 5, offset: 33438},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1386, col: 5, offset: 33432},
+							pos: position{line: 1386, col: 5, offset: 33438},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1386, col: 5, offset: 33432},
+									pos:   position{line: 1386, col: 5, offset: 33438},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1386, col: 7, offset: 33434},
+										pos:  position{line: 1386, col: 7, offset: 33440},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1386, col: 11, offset: 33438},
+									pos: position{line: 1386, col: 11, offset: 33444},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1386, col: 12, offset: 33439},
+										pos:  position{line: 1386, col: 12, offset: 33445},
 										name: "IdentifierRest",
 									},
 								},
@@ -9497,13 +9497,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1389, col: 5, offset: 33518},
+						pos: position{line: 1389, col: 5, offset: 33524},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1389, col: 5, offset: 33518},
+							pos:   position{line: 1389, col: 5, offset: 33524},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1389, col: 7, offset: 33520},
+								pos:  position{line: 1389, col: 7, offset: 33526},
 								name: "IP",
 							},
 						},
@@ -9515,15 +9515,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1393, col: 1, offset: 33584},
+			pos:  position{line: 1393, col: 1, offset: 33590},
 			expr: &actionExpr{
-				pos: position{line: 1394, col: 5, offset: 33601},
+				pos: position{line: 1394, col: 5, offset: 33607},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1394, col: 5, offset: 33601},
+					pos:   position{line: 1394, col: 5, offset: 33607},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1394, col: 7, offset: 33603},
+						pos:  position{line: 1394, col: 7, offset: 33609},
 						name: "FloatString",
 					},
 				},
@@ -9533,15 +9533,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1398, col: 1, offset: 33681},
+			pos:  position{line: 1398, col: 1, offset: 33687},
 			expr: &actionExpr{
-				pos: position{line: 1399, col: 5, offset: 33700},
+				pos: position{line: 1399, col: 5, offset: 33706},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1399, col: 5, offset: 33700},
+					pos:   position{line: 1399, col: 5, offset: 33706},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1399, col: 7, offset: 33702},
+						pos:  position{line: 1399, col: 7, offset: 33708},
 						name: "IntString",
 					},
 				},
@@ -9551,23 +9551,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1403, col: 1, offset: 33776},
+			pos:  position{line: 1403, col: 1, offset: 33782},
 			expr: &choiceExpr{
-				pos: position{line: 1404, col: 5, offset: 33795},
+				pos: position{line: 1404, col: 5, offset: 33801},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1404, col: 5, offset: 33795},
+						pos: position{line: 1404, col: 5, offset: 33801},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1404, col: 5, offset: 33795},
+							pos:  position{line: 1404, col: 5, offset: 33801},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1405, col: 5, offset: 33853},
+						pos: position{line: 1405, col: 5, offset: 33859},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1405, col: 5, offset: 33853},
+							pos:  position{line: 1405, col: 5, offset: 33859},
 							name: "FALSE",
 						},
 					},
@@ -9578,12 +9578,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1407, col: 1, offset: 33909},
+			pos:  position{line: 1407, col: 1, offset: 33915},
 			expr: &actionExpr{
-				pos: position{line: 1408, col: 5, offset: 33925},
+				pos: position{line: 1408, col: 5, offset: 33931},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1408, col: 5, offset: 33925},
+					pos:  position{line: 1408, col: 5, offset: 33931},
 					name: "NULL",
 				},
 			},
@@ -9592,23 +9592,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1410, col: 1, offset: 33975},
+			pos:  position{line: 1410, col: 1, offset: 33981},
 			expr: &actionExpr{
-				pos: position{line: 1411, col: 5, offset: 33992},
+				pos: position{line: 1411, col: 5, offset: 33998},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1411, col: 5, offset: 33992},
+					pos: position{line: 1411, col: 5, offset: 33998},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1411, col: 5, offset: 33992},
+							pos:        position{line: 1411, col: 5, offset: 33998},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1411, col: 10, offset: 33997},
+							pos: position{line: 1411, col: 10, offset: 34003},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 10, offset: 33997},
+								pos:  position{line: 1411, col: 10, offset: 34003},
 								name: "HexDigit",
 							},
 						},
@@ -9620,29 +9620,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1415, col: 1, offset: 34071},
+			pos:  position{line: 1415, col: 1, offset: 34077},
 			expr: &actionExpr{
-				pos: position{line: 1416, col: 5, offset: 34087},
+				pos: position{line: 1416, col: 5, offset: 34093},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1416, col: 5, offset: 34087},
+					pos: position{line: 1416, col: 5, offset: 34093},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1416, col: 5, offset: 34087},
+							pos:        position{line: 1416, col: 5, offset: 34093},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1416, col: 9, offset: 34091},
+							pos:   position{line: 1416, col: 9, offset: 34097},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1416, col: 13, offset: 34095},
+								pos:  position{line: 1416, col: 13, offset: 34101},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1416, col: 18, offset: 34100},
+							pos:        position{line: 1416, col: 18, offset: 34106},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -9655,16 +9655,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1424, col: 1, offset: 34233},
+			pos:  position{line: 1424, col: 1, offset: 34239},
 			expr: &choiceExpr{
-				pos: position{line: 1425, col: 5, offset: 34242},
+				pos: position{line: 1425, col: 5, offset: 34248},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1425, col: 5, offset: 34242},
+						pos:  position{line: 1425, col: 5, offset: 34248},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1426, col: 5, offset: 34260},
+						pos:  position{line: 1426, col: 5, offset: 34266},
 						name: "ComplexType",
 					},
 				},
@@ -9674,28 +9674,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1428, col: 1, offset: 34273},
+			pos:  position{line: 1428, col: 1, offset: 34279},
 			expr: &choiceExpr{
-				pos: position{line: 1429, col: 5, offset: 34291},
+				pos: position{line: 1429, col: 5, offset: 34297},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1429, col: 5, offset: 34291},
+						pos: position{line: 1429, col: 5, offset: 34297},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1429, col: 5, offset: 34291},
+							pos: position{line: 1429, col: 5, offset: 34297},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1429, col: 5, offset: 34291},
+									pos:   position{line: 1429, col: 5, offset: 34297},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1429, col: 10, offset: 34296},
+										pos:  position{line: 1429, col: 10, offset: 34302},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1429, col: 24, offset: 34310},
+									pos: position{line: 1429, col: 24, offset: 34316},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1429, col: 25, offset: 34311},
+										pos:  position{line: 1429, col: 25, offset: 34317},
 										name: "IdentifierRest",
 									},
 								},
@@ -9703,43 +9703,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1430, col: 5, offset: 34351},
+						pos: position{line: 1430, col: 5, offset: 34357},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1430, col: 5, offset: 34351},
+							pos: position{line: 1430, col: 5, offset: 34357},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 5, offset: 34351},
+									pos:  position{line: 1430, col: 5, offset: 34357},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 11, offset: 34357},
+									pos:  position{line: 1430, col: 11, offset: 34363},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1430, col: 14, offset: 34360},
+									pos:        position{line: 1430, col: 14, offset: 34366},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 18, offset: 34364},
+									pos:  position{line: 1430, col: 18, offset: 34370},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1430, col: 21, offset: 34367},
+									pos:   position{line: 1430, col: 21, offset: 34373},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1430, col: 23, offset: 34369},
+										pos:  position{line: 1430, col: 23, offset: 34375},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 28, offset: 34374},
+									pos:  position{line: 1430, col: 28, offset: 34380},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1430, col: 31, offset: 34377},
+									pos:        position{line: 1430, col: 31, offset: 34383},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9748,43 +9748,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1437, col: 5, offset: 34517},
+						pos: position{line: 1437, col: 5, offset: 34523},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1437, col: 5, offset: 34517},
+							pos: position{line: 1437, col: 5, offset: 34523},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1437, col: 5, offset: 34517},
+									pos:   position{line: 1437, col: 5, offset: 34523},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1437, col: 10, offset: 34522},
+										pos:  position{line: 1437, col: 10, offset: 34528},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1437, col: 15, offset: 34527},
+									pos:   position{line: 1437, col: 15, offset: 34533},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1437, col: 19, offset: 34531},
+										pos: position{line: 1437, col: 19, offset: 34537},
 										expr: &seqExpr{
-											pos: position{line: 1437, col: 20, offset: 34532},
+											pos: position{line: 1437, col: 20, offset: 34538},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1437, col: 20, offset: 34532},
+													pos:  position{line: 1437, col: 20, offset: 34538},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1437, col: 23, offset: 34535},
+													pos:        position{line: 1437, col: 23, offset: 34541},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1437, col: 27, offset: 34539},
+													pos:  position{line: 1437, col: 27, offset: 34545},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1437, col: 30, offset: 34542},
+													pos:  position{line: 1437, col: 30, offset: 34548},
 													name: "Type",
 												},
 											},
@@ -9795,31 +9795,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1448, col: 5, offset: 34867},
+						pos: position{line: 1448, col: 5, offset: 34873},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1448, col: 5, offset: 34867},
+							pos: position{line: 1448, col: 5, offset: 34873},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1448, col: 5, offset: 34867},
+									pos:        position{line: 1448, col: 5, offset: 34873},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1448, col: 9, offset: 34871},
+									pos:  position{line: 1448, col: 9, offset: 34877},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1448, col: 12, offset: 34874},
+									pos:   position{line: 1448, col: 12, offset: 34880},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1448, col: 18, offset: 34880},
+										pos:  position{line: 1448, col: 18, offset: 34886},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1448, col: 27, offset: 34889},
+									pos:        position{line: 1448, col: 27, offset: 34895},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9834,28 +9834,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1456, col: 1, offset: 35033},
+			pos:  position{line: 1456, col: 1, offset: 35039},
 			expr: &actionExpr{
-				pos: position{line: 1457, col: 5, offset: 35046},
+				pos: position{line: 1457, col: 5, offset: 35052},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1457, col: 5, offset: 35046},
+					pos: position{line: 1457, col: 5, offset: 35052},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1457, col: 5, offset: 35046},
+							pos:   position{line: 1457, col: 5, offset: 35052},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1457, col: 11, offset: 35052},
+								pos:  position{line: 1457, col: 11, offset: 35058},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1457, col: 16, offset: 35057},
+							pos:   position{line: 1457, col: 16, offset: 35063},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1457, col: 21, offset: 35062},
+								pos: position{line: 1457, col: 21, offset: 35068},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1457, col: 21, offset: 35062},
+									pos:  position{line: 1457, col: 21, offset: 35068},
 									name: "TypeListTail",
 								},
 							},
@@ -9868,32 +9868,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1461, col: 1, offset: 35120},
+			pos:  position{line: 1461, col: 1, offset: 35126},
 			expr: &actionExpr{
-				pos: position{line: 1461, col: 16, offset: 35135},
+				pos: position{line: 1461, col: 16, offset: 35141},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1461, col: 16, offset: 35135},
+					pos: position{line: 1461, col: 16, offset: 35141},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 16, offset: 35135},
+							pos:  position{line: 1461, col: 16, offset: 35141},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 19, offset: 35138},
+							pos:        position{line: 1461, col: 19, offset: 35144},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 23, offset: 35142},
+							pos:  position{line: 1461, col: 23, offset: 35148},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1461, col: 26, offset: 35145},
+							pos:   position{line: 1461, col: 26, offset: 35151},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1461, col: 30, offset: 35149},
+								pos:  position{line: 1461, col: 30, offset: 35155},
 								name: "Type",
 							},
 						},
@@ -9905,40 +9905,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1463, col: 1, offset: 35175},
+			pos:  position{line: 1463, col: 1, offset: 35181},
 			expr: &choiceExpr{
-				pos: position{line: 1464, col: 5, offset: 35191},
+				pos: position{line: 1464, col: 5, offset: 35197},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1464, col: 5, offset: 35191},
+						pos: position{line: 1464, col: 5, offset: 35197},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1464, col: 5, offset: 35191},
+							pos: position{line: 1464, col: 5, offset: 35197},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1464, col: 5, offset: 35191},
+									pos:        position{line: 1464, col: 5, offset: 35197},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1464, col: 9, offset: 35195},
+									pos:  position{line: 1464, col: 9, offset: 35201},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1464, col: 12, offset: 35198},
+									pos:   position{line: 1464, col: 12, offset: 35204},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1464, col: 19, offset: 35205},
+										pos:  position{line: 1464, col: 19, offset: 35211},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1464, col: 33, offset: 35219},
+									pos:  position{line: 1464, col: 33, offset: 35225},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1464, col: 36, offset: 35222},
+									pos:        position{line: 1464, col: 36, offset: 35228},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9947,35 +9947,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1471, col: 5, offset: 35384},
+						pos: position{line: 1471, col: 5, offset: 35390},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1471, col: 5, offset: 35384},
+							pos: position{line: 1471, col: 5, offset: 35390},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1471, col: 5, offset: 35384},
+									pos:        position{line: 1471, col: 5, offset: 35390},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1471, col: 9, offset: 35388},
+									pos:  position{line: 1471, col: 9, offset: 35394},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1471, col: 12, offset: 35391},
+									pos:   position{line: 1471, col: 12, offset: 35397},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1471, col: 16, offset: 35395},
+										pos:  position{line: 1471, col: 16, offset: 35401},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1471, col: 21, offset: 35400},
+									pos:  position{line: 1471, col: 21, offset: 35406},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1471, col: 24, offset: 35403},
+									pos:        position{line: 1471, col: 24, offset: 35409},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9984,35 +9984,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1478, col: 5, offset: 35545},
+						pos: position{line: 1478, col: 5, offset: 35551},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1478, col: 5, offset: 35545},
+							pos: position{line: 1478, col: 5, offset: 35551},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1478, col: 5, offset: 35545},
+									pos:        position{line: 1478, col: 5, offset: 35551},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1478, col: 10, offset: 35550},
+									pos:  position{line: 1478, col: 10, offset: 35556},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1478, col: 13, offset: 35553},
+									pos:   position{line: 1478, col: 13, offset: 35559},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1478, col: 17, offset: 35557},
+										pos:  position{line: 1478, col: 17, offset: 35563},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1478, col: 22, offset: 35562},
+									pos:  position{line: 1478, col: 22, offset: 35568},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1478, col: 25, offset: 35565},
+									pos:        position{line: 1478, col: 25, offset: 35571},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -10021,57 +10021,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1485, col: 5, offset: 35704},
+						pos: position{line: 1485, col: 5, offset: 35710},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1485, col: 5, offset: 35704},
+							pos: position{line: 1485, col: 5, offset: 35710},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1485, col: 5, offset: 35704},
+									pos:        position{line: 1485, col: 5, offset: 35710},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 10, offset: 35709},
+									pos:  position{line: 1485, col: 10, offset: 35715},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1485, col: 13, offset: 35712},
+									pos:   position{line: 1485, col: 13, offset: 35718},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1485, col: 21, offset: 35720},
+										pos:  position{line: 1485, col: 21, offset: 35726},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 26, offset: 35725},
+									pos:  position{line: 1485, col: 26, offset: 35731},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1485, col: 29, offset: 35728},
+									pos:        position{line: 1485, col: 29, offset: 35734},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 33, offset: 35732},
+									pos:  position{line: 1485, col: 33, offset: 35738},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1485, col: 36, offset: 35735},
+									pos:   position{line: 1485, col: 36, offset: 35741},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1485, col: 44, offset: 35743},
+										pos:  position{line: 1485, col: 44, offset: 35749},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 49, offset: 35748},
+									pos:  position{line: 1485, col: 49, offset: 35754},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1485, col: 52, offset: 35751},
+									pos:        position{line: 1485, col: 52, offset: 35757},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -10086,30 +10086,30 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1494, col: 1, offset: 35925},
+			pos:  position{line: 1494, col: 1, offset: 35931},
 			expr: &choiceExpr{
-				pos: position{line: 1495, col: 5, offset: 35943},
+				pos: position{line: 1495, col: 5, offset: 35949},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1495, col: 5, offset: 35943},
+						pos: position{line: 1495, col: 5, offset: 35949},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1495, col: 5, offset: 35943},
+							pos:   position{line: 1495, col: 5, offset: 35949},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1495, col: 7, offset: 35945},
+								pos:  position{line: 1495, col: 7, offset: 35951},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1496, col: 5, offset: 36052},
+						pos: position{line: 1496, col: 5, offset: 36058},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1496, col: 5, offset: 36052},
+							pos:   position{line: 1496, col: 5, offset: 36058},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1496, col: 7, offset: 36054},
+								pos:  position{line: 1496, col: 7, offset: 36060},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10121,35 +10121,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1498, col: 1, offset: 36128},
+			pos:  position{line: 1498, col: 1, offset: 36134},
 			expr: &choiceExpr{
-				pos: position{line: 1499, col: 5, offset: 36140},
+				pos: position{line: 1499, col: 5, offset: 36146},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1499, col: 5, offset: 36140},
+						pos: position{line: 1499, col: 5, offset: 36146},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1499, col: 5, offset: 36140},
+							pos: position{line: 1499, col: 5, offset: 36146},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1499, col: 5, offset: 36140},
+									pos:        position{line: 1499, col: 5, offset: 36146},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1499, col: 11, offset: 36146},
+									pos:   position{line: 1499, col: 11, offset: 36152},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1499, col: 13, offset: 36148},
+										pos: position{line: 1499, col: 13, offset: 36154},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1499, col: 13, offset: 36148},
+											pos:  position{line: 1499, col: 13, offset: 36154},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1499, col: 38, offset: 36173},
+									pos:        position{line: 1499, col: 38, offset: 36179},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -10158,30 +10158,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1506, col: 5, offset: 36319},
+						pos: position{line: 1506, col: 5, offset: 36325},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1506, col: 5, offset: 36319},
+							pos: position{line: 1506, col: 5, offset: 36325},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1506, col: 5, offset: 36319},
+									pos:        position{line: 1506, col: 5, offset: 36325},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1506, col: 10, offset: 36324},
+									pos:   position{line: 1506, col: 10, offset: 36330},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1506, col: 12, offset: 36326},
+										pos: position{line: 1506, col: 12, offset: 36332},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1506, col: 12, offset: 36326},
+											pos:  position{line: 1506, col: 12, offset: 36332},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1506, col: 37, offset: 36351},
+									pos:        position{line: 1506, col: 37, offset: 36357},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -10196,24 +10196,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1514, col: 1, offset: 36494},
+			pos:  position{line: 1514, col: 1, offset: 36500},
 			expr: &choiceExpr{
-				pos: position{line: 1515, col: 5, offset: 36522},
+				pos: position{line: 1515, col: 5, offset: 36528},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1515, col: 5, offset: 36522},
+						pos:  position{line: 1515, col: 5, offset: 36528},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1516, col: 5, offset: 36538},
+						pos: position{line: 1516, col: 5, offset: 36544},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1516, col: 5, offset: 36538},
+							pos:   position{line: 1516, col: 5, offset: 36544},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1516, col: 7, offset: 36540},
+								pos: position{line: 1516, col: 7, offset: 36546},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1516, col: 7, offset: 36540},
+									pos:  position{line: 1516, col: 7, offset: 36546},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -10226,27 +10226,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1520, col: 1, offset: 36663},
+			pos:  position{line: 1520, col: 1, offset: 36669},
 			expr: &choiceExpr{
-				pos: position{line: 1521, col: 5, offset: 36691},
+				pos: position{line: 1521, col: 5, offset: 36697},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1521, col: 5, offset: 36691},
+						pos: position{line: 1521, col: 5, offset: 36697},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1521, col: 5, offset: 36691},
+							pos: position{line: 1521, col: 5, offset: 36697},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1521, col: 5, offset: 36691},
+									pos:        position{line: 1521, col: 5, offset: 36697},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1521, col: 10, offset: 36696},
+									pos:   position{line: 1521, col: 10, offset: 36702},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1521, col: 12, offset: 36698},
+										pos:        position{line: 1521, col: 12, offset: 36704},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -10256,25 +10256,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1522, col: 5, offset: 36724},
+						pos: position{line: 1522, col: 5, offset: 36730},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1522, col: 5, offset: 36724},
+							pos: position{line: 1522, col: 5, offset: 36730},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1522, col: 5, offset: 36724},
+									pos: position{line: 1522, col: 5, offset: 36730},
 									expr: &litMatcher{
-										pos:        position{line: 1522, col: 7, offset: 36726},
+										pos:        position{line: 1522, col: 7, offset: 36732},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1522, col: 12, offset: 36731},
+									pos:   position{line: 1522, col: 12, offset: 36737},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1522, col: 14, offset: 36733},
+										pos:  position{line: 1522, col: 14, offset: 36739},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -10288,24 +10288,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1524, col: 1, offset: 36769},
+			pos:  position{line: 1524, col: 1, offset: 36775},
 			expr: &choiceExpr{
-				pos: position{line: 1525, col: 5, offset: 36797},
+				pos: position{line: 1525, col: 5, offset: 36803},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1525, col: 5, offset: 36797},
+						pos:  position{line: 1525, col: 5, offset: 36803},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1526, col: 5, offset: 36813},
+						pos: position{line: 1526, col: 5, offset: 36819},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1526, col: 5, offset: 36813},
+							pos:   position{line: 1526, col: 5, offset: 36819},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1526, col: 7, offset: 36815},
+								pos: position{line: 1526, col: 7, offset: 36821},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1526, col: 7, offset: 36815},
+									pos:  position{line: 1526, col: 7, offset: 36821},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -10318,27 +10318,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1530, col: 1, offset: 36938},
+			pos:  position{line: 1530, col: 1, offset: 36944},
 			expr: &choiceExpr{
-				pos: position{line: 1531, col: 5, offset: 36966},
+				pos: position{line: 1531, col: 5, offset: 36972},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1531, col: 5, offset: 36966},
+						pos: position{line: 1531, col: 5, offset: 36972},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1531, col: 5, offset: 36966},
+							pos: position{line: 1531, col: 5, offset: 36972},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1531, col: 5, offset: 36966},
+									pos:        position{line: 1531, col: 5, offset: 36972},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1531, col: 10, offset: 36971},
+									pos:   position{line: 1531, col: 10, offset: 36977},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1531, col: 12, offset: 36973},
+										pos:        position{line: 1531, col: 12, offset: 36979},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -10348,25 +10348,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1532, col: 5, offset: 36999},
+						pos: position{line: 1532, col: 5, offset: 37005},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1532, col: 5, offset: 36999},
+							pos: position{line: 1532, col: 5, offset: 37005},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1532, col: 5, offset: 36999},
+									pos: position{line: 1532, col: 5, offset: 37005},
 									expr: &litMatcher{
-										pos:        position{line: 1532, col: 7, offset: 37001},
+										pos:        position{line: 1532, col: 7, offset: 37007},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1532, col: 12, offset: 37006},
+									pos:   position{line: 1532, col: 12, offset: 37012},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1532, col: 14, offset: 37008},
+										pos:  position{line: 1532, col: 14, offset: 37014},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -10380,37 +10380,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1534, col: 1, offset: 37044},
+			pos:  position{line: 1534, col: 1, offset: 37050},
 			expr: &actionExpr{
-				pos: position{line: 1535, col: 5, offset: 37060},
+				pos: position{line: 1535, col: 5, offset: 37066},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1535, col: 5, offset: 37060},
+					pos: position{line: 1535, col: 5, offset: 37066},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1535, col: 5, offset: 37060},
+							pos:        position{line: 1535, col: 5, offset: 37066},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1535, col: 9, offset: 37064},
+							pos:  position{line: 1535, col: 9, offset: 37070},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1535, col: 12, offset: 37067},
+							pos:   position{line: 1535, col: 12, offset: 37073},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1535, col: 14, offset: 37069},
+								pos:  position{line: 1535, col: 14, offset: 37075},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1535, col: 19, offset: 37074},
+							pos:  position{line: 1535, col: 19, offset: 37080},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1535, col: 22, offset: 37077},
+							pos:        position{line: 1535, col: 22, offset: 37083},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -10423,129 +10423,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1543, col: 1, offset: 37212},
+			pos:  position{line: 1543, col: 1, offset: 37218},
 			expr: &actionExpr{
-				pos: position{line: 1544, col: 5, offset: 37230},
+				pos: position{line: 1544, col: 5, offset: 37236},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1544, col: 9, offset: 37234},
+					pos: position{line: 1544, col: 9, offset: 37240},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1544, col: 9, offset: 37234},
+							pos:        position{line: 1544, col: 9, offset: 37240},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1544, col: 19, offset: 37244},
+							pos:        position{line: 1544, col: 19, offset: 37250},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1544, col: 30, offset: 37255},
+							pos:        position{line: 1544, col: 30, offset: 37261},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1544, col: 41, offset: 37266},
+							pos:        position{line: 1544, col: 41, offset: 37272},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 9, offset: 37283},
+							pos:        position{line: 1545, col: 9, offset: 37289},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 18, offset: 37292},
+							pos:        position{line: 1545, col: 18, offset: 37298},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 28, offset: 37302},
+							pos:        position{line: 1545, col: 28, offset: 37308},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 38, offset: 37312},
+							pos:        position{line: 1545, col: 38, offset: 37318},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1546, col: 9, offset: 37328},
+							pos:        position{line: 1546, col: 9, offset: 37334},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1546, col: 21, offset: 37340},
+							pos:        position{line: 1546, col: 21, offset: 37346},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1546, col: 33, offset: 37352},
+							pos:        position{line: 1546, col: 33, offset: 37358},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1547, col: 9, offset: 37370},
+							pos:        position{line: 1547, col: 9, offset: 37376},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1547, col: 18, offset: 37379},
+							pos:        position{line: 1547, col: 18, offset: 37385},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1548, col: 9, offset: 37396},
+							pos:        position{line: 1548, col: 9, offset: 37402},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1548, col: 22, offset: 37409},
+							pos:        position{line: 1548, col: 22, offset: 37415},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1549, col: 9, offset: 37424},
+							pos:        position{line: 1549, col: 9, offset: 37430},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1550, col: 9, offset: 37440},
+							pos:        position{line: 1550, col: 9, offset: 37446},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1550, col: 16, offset: 37447},
+							pos:        position{line: 1550, col: 16, offset: 37453},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1551, col: 9, offset: 37461},
+							pos:        position{line: 1551, col: 9, offset: 37467},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1551, col: 18, offset: 37470},
+							pos:        position{line: 1551, col: 18, offset: 37476},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -10558,31 +10558,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1559, col: 1, offset: 37655},
+			pos:  position{line: 1559, col: 1, offset: 37661},
 			expr: &choiceExpr{
-				pos: position{line: 1560, col: 5, offset: 37673},
+				pos: position{line: 1560, col: 5, offset: 37679},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1560, col: 5, offset: 37673},
+						pos: position{line: 1560, col: 5, offset: 37679},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1560, col: 5, offset: 37673},
+							pos: position{line: 1560, col: 5, offset: 37679},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1560, col: 5, offset: 37673},
+									pos:   position{line: 1560, col: 5, offset: 37679},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1560, col: 11, offset: 37679},
+										pos:  position{line: 1560, col: 11, offset: 37685},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1560, col: 21, offset: 37689},
+									pos:   position{line: 1560, col: 21, offset: 37695},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1560, col: 26, offset: 37694},
+										pos: position{line: 1560, col: 26, offset: 37700},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1560, col: 26, offset: 37694},
+											pos:  position{line: 1560, col: 26, offset: 37700},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10591,10 +10591,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1563, col: 5, offset: 37760},
+						pos: position{line: 1563, col: 5, offset: 37766},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1563, col: 5, offset: 37760},
+							pos:        position{line: 1563, col: 5, offset: 37766},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10607,32 +10607,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1565, col: 1, offset: 37784},
+			pos:  position{line: 1565, col: 1, offset: 37790},
 			expr: &actionExpr{
-				pos: position{line: 1565, col: 21, offset: 37804},
+				pos: position{line: 1565, col: 21, offset: 37810},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1565, col: 21, offset: 37804},
+					pos: position{line: 1565, col: 21, offset: 37810},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1565, col: 21, offset: 37804},
+							pos:  position{line: 1565, col: 21, offset: 37810},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1565, col: 24, offset: 37807},
+							pos:        position{line: 1565, col: 24, offset: 37813},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1565, col: 28, offset: 37811},
+							pos:  position{line: 1565, col: 28, offset: 37817},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1565, col: 31, offset: 37814},
+							pos:   position{line: 1565, col: 31, offset: 37820},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1565, col: 35, offset: 37818},
+								pos:  position{line: 1565, col: 35, offset: 37824},
 								name: "TypeField",
 							},
 						},
@@ -10644,40 +10644,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1567, col: 1, offset: 37849},
+			pos:  position{line: 1567, col: 1, offset: 37855},
 			expr: &actionExpr{
-				pos: position{line: 1568, col: 5, offset: 37863},
+				pos: position{line: 1568, col: 5, offset: 37869},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1568, col: 5, offset: 37863},
+					pos: position{line: 1568, col: 5, offset: 37869},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1568, col: 5, offset: 37863},
+							pos:   position{line: 1568, col: 5, offset: 37869},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1568, col: 10, offset: 37868},
+								pos:  position{line: 1568, col: 10, offset: 37874},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1568, col: 15, offset: 37873},
+							pos:  position{line: 1568, col: 15, offset: 37879},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1568, col: 18, offset: 37876},
+							pos:        position{line: 1568, col: 18, offset: 37882},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1568, col: 22, offset: 37880},
+							pos:  position{line: 1568, col: 22, offset: 37886},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1568, col: 25, offset: 37883},
+							pos:   position{line: 1568, col: 25, offset: 37889},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1568, col: 29, offset: 37887},
+								pos:  position{line: 1568, col: 29, offset: 37893},
 								name: "Type",
 							},
 						},
@@ -10689,66 +10689,66 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1576, col: 1, offset: 38036},
+			pos:  position{line: 1576, col: 1, offset: 38042},
 			expr: &choiceExpr{
-				pos: position{line: 1577, col: 5, offset: 38045},
+				pos: position{line: 1577, col: 5, offset: 38051},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1577, col: 5, offset: 38045},
+						pos: position{line: 1577, col: 5, offset: 38051},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1577, col: 5, offset: 38045},
+							pos:   position{line: 1577, col: 5, offset: 38051},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1577, col: 7, offset: 38047},
+								pos:  position{line: 1577, col: 7, offset: 38053},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1578, col: 5, offset: 38137},
+						pos: position{line: 1578, col: 5, offset: 38143},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1578, col: 5, offset: 38137},
+							pos:   position{line: 1578, col: 5, offset: 38143},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1578, col: 7, offset: 38139},
+								pos:  position{line: 1578, col: 7, offset: 38145},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1579, col: 5, offset: 38229},
+						pos: position{line: 1579, col: 5, offset: 38235},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1579, col: 5, offset: 38229},
+							pos:   position{line: 1579, col: 5, offset: 38235},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1579, col: 7, offset: 38231},
+								pos:  position{line: 1579, col: 7, offset: 38237},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1580, col: 5, offset: 38321},
+						pos: position{line: 1580, col: 5, offset: 38327},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1580, col: 5, offset: 38321},
+							pos:   position{line: 1580, col: 5, offset: 38327},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1580, col: 7, offset: 38323},
+								pos:  position{line: 1580, col: 7, offset: 38329},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1581, col: 5, offset: 38413},
+						pos: position{line: 1581, col: 5, offset: 38419},
 						run: (*parser).callonName14,
 						expr: &labeledExpr{
-							pos:   position{line: 1581, col: 5, offset: 38413},
+							pos:   position{line: 1581, col: 5, offset: 38419},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1581, col: 7, offset: 38415},
+								pos:  position{line: 1581, col: 7, offset: 38421},
 								name: "KSUID",
 							},
 						},
@@ -10760,22 +10760,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1583, col: 1, offset: 38502},
+			pos:  position{line: 1583, col: 1, offset: 38508},
 			expr: &actionExpr{
-				pos: position{line: 1584, col: 5, offset: 38516},
+				pos: position{line: 1584, col: 5, offset: 38522},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1584, col: 5, offset: 38516},
+					pos: position{line: 1584, col: 5, offset: 38522},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1584, col: 6, offset: 38517},
+							pos: position{line: 1584, col: 6, offset: 38523},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1584, col: 6, offset: 38517},
+									pos:  position{line: 1584, col: 6, offset: 38523},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1584, col: 24, offset: 38535},
+									pos:        position{line: 1584, col: 24, offset: 38541},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -10783,16 +10783,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1584, col: 29, offset: 38540},
+							pos: position{line: 1584, col: 29, offset: 38546},
 							expr: &choiceExpr{
-								pos: position{line: 1584, col: 30, offset: 38541},
+								pos: position{line: 1584, col: 30, offset: 38547},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1584, col: 30, offset: 38541},
+										pos:  position{line: 1584, col: 30, offset: 38547},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1584, col: 47, offset: 38558},
+										pos:        position{line: 1584, col: 47, offset: 38564},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -10808,15 +10808,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1586, col: 1, offset: 38596},
+			pos:  position{line: 1586, col: 1, offset: 38602},
 			expr: &actionExpr{
-				pos: position{line: 1587, col: 5, offset: 38611},
+				pos: position{line: 1587, col: 5, offset: 38617},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1587, col: 5, offset: 38611},
+					pos:   position{line: 1587, col: 5, offset: 38617},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1587, col: 8, offset: 38614},
+						pos:  position{line: 1587, col: 8, offset: 38620},
 						name: "IdentifierName",
 					},
 				},
@@ -10826,51 +10826,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1595, col: 1, offset: 38747},
+			pos:  position{line: 1595, col: 1, offset: 38753},
 			expr: &actionExpr{
-				pos: position{line: 1596, col: 5, offset: 38763},
+				pos: position{line: 1596, col: 5, offset: 38769},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1596, col: 5, offset: 38763},
+					pos: position{line: 1596, col: 5, offset: 38769},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1596, col: 5, offset: 38763},
+							pos:   position{line: 1596, col: 5, offset: 38769},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1596, col: 11, offset: 38769},
+								pos:  position{line: 1596, col: 11, offset: 38775},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1596, col: 22, offset: 38780},
+							pos:   position{line: 1596, col: 22, offset: 38786},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1596, col: 27, offset: 38785},
+								pos: position{line: 1596, col: 27, offset: 38791},
 								expr: &actionExpr{
-									pos: position{line: 1596, col: 28, offset: 38786},
+									pos: position{line: 1596, col: 28, offset: 38792},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1596, col: 28, offset: 38786},
+										pos: position{line: 1596, col: 28, offset: 38792},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1596, col: 28, offset: 38786},
+												pos:  position{line: 1596, col: 28, offset: 38792},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1596, col: 31, offset: 38789},
+												pos:        position{line: 1596, col: 31, offset: 38795},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1596, col: 35, offset: 38793},
+												pos:  position{line: 1596, col: 35, offset: 38799},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1596, col: 38, offset: 38796},
+												pos:   position{line: 1596, col: 38, offset: 38802},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1596, col: 43, offset: 38801},
+													pos:  position{line: 1596, col: 43, offset: 38807},
 													name: "Identifier",
 												},
 											},
@@ -10887,34 +10887,34 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1600, col: 1, offset: 38879},
+			pos:  position{line: 1600, col: 1, offset: 38885},
 			expr: &choiceExpr{
-				pos: position{line: 1601, col: 5, offset: 38897},
+				pos: position{line: 1601, col: 5, offset: 38903},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1601, col: 5, offset: 38897},
+						pos:  position{line: 1601, col: 5, offset: 38903},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1602, col: 5, offset: 38912},
+						pos: position{line: 1602, col: 5, offset: 38918},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1602, col: 5, offset: 38912},
+							pos:   position{line: 1602, col: 5, offset: 38918},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1602, col: 7, offset: 38914},
+								pos:  position{line: 1602, col: 7, offset: 38920},
 								name: "BacktickString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1603, col: 5, offset: 39002},
+						pos: position{line: 1603, col: 5, offset: 39008},
 						run: (*parser).callonSQLIdentifier6,
 						expr: &labeledExpr{
-							pos:   position{line: 1603, col: 5, offset: 39002},
+							pos:   position{line: 1603, col: 5, offset: 39008},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1603, col: 7, offset: 39004},
+								pos:  position{line: 1603, col: 7, offset: 39010},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10926,29 +10926,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1605, col: 1, offset: 39089},
+			pos:  position{line: 1605, col: 1, offset: 39095},
 			expr: &choiceExpr{
-				pos: position{line: 1606, col: 5, offset: 39108},
+				pos: position{line: 1606, col: 5, offset: 39114},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1606, col: 5, offset: 39108},
+						pos: position{line: 1606, col: 5, offset: 39114},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1606, col: 5, offset: 39108},
+							pos: position{line: 1606, col: 5, offset: 39114},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1606, col: 5, offset: 39108},
+									pos: position{line: 1606, col: 5, offset: 39114},
 									expr: &seqExpr{
-										pos: position{line: 1606, col: 7, offset: 39110},
+										pos: position{line: 1606, col: 7, offset: 39116},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1606, col: 7, offset: 39110},
+												pos:  position{line: 1606, col: 7, offset: 39116},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1606, col: 15, offset: 39118},
+												pos: position{line: 1606, col: 15, offset: 39124},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 16, offset: 39119},
+													pos:  position{line: 1606, col: 16, offset: 39125},
 													name: "IdentifierRest",
 												},
 											},
@@ -10956,13 +10956,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1606, col: 32, offset: 39135},
+									pos:  position{line: 1606, col: 32, offset: 39141},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1606, col: 48, offset: 39151},
+									pos: position{line: 1606, col: 48, offset: 39157},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1606, col: 48, offset: 39151},
+										pos:  position{line: 1606, col: 48, offset: 39157},
 										name: "IdentifierRest",
 									},
 								},
@@ -10970,32 +10970,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1607, col: 5, offset: 39202},
+						pos: position{line: 1607, col: 5, offset: 39208},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1607, col: 5, offset: 39202},
+							pos:        position{line: 1607, col: 5, offset: 39208},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1608, col: 5, offset: 39241},
+						pos: position{line: 1608, col: 5, offset: 39247},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1608, col: 5, offset: 39241},
+							pos: position{line: 1608, col: 5, offset: 39247},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1608, col: 5, offset: 39241},
+									pos:        position{line: 1608, col: 5, offset: 39247},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1608, col: 10, offset: 39246},
+									pos:   position{line: 1608, col: 10, offset: 39252},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1608, col: 13, offset: 39249},
+										pos:  position{line: 1608, col: 13, offset: 39255},
 										name: "IDGuard",
 									},
 								},
@@ -11003,17 +11003,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1610, col: 5, offset: 39340},
+						pos: position{line: 1610, col: 5, offset: 39346},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1610, col: 5, offset: 39340},
+							pos:        position{line: 1610, col: 5, offset: 39346},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1611, col: 5, offset: 39382},
+						pos:  position{line: 1611, col: 5, offset: 39388},
 						name: "BacktickString",
 					},
 				},
@@ -11023,22 +11023,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1613, col: 1, offset: 39399},
+			pos:  position{line: 1613, col: 1, offset: 39405},
 			expr: &choiceExpr{
-				pos: position{line: 1614, col: 5, offset: 39419},
+				pos: position{line: 1614, col: 5, offset: 39425},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1614, col: 5, offset: 39419},
+						pos:  position{line: 1614, col: 5, offset: 39425},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1615, col: 5, offset: 39437},
+						pos:        position{line: 1615, col: 5, offset: 39443},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1616, col: 5, offset: 39445},
+						pos:        position{line: 1616, col: 5, offset: 39451},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -11050,24 +11050,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1618, col: 1, offset: 39450},
+			pos:  position{line: 1618, col: 1, offset: 39456},
 			expr: &choiceExpr{
-				pos: position{line: 1619, col: 5, offset: 39469},
+				pos: position{line: 1619, col: 5, offset: 39475},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1619, col: 5, offset: 39469},
+						pos:  position{line: 1619, col: 5, offset: 39475},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1620, col: 5, offset: 39489},
+						pos:  position{line: 1620, col: 5, offset: 39495},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1621, col: 5, offset: 39514},
+						pos:  position{line: 1621, col: 5, offset: 39520},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1622, col: 5, offset: 39531},
+						pos:  position{line: 1622, col: 5, offset: 39537},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -11077,24 +11077,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1624, col: 1, offset: 39560},
+			pos:  position{line: 1624, col: 1, offset: 39566},
 			expr: &choiceExpr{
-				pos: position{line: 1625, col: 5, offset: 39572},
+				pos: position{line: 1625, col: 5, offset: 39578},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1625, col: 5, offset: 39572},
+						pos:  position{line: 1625, col: 5, offset: 39578},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1626, col: 5, offset: 39591},
+						pos:  position{line: 1626, col: 5, offset: 39597},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1627, col: 5, offset: 39607},
+						pos:  position{line: 1627, col: 5, offset: 39613},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1628, col: 5, offset: 39615},
+						pos:  position{line: 1628, col: 5, offset: 39621},
 						name: "Infinity",
 					},
 				},
@@ -11104,25 +11104,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1630, col: 1, offset: 39625},
+			pos:  position{line: 1630, col: 1, offset: 39631},
 			expr: &actionExpr{
-				pos: position{line: 1631, col: 5, offset: 39634},
+				pos: position{line: 1631, col: 5, offset: 39640},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1631, col: 5, offset: 39634},
+					pos: position{line: 1631, col: 5, offset: 39640},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1631, col: 5, offset: 39634},
+							pos:  position{line: 1631, col: 5, offset: 39640},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1631, col: 14, offset: 39643},
+							pos:        position{line: 1631, col: 14, offset: 39649},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1631, col: 18, offset: 39647},
+							pos:  position{line: 1631, col: 18, offset: 39653},
 							name: "FullTime",
 						},
 					},
@@ -11133,32 +11133,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1635, col: 1, offset: 39723},
+			pos:  position{line: 1635, col: 1, offset: 39729},
 			expr: &seqExpr{
-				pos: position{line: 1635, col: 12, offset: 39734},
+				pos: position{line: 1635, col: 12, offset: 39740},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 12, offset: 39734},
+						pos:  position{line: 1635, col: 12, offset: 39740},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1635, col: 15, offset: 39737},
+						pos:        position{line: 1635, col: 15, offset: 39743},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 19, offset: 39741},
+						pos:  position{line: 1635, col: 19, offset: 39747},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1635, col: 22, offset: 39744},
+						pos:        position{line: 1635, col: 22, offset: 39750},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 26, offset: 39748},
+						pos:  position{line: 1635, col: 26, offset: 39754},
 						name: "D2",
 					},
 				},
@@ -11168,33 +11168,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1637, col: 1, offset: 39752},
+			pos:  position{line: 1637, col: 1, offset: 39758},
 			expr: &seqExpr{
-				pos: position{line: 1637, col: 6, offset: 39757},
+				pos: position{line: 1637, col: 6, offset: 39763},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1637, col: 6, offset: 39757},
+						pos:        position{line: 1637, col: 6, offset: 39763},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1637, col: 11, offset: 39762},
+						pos:        position{line: 1637, col: 11, offset: 39768},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1637, col: 16, offset: 39767},
+						pos:        position{line: 1637, col: 16, offset: 39773},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1637, col: 21, offset: 39772},
+						pos:        position{line: 1637, col: 21, offset: 39778},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11207,19 +11207,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1638, col: 1, offset: 39778},
+			pos:  position{line: 1638, col: 1, offset: 39784},
 			expr: &seqExpr{
-				pos: position{line: 1638, col: 6, offset: 39783},
+				pos: position{line: 1638, col: 6, offset: 39789},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1638, col: 6, offset: 39783},
+						pos:        position{line: 1638, col: 6, offset: 39789},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1638, col: 11, offset: 39788},
+						pos:        position{line: 1638, col: 11, offset: 39794},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11232,16 +11232,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1640, col: 1, offset: 39795},
+			pos:  position{line: 1640, col: 1, offset: 39801},
 			expr: &seqExpr{
-				pos: position{line: 1640, col: 12, offset: 39806},
+				pos: position{line: 1640, col: 12, offset: 39812},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1640, col: 12, offset: 39806},
+						pos:  position{line: 1640, col: 12, offset: 39812},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1640, col: 24, offset: 39818},
+						pos:  position{line: 1640, col: 24, offset: 39824},
 						name: "TimeOffset",
 					},
 				},
@@ -11251,49 +11251,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1642, col: 1, offset: 39830},
+			pos:  position{line: 1642, col: 1, offset: 39836},
 			expr: &seqExpr{
-				pos: position{line: 1642, col: 15, offset: 39844},
+				pos: position{line: 1642, col: 15, offset: 39850},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 15, offset: 39844},
+						pos:  position{line: 1642, col: 15, offset: 39850},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1642, col: 18, offset: 39847},
+						pos:        position{line: 1642, col: 18, offset: 39853},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 22, offset: 39851},
+						pos:  position{line: 1642, col: 22, offset: 39857},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1642, col: 25, offset: 39854},
+						pos:        position{line: 1642, col: 25, offset: 39860},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 29, offset: 39858},
+						pos:  position{line: 1642, col: 29, offset: 39864},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1642, col: 32, offset: 39861},
+						pos: position{line: 1642, col: 32, offset: 39867},
 						expr: &seqExpr{
-							pos: position{line: 1642, col: 33, offset: 39862},
+							pos: position{line: 1642, col: 33, offset: 39868},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1642, col: 33, offset: 39862},
+									pos:        position{line: 1642, col: 33, offset: 39868},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1642, col: 37, offset: 39866},
+									pos: position{line: 1642, col: 37, offset: 39872},
 									expr: &charClassMatcher{
-										pos:        position{line: 1642, col: 37, offset: 39866},
+										pos:        position{line: 1642, col: 37, offset: 39872},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11310,30 +11310,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1644, col: 1, offset: 39876},
+			pos:  position{line: 1644, col: 1, offset: 39882},
 			expr: &choiceExpr{
-				pos: position{line: 1645, col: 5, offset: 39891},
+				pos: position{line: 1645, col: 5, offset: 39897},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1645, col: 5, offset: 39891},
+						pos:        position{line: 1645, col: 5, offset: 39897},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1646, col: 5, offset: 39899},
+						pos: position{line: 1646, col: 5, offset: 39905},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1646, col: 6, offset: 39900},
+								pos: position{line: 1646, col: 6, offset: 39906},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1646, col: 6, offset: 39900},
+										pos:        position{line: 1646, col: 6, offset: 39906},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1646, col: 12, offset: 39906},
+										pos:        position{line: 1646, col: 12, offset: 39912},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -11341,34 +11341,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1646, col: 17, offset: 39911},
+								pos:  position{line: 1646, col: 17, offset: 39917},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1646, col: 20, offset: 39914},
+								pos:        position{line: 1646, col: 20, offset: 39920},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1646, col: 24, offset: 39918},
+								pos:  position{line: 1646, col: 24, offset: 39924},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1646, col: 27, offset: 39921},
+								pos: position{line: 1646, col: 27, offset: 39927},
 								expr: &seqExpr{
-									pos: position{line: 1646, col: 28, offset: 39922},
+									pos: position{line: 1646, col: 28, offset: 39928},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1646, col: 28, offset: 39922},
+											pos:        position{line: 1646, col: 28, offset: 39928},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1646, col: 32, offset: 39926},
+											pos: position{line: 1646, col: 32, offset: 39932},
 											expr: &charClassMatcher{
-												pos:        position{line: 1646, col: 32, offset: 39926},
+												pos:        position{line: 1646, col: 32, offset: 39932},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -11387,33 +11387,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1648, col: 1, offset: 39936},
+			pos:  position{line: 1648, col: 1, offset: 39942},
 			expr: &actionExpr{
-				pos: position{line: 1649, col: 5, offset: 39949},
+				pos: position{line: 1649, col: 5, offset: 39955},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1649, col: 5, offset: 39949},
+					pos: position{line: 1649, col: 5, offset: 39955},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1649, col: 5, offset: 39949},
+							pos: position{line: 1649, col: 5, offset: 39955},
 							expr: &litMatcher{
-								pos:        position{line: 1649, col: 5, offset: 39949},
+								pos:        position{line: 1649, col: 5, offset: 39955},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1649, col: 10, offset: 39954},
+							pos: position{line: 1649, col: 10, offset: 39960},
 							expr: &seqExpr{
-								pos: position{line: 1649, col: 11, offset: 39955},
+								pos: position{line: 1649, col: 11, offset: 39961},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1649, col: 11, offset: 39955},
+										pos:  position{line: 1649, col: 11, offset: 39961},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1649, col: 19, offset: 39963},
+										pos:  position{line: 1649, col: 19, offset: 39969},
 										name: "TimeUnit",
 									},
 								},
@@ -11427,27 +11427,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1653, col: 1, offset: 40045},
+			pos:  position{line: 1653, col: 1, offset: 40051},
 			expr: &seqExpr{
-				pos: position{line: 1653, col: 11, offset: 40055},
+				pos: position{line: 1653, col: 11, offset: 40061},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1653, col: 11, offset: 40055},
+						pos:  position{line: 1653, col: 11, offset: 40061},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1653, col: 16, offset: 40060},
+						pos: position{line: 1653, col: 16, offset: 40066},
 						expr: &seqExpr{
-							pos: position{line: 1653, col: 17, offset: 40061},
+							pos: position{line: 1653, col: 17, offset: 40067},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1653, col: 17, offset: 40061},
+									pos:        position{line: 1653, col: 17, offset: 40067},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1653, col: 21, offset: 40065},
+									pos:  position{line: 1653, col: 21, offset: 40071},
 									name: "UInt",
 								},
 							},
@@ -11460,60 +11460,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1655, col: 1, offset: 40073},
+			pos:  position{line: 1655, col: 1, offset: 40079},
 			expr: &choiceExpr{
-				pos: position{line: 1656, col: 5, offset: 40086},
+				pos: position{line: 1656, col: 5, offset: 40092},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1656, col: 5, offset: 40086},
+						pos:        position{line: 1656, col: 5, offset: 40092},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1657, col: 5, offset: 40095},
+						pos:        position{line: 1657, col: 5, offset: 40101},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1658, col: 5, offset: 40104},
+						pos:        position{line: 1658, col: 5, offset: 40110},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1659, col: 5, offset: 40113},
+						pos:        position{line: 1659, col: 5, offset: 40119},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1660, col: 5, offset: 40121},
+						pos:        position{line: 1660, col: 5, offset: 40127},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1661, col: 5, offset: 40129},
+						pos:        position{line: 1661, col: 5, offset: 40135},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1662, col: 5, offset: 40137},
+						pos:        position{line: 1662, col: 5, offset: 40143},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1663, col: 5, offset: 40145},
+						pos:        position{line: 1663, col: 5, offset: 40151},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1664, col: 5, offset: 40153},
+						pos:        position{line: 1664, col: 5, offset: 40159},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -11525,45 +11525,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1666, col: 1, offset: 40158},
+			pos:  position{line: 1666, col: 1, offset: 40164},
 			expr: &actionExpr{
-				pos: position{line: 1667, col: 5, offset: 40165},
+				pos: position{line: 1667, col: 5, offset: 40171},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1667, col: 5, offset: 40165},
+					pos: position{line: 1667, col: 5, offset: 40171},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 5, offset: 40165},
+							pos:  position{line: 1667, col: 5, offset: 40171},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 10, offset: 40170},
+							pos:        position{line: 1667, col: 10, offset: 40176},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 14, offset: 40174},
+							pos:  position{line: 1667, col: 14, offset: 40180},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 19, offset: 40179},
+							pos:        position{line: 1667, col: 19, offset: 40185},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 23, offset: 40183},
+							pos:  position{line: 1667, col: 23, offset: 40189},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 28, offset: 40188},
+							pos:        position{line: 1667, col: 28, offset: 40194},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 32, offset: 40192},
+							pos:  position{line: 1667, col: 32, offset: 40198},
 							name: "UInt",
 						},
 					},
@@ -11574,43 +11574,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1669, col: 1, offset: 40229},
+			pos:  position{line: 1669, col: 1, offset: 40235},
 			expr: &actionExpr{
-				pos: position{line: 1670, col: 5, offset: 40237},
+				pos: position{line: 1670, col: 5, offset: 40243},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1670, col: 5, offset: 40237},
+					pos: position{line: 1670, col: 5, offset: 40243},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1670, col: 5, offset: 40237},
+							pos: position{line: 1670, col: 5, offset: 40243},
 							expr: &seqExpr{
-								pos: position{line: 1670, col: 7, offset: 40239},
+								pos: position{line: 1670, col: 7, offset: 40245},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1670, col: 7, offset: 40239},
+										pos:  position{line: 1670, col: 7, offset: 40245},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1670, col: 11, offset: 40243},
+										pos:        position{line: 1670, col: 11, offset: 40249},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1670, col: 15, offset: 40247},
+										pos:  position{line: 1670, col: 15, offset: 40253},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1670, col: 19, offset: 40251},
+										pos: position{line: 1670, col: 19, offset: 40257},
 										expr: &choiceExpr{
-											pos: position{line: 1670, col: 21, offset: 40253},
+											pos: position{line: 1670, col: 21, offset: 40259},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1670, col: 21, offset: 40253},
+													pos:  position{line: 1670, col: 21, offset: 40259},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1670, col: 32, offset: 40264},
+													pos:        position{line: 1670, col: 32, offset: 40270},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11622,10 +11622,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1670, col: 38, offset: 40270},
+							pos:   position{line: 1670, col: 38, offset: 40276},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1670, col: 40, offset: 40272},
+								pos:  position{line: 1670, col: 40, offset: 40278},
 								name: "IP6Variations",
 							},
 						},
@@ -11637,32 +11637,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1674, col: 1, offset: 40436},
+			pos:  position{line: 1674, col: 1, offset: 40442},
 			expr: &choiceExpr{
-				pos: position{line: 1675, col: 5, offset: 40454},
+				pos: position{line: 1675, col: 5, offset: 40460},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1675, col: 5, offset: 40454},
+						pos: position{line: 1675, col: 5, offset: 40460},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1675, col: 5, offset: 40454},
+							pos: position{line: 1675, col: 5, offset: 40460},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1675, col: 5, offset: 40454},
+									pos:   position{line: 1675, col: 5, offset: 40460},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1675, col: 7, offset: 40456},
+										pos: position{line: 1675, col: 7, offset: 40462},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1675, col: 7, offset: 40456},
+											pos:  position{line: 1675, col: 7, offset: 40462},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1675, col: 17, offset: 40466},
+									pos:   position{line: 1675, col: 17, offset: 40472},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1675, col: 19, offset: 40468},
+										pos:  position{line: 1675, col: 19, offset: 40474},
 										name: "IP6Tail",
 									},
 								},
@@ -11670,52 +11670,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1678, col: 5, offset: 40532},
+						pos: position{line: 1678, col: 5, offset: 40538},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1678, col: 5, offset: 40532},
+							pos: position{line: 1678, col: 5, offset: 40538},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1678, col: 5, offset: 40532},
+									pos:   position{line: 1678, col: 5, offset: 40538},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1678, col: 7, offset: 40534},
+										pos:  position{line: 1678, col: 7, offset: 40540},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1678, col: 11, offset: 40538},
+									pos:   position{line: 1678, col: 11, offset: 40544},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1678, col: 13, offset: 40540},
+										pos: position{line: 1678, col: 13, offset: 40546},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1678, col: 13, offset: 40540},
+											pos:  position{line: 1678, col: 13, offset: 40546},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1678, col: 23, offset: 40550},
+									pos:        position{line: 1678, col: 23, offset: 40556},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1678, col: 28, offset: 40555},
+									pos:   position{line: 1678, col: 28, offset: 40561},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1678, col: 30, offset: 40557},
+										pos: position{line: 1678, col: 30, offset: 40563},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1678, col: 30, offset: 40557},
+											pos:  position{line: 1678, col: 30, offset: 40563},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1678, col: 40, offset: 40567},
+									pos:   position{line: 1678, col: 40, offset: 40573},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1678, col: 42, offset: 40569},
+										pos:  position{line: 1678, col: 42, offset: 40575},
 										name: "IP6Tail",
 									},
 								},
@@ -11723,33 +11723,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1681, col: 5, offset: 40668},
+						pos: position{line: 1681, col: 5, offset: 40674},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1681, col: 5, offset: 40668},
+							pos: position{line: 1681, col: 5, offset: 40674},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1681, col: 5, offset: 40668},
+									pos:        position{line: 1681, col: 5, offset: 40674},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1681, col: 10, offset: 40673},
+									pos:   position{line: 1681, col: 10, offset: 40679},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1681, col: 12, offset: 40675},
+										pos: position{line: 1681, col: 12, offset: 40681},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1681, col: 12, offset: 40675},
+											pos:  position{line: 1681, col: 12, offset: 40681},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1681, col: 22, offset: 40685},
+									pos:   position{line: 1681, col: 22, offset: 40691},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1681, col: 24, offset: 40687},
+										pos:  position{line: 1681, col: 24, offset: 40693},
 										name: "IP6Tail",
 									},
 								},
@@ -11757,32 +11757,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1684, col: 5, offset: 40758},
+						pos: position{line: 1684, col: 5, offset: 40764},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1684, col: 5, offset: 40758},
+							pos: position{line: 1684, col: 5, offset: 40764},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1684, col: 5, offset: 40758},
+									pos:   position{line: 1684, col: 5, offset: 40764},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1684, col: 7, offset: 40760},
+										pos:  position{line: 1684, col: 7, offset: 40766},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1684, col: 11, offset: 40764},
+									pos:   position{line: 1684, col: 11, offset: 40770},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1684, col: 13, offset: 40766},
+										pos: position{line: 1684, col: 13, offset: 40772},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1684, col: 13, offset: 40766},
+											pos:  position{line: 1684, col: 13, offset: 40772},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1684, col: 23, offset: 40776},
+									pos:        position{line: 1684, col: 23, offset: 40782},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -11791,10 +11791,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1687, col: 5, offset: 40844},
+						pos: position{line: 1687, col: 5, offset: 40850},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1687, col: 5, offset: 40844},
+							pos:        position{line: 1687, col: 5, offset: 40850},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11807,16 +11807,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1691, col: 1, offset: 40881},
+			pos:  position{line: 1691, col: 1, offset: 40887},
 			expr: &choiceExpr{
-				pos: position{line: 1692, col: 5, offset: 40893},
+				pos: position{line: 1692, col: 5, offset: 40899},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1692, col: 5, offset: 40893},
+						pos:  position{line: 1692, col: 5, offset: 40899},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1693, col: 5, offset: 40900},
+						pos:  position{line: 1693, col: 5, offset: 40906},
 						name: "Hex",
 					},
 				},
@@ -11826,24 +11826,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1695, col: 1, offset: 40905},
+			pos:  position{line: 1695, col: 1, offset: 40911},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 12, offset: 40916},
+				pos: position{line: 1695, col: 12, offset: 40922},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1695, col: 12, offset: 40916},
+					pos: position{line: 1695, col: 12, offset: 40922},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1695, col: 12, offset: 40916},
+							pos:        position{line: 1695, col: 12, offset: 40922},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1695, col: 16, offset: 40920},
+							pos:   position{line: 1695, col: 16, offset: 40926},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1695, col: 18, offset: 40922},
+								pos:  position{line: 1695, col: 18, offset: 40928},
 								name: "Hex",
 							},
 						},
@@ -11855,23 +11855,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1697, col: 1, offset: 40960},
+			pos:  position{line: 1697, col: 1, offset: 40966},
 			expr: &actionExpr{
-				pos: position{line: 1697, col: 12, offset: 40971},
+				pos: position{line: 1697, col: 12, offset: 40977},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1697, col: 12, offset: 40971},
+					pos: position{line: 1697, col: 12, offset: 40977},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1697, col: 12, offset: 40971},
+							pos:   position{line: 1697, col: 12, offset: 40977},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1697, col: 14, offset: 40973},
+								pos:  position{line: 1697, col: 14, offset: 40979},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1697, col: 18, offset: 40977},
+							pos:        position{line: 1697, col: 18, offset: 40983},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11884,32 +11884,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1699, col: 1, offset: 41015},
+			pos:  position{line: 1699, col: 1, offset: 41021},
 			expr: &actionExpr{
-				pos: position{line: 1700, col: 5, offset: 41026},
+				pos: position{line: 1700, col: 5, offset: 41032},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1700, col: 5, offset: 41026},
+					pos: position{line: 1700, col: 5, offset: 41032},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1700, col: 5, offset: 41026},
+							pos:   position{line: 1700, col: 5, offset: 41032},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1700, col: 7, offset: 41028},
+								pos:  position{line: 1700, col: 7, offset: 41034},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1700, col: 10, offset: 41031},
+							pos:        position{line: 1700, col: 10, offset: 41037},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1700, col: 14, offset: 41035},
+							pos:   position{line: 1700, col: 14, offset: 41041},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1700, col: 16, offset: 41037},
+								pos:  position{line: 1700, col: 16, offset: 41043},
 								name: "UIntString",
 							},
 						},
@@ -11921,32 +11921,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1704, col: 1, offset: 41105},
+			pos:  position{line: 1704, col: 1, offset: 41111},
 			expr: &actionExpr{
-				pos: position{line: 1705, col: 5, offset: 41116},
+				pos: position{line: 1705, col: 5, offset: 41122},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1705, col: 5, offset: 41116},
+					pos: position{line: 1705, col: 5, offset: 41122},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1705, col: 5, offset: 41116},
+							pos:   position{line: 1705, col: 5, offset: 41122},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1705, col: 7, offset: 41118},
+								pos:  position{line: 1705, col: 7, offset: 41124},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1705, col: 11, offset: 41122},
+							pos:        position{line: 1705, col: 11, offset: 41128},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1705, col: 15, offset: 41126},
+							pos:   position{line: 1705, col: 15, offset: 41132},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1705, col: 17, offset: 41128},
+								pos:  position{line: 1705, col: 17, offset: 41134},
 								name: "UIntString",
 							},
 						},
@@ -11958,15 +11958,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1709, col: 1, offset: 41196},
+			pos:  position{line: 1709, col: 1, offset: 41202},
 			expr: &actionExpr{
-				pos: position{line: 1710, col: 4, offset: 41204},
+				pos: position{line: 1710, col: 4, offset: 41210},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1710, col: 4, offset: 41204},
+					pos:   position{line: 1710, col: 4, offset: 41210},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1710, col: 6, offset: 41206},
+						pos:  position{line: 1710, col: 6, offset: 41212},
 						name: "UIntString",
 					},
 				},
@@ -11976,16 +11976,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1712, col: 1, offset: 41246},
+			pos:  position{line: 1712, col: 1, offset: 41252},
 			expr: &choiceExpr{
-				pos: position{line: 1713, col: 5, offset: 41260},
+				pos: position{line: 1713, col: 5, offset: 41266},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1713, col: 5, offset: 41260},
+						pos:  position{line: 1713, col: 5, offset: 41266},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1714, col: 5, offset: 41275},
+						pos:  position{line: 1714, col: 5, offset: 41281},
 						name: "MinusIntString",
 					},
 				},
@@ -11995,14 +11995,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1716, col: 1, offset: 41291},
+			pos:  position{line: 1716, col: 1, offset: 41297},
 			expr: &actionExpr{
-				pos: position{line: 1716, col: 14, offset: 41304},
+				pos: position{line: 1716, col: 14, offset: 41310},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1716, col: 14, offset: 41304},
+					pos: position{line: 1716, col: 14, offset: 41310},
 					expr: &charClassMatcher{
-						pos:        position{line: 1716, col: 14, offset: 41304},
+						pos:        position{line: 1716, col: 14, offset: 41310},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12015,21 +12015,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1718, col: 1, offset: 41343},
+			pos:  position{line: 1718, col: 1, offset: 41349},
 			expr: &actionExpr{
-				pos: position{line: 1719, col: 5, offset: 41362},
+				pos: position{line: 1719, col: 5, offset: 41368},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1719, col: 5, offset: 41362},
+					pos: position{line: 1719, col: 5, offset: 41368},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1719, col: 5, offset: 41362},
+							pos:        position{line: 1719, col: 5, offset: 41368},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1719, col: 9, offset: 41366},
+							pos:  position{line: 1719, col: 9, offset: 41372},
 							name: "UIntString",
 						},
 					},
@@ -12040,29 +12040,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1721, col: 1, offset: 41409},
+			pos:  position{line: 1721, col: 1, offset: 41415},
 			expr: &choiceExpr{
-				pos: position{line: 1722, col: 5, offset: 41425},
+				pos: position{line: 1722, col: 5, offset: 41431},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1722, col: 5, offset: 41425},
+						pos: position{line: 1722, col: 5, offset: 41431},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1722, col: 5, offset: 41425},
+							pos: position{line: 1722, col: 5, offset: 41431},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1722, col: 5, offset: 41425},
+									pos: position{line: 1722, col: 5, offset: 41431},
 									expr: &litMatcher{
-										pos:        position{line: 1722, col: 5, offset: 41425},
+										pos:        position{line: 1722, col: 5, offset: 41431},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1722, col: 10, offset: 41430},
+									pos: position{line: 1722, col: 10, offset: 41436},
 									expr: &charClassMatcher{
-										pos:        position{line: 1722, col: 10, offset: 41430},
+										pos:        position{line: 1722, col: 10, offset: 41436},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -12070,15 +12070,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1722, col: 17, offset: 41437},
+									pos:        position{line: 1722, col: 17, offset: 41443},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1722, col: 21, offset: 41441},
+									pos: position{line: 1722, col: 21, offset: 41447},
 									expr: &charClassMatcher{
-										pos:        position{line: 1722, col: 21, offset: 41441},
+										pos:        position{line: 1722, col: 21, offset: 41447},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -12086,9 +12086,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1722, col: 28, offset: 41448},
+									pos: position{line: 1722, col: 28, offset: 41454},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1722, col: 28, offset: 41448},
+										pos:  position{line: 1722, col: 28, offset: 41454},
 										name: "ExponentPart",
 									},
 								},
@@ -12096,30 +12096,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1723, col: 5, offset: 41497},
+						pos: position{line: 1723, col: 5, offset: 41503},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1723, col: 5, offset: 41497},
+							pos: position{line: 1723, col: 5, offset: 41503},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1723, col: 5, offset: 41497},
+									pos: position{line: 1723, col: 5, offset: 41503},
 									expr: &litMatcher{
-										pos:        position{line: 1723, col: 5, offset: 41497},
+										pos:        position{line: 1723, col: 5, offset: 41503},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1723, col: 10, offset: 41502},
+									pos:        position{line: 1723, col: 10, offset: 41508},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1723, col: 14, offset: 41506},
+									pos: position{line: 1723, col: 14, offset: 41512},
 									expr: &charClassMatcher{
-										pos:        position{line: 1723, col: 14, offset: 41506},
+										pos:        position{line: 1723, col: 14, offset: 41512},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -12127,9 +12127,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1723, col: 21, offset: 41513},
+									pos: position{line: 1723, col: 21, offset: 41519},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1723, col: 21, offset: 41513},
+										pos:  position{line: 1723, col: 21, offset: 41519},
 										name: "ExponentPart",
 									},
 								},
@@ -12137,17 +12137,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1724, col: 5, offset: 41562},
+						pos: position{line: 1724, col: 5, offset: 41568},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1724, col: 6, offset: 41563},
+							pos: position{line: 1724, col: 6, offset: 41569},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1724, col: 6, offset: 41563},
+									pos:  position{line: 1724, col: 6, offset: 41569},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1724, col: 12, offset: 41569},
+									pos:  position{line: 1724, col: 12, offset: 41575},
 									name: "Infinity",
 								},
 							},
@@ -12160,20 +12160,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1727, col: 1, offset: 41612},
+			pos:  position{line: 1727, col: 1, offset: 41618},
 			expr: &seqExpr{
-				pos: position{line: 1727, col: 16, offset: 41627},
+				pos: position{line: 1727, col: 16, offset: 41633},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1727, col: 16, offset: 41627},
+						pos:        position{line: 1727, col: 16, offset: 41633},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1727, col: 21, offset: 41632},
+						pos: position{line: 1727, col: 21, offset: 41638},
 						expr: &charClassMatcher{
-							pos:        position{line: 1727, col: 21, offset: 41632},
+							pos:        position{line: 1727, col: 21, offset: 41638},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -12181,7 +12181,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1727, col: 27, offset: 41638},
+						pos:  position{line: 1727, col: 27, offset: 41644},
 						name: "UIntString",
 					},
 				},
@@ -12191,9 +12191,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1729, col: 1, offset: 41650},
+			pos:  position{line: 1729, col: 1, offset: 41656},
 			expr: &litMatcher{
-				pos:        position{line: 1729, col: 7, offset: 41656},
+				pos:        position{line: 1729, col: 7, offset: 41662},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -12203,23 +12203,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1731, col: 1, offset: 41663},
+			pos:  position{line: 1731, col: 1, offset: 41669},
 			expr: &seqExpr{
-				pos: position{line: 1731, col: 12, offset: 41674},
+				pos: position{line: 1731, col: 12, offset: 41680},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1731, col: 12, offset: 41674},
+						pos: position{line: 1731, col: 12, offset: 41680},
 						expr: &choiceExpr{
-							pos: position{line: 1731, col: 13, offset: 41675},
+							pos: position{line: 1731, col: 13, offset: 41681},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1731, col: 13, offset: 41675},
+									pos:        position{line: 1731, col: 13, offset: 41681},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1731, col: 19, offset: 41681},
+									pos:        position{line: 1731, col: 19, offset: 41687},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -12228,7 +12228,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1731, col: 25, offset: 41687},
+						pos:        position{line: 1731, col: 25, offset: 41693},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -12240,14 +12240,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1733, col: 1, offset: 41694},
+			pos:  position{line: 1733, col: 1, offset: 41700},
 			expr: &actionExpr{
-				pos: position{line: 1733, col: 7, offset: 41700},
+				pos: position{line: 1733, col: 7, offset: 41706},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1733, col: 7, offset: 41700},
+					pos: position{line: 1733, col: 7, offset: 41706},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1733, col: 7, offset: 41700},
+						pos:  position{line: 1733, col: 7, offset: 41706},
 						name: "HexDigit",
 					},
 				},
@@ -12257,9 +12257,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1735, col: 1, offset: 41742},
+			pos:  position{line: 1735, col: 1, offset: 41748},
 			expr: &charClassMatcher{
-				pos:        position{line: 1735, col: 12, offset: 41753},
+				pos:        position{line: 1735, col: 12, offset: 41759},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -12270,32 +12270,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1737, col: 1, offset: 41766},
+			pos:  position{line: 1737, col: 1, offset: 41772},
 			expr: &actionExpr{
-				pos: position{line: 1738, col: 5, offset: 41789},
+				pos: position{line: 1738, col: 5, offset: 41795},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1738, col: 5, offset: 41789},
+					pos: position{line: 1738, col: 5, offset: 41795},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1738, col: 5, offset: 41789},
+							pos:        position{line: 1738, col: 5, offset: 41795},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1738, col: 9, offset: 41793},
+							pos:   position{line: 1738, col: 9, offset: 41799},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1738, col: 11, offset: 41795},
+								pos: position{line: 1738, col: 11, offset: 41801},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1738, col: 11, offset: 41795},
+									pos:  position{line: 1738, col: 11, offset: 41801},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1738, col: 29, offset: 41813},
+							pos:        position{line: 1738, col: 29, offset: 41819},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -12308,32 +12308,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1740, col: 1, offset: 41847},
+			pos:  position{line: 1740, col: 1, offset: 41853},
 			expr: &actionExpr{
-				pos: position{line: 1741, col: 5, offset: 41870},
+				pos: position{line: 1741, col: 5, offset: 41876},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1741, col: 5, offset: 41870},
+					pos: position{line: 1741, col: 5, offset: 41876},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1741, col: 5, offset: 41870},
+							pos:        position{line: 1741, col: 5, offset: 41876},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1741, col: 9, offset: 41874},
+							pos:   position{line: 1741, col: 9, offset: 41880},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1741, col: 11, offset: 41876},
+								pos: position{line: 1741, col: 11, offset: 41882},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1741, col: 11, offset: 41876},
+									pos:  position{line: 1741, col: 11, offset: 41882},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1741, col: 29, offset: 41894},
+							pos:        position{line: 1741, col: 29, offset: 41900},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12346,57 +12346,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1743, col: 1, offset: 41928},
+			pos:  position{line: 1743, col: 1, offset: 41934},
 			expr: &choiceExpr{
-				pos: position{line: 1744, col: 5, offset: 41949},
+				pos: position{line: 1744, col: 5, offset: 41955},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1744, col: 5, offset: 41949},
+						pos: position{line: 1744, col: 5, offset: 41955},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1744, col: 5, offset: 41949},
+							pos: position{line: 1744, col: 5, offset: 41955},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1744, col: 5, offset: 41949},
+									pos: position{line: 1744, col: 5, offset: 41955},
 									expr: &choiceExpr{
-										pos: position{line: 1744, col: 7, offset: 41951},
+										pos: position{line: 1744, col: 7, offset: 41957},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1744, col: 7, offset: 41951},
+												pos:        position{line: 1744, col: 7, offset: 41957},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1744, col: 13, offset: 41957},
+												pos:  position{line: 1744, col: 13, offset: 41963},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1744, col: 26, offset: 41970,
+									line: 1744, col: 26, offset: 41976,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1745, col: 5, offset: 42007},
+						pos: position{line: 1745, col: 5, offset: 42013},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1745, col: 5, offset: 42007},
+							pos: position{line: 1745, col: 5, offset: 42013},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1745, col: 5, offset: 42007},
+									pos:        position{line: 1745, col: 5, offset: 42013},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1745, col: 10, offset: 42012},
+									pos:   position{line: 1745, col: 10, offset: 42018},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1745, col: 12, offset: 42014},
+										pos:  position{line: 1745, col: 12, offset: 42020},
 										name: "EscapeSequence",
 									},
 								},
@@ -12410,32 +12410,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1747, col: 1, offset: 42048},
+			pos:  position{line: 1747, col: 1, offset: 42054},
 			expr: &actionExpr{
-				pos: position{line: 1748, col: 5, offset: 42067},
+				pos: position{line: 1748, col: 5, offset: 42073},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1748, col: 5, offset: 42067},
+					pos: position{line: 1748, col: 5, offset: 42073},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1748, col: 5, offset: 42067},
+							pos:        position{line: 1748, col: 5, offset: 42073},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1748, col: 9, offset: 42071},
+							pos:   position{line: 1748, col: 9, offset: 42077},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1748, col: 11, offset: 42073},
+								pos: position{line: 1748, col: 11, offset: 42079},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1748, col: 11, offset: 42073},
+									pos:  position{line: 1748, col: 11, offset: 42079},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1748, col: 25, offset: 42087},
+							pos:        position{line: 1748, col: 25, offset: 42093},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -12448,57 +12448,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1750, col: 1, offset: 42121},
+			pos:  position{line: 1750, col: 1, offset: 42127},
 			expr: &choiceExpr{
-				pos: position{line: 1751, col: 5, offset: 42138},
+				pos: position{line: 1751, col: 5, offset: 42144},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1751, col: 5, offset: 42138},
+						pos: position{line: 1751, col: 5, offset: 42144},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1751, col: 5, offset: 42138},
+							pos: position{line: 1751, col: 5, offset: 42144},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1751, col: 5, offset: 42138},
+									pos: position{line: 1751, col: 5, offset: 42144},
 									expr: &choiceExpr{
-										pos: position{line: 1751, col: 7, offset: 42140},
+										pos: position{line: 1751, col: 7, offset: 42146},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1751, col: 7, offset: 42140},
+												pos:        position{line: 1751, col: 7, offset: 42146},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1751, col: 13, offset: 42146},
+												pos:  position{line: 1751, col: 13, offset: 42152},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1751, col: 26, offset: 42159,
+									line: 1751, col: 26, offset: 42165,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1752, col: 5, offset: 42196},
+						pos: position{line: 1752, col: 5, offset: 42202},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1752, col: 5, offset: 42196},
+							pos: position{line: 1752, col: 5, offset: 42202},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1752, col: 5, offset: 42196},
+									pos:        position{line: 1752, col: 5, offset: 42202},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1752, col: 10, offset: 42201},
+									pos:   position{line: 1752, col: 10, offset: 42207},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1752, col: 12, offset: 42203},
+										pos:  position{line: 1752, col: 12, offset: 42209},
 										name: "EscapeSequence",
 									},
 								},
@@ -12512,28 +12512,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1754, col: 1, offset: 42237},
+			pos:  position{line: 1754, col: 1, offset: 42243},
 			expr: &actionExpr{
-				pos: position{line: 1755, col: 5, offset: 42249},
+				pos: position{line: 1755, col: 5, offset: 42255},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1755, col: 5, offset: 42249},
+					pos: position{line: 1755, col: 5, offset: 42255},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1755, col: 5, offset: 42249},
+							pos:   position{line: 1755, col: 5, offset: 42255},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1755, col: 10, offset: 42254},
+								pos:  position{line: 1755, col: 10, offset: 42260},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1755, col: 23, offset: 42267},
+							pos:   position{line: 1755, col: 23, offset: 42273},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1755, col: 28, offset: 42272},
+								pos: position{line: 1755, col: 28, offset: 42278},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1755, col: 28, offset: 42272},
+									pos:  position{line: 1755, col: 28, offset: 42278},
 									name: "KeyWordRest",
 								},
 							},
@@ -12546,16 +12546,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1757, col: 1, offset: 42334},
+			pos:  position{line: 1757, col: 1, offset: 42340},
 			expr: &choiceExpr{
-				pos: position{line: 1758, col: 5, offset: 42351},
+				pos: position{line: 1758, col: 5, offset: 42357},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1758, col: 5, offset: 42351},
+						pos:  position{line: 1758, col: 5, offset: 42357},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1759, col: 5, offset: 42368},
+						pos:  position{line: 1759, col: 5, offset: 42374},
 						name: "KeyWordEsc",
 					},
 				},
@@ -12565,16 +12565,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1761, col: 1, offset: 42380},
+			pos:  position{line: 1761, col: 1, offset: 42386},
 			expr: &choiceExpr{
-				pos: position{line: 1762, col: 5, offset: 42396},
+				pos: position{line: 1762, col: 5, offset: 42402},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1762, col: 5, offset: 42396},
+						pos:  position{line: 1762, col: 5, offset: 42402},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1763, col: 5, offset: 42413},
+						pos:        position{line: 1763, col: 5, offset: 42419},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12587,19 +12587,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1765, col: 1, offset: 42420},
+			pos:  position{line: 1765, col: 1, offset: 42426},
 			expr: &actionExpr{
-				pos: position{line: 1765, col: 16, offset: 42435},
+				pos: position{line: 1765, col: 16, offset: 42441},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1765, col: 17, offset: 42436},
+					pos: position{line: 1765, col: 17, offset: 42442},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1765, col: 17, offset: 42436},
+							pos:  position{line: 1765, col: 17, offset: 42442},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1765, col: 33, offset: 42452},
+							pos:        position{line: 1765, col: 33, offset: 42458},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12613,31 +12613,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1767, col: 1, offset: 42496},
+			pos:  position{line: 1767, col: 1, offset: 42502},
 			expr: &actionExpr{
-				pos: position{line: 1767, col: 14, offset: 42509},
+				pos: position{line: 1767, col: 14, offset: 42515},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1767, col: 14, offset: 42509},
+					pos: position{line: 1767, col: 14, offset: 42515},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1767, col: 14, offset: 42509},
+							pos:        position{line: 1767, col: 14, offset: 42515},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1767, col: 19, offset: 42514},
+							pos:   position{line: 1767, col: 19, offset: 42520},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1767, col: 22, offset: 42517},
+								pos: position{line: 1767, col: 22, offset: 42523},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1767, col: 22, offset: 42517},
+										pos:  position{line: 1767, col: 22, offset: 42523},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1767, col: 38, offset: 42533},
+										pos:  position{line: 1767, col: 38, offset: 42539},
 										name: "EscapeSequence",
 									},
 								},
@@ -12651,42 +12651,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1769, col: 1, offset: 42568},
+			pos:  position{line: 1769, col: 1, offset: 42574},
 			expr: &actionExpr{
-				pos: position{line: 1770, col: 5, offset: 42584},
+				pos: position{line: 1770, col: 5, offset: 42590},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1770, col: 5, offset: 42584},
+					pos: position{line: 1770, col: 5, offset: 42590},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1770, col: 5, offset: 42584},
+							pos: position{line: 1770, col: 5, offset: 42590},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1770, col: 6, offset: 42585},
+								pos:  position{line: 1770, col: 6, offset: 42591},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1770, col: 22, offset: 42601},
+							pos: position{line: 1770, col: 22, offset: 42607},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1770, col: 23, offset: 42602},
+								pos:  position{line: 1770, col: 23, offset: 42608},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1770, col: 35, offset: 42614},
+							pos:   position{line: 1770, col: 35, offset: 42620},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1770, col: 40, offset: 42619},
+								pos:  position{line: 1770, col: 40, offset: 42625},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1770, col: 50, offset: 42629},
+							pos:   position{line: 1770, col: 50, offset: 42635},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1770, col: 55, offset: 42634},
+								pos: position{line: 1770, col: 55, offset: 42640},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1770, col: 55, offset: 42634},
+									pos:  position{line: 1770, col: 55, offset: 42640},
 									name: "GlobRest",
 								},
 							},
@@ -12699,28 +12699,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1774, col: 1, offset: 42703},
+			pos:  position{line: 1774, col: 1, offset: 42709},
 			expr: &choiceExpr{
-				pos: position{line: 1774, col: 19, offset: 42721},
+				pos: position{line: 1774, col: 19, offset: 42727},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1774, col: 19, offset: 42721},
+						pos:  position{line: 1774, col: 19, offset: 42727},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1774, col: 34, offset: 42736},
+						pos: position{line: 1774, col: 34, offset: 42742},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1774, col: 34, offset: 42736},
+								pos: position{line: 1774, col: 34, offset: 42742},
 								expr: &litMatcher{
-									pos:        position{line: 1774, col: 34, offset: 42736},
+									pos:        position{line: 1774, col: 34, offset: 42742},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1774, col: 39, offset: 42741},
+								pos:  position{line: 1774, col: 39, offset: 42747},
 								name: "KeyWordRest",
 							},
 						},
@@ -12732,19 +12732,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1775, col: 1, offset: 42753},
+			pos:  position{line: 1775, col: 1, offset: 42759},
 			expr: &seqExpr{
-				pos: position{line: 1775, col: 15, offset: 42767},
+				pos: position{line: 1775, col: 15, offset: 42773},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1775, col: 15, offset: 42767},
+						pos: position{line: 1775, col: 15, offset: 42773},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1775, col: 15, offset: 42767},
+							pos:  position{line: 1775, col: 15, offset: 42773},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1775, col: 28, offset: 42780},
+						pos:        position{line: 1775, col: 28, offset: 42786},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12756,23 +12756,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1777, col: 1, offset: 42785},
+			pos:  position{line: 1777, col: 1, offset: 42791},
 			expr: &choiceExpr{
-				pos: position{line: 1778, col: 5, offset: 42799},
+				pos: position{line: 1778, col: 5, offset: 42805},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1778, col: 5, offset: 42799},
+						pos:  position{line: 1778, col: 5, offset: 42805},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1779, col: 5, offset: 42816},
+						pos:  position{line: 1779, col: 5, offset: 42822},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1780, col: 5, offset: 42828},
+						pos: position{line: 1780, col: 5, offset: 42834},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1780, col: 5, offset: 42828},
+							pos:        position{line: 1780, col: 5, offset: 42834},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12785,16 +12785,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1782, col: 1, offset: 42853},
+			pos:  position{line: 1782, col: 1, offset: 42859},
 			expr: &choiceExpr{
-				pos: position{line: 1783, col: 5, offset: 42866},
+				pos: position{line: 1783, col: 5, offset: 42872},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1783, col: 5, offset: 42866},
+						pos:  position{line: 1783, col: 5, offset: 42872},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1784, col: 5, offset: 42880},
+						pos:        position{line: 1784, col: 5, offset: 42886},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12807,31 +12807,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1786, col: 1, offset: 42887},
+			pos:  position{line: 1786, col: 1, offset: 42893},
 			expr: &actionExpr{
-				pos: position{line: 1786, col: 11, offset: 42897},
+				pos: position{line: 1786, col: 11, offset: 42903},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1786, col: 11, offset: 42897},
+					pos: position{line: 1786, col: 11, offset: 42903},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1786, col: 11, offset: 42897},
+							pos:        position{line: 1786, col: 11, offset: 42903},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1786, col: 16, offset: 42902},
+							pos:   position{line: 1786, col: 16, offset: 42908},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1786, col: 19, offset: 42905},
+								pos: position{line: 1786, col: 19, offset: 42911},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1786, col: 19, offset: 42905},
+										pos:  position{line: 1786, col: 19, offset: 42911},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1786, col: 32, offset: 42918},
+										pos:  position{line: 1786, col: 32, offset: 42924},
 										name: "EscapeSequence",
 									},
 								},
@@ -12845,32 +12845,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1788, col: 1, offset: 42953},
+			pos:  position{line: 1788, col: 1, offset: 42959},
 			expr: &choiceExpr{
-				pos: position{line: 1789, col: 5, offset: 42968},
+				pos: position{line: 1789, col: 5, offset: 42974},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1789, col: 5, offset: 42968},
+						pos: position{line: 1789, col: 5, offset: 42974},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1789, col: 5, offset: 42968},
+							pos:        position{line: 1789, col: 5, offset: 42974},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1790, col: 5, offset: 42996},
+						pos: position{line: 1790, col: 5, offset: 43002},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1790, col: 5, offset: 42996},
+							pos:        position{line: 1790, col: 5, offset: 43002},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1791, col: 5, offset: 43026},
+						pos:        position{line: 1791, col: 5, offset: 43032},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12883,57 +12883,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1793, col: 1, offset: 43032},
+			pos:  position{line: 1793, col: 1, offset: 43038},
 			expr: &choiceExpr{
-				pos: position{line: 1794, col: 5, offset: 43053},
+				pos: position{line: 1794, col: 5, offset: 43059},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1794, col: 5, offset: 43053},
+						pos: position{line: 1794, col: 5, offset: 43059},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1794, col: 5, offset: 43053},
+							pos: position{line: 1794, col: 5, offset: 43059},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1794, col: 5, offset: 43053},
+									pos: position{line: 1794, col: 5, offset: 43059},
 									expr: &choiceExpr{
-										pos: position{line: 1794, col: 7, offset: 43055},
+										pos: position{line: 1794, col: 7, offset: 43061},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1794, col: 7, offset: 43055},
+												pos:        position{line: 1794, col: 7, offset: 43061},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1794, col: 13, offset: 43061},
+												pos:  position{line: 1794, col: 13, offset: 43067},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1794, col: 26, offset: 43074,
+									line: 1794, col: 26, offset: 43080,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1795, col: 5, offset: 43111},
+						pos: position{line: 1795, col: 5, offset: 43117},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1795, col: 5, offset: 43111},
+							pos: position{line: 1795, col: 5, offset: 43117},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1795, col: 5, offset: 43111},
+									pos:        position{line: 1795, col: 5, offset: 43117},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1795, col: 10, offset: 43116},
+									pos:   position{line: 1795, col: 10, offset: 43122},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1795, col: 12, offset: 43118},
+										pos:  position{line: 1795, col: 12, offset: 43124},
 										name: "EscapeSequence",
 									},
 								},
@@ -12947,16 +12947,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1797, col: 1, offset: 43152},
+			pos:  position{line: 1797, col: 1, offset: 43158},
 			expr: &choiceExpr{
-				pos: position{line: 1798, col: 5, offset: 43171},
+				pos: position{line: 1798, col: 5, offset: 43177},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1798, col: 5, offset: 43171},
+						pos:  position{line: 1798, col: 5, offset: 43177},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1799, col: 5, offset: 43192},
+						pos:  position{line: 1799, col: 5, offset: 43198},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12966,87 +12966,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1801, col: 1, offset: 43207},
+			pos:  position{line: 1801, col: 1, offset: 43213},
 			expr: &choiceExpr{
-				pos: position{line: 1802, col: 5, offset: 43228},
+				pos: position{line: 1802, col: 5, offset: 43234},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1802, col: 5, offset: 43228},
+						pos:        position{line: 1802, col: 5, offset: 43234},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1803, col: 5, offset: 43236},
+						pos: position{line: 1803, col: 5, offset: 43242},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1803, col: 5, offset: 43236},
+							pos:        position{line: 1803, col: 5, offset: 43242},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1804, col: 5, offset: 43276},
+						pos:        position{line: 1804, col: 5, offset: 43282},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1805, col: 5, offset: 43285},
+						pos: position{line: 1805, col: 5, offset: 43291},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1805, col: 5, offset: 43285},
+							pos:        position{line: 1805, col: 5, offset: 43291},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1806, col: 5, offset: 43314},
+						pos: position{line: 1806, col: 5, offset: 43320},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1806, col: 5, offset: 43314},
+							pos:        position{line: 1806, col: 5, offset: 43320},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1807, col: 5, offset: 43343},
+						pos: position{line: 1807, col: 5, offset: 43349},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1807, col: 5, offset: 43343},
+							pos:        position{line: 1807, col: 5, offset: 43349},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1808, col: 5, offset: 43372},
+						pos: position{line: 1808, col: 5, offset: 43378},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1808, col: 5, offset: 43372},
+							pos:        position{line: 1808, col: 5, offset: 43378},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1809, col: 5, offset: 43401},
+						pos: position{line: 1809, col: 5, offset: 43407},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1809, col: 5, offset: 43401},
+							pos:        position{line: 1809, col: 5, offset: 43407},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1810, col: 5, offset: 43430},
+						pos: position{line: 1810, col: 5, offset: 43436},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1810, col: 5, offset: 43430},
+							pos:        position{line: 1810, col: 5, offset: 43436},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -13059,32 +13059,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1812, col: 1, offset: 43456},
+			pos:  position{line: 1812, col: 1, offset: 43462},
 			expr: &choiceExpr{
-				pos: position{line: 1813, col: 5, offset: 43474},
+				pos: position{line: 1813, col: 5, offset: 43480},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1813, col: 5, offset: 43474},
+						pos: position{line: 1813, col: 5, offset: 43480},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1813, col: 5, offset: 43474},
+							pos:        position{line: 1813, col: 5, offset: 43480},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1814, col: 5, offset: 43502},
+						pos: position{line: 1814, col: 5, offset: 43508},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1814, col: 5, offset: 43502},
+							pos:        position{line: 1814, col: 5, offset: 43508},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1815, col: 5, offset: 43530},
+						pos:        position{line: 1815, col: 5, offset: 43536},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -13097,42 +13097,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1817, col: 1, offset: 43536},
+			pos:  position{line: 1817, col: 1, offset: 43542},
 			expr: &choiceExpr{
-				pos: position{line: 1818, col: 5, offset: 43554},
+				pos: position{line: 1818, col: 5, offset: 43560},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1818, col: 5, offset: 43554},
+						pos: position{line: 1818, col: 5, offset: 43560},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1818, col: 5, offset: 43554},
+							pos: position{line: 1818, col: 5, offset: 43560},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1818, col: 5, offset: 43554},
+									pos:        position{line: 1818, col: 5, offset: 43560},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1818, col: 9, offset: 43558},
+									pos:   position{line: 1818, col: 9, offset: 43564},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1818, col: 16, offset: 43565},
+										pos: position{line: 1818, col: 16, offset: 43571},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1818, col: 16, offset: 43565},
+												pos:  position{line: 1818, col: 16, offset: 43571},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1818, col: 25, offset: 43574},
+												pos:  position{line: 1818, col: 25, offset: 43580},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1818, col: 34, offset: 43583},
+												pos:  position{line: 1818, col: 34, offset: 43589},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1818, col: 43, offset: 43592},
+												pos:  position{line: 1818, col: 43, offset: 43598},
 												name: "HexDigit",
 											},
 										},
@@ -13142,65 +13142,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1821, col: 5, offset: 43655},
+						pos: position{line: 1821, col: 5, offset: 43661},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1821, col: 5, offset: 43655},
+							pos: position{line: 1821, col: 5, offset: 43661},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1821, col: 5, offset: 43655},
+									pos:        position{line: 1821, col: 5, offset: 43661},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1821, col: 9, offset: 43659},
+									pos:        position{line: 1821, col: 9, offset: 43665},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1821, col: 13, offset: 43663},
+									pos:   position{line: 1821, col: 13, offset: 43669},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1821, col: 20, offset: 43670},
+										pos: position{line: 1821, col: 20, offset: 43676},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1821, col: 20, offset: 43670},
+												pos:  position{line: 1821, col: 20, offset: 43676},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 29, offset: 43679},
+												pos: position{line: 1821, col: 29, offset: 43685},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 29, offset: 43679},
+													pos:  position{line: 1821, col: 29, offset: 43685},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 39, offset: 43689},
+												pos: position{line: 1821, col: 39, offset: 43695},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 39, offset: 43689},
+													pos:  position{line: 1821, col: 39, offset: 43695},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 49, offset: 43699},
+												pos: position{line: 1821, col: 49, offset: 43705},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 49, offset: 43699},
+													pos:  position{line: 1821, col: 49, offset: 43705},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 59, offset: 43709},
+												pos: position{line: 1821, col: 59, offset: 43715},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 59, offset: 43709},
+													pos:  position{line: 1821, col: 59, offset: 43715},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 69, offset: 43719},
+												pos: position{line: 1821, col: 69, offset: 43725},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 69, offset: 43719},
+													pos:  position{line: 1821, col: 69, offset: 43725},
 													name: "HexDigit",
 												},
 											},
@@ -13208,7 +13208,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1821, col: 80, offset: 43730},
+									pos:        position{line: 1821, col: 80, offset: 43736},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -13223,37 +13223,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1825, col: 1, offset: 43784},
+			pos:  position{line: 1825, col: 1, offset: 43790},
 			expr: &actionExpr{
-				pos: position{line: 1826, col: 5, offset: 43802},
+				pos: position{line: 1826, col: 5, offset: 43808},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1826, col: 5, offset: 43802},
+					pos: position{line: 1826, col: 5, offset: 43808},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1826, col: 5, offset: 43802},
+							pos:        position{line: 1826, col: 5, offset: 43808},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1826, col: 9, offset: 43806},
+							pos:   position{line: 1826, col: 9, offset: 43812},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1826, col: 14, offset: 43811},
+								pos:  position{line: 1826, col: 14, offset: 43817},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1826, col: 25, offset: 43822},
+							pos:        position{line: 1826, col: 25, offset: 43828},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1826, col: 29, offset: 43826},
+							pos: position{line: 1826, col: 29, offset: 43832},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1826, col: 30, offset: 43827},
+								pos:  position{line: 1826, col: 30, offset: 43833},
 								name: "KeyWordStart",
 							},
 						},
@@ -13265,33 +13265,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1828, col: 1, offset: 43862},
+			pos:  position{line: 1828, col: 1, offset: 43868},
 			expr: &actionExpr{
-				pos: position{line: 1829, col: 5, offset: 43877},
+				pos: position{line: 1829, col: 5, offset: 43883},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1829, col: 5, offset: 43877},
+					pos: position{line: 1829, col: 5, offset: 43883},
 					expr: &choiceExpr{
-						pos: position{line: 1829, col: 6, offset: 43878},
+						pos: position{line: 1829, col: 6, offset: 43884},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1829, col: 6, offset: 43878},
+								pos:        position{line: 1829, col: 6, offset: 43884},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1829, col: 15, offset: 43887},
+								pos: position{line: 1829, col: 15, offset: 43893},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1829, col: 15, offset: 43887},
+										pos:        position{line: 1829, col: 15, offset: 43893},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1829, col: 20, offset: 43892,
+										line: 1829, col: 20, offset: 43898,
 									},
 								},
 							},
@@ -13304,9 +13304,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1831, col: 1, offset: 43928},
+			pos:  position{line: 1831, col: 1, offset: 43934},
 			expr: &charClassMatcher{
-				pos:        position{line: 1832, col: 5, offset: 43944},
+				pos:        position{line: 1832, col: 5, offset: 43950},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -13318,11 +13318,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1834, col: 1, offset: 43959},
+			pos:  position{line: 1834, col: 1, offset: 43965},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1834, col: 5, offset: 43963},
+				pos: position{line: 1834, col: 5, offset: 43969},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1834, col: 5, offset: 43963},
+					pos:  position{line: 1834, col: 5, offset: 43969},
 					name: "AnySpace",
 				},
 			},
@@ -13331,11 +13331,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1836, col: 1, offset: 43974},
+			pos:  position{line: 1836, col: 1, offset: 43980},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1836, col: 6, offset: 43979},
+				pos: position{line: 1836, col: 6, offset: 43985},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1836, col: 6, offset: 43979},
+					pos:  position{line: 1836, col: 6, offset: 43985},
 					name: "AnySpace",
 				},
 			},
@@ -13344,20 +13344,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1838, col: 1, offset: 43990},
+			pos:  position{line: 1838, col: 1, offset: 43996},
 			expr: &choiceExpr{
-				pos: position{line: 1839, col: 5, offset: 44003},
+				pos: position{line: 1839, col: 5, offset: 44009},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1839, col: 5, offset: 44003},
+						pos:  position{line: 1839, col: 5, offset: 44009},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1840, col: 5, offset: 44018},
+						pos:  position{line: 1840, col: 5, offset: 44024},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1841, col: 5, offset: 44037},
+						pos:  position{line: 1841, col: 5, offset: 44043},
 						name: "Comment",
 					},
 				},
@@ -13367,32 +13367,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1843, col: 1, offset: 44046},
+			pos:  position{line: 1843, col: 1, offset: 44052},
 			expr: &choiceExpr{
-				pos: position{line: 1844, col: 5, offset: 44064},
+				pos: position{line: 1844, col: 5, offset: 44070},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1844, col: 5, offset: 44064},
+						pos:  position{line: 1844, col: 5, offset: 44070},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1845, col: 5, offset: 44071},
+						pos:  position{line: 1845, col: 5, offset: 44077},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1846, col: 5, offset: 44078},
+						pos:  position{line: 1846, col: 5, offset: 44084},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1847, col: 5, offset: 44085},
+						pos:  position{line: 1847, col: 5, offset: 44091},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1848, col: 5, offset: 44092},
+						pos:  position{line: 1848, col: 5, offset: 44098},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1849, col: 5, offset: 44099},
+						pos:  position{line: 1849, col: 5, offset: 44105},
 						name: "Nl",
 					},
 				},
@@ -13402,16 +13402,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1851, col: 1, offset: 44103},
+			pos:  position{line: 1851, col: 1, offset: 44109},
 			expr: &choiceExpr{
-				pos: position{line: 1852, col: 5, offset: 44128},
+				pos: position{line: 1852, col: 5, offset: 44134},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1852, col: 5, offset: 44128},
+						pos:  position{line: 1852, col: 5, offset: 44134},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1853, col: 5, offset: 44135},
+						pos:  position{line: 1853, col: 5, offset: 44141},
 						name: "Mc",
 					},
 				},
@@ -13421,9 +13421,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1855, col: 1, offset: 44139},
+			pos:  position{line: 1855, col: 1, offset: 44145},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1856, col: 5, offset: 44156},
+				pos:  position{line: 1856, col: 5, offset: 44162},
 				name: "Nd",
 			},
 			leader:        false,
@@ -13431,9 +13431,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1858, col: 1, offset: 44160},
+			pos:  position{line: 1858, col: 1, offset: 44166},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1859, col: 5, offset: 44192},
+				pos:  position{line: 1859, col: 5, offset: 44198},
 				name: "Pc",
 			},
 			leader:        false,
@@ -13441,9 +13441,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1865, col: 1, offset: 44373},
+			pos:  position{line: 1865, col: 1, offset: 44379},
 			expr: &charClassMatcher{
-				pos:        position{line: 1865, col: 6, offset: 44378},
+				pos:        position{line: 1865, col: 6, offset: 44384},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -13455,9 +13455,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1868, col: 1, offset: 48530},
+			pos:  position{line: 1868, col: 1, offset: 48536},
 			expr: &charClassMatcher{
-				pos:        position{line: 1868, col: 6, offset: 48535},
+				pos:        position{line: 1868, col: 6, offset: 48541},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -13469,9 +13469,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1871, col: 1, offset: 49020},
+			pos:  position{line: 1871, col: 1, offset: 49026},
 			expr: &charClassMatcher{
-				pos:        position{line: 1871, col: 6, offset: 49025},
+				pos:        position{line: 1871, col: 6, offset: 49031},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -13483,9 +13483,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1874, col: 1, offset: 52472},
+			pos:  position{line: 1874, col: 1, offset: 52478},
 			expr: &charClassMatcher{
-				pos:        position{line: 1874, col: 6, offset: 52477},
+				pos:        position{line: 1874, col: 6, offset: 52483},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -13497,9 +13497,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1877, col: 1, offset: 52583},
+			pos:  position{line: 1877, col: 1, offset: 52589},
 			expr: &charClassMatcher{
-				pos:        position{line: 1877, col: 6, offset: 52588},
+				pos:        position{line: 1877, col: 6, offset: 52594},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -13511,9 +13511,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1880, col: 1, offset: 56589},
+			pos:  position{line: 1880, col: 1, offset: 56595},
 			expr: &charClassMatcher{
-				pos:        position{line: 1880, col: 6, offset: 56594},
+				pos:        position{line: 1880, col: 6, offset: 56600},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -13525,9 +13525,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1883, col: 1, offset: 57782},
+			pos:  position{line: 1883, col: 1, offset: 57788},
 			expr: &charClassMatcher{
-				pos:        position{line: 1883, col: 6, offset: 57787},
+				pos:        position{line: 1883, col: 6, offset: 57793},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -13539,9 +13539,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1886, col: 1, offset: 59967},
+			pos:  position{line: 1886, col: 1, offset: 59973},
 			expr: &charClassMatcher{
-				pos:        position{line: 1886, col: 6, offset: 59972},
+				pos:        position{line: 1886, col: 6, offset: 59978},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -13552,9 +13552,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1889, col: 1, offset: 60475},
+			pos:  position{line: 1889, col: 1, offset: 60481},
 			expr: &charClassMatcher{
-				pos:        position{line: 1889, col: 6, offset: 60480},
+				pos:        position{line: 1889, col: 6, offset: 60486},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -13566,9 +13566,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1892, col: 1, offset: 60594},
+			pos:  position{line: 1892, col: 1, offset: 60600},
 			expr: &charClassMatcher{
-				pos:        position{line: 1892, col: 6, offset: 60599},
+				pos:        position{line: 1892, col: 6, offset: 60605},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -13580,9 +13580,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1895, col: 1, offset: 60680},
+			pos:  position{line: 1895, col: 1, offset: 60686},
 			expr: &charClassMatcher{
-				pos:        position{line: 1895, col: 6, offset: 60685},
+				pos:        position{line: 1895, col: 6, offset: 60691},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13594,9 +13594,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1897, col: 1, offset: 60738},
+			pos:  position{line: 1897, col: 1, offset: 60744},
 			expr: &anyMatcher{
-				line: 1898, col: 5, offset: 60758,
+				line: 1898, col: 5, offset: 60764,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13604,48 +13604,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1900, col: 1, offset: 60761},
+			pos:         position{line: 1900, col: 1, offset: 60767},
 			expr: &choiceExpr{
-				pos: position{line: 1901, col: 5, offset: 60789},
+				pos: position{line: 1901, col: 5, offset: 60795},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1901, col: 5, offset: 60789},
+						pos:        position{line: 1901, col: 5, offset: 60795},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1902, col: 5, offset: 60798},
+						pos:        position{line: 1902, col: 5, offset: 60804},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1903, col: 5, offset: 60807},
+						pos:        position{line: 1903, col: 5, offset: 60813},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1904, col: 5, offset: 60816},
+						pos:        position{line: 1904, col: 5, offset: 60822},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1905, col: 5, offset: 60824},
+						pos:        position{line: 1905, col: 5, offset: 60830},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1906, col: 5, offset: 60837},
+						pos:        position{line: 1906, col: 5, offset: 60843},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1907, col: 5, offset: 60850},
+						pos:  position{line: 1907, col: 5, offset: 60856},
 						name: "Zs",
 					},
 				},
@@ -13655,9 +13655,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1909, col: 1, offset: 60854},
+			pos:  position{line: 1909, col: 1, offset: 60860},
 			expr: &charClassMatcher{
-				pos:        position{line: 1910, col: 5, offset: 60873},
+				pos:        position{line: 1910, col: 5, offset: 60879},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13669,9 +13669,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1916, col: 1, offset: 61203},
+			pos:         position{line: 1916, col: 1, offset: 61209},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1919, col: 5, offset: 61274},
+				pos:  position{line: 1919, col: 5, offset: 61280},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -13679,39 +13679,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1921, col: 1, offset: 61293},
+			pos:  position{line: 1921, col: 1, offset: 61299},
 			expr: &seqExpr{
-				pos: position{line: 1922, col: 5, offset: 61314},
+				pos: position{line: 1922, col: 5, offset: 61320},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1922, col: 5, offset: 61314},
+						pos:        position{line: 1922, col: 5, offset: 61320},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1922, col: 10, offset: 61319},
+						pos: position{line: 1922, col: 10, offset: 61325},
 						expr: &seqExpr{
-							pos: position{line: 1922, col: 11, offset: 61320},
+							pos: position{line: 1922, col: 11, offset: 61326},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1922, col: 11, offset: 61320},
+									pos: position{line: 1922, col: 11, offset: 61326},
 									expr: &litMatcher{
-										pos:        position{line: 1922, col: 12, offset: 61321},
+										pos:        position{line: 1922, col: 12, offset: 61327},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1922, col: 17, offset: 61326},
+									pos:  position{line: 1922, col: 17, offset: 61332},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1922, col: 35, offset: 61344},
+						pos:        position{line: 1922, col: 35, offset: 61350},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13723,33 +13723,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1924, col: 1, offset: 61350},
+			pos:  position{line: 1924, col: 1, offset: 61356},
 			expr: &choiceExpr{
-				pos: position{line: 1925, col: 5, offset: 61372},
+				pos: position{line: 1925, col: 5, offset: 61378},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1925, col: 5, offset: 61372},
+						pos: position{line: 1925, col: 5, offset: 61378},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1925, col: 5, offset: 61372},
+								pos:        position{line: 1925, col: 5, offset: 61378},
 								val:        "//",
 								ignoreCase: false,
 								want:       "\"//\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1925, col: 10, offset: 61377},
+								pos: position{line: 1925, col: 10, offset: 61383},
 								expr: &seqExpr{
-									pos: position{line: 1925, col: 11, offset: 61378},
+									pos: position{line: 1925, col: 11, offset: 61384},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1925, col: 11, offset: 61378},
+											pos: position{line: 1925, col: 11, offset: 61384},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1925, col: 12, offset: 61379},
+												pos:  position{line: 1925, col: 12, offset: 61385},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1925, col: 27, offset: 61394},
+											pos:  position{line: 1925, col: 27, offset: 61400},
 											name: "SourceCharacter",
 										},
 									},
@@ -13758,28 +13758,28 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1926, col: 5, offset: 61416},
+						pos: position{line: 1926, col: 5, offset: 61422},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1926, col: 5, offset: 61416},
+								pos:        position{line: 1926, col: 5, offset: 61422},
 								val:        "--",
 								ignoreCase: false,
 								want:       "\"--\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1926, col: 10, offset: 61421},
+								pos: position{line: 1926, col: 10, offset: 61427},
 								expr: &seqExpr{
-									pos: position{line: 1926, col: 11, offset: 61422},
+									pos: position{line: 1926, col: 11, offset: 61428},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1926, col: 11, offset: 61422},
+											pos: position{line: 1926, col: 11, offset: 61428},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1926, col: 12, offset: 61423},
+												pos:  position{line: 1926, col: 12, offset: 61429},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1926, col: 27, offset: 61438},
+											pos:  position{line: 1926, col: 27, offset: 61444},
 											name: "SourceCharacter",
 										},
 									},
@@ -13794,19 +13794,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1928, col: 1, offset: 61457},
+			pos:  position{line: 1928, col: 1, offset: 61463},
 			expr: &seqExpr{
-				pos: position{line: 1928, col: 7, offset: 61463},
+				pos: position{line: 1928, col: 7, offset: 61469},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1928, col: 7, offset: 61463},
+						pos: position{line: 1928, col: 7, offset: 61469},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1928, col: 7, offset: 61463},
+							pos:  position{line: 1928, col: 7, offset: 61469},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1928, col: 19, offset: 61475},
+						pos:  position{line: 1928, col: 19, offset: 61481},
 						name: "LineTerminator",
 					},
 				},
@@ -13816,16 +13816,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1930, col: 1, offset: 61491},
+			pos:  position{line: 1930, col: 1, offset: 61497},
 			expr: &choiceExpr{
-				pos: position{line: 1930, col: 7, offset: 61497},
+				pos: position{line: 1930, col: 7, offset: 61503},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1930, col: 7, offset: 61497},
+						pos:  position{line: 1930, col: 7, offset: 61503},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1930, col: 11, offset: 61501},
+						pos:  position{line: 1930, col: 11, offset: 61507},
 						name: "EOF",
 					},
 				},
@@ -13835,11 +13835,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1932, col: 1, offset: 61506},
+			pos:  position{line: 1932, col: 1, offset: 61512},
 			expr: &notExpr{
-				pos: position{line: 1932, col: 7, offset: 61512},
+				pos: position{line: 1932, col: 7, offset: 61518},
 				expr: &anyMatcher{
-					line: 1932, col: 8, offset: 61513,
+					line: 1932, col: 8, offset: 61519,
 				},
 			},
 			leader:        false,
@@ -13847,11 +13847,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1934, col: 1, offset: 61516},
+			pos:  position{line: 1934, col: 1, offset: 61522},
 			expr: &notExpr{
-				pos: position{line: 1934, col: 8, offset: 61523},
+				pos: position{line: 1934, col: 8, offset: 61529},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1934, col: 9, offset: 61524},
+					pos:  position{line: 1934, col: 9, offset: 61530},
 					name: "KeyWordChars",
 				},
 			},
@@ -13860,15 +13860,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1938, col: 1, offset: 61560},
+			pos:  position{line: 1938, col: 1, offset: 61566},
 			expr: &actionExpr{
-				pos: position{line: 1939, col: 5, offset: 61573},
+				pos: position{line: 1939, col: 5, offset: 61579},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1939, col: 5, offset: 61573},
+					pos:   position{line: 1939, col: 5, offset: 61579},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1939, col: 7, offset: 61575},
+						pos:  position{line: 1939, col: 7, offset: 61581},
 						name: "Seq",
 					},
 				},
@@ -13878,27 +13878,27 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1947, col: 1, offset: 61721},
+			pos:  position{line: 1947, col: 1, offset: 61727},
 			expr: &actionExpr{
-				pos: position{line: 1947, col: 12, offset: 61732},
+				pos: position{line: 1947, col: 12, offset: 61738},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1947, col: 12, offset: 61732},
+					pos: position{line: 1947, col: 12, offset: 61738},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1947, col: 12, offset: 61732},
+							pos: position{line: 1947, col: 12, offset: 61738},
 							expr: &litMatcher{
-								pos:        position{line: 1947, col: 13, offset: 61733},
+								pos:        position{line: 1947, col: 13, offset: 61739},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1947, col: 17, offset: 61737},
+							pos:   position{line: 1947, col: 17, offset: 61743},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 20, offset: 61740},
+								pos:  position{line: 1947, col: 20, offset: 61746},
 								name: "SelectExpr",
 							},
 						},
@@ -13910,65 +13910,69 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1949, col: 1, offset: 61770},
+			pos:  position{line: 1949, col: 1, offset: 61776},
 			expr: &actionExpr{
-				pos: position{line: 1950, col: 5, offset: 61786},
+				pos: position{line: 1950, col: 5, offset: 61792},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1950, col: 5, offset: 61786},
+					pos: position{line: 1950, col: 5, offset: 61792},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1950, col: 5, offset: 61786},
+							pos:   position{line: 1950, col: 5, offset: 61792},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1950, col: 10, offset: 61791},
+								pos:  position{line: 1950, col: 10, offset: 61797},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1951, col: 5, offset: 61809},
+							pos:   position{line: 1951, col: 5, offset: 61815},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1952, col: 9, offset: 61824},
+								pos: position{line: 1952, col: 9, offset: 61830},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1952, col: 9, offset: 61824},
+										pos:  position{line: 1952, col: 9, offset: 61830},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1953, col: 9, offset: 61845},
+										pos:  position{line: 1953, col: 9, offset: 61851},
 										name: "Select",
 									},
+									&ruleRefExpr{
+										pos:  position{line: 1954, col: 9, offset: 61866},
+										name: "Values",
+									},
 									&actionExpr{
-										pos: position{line: 1954, col: 9, offset: 61860},
-										run: (*parser).callonSelectExpr9,
+										pos: position{line: 1955, col: 9, offset: 61881},
+										run: (*parser).callonSelectExpr10,
 										expr: &seqExpr{
-											pos: position{line: 1954, col: 9, offset: 61860},
+											pos: position{line: 1955, col: 9, offset: 61881},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1954, col: 9, offset: 61860},
+													pos:        position{line: 1955, col: 9, offset: 61881},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1954, col: 13, offset: 61864},
+													pos:  position{line: 1955, col: 13, offset: 61885},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1954, col: 16, offset: 61867},
+													pos:   position{line: 1955, col: 16, offset: 61888},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1954, col: 18, offset: 61869},
+														pos:  position{line: 1955, col: 18, offset: 61890},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1954, col: 26, offset: 61877},
+													pos:  position{line: 1955, col: 26, offset: 61898},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1954, col: 28, offset: 61879},
+													pos:        position{line: 1955, col: 28, offset: 61900},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13980,18 +13984,18 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1956, col: 5, offset: 61916},
+							pos:   position{line: 1957, col: 5, offset: 61937},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1956, col: 13, offset: 61924},
+								pos:  position{line: 1957, col: 13, offset: 61945},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1957, col: 5, offset: 61945},
+							pos:   position{line: 1958, col: 5, offset: 61966},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1957, col: 10, offset: 61950},
+								pos:  position{line: 1958, col: 10, offset: 61971},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -14003,74 +14007,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1977, col: 1, offset: 62346},
+			pos:  position{line: 1978, col: 1, offset: 62367},
 			expr: &actionExpr{
-				pos: position{line: 1978, col: 5, offset: 62358},
+				pos: position{line: 1979, col: 5, offset: 62379},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1978, col: 5, offset: 62358},
+					pos: position{line: 1979, col: 5, offset: 62379},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1978, col: 5, offset: 62358},
+							pos:  position{line: 1979, col: 5, offset: 62379},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1979, col: 5, offset: 62370},
+							pos:   position{line: 1980, col: 5, offset: 62391},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1979, col: 14, offset: 62379},
+								pos:  position{line: 1980, col: 14, offset: 62400},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1980, col: 5, offset: 62395},
+							pos:   position{line: 1981, col: 5, offset: 62416},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1980, col: 11, offset: 62401},
+								pos:  position{line: 1981, col: 11, offset: 62422},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1983, col: 5, offset: 62541},
+							pos:  position{line: 1984, col: 5, offset: 62562},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1983, col: 7, offset: 62543},
+							pos:   position{line: 1984, col: 7, offset: 62564},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1983, col: 17, offset: 62553},
+								pos:  position{line: 1984, col: 17, offset: 62574},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1984, col: 5, offset: 62567},
+							pos:   position{line: 1985, col: 5, offset: 62588},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1984, col: 10, offset: 62572},
+								pos:  position{line: 1985, col: 10, offset: 62593},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1985, col: 5, offset: 62590},
+							pos:   position{line: 1986, col: 5, offset: 62611},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1985, col: 11, offset: 62596},
+								pos:  position{line: 1986, col: 11, offset: 62617},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1986, col: 5, offset: 62615},
+							pos:   position{line: 1987, col: 5, offset: 62636},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1986, col: 11, offset: 62621},
+								pos:  position{line: 1987, col: 11, offset: 62642},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1987, col: 5, offset: 62640},
+							pos:   position{line: 1988, col: 5, offset: 62661},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 12, offset: 62647},
+								pos:  position{line: 1988, col: 12, offset: 62668},
 								name: "OptHavingClause",
 							},
 						},
@@ -14081,50 +14085,81 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
+			name: "Values",
+			pos:  position{line: 2014, col: 1, offset: 63274},
+			expr: &actionExpr{
+				pos: position{line: 2015, col: 5, offset: 63285},
+				run: (*parser).callonValues1,
+				expr: &seqExpr{
+					pos: position{line: 2015, col: 5, offset: 63285},
+					exprs: []any{
+						&ruleRefExpr{
+							pos:  position{line: 2015, col: 5, offset: 63285},
+							name: "VALUES",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 2015, col: 12, offset: 63292},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 2015, col: 14, offset: 63294},
+							label: "exprs",
+							expr: &ruleRefExpr{
+								pos:  position{line: 2015, col: 20, offset: 63300},
+								name: "Exprs",
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
 			name: "OptDistinct",
-			pos:  position{line: 2013, col: 1, offset: 63253},
+			pos:  position{line: 2023, col: 1, offset: 63446},
 			expr: &choiceExpr{
-				pos: position{line: 2014, col: 5, offset: 63269},
+				pos: position{line: 2024, col: 5, offset: 63462},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2014, col: 5, offset: 63269},
+						pos: position{line: 2024, col: 5, offset: 63462},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2014, col: 5, offset: 63269},
+							pos: position{line: 2024, col: 5, offset: 63462},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2014, col: 5, offset: 63269},
+									pos:  position{line: 2024, col: 5, offset: 63462},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2014, col: 7, offset: 63271},
+									pos:  position{line: 2024, col: 7, offset: 63464},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2015, col: 5, offset: 63308},
+						pos: position{line: 2025, col: 5, offset: 63501},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2015, col: 5, offset: 63308},
+							pos: position{line: 2025, col: 5, offset: 63501},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2015, col: 5, offset: 63308},
+									pos:  position{line: 2025, col: 5, offset: 63501},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2015, col: 7, offset: 63310},
+									pos:  position{line: 2025, col: 7, offset: 63503},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2016, col: 5, offset: 63346},
+						pos: position{line: 2026, col: 5, offset: 63539},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2016, col: 5, offset: 63346},
+							pos:        position{line: 2026, col: 5, offset: 63539},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14137,57 +14172,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2018, col: 1, offset: 63385},
+			pos:  position{line: 2028, col: 1, offset: 63578},
 			expr: &choiceExpr{
-				pos: position{line: 2019, col: 5, offset: 63404},
+				pos: position{line: 2029, col: 5, offset: 63597},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2019, col: 5, offset: 63404},
+						pos: position{line: 2029, col: 5, offset: 63597},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2019, col: 5, offset: 63404},
+							pos: position{line: 2029, col: 5, offset: 63597},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2019, col: 5, offset: 63404},
+									pos:  position{line: 2029, col: 5, offset: 63597},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2019, col: 7, offset: 63406},
+									pos:  position{line: 2029, col: 7, offset: 63599},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2019, col: 10, offset: 63409},
+									pos:  position{line: 2029, col: 10, offset: 63602},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2019, col: 12, offset: 63411},
+									pos:  position{line: 2029, col: 12, offset: 63604},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2020, col: 5, offset: 63443},
+						pos: position{line: 2030, col: 5, offset: 63636},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2020, col: 5, offset: 63443},
+							pos: position{line: 2030, col: 5, offset: 63636},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2020, col: 5, offset: 63443},
+									pos:  position{line: 2030, col: 5, offset: 63636},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2020, col: 7, offset: 63445},
+									pos:  position{line: 2030, col: 7, offset: 63638},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2021, col: 5, offset: 63516},
+						pos: position{line: 2031, col: 5, offset: 63709},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2021, col: 5, offset: 63516},
+							pos:        position{line: 2031, col: 5, offset: 63709},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14200,19 +14235,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2023, col: 1, offset: 63559},
+			pos:  position{line: 2033, col: 1, offset: 63752},
 			expr: &choiceExpr{
-				pos: position{line: 2024, col: 5, offset: 63578},
+				pos: position{line: 2034, col: 5, offset: 63771},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2024, col: 5, offset: 63578},
+						pos:  position{line: 2034, col: 5, offset: 63771},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2025, col: 5, offset: 63594},
+						pos: position{line: 2035, col: 5, offset: 63787},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2025, col: 5, offset: 63594},
+							pos:        position{line: 2035, col: 5, offset: 63787},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14225,38 +14260,38 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2027, col: 1, offset: 63627},
+			pos:  position{line: 2037, col: 1, offset: 63820},
 			expr: &actionExpr{
-				pos: position{line: 2028, col: 5, offset: 63643},
+				pos: position{line: 2038, col: 5, offset: 63836},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2028, col: 5, offset: 63643},
+					pos: position{line: 2038, col: 5, offset: 63836},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 5, offset: 63643},
+							pos:  position{line: 2038, col: 5, offset: 63836},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 7, offset: 63645},
+							pos:  position{line: 2038, col: 7, offset: 63838},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2028, col: 12, offset: 63650},
+							pos:   position{line: 2038, col: 12, offset: 63843},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2028, col: 14, offset: 63652},
+								pos:  position{line: 2038, col: 14, offset: 63845},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 27, offset: 63665},
+							pos:  position{line: 2038, col: 27, offset: 63858},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2028, col: 29, offset: 63667},
+							pos:   position{line: 2038, col: 29, offset: 63860},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2028, col: 34, offset: 63672},
+								pos:  position{line: 2038, col: 34, offset: 63865},
 								name: "CteList",
 							},
 						},
@@ -14268,32 +14303,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2037, col: 1, offset: 63857},
+			pos:  position{line: 2047, col: 1, offset: 64050},
 			expr: &choiceExpr{
-				pos: position{line: 2038, col: 5, offset: 63875},
+				pos: position{line: 2048, col: 5, offset: 64068},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2038, col: 5, offset: 63875},
+						pos: position{line: 2048, col: 5, offset: 64068},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2038, col: 5, offset: 63875},
+							pos: position{line: 2048, col: 5, offset: 64068},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2038, col: 5, offset: 63875},
+									pos:  position{line: 2048, col: 5, offset: 64068},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2038, col: 7, offset: 63877},
+									pos:  position{line: 2048, col: 7, offset: 64070},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2039, col: 5, offset: 63913},
+						pos: position{line: 2049, col: 5, offset: 64106},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2039, col: 5, offset: 63913},
+							pos:        position{line: 2049, col: 5, offset: 64106},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14306,51 +14341,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2041, col: 1, offset: 63952},
+			pos:  position{line: 2051, col: 1, offset: 64145},
 			expr: &actionExpr{
-				pos: position{line: 2041, col: 11, offset: 63962},
+				pos: position{line: 2051, col: 11, offset: 64155},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2041, col: 11, offset: 63962},
+					pos: position{line: 2051, col: 11, offset: 64155},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2041, col: 11, offset: 63962},
+							pos:   position{line: 2051, col: 11, offset: 64155},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2041, col: 17, offset: 63968},
+								pos:  position{line: 2051, col: 17, offset: 64161},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2041, col: 21, offset: 63972},
+							pos:   position{line: 2051, col: 21, offset: 64165},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2041, col: 26, offset: 63977},
+								pos: position{line: 2051, col: 26, offset: 64170},
 								expr: &actionExpr{
-									pos: position{line: 2041, col: 28, offset: 63979},
+									pos: position{line: 2051, col: 28, offset: 64172},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2041, col: 28, offset: 63979},
+										pos: position{line: 2051, col: 28, offset: 64172},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2041, col: 28, offset: 63979},
+												pos:  position{line: 2051, col: 28, offset: 64172},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2041, col: 31, offset: 63982},
+												pos:        position{line: 2051, col: 31, offset: 64175},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2041, col: 35, offset: 63986},
+												pos:  position{line: 2051, col: 35, offset: 64179},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2041, col: 38, offset: 63989},
+												pos:   position{line: 2051, col: 38, offset: 64182},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2041, col: 42, offset: 63993},
+													pos:  position{line: 2051, col: 42, offset: 64186},
 													name: "Cte",
 												},
 											},
@@ -14367,65 +14402,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2045, col: 1, offset: 64062},
+			pos:  position{line: 2055, col: 1, offset: 64255},
 			expr: &actionExpr{
-				pos: position{line: 2046, col: 5, offset: 64070},
+				pos: position{line: 2056, col: 5, offset: 64263},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2046, col: 5, offset: 64070},
+					pos: position{line: 2056, col: 5, offset: 64263},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2046, col: 5, offset: 64070},
+							pos:   position{line: 2056, col: 5, offset: 64263},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2046, col: 10, offset: 64075},
+								pos:  position{line: 2056, col: 10, offset: 64268},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2046, col: 24, offset: 64089},
+							pos:  position{line: 2056, col: 24, offset: 64282},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2046, col: 26, offset: 64091},
+							pos:  position{line: 2056, col: 26, offset: 64284},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2046, col: 29, offset: 64094},
+							pos:   position{line: 2056, col: 29, offset: 64287},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2046, col: 31, offset: 64096},
+								pos:  position{line: 2056, col: 31, offset: 64289},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2046, col: 47, offset: 64112},
+							pos:  position{line: 2056, col: 47, offset: 64305},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2046, col: 50, offset: 64115},
+							pos:        position{line: 2056, col: 50, offset: 64308},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2046, col: 54, offset: 64119},
+							pos:  position{line: 2056, col: 54, offset: 64312},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2046, col: 57, offset: 64122},
+							pos:   position{line: 2056, col: 57, offset: 64315},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2046, col: 59, offset: 64124},
+								pos:  position{line: 2056, col: 59, offset: 64317},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2046, col: 67, offset: 64132},
+							pos:  position{line: 2056, col: 67, offset: 64325},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2046, col: 70, offset: 64135},
+							pos:        position{line: 2056, col: 70, offset: 64328},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14438,65 +14473,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2055, col: 1, offset: 64310},
+			pos:  position{line: 2065, col: 1, offset: 64509},
 			expr: &choiceExpr{
-				pos: position{line: 2056, col: 5, offset: 64331},
+				pos: position{line: 2066, col: 5, offset: 64530},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2056, col: 5, offset: 64331},
+						pos: position{line: 2066, col: 5, offset: 64530},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2056, col: 5, offset: 64331},
+							pos: position{line: 2066, col: 5, offset: 64530},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2056, col: 5, offset: 64331},
+									pos:  position{line: 2066, col: 5, offset: 64530},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2056, col: 7, offset: 64333},
+									pos:  position{line: 2066, col: 7, offset: 64532},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2056, col: 20, offset: 64346},
+									pos:  position{line: 2066, col: 20, offset: 64545},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2057, col: 5, offset: 64385},
+						pos: position{line: 2067, col: 5, offset: 64584},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2057, col: 5, offset: 64385},
+							pos: position{line: 2067, col: 5, offset: 64584},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 5, offset: 64385},
+									pos:  position{line: 2067, col: 5, offset: 64584},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 7, offset: 64387},
+									pos:  position{line: 2067, col: 7, offset: 64586},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 11, offset: 64391},
+									pos:  position{line: 2067, col: 11, offset: 64590},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 13, offset: 64393},
+									pos:  position{line: 2067, col: 13, offset: 64592},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 26, offset: 64406},
+									pos:  position{line: 2067, col: 26, offset: 64605},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2058, col: 5, offset: 64437},
+						pos: position{line: 2068, col: 5, offset: 64636},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2058, col: 5, offset: 64437},
+							pos:        position{line: 2068, col: 5, offset: 64636},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14509,25 +14544,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2060, col: 1, offset: 64492},
+			pos:  position{line: 2070, col: 1, offset: 64691},
 			expr: &choiceExpr{
-				pos: position{line: 2061, col: 5, offset: 64509},
+				pos: position{line: 2071, col: 5, offset: 64708},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2061, col: 5, offset: 64509},
+						pos: position{line: 2071, col: 5, offset: 64708},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2061, col: 5, offset: 64509},
+								pos:  position{line: 2071, col: 5, offset: 64708},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2061, col: 7, offset: 64511},
+								pos:  position{line: 2071, col: 7, offset: 64710},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2062, col: 5, offset: 64520},
+						pos:        position{line: 2072, col: 5, offset: 64719},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14539,25 +14574,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2064, col: 1, offset: 64524},
+			pos:  position{line: 2074, col: 1, offset: 64723},
 			expr: &choiceExpr{
-				pos: position{line: 2065, col: 5, offset: 64542},
+				pos: position{line: 2075, col: 5, offset: 64741},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2065, col: 5, offset: 64542},
+						pos: position{line: 2075, col: 5, offset: 64741},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2065, col: 5, offset: 64542},
+							pos: position{line: 2075, col: 5, offset: 64741},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2065, col: 5, offset: 64542},
+									pos:  position{line: 2075, col: 5, offset: 64741},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2065, col: 7, offset: 64544},
+									pos:   position{line: 2075, col: 7, offset: 64743},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2065, col: 12, offset: 64549},
+										pos:  position{line: 2075, col: 12, offset: 64748},
 										name: "FromOp",
 									},
 								},
@@ -14565,10 +14600,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2068, col: 5, offset: 64591},
+						pos: position{line: 2078, col: 5, offset: 64790},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2068, col: 5, offset: 64591},
+							pos:        position{line: 2078, col: 5, offset: 64790},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14581,27 +14616,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2070, col: 1, offset: 64632},
+			pos:  position{line: 2080, col: 1, offset: 64831},
 			expr: &choiceExpr{
-				pos: position{line: 2071, col: 5, offset: 64651},
+				pos: position{line: 2081, col: 5, offset: 64850},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2071, col: 5, offset: 64651},
+						pos: position{line: 2081, col: 5, offset: 64850},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2071, col: 5, offset: 64651},
+							pos:   position{line: 2081, col: 5, offset: 64850},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2071, col: 11, offset: 64657},
+								pos:  position{line: 2081, col: 11, offset: 64856},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2072, col: 5, offset: 64699},
+						pos: position{line: 2082, col: 5, offset: 64898},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2072, col: 5, offset: 64699},
+							pos:        position{line: 2082, col: 5, offset: 64898},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14614,25 +14649,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2074, col: 1, offset: 64744},
+			pos:  position{line: 2084, col: 1, offset: 64943},
 			expr: &choiceExpr{
-				pos: position{line: 2075, col: 5, offset: 64763},
+				pos: position{line: 2085, col: 5, offset: 64962},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2075, col: 5, offset: 64763},
+						pos: position{line: 2085, col: 5, offset: 64962},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2075, col: 5, offset: 64763},
+							pos: position{line: 2085, col: 5, offset: 64962},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2075, col: 5, offset: 64763},
+									pos:  position{line: 2085, col: 5, offset: 64962},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2075, col: 7, offset: 64765},
+									pos:   position{line: 2085, col: 7, offset: 64964},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2075, col: 13, offset: 64771},
+										pos:  position{line: 2085, col: 13, offset: 64970},
 										name: "GroupClause",
 									},
 								},
@@ -14640,10 +14675,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2076, col: 5, offset: 64809},
+						pos: position{line: 2086, col: 5, offset: 65008},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2076, col: 5, offset: 64809},
+							pos:        position{line: 2086, col: 5, offset: 65008},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14656,34 +14691,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2078, col: 1, offset: 64850},
+			pos:  position{line: 2088, col: 1, offset: 65049},
 			expr: &actionExpr{
-				pos: position{line: 2079, col: 5, offset: 64866},
+				pos: position{line: 2089, col: 5, offset: 65065},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2079, col: 5, offset: 64866},
+					pos: position{line: 2089, col: 5, offset: 65065},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 5, offset: 64866},
+							pos:  position{line: 2089, col: 5, offset: 65065},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 11, offset: 64872},
+							pos:  position{line: 2089, col: 11, offset: 65071},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 13, offset: 64874},
+							pos:  position{line: 2089, col: 13, offset: 65073},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 16, offset: 64877},
+							pos:  position{line: 2089, col: 16, offset: 65076},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2079, col: 18, offset: 64879},
+							pos:   position{line: 2089, col: 18, offset: 65078},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2079, col: 23, offset: 64884},
+								pos:  position{line: 2089, col: 23, offset: 65083},
 								name: "GroupByList",
 							},
 						},
@@ -14695,51 +14730,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2081, col: 1, offset: 64918},
+			pos:  position{line: 2091, col: 1, offset: 65117},
 			expr: &actionExpr{
-				pos: position{line: 2082, col: 5, offset: 64935},
+				pos: position{line: 2092, col: 5, offset: 65134},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2082, col: 5, offset: 64935},
+					pos: position{line: 2092, col: 5, offset: 65134},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2082, col: 5, offset: 64935},
+							pos:   position{line: 2092, col: 5, offset: 65134},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2082, col: 11, offset: 64941},
+								pos:  position{line: 2092, col: 11, offset: 65140},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2082, col: 23, offset: 64953},
+							pos:   position{line: 2092, col: 23, offset: 65152},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2082, col: 28, offset: 64958},
+								pos: position{line: 2092, col: 28, offset: 65157},
 								expr: &actionExpr{
-									pos: position{line: 2082, col: 30, offset: 64960},
+									pos: position{line: 2092, col: 30, offset: 65159},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2082, col: 30, offset: 64960},
+										pos: position{line: 2092, col: 30, offset: 65159},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2082, col: 30, offset: 64960},
+												pos:  position{line: 2092, col: 30, offset: 65159},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2082, col: 33, offset: 64963},
+												pos:        position{line: 2092, col: 33, offset: 65162},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2082, col: 37, offset: 64967},
+												pos:  position{line: 2092, col: 37, offset: 65166},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2082, col: 40, offset: 64970},
+												pos:   position{line: 2092, col: 40, offset: 65169},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2082, col: 42, offset: 64972},
+													pos:  position{line: 2092, col: 42, offset: 65171},
 													name: "GroupByItem",
 												},
 											},
@@ -14756,9 +14791,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2086, col: 1, offset: 65053},
+			pos:  position{line: 2096, col: 1, offset: 65252},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2086, col: 15, offset: 65067},
+				pos:  position{line: 2096, col: 15, offset: 65266},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14766,25 +14801,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2088, col: 1, offset: 65073},
+			pos:  position{line: 2098, col: 1, offset: 65272},
 			expr: &choiceExpr{
-				pos: position{line: 2089, col: 5, offset: 65093},
+				pos: position{line: 2099, col: 5, offset: 65292},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2089, col: 5, offset: 65093},
+						pos: position{line: 2099, col: 5, offset: 65292},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2089, col: 5, offset: 65093},
+							pos: position{line: 2099, col: 5, offset: 65292},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2089, col: 5, offset: 65093},
+									pos:  position{line: 2099, col: 5, offset: 65292},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2089, col: 7, offset: 65095},
+									pos:   position{line: 2099, col: 7, offset: 65294},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2089, col: 9, offset: 65097},
+										pos:  position{line: 2099, col: 9, offset: 65296},
 										name: "HavingClause",
 									},
 								},
@@ -14792,10 +14827,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2090, col: 5, offset: 65132},
+						pos: position{line: 2100, col: 5, offset: 65331},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2090, col: 5, offset: 65132},
+							pos:        position{line: 2100, col: 5, offset: 65331},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14808,26 +14843,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2092, col: 1, offset: 65156},
+			pos:  position{line: 2102, col: 1, offset: 65355},
 			expr: &actionExpr{
-				pos: position{line: 2093, col: 5, offset: 65173},
+				pos: position{line: 2103, col: 5, offset: 65372},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2093, col: 5, offset: 65173},
+					pos: position{line: 2103, col: 5, offset: 65372},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2093, col: 5, offset: 65173},
+							pos:  position{line: 2103, col: 5, offset: 65372},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2093, col: 12, offset: 65180},
+							pos:  position{line: 2103, col: 12, offset: 65379},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2093, col: 14, offset: 65182},
+							pos:   position{line: 2103, col: 14, offset: 65381},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2093, col: 16, offset: 65184},
+								pos:  position{line: 2103, col: 16, offset: 65383},
 								name: "Expr",
 							},
 						},
@@ -14839,16 +14874,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2095, col: 1, offset: 65208},
+			pos:  position{line: 2105, col: 1, offset: 65407},
 			expr: &choiceExpr{
-				pos: position{line: 2096, col: 5, offset: 65226},
+				pos: position{line: 2106, col: 5, offset: 65425},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2096, col: 5, offset: 65226},
+						pos:  position{line: 2106, col: 5, offset: 65425},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2097, col: 5, offset: 65240},
+						pos:  position{line: 2107, col: 5, offset: 65439},
 						name: "ConditionJoin",
 					},
 				},
@@ -14858,30 +14893,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2099, col: 1, offset: 65255},
+			pos:  position{line: 2109, col: 1, offset: 65454},
 			expr: &actionExpr{
-				pos: position{line: 2100, col: 5, offset: 65269},
+				pos: position{line: 2110, col: 5, offset: 65468},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2100, col: 5, offset: 65269},
+					pos: position{line: 2110, col: 5, offset: 65468},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2100, col: 5, offset: 65269},
+							pos:   position{line: 2110, col: 5, offset: 65468},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2100, col: 10, offset: 65274},
+								pos:  position{line: 2110, col: 10, offset: 65473},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2100, col: 19, offset: 65283},
+							pos:  position{line: 2110, col: 19, offset: 65482},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2100, col: 31, offset: 65295},
+							pos:   position{line: 2110, col: 31, offset: 65494},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2100, col: 37, offset: 65301},
+								pos:  position{line: 2110, col: 37, offset: 65500},
 								name: "FromElem",
 							},
 						},
@@ -14893,50 +14928,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2109, col: 1, offset: 65503},
+			pos:  position{line: 2119, col: 1, offset: 65702},
 			expr: &choiceExpr{
-				pos: position{line: 2110, col: 5, offset: 65520},
+				pos: position{line: 2120, col: 5, offset: 65719},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2110, col: 5, offset: 65520},
+						pos: position{line: 2120, col: 5, offset: 65719},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2110, col: 5, offset: 65520},
+								pos:  position{line: 2120, col: 5, offset: 65719},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2110, col: 8, offset: 65523},
+								pos:        position{line: 2120, col: 8, offset: 65722},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2110, col: 12, offset: 65527},
+								pos:  position{line: 2120, col: 12, offset: 65726},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2111, col: 5, offset: 65535},
+						pos: position{line: 2121, col: 5, offset: 65734},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2111, col: 5, offset: 65535},
+								pos:  position{line: 2121, col: 5, offset: 65734},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2111, col: 7, offset: 65537},
+								pos:  position{line: 2121, col: 7, offset: 65736},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2111, col: 13, offset: 65543},
+								pos:  position{line: 2121, col: 13, offset: 65742},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2111, col: 15, offset: 65545},
+								pos:  position{line: 2121, col: 15, offset: 65744},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2111, col: 20, offset: 65550},
+								pos:  position{line: 2121, col: 20, offset: 65749},
 								name: "_",
 							},
 						},
@@ -14948,46 +14983,46 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2113, col: 1, offset: 65554},
+			pos:  position{line: 2123, col: 1, offset: 65753},
 			expr: &actionExpr{
-				pos: position{line: 2114, col: 5, offset: 65572},
+				pos: position{line: 2124, col: 5, offset: 65771},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2114, col: 5, offset: 65572},
+					pos: position{line: 2124, col: 5, offset: 65771},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2114, col: 5, offset: 65572},
+							pos:   position{line: 2124, col: 5, offset: 65771},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2114, col: 10, offset: 65577},
+								pos:  position{line: 2124, col: 10, offset: 65776},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2114, col: 19, offset: 65586},
+							pos:   position{line: 2124, col: 19, offset: 65785},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2114, col: 25, offset: 65592},
+								pos:  position{line: 2124, col: 25, offset: 65791},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2114, col: 38, offset: 65605},
+							pos:  position{line: 2124, col: 38, offset: 65804},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2114, col: 40, offset: 65607},
+							pos:   position{line: 2124, col: 40, offset: 65806},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2114, col: 46, offset: 65613},
+								pos:  position{line: 2124, col: 46, offset: 65812},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2114, col: 55, offset: 65622},
+							pos:   position{line: 2124, col: 55, offset: 65821},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2114, col: 57, offset: 65624},
+								pos:  position{line: 2124, col: 57, offset: 65823},
 								name: "JoinExpr",
 							},
 						},
@@ -14999,161 +15034,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2125, col: 1, offset: 65893},
+			pos:  position{line: 2135, col: 1, offset: 66092},
 			expr: &choiceExpr{
-				pos: position{line: 2126, col: 5, offset: 65911},
+				pos: position{line: 2136, col: 5, offset: 66110},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2126, col: 5, offset: 65911},
+						pos: position{line: 2136, col: 5, offset: 66110},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2126, col: 5, offset: 65911},
+							pos: position{line: 2136, col: 5, offset: 66110},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2126, col: 5, offset: 65911},
+									pos: position{line: 2136, col: 5, offset: 66110},
 									expr: &seqExpr{
-										pos: position{line: 2126, col: 6, offset: 65912},
+										pos: position{line: 2136, col: 6, offset: 66111},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2126, col: 6, offset: 65912},
+												pos:  position{line: 2136, col: 6, offset: 66111},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2126, col: 8, offset: 65914},
+												pos:  position{line: 2136, col: 8, offset: 66113},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2126, col: 16, offset: 65922},
+									pos:  position{line: 2136, col: 16, offset: 66121},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2126, col: 18, offset: 65924},
+									pos:  position{line: 2136, col: 18, offset: 66123},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2127, col: 5, offset: 65969},
+						pos: position{line: 2137, col: 5, offset: 66168},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2127, col: 5, offset: 65969},
+							pos: position{line: 2137, col: 5, offset: 66168},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 5, offset: 65969},
+									pos:  position{line: 2137, col: 5, offset: 66168},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 7, offset: 65971},
+									pos:  position{line: 2137, col: 7, offset: 66170},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2127, col: 12, offset: 65976},
+									pos: position{line: 2137, col: 12, offset: 66175},
 									expr: &seqExpr{
-										pos: position{line: 2127, col: 13, offset: 65977},
+										pos: position{line: 2137, col: 13, offset: 66176},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2127, col: 13, offset: 65977},
+												pos:  position{line: 2137, col: 13, offset: 66176},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2127, col: 15, offset: 65979},
+												pos:  position{line: 2137, col: 15, offset: 66178},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 23, offset: 65987},
+									pos:  position{line: 2137, col: 23, offset: 66186},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 25, offset: 65989},
+									pos:  position{line: 2137, col: 25, offset: 66188},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2128, col: 5, offset: 66023},
+						pos: position{line: 2138, col: 5, offset: 66222},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2128, col: 5, offset: 66023},
+							pos: position{line: 2138, col: 5, offset: 66222},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 5, offset: 66023},
+									pos:  position{line: 2138, col: 5, offset: 66222},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 7, offset: 66025},
+									pos:  position{line: 2138, col: 7, offset: 66224},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2128, col: 12, offset: 66030},
+									pos: position{line: 2138, col: 12, offset: 66229},
 									expr: &seqExpr{
-										pos: position{line: 2128, col: 13, offset: 66031},
+										pos: position{line: 2138, col: 13, offset: 66230},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2128, col: 13, offset: 66031},
+												pos:  position{line: 2138, col: 13, offset: 66230},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2128, col: 15, offset: 66033},
+												pos:  position{line: 2138, col: 15, offset: 66232},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 23, offset: 66041},
+									pos:  position{line: 2138, col: 23, offset: 66240},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 25, offset: 66043},
+									pos:  position{line: 2138, col: 25, offset: 66242},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2129, col: 5, offset: 66077},
+						pos: position{line: 2139, col: 5, offset: 66276},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2129, col: 5, offset: 66077},
+							pos: position{line: 2139, col: 5, offset: 66276},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 5, offset: 66077},
+									pos:  position{line: 2139, col: 5, offset: 66276},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 7, offset: 66079},
+									pos:  position{line: 2139, col: 7, offset: 66278},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2129, col: 13, offset: 66085},
+									pos: position{line: 2139, col: 13, offset: 66284},
 									expr: &seqExpr{
-										pos: position{line: 2129, col: 14, offset: 66086},
+										pos: position{line: 2139, col: 14, offset: 66285},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2129, col: 14, offset: 66086},
+												pos:  position{line: 2139, col: 14, offset: 66285},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2129, col: 16, offset: 66088},
+												pos:  position{line: 2139, col: 16, offset: 66287},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 24, offset: 66096},
+									pos:  position{line: 2139, col: 24, offset: 66295},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 26, offset: 66098},
+									pos:  position{line: 2139, col: 26, offset: 66297},
 									name: "JOIN",
 								},
 							},
@@ -15166,33 +15201,33 @@ var g = &grammar{
 		},
 		{
 			name: "JoinExpr",
-			pos:  position{line: 2131, col: 1, offset: 66130},
+			pos:  position{line: 2141, col: 1, offset: 66329},
 			expr: &choiceExpr{
-				pos: position{line: 2132, col: 5, offset: 66144},
+				pos: position{line: 2142, col: 5, offset: 66343},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2132, col: 5, offset: 66144},
+						pos: position{line: 2142, col: 5, offset: 66343},
 						run: (*parser).callonJoinExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2132, col: 5, offset: 66144},
+							pos: position{line: 2142, col: 5, offset: 66343},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2132, col: 5, offset: 66144},
+									pos:  position{line: 2142, col: 5, offset: 66343},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2132, col: 7, offset: 66146},
+									pos:  position{line: 2142, col: 7, offset: 66345},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2132, col: 10, offset: 66149},
+									pos:  position{line: 2142, col: 10, offset: 66348},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2132, col: 12, offset: 66151},
+									pos:   position{line: 2142, col: 12, offset: 66350},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2132, col: 14, offset: 66153},
+										pos:  position{line: 2142, col: 14, offset: 66352},
 										name: "Expr",
 									},
 								},
@@ -15200,47 +15235,47 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2139, col: 5, offset: 66308},
+						pos: position{line: 2149, col: 5, offset: 66507},
 						run: (*parser).callonJoinExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2139, col: 5, offset: 66308},
+							pos: position{line: 2149, col: 5, offset: 66507},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2139, col: 5, offset: 66308},
+									pos:  position{line: 2149, col: 5, offset: 66507},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2139, col: 7, offset: 66310},
+									pos:  position{line: 2149, col: 7, offset: 66509},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2139, col: 13, offset: 66316},
+									pos:  position{line: 2149, col: 13, offset: 66515},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2139, col: 16, offset: 66319},
+									pos:        position{line: 2149, col: 16, offset: 66518},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2139, col: 20, offset: 66323},
+									pos:  position{line: 2149, col: 20, offset: 66522},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2139, col: 23, offset: 66326},
+									pos:   position{line: 2149, col: 23, offset: 66525},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2139, col: 30, offset: 66333},
+										pos:  position{line: 2149, col: 30, offset: 66532},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2139, col: 36, offset: 66339},
+									pos:  position{line: 2149, col: 36, offset: 66538},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2139, col: 39, offset: 66342},
+									pos:        position{line: 2149, col: 39, offset: 66541},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -15255,40 +15290,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2147, col: 1, offset: 66512},
+			pos:  position{line: 2157, col: 1, offset: 66711},
 			expr: &choiceExpr{
-				pos: position{line: 2148, col: 5, offset: 66531},
+				pos: position{line: 2158, col: 5, offset: 66730},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2148, col: 5, offset: 66531},
+						pos: position{line: 2158, col: 5, offset: 66730},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2148, col: 5, offset: 66531},
+							pos: position{line: 2158, col: 5, offset: 66730},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2148, col: 5, offset: 66531},
+									pos:  position{line: 2158, col: 5, offset: 66730},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2148, col: 7, offset: 66533},
+									pos:  position{line: 2158, col: 7, offset: 66732},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2148, col: 12, offset: 66538},
+									pos:  position{line: 2158, col: 12, offset: 66737},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2148, col: 14, offset: 66540},
+									pos:  position{line: 2158, col: 14, offset: 66739},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2154, col: 5, offset: 66669},
+						pos: position{line: 2164, col: 5, offset: 66868},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2154, col: 5, offset: 66669},
+							pos:        position{line: 2164, col: 5, offset: 66868},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15301,25 +15336,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2156, col: 1, offset: 66718},
+			pos:  position{line: 2166, col: 1, offset: 66917},
 			expr: &choiceExpr{
-				pos: position{line: 2157, col: 5, offset: 66731},
+				pos: position{line: 2167, col: 5, offset: 66930},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2157, col: 5, offset: 66731},
+						pos: position{line: 2167, col: 5, offset: 66930},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2157, col: 5, offset: 66731},
+							pos: position{line: 2167, col: 5, offset: 66930},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2157, col: 5, offset: 66731},
+									pos:  position{line: 2167, col: 5, offset: 66930},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2157, col: 7, offset: 66733},
+									pos:   position{line: 2167, col: 7, offset: 66932},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2157, col: 9, offset: 66735},
+										pos:  position{line: 2167, col: 9, offset: 66934},
 										name: "AliasClause",
 									},
 								},
@@ -15327,10 +15362,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2158, col: 5, offset: 66769},
+						pos: position{line: 2168, col: 5, offset: 66968},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2158, col: 5, offset: 66769},
+							pos:        position{line: 2168, col: 5, offset: 66968},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15343,51 +15378,59 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2160, col: 1, offset: 66806},
+			pos:  position{line: 2170, col: 1, offset: 67005},
 			expr: &actionExpr{
-				pos: position{line: 2161, col: 5, offset: 66823},
+				pos: position{line: 2171, col: 5, offset: 67022},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2161, col: 5, offset: 66823},
+					pos: position{line: 2171, col: 5, offset: 67022},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2161, col: 5, offset: 66823},
+							pos: position{line: 2171, col: 5, offset: 67022},
 							expr: &seqExpr{
-								pos: position{line: 2161, col: 6, offset: 66824},
+								pos: position{line: 2171, col: 6, offset: 67023},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2161, col: 6, offset: 66824},
+										pos:  position{line: 2171, col: 6, offset: 67023},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2161, col: 9, offset: 66827},
+										pos:  position{line: 2171, col: 9, offset: 67026},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2161, col: 13, offset: 66831},
+							pos: position{line: 2171, col: 13, offset: 67030},
 							expr: &choiceExpr{
-								pos: position{line: 2161, col: 15, offset: 66833},
+								pos: position{line: 2171, col: 15, offset: 67032},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2161, col: 15, offset: 66833},
+										pos:  position{line: 2171, col: 15, offset: 67032},
 										name: "SQLGuard",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2161, col: 26, offset: 66844},
+										pos:  position{line: 2171, col: 26, offset: 67043},
 										name: "DeprecatedFroms",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2161, col: 43, offset: 66861},
+							pos:   position{line: 2171, col: 43, offset: 67060},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2161, col: 48, offset: 66866},
+								pos:  position{line: 2171, col: 48, offset: 67065},
 								name: "IdentifierName",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 2171, col: 63, offset: 67080},
+							label: "cols",
+							expr: &ruleRefExpr{
+								pos:  position{line: 2171, col: 68, offset: 67085},
+								name: "OptColumns",
 							},
 						},
 					},
@@ -15397,52 +15440,148 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
+			name: "OptColumns",
+			pos:  position{line: 2179, col: 1, offset: 67287},
+			expr: &choiceExpr{
+				pos: position{line: 2180, col: 5, offset: 67303},
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 2180, col: 5, offset: 67303},
+						run: (*parser).callonOptColumns2,
+						expr: &seqExpr{
+							pos: position{line: 2180, col: 5, offset: 67303},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 2180, col: 5, offset: 67303},
+									val:        "(",
+									ignoreCase: false,
+									want:       "\"(\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 2180, col: 9, offset: 67307},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 2180, col: 12, offset: 67310},
+									label: "first",
+									expr: &ruleRefExpr{
+										pos:  position{line: 2180, col: 18, offset: 67316},
+										name: "SQLIdentifier",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 2180, col: 32, offset: 67330},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 2180, col: 37, offset: 67335},
+										expr: &actionExpr{
+											pos: position{line: 2180, col: 39, offset: 67337},
+											run: (*parser).callonOptColumns10,
+											expr: &seqExpr{
+												pos: position{line: 2180, col: 39, offset: 67337},
+												exprs: []any{
+													&ruleRefExpr{
+														pos:  position{line: 2180, col: 39, offset: 67337},
+														name: "__",
+													},
+													&litMatcher{
+														pos:        position{line: 2180, col: 42, offset: 67340},
+														val:        ",",
+														ignoreCase: false,
+														want:       "\",\"",
+													},
+													&ruleRefExpr{
+														pos:  position{line: 2180, col: 46, offset: 67344},
+														name: "__",
+													},
+													&labeledExpr{
+														pos:   position{line: 2180, col: 49, offset: 67347},
+														label: "s",
+														expr: &ruleRefExpr{
+															pos:  position{line: 2180, col: 51, offset: 67349},
+															name: "SQLIdentifier",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 2180, col: 84, offset: 67382},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 2180, col: 87, offset: 67385},
+									val:        ")",
+									ignoreCase: false,
+									want:       "\")\"",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 2183, col: 5, offset: 67460},
+						run: (*parser).callonOptColumns19,
+						expr: &litMatcher{
+							pos:        position{line: 2183, col: 5, offset: 67460},
+							val:        "",
+							ignoreCase: false,
+							want:       "\"\"",
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
 			name: "Selection",
-			pos:  position{line: 2165, col: 1, offset: 66999},
+			pos:  position{line: 2185, col: 1, offset: 67484},
 			expr: &actionExpr{
-				pos: position{line: 2166, col: 5, offset: 67013},
+				pos: position{line: 2186, col: 5, offset: 67498},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2166, col: 5, offset: 67013},
+					pos: position{line: 2186, col: 5, offset: 67498},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2166, col: 5, offset: 67013},
+							pos:   position{line: 2186, col: 5, offset: 67498},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2166, col: 11, offset: 67019},
+								pos:  position{line: 2186, col: 11, offset: 67504},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2166, col: 22, offset: 67030},
+							pos:   position{line: 2186, col: 22, offset: 67515},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2166, col: 27, offset: 67035},
+								pos: position{line: 2186, col: 27, offset: 67520},
 								expr: &actionExpr{
-									pos: position{line: 2166, col: 29, offset: 67037},
+									pos: position{line: 2186, col: 29, offset: 67522},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2166, col: 29, offset: 67037},
+										pos: position{line: 2186, col: 29, offset: 67522},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2166, col: 29, offset: 67037},
+												pos:  position{line: 2186, col: 29, offset: 67522},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2166, col: 32, offset: 67040},
+												pos:        position{line: 2186, col: 32, offset: 67525},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2166, col: 36, offset: 67044},
+												pos:  position{line: 2186, col: 36, offset: 67529},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2166, col: 39, offset: 67047},
+												pos:   position{line: 2186, col: 39, offset: 67532},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2166, col: 41, offset: 67049},
+													pos:  position{line: 2186, col: 41, offset: 67534},
 													name: "SelectElem",
 												},
 											},
@@ -15459,38 +15598,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2175, col: 1, offset: 67275},
+			pos:  position{line: 2195, col: 1, offset: 67760},
 			expr: &choiceExpr{
-				pos: position{line: 2176, col: 5, offset: 67291},
+				pos: position{line: 2196, col: 5, offset: 67776},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2176, col: 5, offset: 67291},
+						pos: position{line: 2196, col: 5, offset: 67776},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2176, col: 5, offset: 67291},
+							pos: position{line: 2196, col: 5, offset: 67776},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2176, col: 5, offset: 67291},
+									pos:   position{line: 2196, col: 5, offset: 67776},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2176, col: 11, offset: 67297},
+										pos: position{line: 2196, col: 11, offset: 67782},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2176, col: 11, offset: 67297},
+												pos:  position{line: 2196, col: 11, offset: 67782},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2176, col: 25, offset: 67311},
+												pos:  position{line: 2196, col: 25, offset: 67796},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2176, col: 31, offset: 67317},
+									pos:   position{line: 2196, col: 31, offset: 67802},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2176, col: 34, offset: 67320},
+										pos:  position{line: 2196, col: 34, offset: 67805},
 										name: "OptAsClause",
 									},
 								},
@@ -15498,10 +15637,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2187, col: 5, offset: 67542},
+						pos: position{line: 2207, col: 5, offset: 68027},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2187, col: 5, offset: 67542},
+							pos:        position{line: 2207, col: 5, offset: 68027},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15514,33 +15653,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2192, col: 1, offset: 67644},
+			pos:  position{line: 2212, col: 1, offset: 68129},
 			expr: &choiceExpr{
-				pos: position{line: 2193, col: 5, offset: 67661},
+				pos: position{line: 2213, col: 5, offset: 68146},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2193, col: 5, offset: 67661},
+						pos: position{line: 2213, col: 5, offset: 68146},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2193, col: 5, offset: 67661},
+							pos: position{line: 2213, col: 5, offset: 68146},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2193, col: 5, offset: 67661},
+									pos:  position{line: 2213, col: 5, offset: 68146},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2193, col: 7, offset: 67663},
+									pos:  position{line: 2213, col: 7, offset: 68148},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2193, col: 10, offset: 67666},
+									pos:  position{line: 2213, col: 10, offset: 68151},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2193, col: 12, offset: 67668},
+									pos:   position{line: 2213, col: 12, offset: 68153},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2193, col: 15, offset: 67671},
+										pos:  position{line: 2213, col: 15, offset: 68156},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15548,27 +15687,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2194, col: 5, offset: 67708},
+						pos: position{line: 2214, col: 5, offset: 68193},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2194, col: 5, offset: 67708},
+							pos: position{line: 2214, col: 5, offset: 68193},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2194, col: 5, offset: 67708},
+									pos:  position{line: 2214, col: 5, offset: 68193},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2194, col: 7, offset: 67710},
+									pos: position{line: 2214, col: 7, offset: 68195},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2194, col: 8, offset: 67711},
+										pos:  position{line: 2214, col: 8, offset: 68196},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2194, col: 17, offset: 67720},
+									pos:   position{line: 2214, col: 17, offset: 68205},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2194, col: 20, offset: 67723},
+										pos:  position{line: 2214, col: 20, offset: 68208},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15576,10 +15715,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2195, col: 5, offset: 67760},
+						pos: position{line: 2215, col: 5, offset: 68245},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2195, col: 5, offset: 67760},
+							pos:        position{line: 2215, col: 5, offset: 68245},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15592,41 +15731,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2197, col: 1, offset: 67785},
+			pos:  position{line: 2217, col: 1, offset: 68270},
 			expr: &choiceExpr{
-				pos: position{line: 2198, col: 5, offset: 67807},
+				pos: position{line: 2218, col: 5, offset: 68292},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2198, col: 5, offset: 67807},
+						pos: position{line: 2218, col: 5, offset: 68292},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2198, col: 5, offset: 67807},
+							pos: position{line: 2218, col: 5, offset: 68292},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 5, offset: 67807},
+									pos:  position{line: 2218, col: 5, offset: 68292},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 7, offset: 67809},
+									pos:  position{line: 2218, col: 7, offset: 68294},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 13, offset: 67815},
+									pos:  position{line: 2218, col: 13, offset: 68300},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 15, offset: 67817},
+									pos:  position{line: 2218, col: 15, offset: 68302},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 18, offset: 67820},
+									pos:  position{line: 2218, col: 18, offset: 68305},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2198, col: 20, offset: 67822},
+									pos:   position{line: 2218, col: 20, offset: 68307},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2198, col: 25, offset: 67827},
+										pos:  position{line: 2218, col: 25, offset: 68312},
 										name: "OrderByList",
 									},
 								},
@@ -15634,10 +15773,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2205, col: 5, offset: 67986},
+						pos: position{line: 2225, col: 5, offset: 68471},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2205, col: 5, offset: 67986},
+							pos:        position{line: 2225, col: 5, offset: 68471},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15650,51 +15789,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2207, col: 1, offset: 68019},
+			pos:  position{line: 2227, col: 1, offset: 68504},
 			expr: &actionExpr{
-				pos: position{line: 2208, col: 5, offset: 68036},
+				pos: position{line: 2228, col: 5, offset: 68521},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2208, col: 5, offset: 68036},
+					pos: position{line: 2228, col: 5, offset: 68521},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2208, col: 5, offset: 68036},
+							pos:   position{line: 2228, col: 5, offset: 68521},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2208, col: 11, offset: 68042},
+								pos:  position{line: 2228, col: 11, offset: 68527},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2208, col: 23, offset: 68054},
+							pos:   position{line: 2228, col: 23, offset: 68539},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2208, col: 28, offset: 68059},
+								pos: position{line: 2228, col: 28, offset: 68544},
 								expr: &actionExpr{
-									pos: position{line: 2208, col: 30, offset: 68061},
+									pos: position{line: 2228, col: 30, offset: 68546},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2208, col: 30, offset: 68061},
+										pos: position{line: 2228, col: 30, offset: 68546},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2208, col: 30, offset: 68061},
+												pos:  position{line: 2228, col: 30, offset: 68546},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2208, col: 33, offset: 68064},
+												pos:        position{line: 2228, col: 33, offset: 68549},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2208, col: 37, offset: 68068},
+												pos:  position{line: 2228, col: 37, offset: 68553},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2208, col: 40, offset: 68071},
+												pos:   position{line: 2228, col: 40, offset: 68556},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2208, col: 42, offset: 68073},
+													pos:  position{line: 2228, col: 42, offset: 68558},
 													name: "OrderByItem",
 												},
 											},
@@ -15711,34 +15850,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2212, col: 1, offset: 68174},
+			pos:  position{line: 2232, col: 1, offset: 68659},
 			expr: &actionExpr{
-				pos: position{line: 2213, col: 5, offset: 68190},
+				pos: position{line: 2233, col: 5, offset: 68675},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2213, col: 5, offset: 68190},
+					pos: position{line: 2233, col: 5, offset: 68675},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2213, col: 5, offset: 68190},
+							pos:   position{line: 2233, col: 5, offset: 68675},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2213, col: 7, offset: 68192},
+								pos:  position{line: 2233, col: 7, offset: 68677},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2213, col: 12, offset: 68197},
+							pos:   position{line: 2233, col: 12, offset: 68682},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2213, col: 18, offset: 68203},
+								pos:  position{line: 2233, col: 18, offset: 68688},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2213, col: 29, offset: 68214},
+							pos:   position{line: 2233, col: 29, offset: 68699},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2213, col: 35, offset: 68220},
+								pos:  position{line: 2233, col: 35, offset: 68705},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15750,49 +15889,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2224, col: 1, offset: 68470},
+			pos:  position{line: 2244, col: 1, offset: 68955},
 			expr: &choiceExpr{
-				pos: position{line: 2225, col: 5, offset: 68485},
+				pos: position{line: 2245, col: 5, offset: 68970},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2225, col: 5, offset: 68485},
+						pos: position{line: 2245, col: 5, offset: 68970},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2225, col: 5, offset: 68485},
+							pos: position{line: 2245, col: 5, offset: 68970},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2225, col: 5, offset: 68485},
+									pos:  position{line: 2245, col: 5, offset: 68970},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2225, col: 7, offset: 68487},
+									pos:  position{line: 2245, col: 7, offset: 68972},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2226, col: 5, offset: 68559},
+						pos: position{line: 2246, col: 5, offset: 69044},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2226, col: 5, offset: 68559},
+							pos: position{line: 2246, col: 5, offset: 69044},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2226, col: 5, offset: 68559},
+									pos:  position{line: 2246, col: 5, offset: 69044},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2226, col: 7, offset: 68561},
+									pos:  position{line: 2246, col: 7, offset: 69046},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2227, col: 5, offset: 68633},
+						pos: position{line: 2247, col: 5, offset: 69118},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2227, col: 5, offset: 68633},
+							pos:        position{line: 2247, col: 5, offset: 69118},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15805,65 +15944,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2229, col: 1, offset: 68665},
+			pos:  position{line: 2249, col: 1, offset: 69150},
 			expr: &choiceExpr{
-				pos: position{line: 2230, col: 5, offset: 68683},
+				pos: position{line: 2250, col: 5, offset: 69168},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2230, col: 5, offset: 68683},
+						pos: position{line: 2250, col: 5, offset: 69168},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2230, col: 5, offset: 68683},
+							pos: position{line: 2250, col: 5, offset: 69168},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2230, col: 5, offset: 68683},
+									pos:  position{line: 2250, col: 5, offset: 69168},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2230, col: 7, offset: 68685},
+									pos:  position{line: 2250, col: 7, offset: 69170},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2230, col: 13, offset: 68691},
+									pos:  position{line: 2250, col: 13, offset: 69176},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2230, col: 15, offset: 68693},
+									pos:  position{line: 2250, col: 15, offset: 69178},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2231, col: 5, offset: 68769},
+						pos: position{line: 2251, col: 5, offset: 69254},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2231, col: 5, offset: 68769},
+							pos: position{line: 2251, col: 5, offset: 69254},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 5, offset: 68769},
+									pos:  position{line: 2251, col: 5, offset: 69254},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 7, offset: 68771},
+									pos:  position{line: 2251, col: 7, offset: 69256},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 13, offset: 68777},
+									pos:  position{line: 2251, col: 13, offset: 69262},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 15, offset: 68779},
+									pos:  position{line: 2251, col: 15, offset: 69264},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2232, col: 5, offset: 68854},
+						pos: position{line: 2252, col: 5, offset: 69339},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2232, col: 5, offset: 68854},
+							pos:        position{line: 2252, col: 5, offset: 69339},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15876,25 +16015,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2234, col: 1, offset: 68899},
+			pos:  position{line: 2254, col: 1, offset: 69384},
 			expr: &choiceExpr{
-				pos: position{line: 2235, col: 5, offset: 68921},
+				pos: position{line: 2255, col: 5, offset: 69406},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2235, col: 5, offset: 68921},
+						pos: position{line: 2255, col: 5, offset: 69406},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2235, col: 5, offset: 68921},
+							pos: position{line: 2255, col: 5, offset: 69406},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2235, col: 5, offset: 68921},
+									pos:  position{line: 2255, col: 5, offset: 69406},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2235, col: 7, offset: 68923},
+									pos:   position{line: 2255, col: 7, offset: 69408},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2235, col: 10, offset: 68926},
+										pos:  position{line: 2255, col: 10, offset: 69411},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15902,10 +16041,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2236, col: 5, offset: 68965},
+						pos: position{line: 2256, col: 5, offset: 69450},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2236, col: 5, offset: 68965},
+							pos:        position{line: 2256, col: 5, offset: 69450},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15918,29 +16057,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2238, col: 1, offset: 69006},
+			pos:  position{line: 2258, col: 1, offset: 69491},
 			expr: &choiceExpr{
-				pos: position{line: 2239, col: 5, offset: 69025},
+				pos: position{line: 2259, col: 5, offset: 69510},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2239, col: 5, offset: 69025},
+						pos: position{line: 2259, col: 5, offset: 69510},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2239, col: 5, offset: 69025},
+							pos: position{line: 2259, col: 5, offset: 69510},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2239, col: 5, offset: 69025},
+									pos:   position{line: 2259, col: 5, offset: 69510},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2239, col: 7, offset: 69027},
+										pos:  position{line: 2259, col: 7, offset: 69512},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2239, col: 19, offset: 69039},
+									pos:   position{line: 2259, col: 19, offset: 69524},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2239, col: 21, offset: 69041},
+										pos:  position{line: 2259, col: 21, offset: 69526},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15948,24 +16087,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2252, col: 5, offset: 69305},
+						pos: position{line: 2272, col: 5, offset: 69790},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2252, col: 5, offset: 69305},
+							pos: position{line: 2272, col: 5, offset: 69790},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2252, col: 5, offset: 69305},
+									pos:   position{line: 2272, col: 5, offset: 69790},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2252, col: 7, offset: 69307},
+										pos:  position{line: 2272, col: 7, offset: 69792},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2252, col: 20, offset: 69320},
+									pos:   position{line: 2272, col: 20, offset: 69805},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2252, col: 22, offset: 69322},
+										pos:  position{line: 2272, col: 22, offset: 69807},
 										name: "OptLimitClause",
 									},
 								},
@@ -15979,25 +16118,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2264, col: 1, offset: 69551},
+			pos:  position{line: 2284, col: 1, offset: 70036},
 			expr: &choiceExpr{
-				pos: position{line: 2265, col: 5, offset: 69571},
+				pos: position{line: 2285, col: 5, offset: 70056},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2265, col: 5, offset: 69571},
+						pos: position{line: 2285, col: 5, offset: 70056},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2265, col: 5, offset: 69571},
+							pos: position{line: 2285, col: 5, offset: 70056},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2265, col: 5, offset: 69571},
+									pos:  position{line: 2285, col: 5, offset: 70056},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2265, col: 7, offset: 69573},
+									pos:   position{line: 2285, col: 7, offset: 70058},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2265, col: 9, offset: 69575},
+										pos:  position{line: 2285, col: 9, offset: 70060},
 										name: "LimitClause",
 									},
 								},
@@ -16005,10 +16144,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2266, col: 5, offset: 69609},
+						pos: position{line: 2286, col: 5, offset: 70094},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2266, col: 5, offset: 69609},
+							pos:        position{line: 2286, col: 5, offset: 70094},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16021,50 +16160,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2268, col: 1, offset: 69646},
+			pos:  position{line: 2288, col: 1, offset: 70131},
 			expr: &choiceExpr{
-				pos: position{line: 2269, col: 5, offset: 69663},
+				pos: position{line: 2289, col: 5, offset: 70148},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2269, col: 5, offset: 69663},
+						pos: position{line: 2289, col: 5, offset: 70148},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2269, col: 5, offset: 69663},
+							pos: position{line: 2289, col: 5, offset: 70148},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2269, col: 5, offset: 69663},
+									pos:  position{line: 2289, col: 5, offset: 70148},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2269, col: 11, offset: 69669},
+									pos:  position{line: 2289, col: 11, offset: 70154},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2269, col: 13, offset: 69671},
+									pos:  position{line: 2289, col: 13, offset: 70156},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2270, col: 5, offset: 69699},
+						pos: position{line: 2290, col: 5, offset: 70184},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2270, col: 5, offset: 69699},
+							pos: position{line: 2290, col: 5, offset: 70184},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2270, col: 5, offset: 69699},
+									pos:  position{line: 2290, col: 5, offset: 70184},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2270, col: 11, offset: 69705},
+									pos:  position{line: 2290, col: 11, offset: 70190},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2270, col: 13, offset: 69707},
+									pos:   position{line: 2290, col: 13, offset: 70192},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2270, col: 15, offset: 69709},
+										pos:  position{line: 2290, col: 15, offset: 70194},
 										name: "Expr",
 									},
 								},
@@ -16078,25 +16217,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2272, col: 1, offset: 69733},
+			pos:  position{line: 2292, col: 1, offset: 70218},
 			expr: &choiceExpr{
-				pos: position{line: 2273, col: 5, offset: 69754},
+				pos: position{line: 2293, col: 5, offset: 70239},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2273, col: 5, offset: 69754},
+						pos: position{line: 2293, col: 5, offset: 70239},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2273, col: 5, offset: 69754},
+							pos: position{line: 2293, col: 5, offset: 70239},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2273, col: 5, offset: 69754},
+									pos:  position{line: 2293, col: 5, offset: 70239},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2273, col: 7, offset: 69756},
+									pos:   position{line: 2293, col: 7, offset: 70241},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2273, col: 9, offset: 69758},
+										pos:  position{line: 2293, col: 9, offset: 70243},
 										name: "OffsetClause",
 									},
 								},
@@ -16104,10 +16243,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2274, col: 5, offset: 69794},
+						pos: position{line: 2294, col: 5, offset: 70279},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2274, col: 5, offset: 69794},
+							pos:        position{line: 2294, col: 5, offset: 70279},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16120,26 +16259,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2276, col: 1, offset: 69819},
+			pos:  position{line: 2296, col: 1, offset: 70304},
 			expr: &actionExpr{
-				pos: position{line: 2277, col: 5, offset: 69837},
+				pos: position{line: 2297, col: 5, offset: 70322},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2277, col: 5, offset: 69837},
+					pos: position{line: 2297, col: 5, offset: 70322},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2277, col: 5, offset: 69837},
+							pos:  position{line: 2297, col: 5, offset: 70322},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2277, col: 12, offset: 69844},
+							pos:  position{line: 2297, col: 12, offset: 70329},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2277, col: 14, offset: 69846},
+							pos:   position{line: 2297, col: 14, offset: 70331},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2277, col: 16, offset: 69848},
+								pos:  position{line: 2297, col: 16, offset: 70333},
 								name: "Expr",
 							},
 						},
@@ -16151,38 +16290,38 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2279, col: 1, offset: 69873},
+			pos:  position{line: 2299, col: 1, offset: 70358},
 			expr: &actionExpr{
-				pos: position{line: 2280, col: 5, offset: 69890},
+				pos: position{line: 2300, col: 5, offset: 70375},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2280, col: 5, offset: 69890},
+					pos: position{line: 2300, col: 5, offset: 70375},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2280, col: 5, offset: 69890},
+							pos:   position{line: 2300, col: 5, offset: 70375},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2280, col: 10, offset: 69895},
+								pos:  position{line: 2300, col: 10, offset: 70380},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2280, col: 21, offset: 69906},
+							pos:   position{line: 2300, col: 21, offset: 70391},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2280, col: 30, offset: 69915},
+								pos:  position{line: 2300, col: 30, offset: 70400},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2280, col: 36, offset: 69921},
+							pos:  position{line: 2300, col: 36, offset: 70406},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2280, col: 38, offset: 69923},
+							pos:   position{line: 2300, col: 38, offset: 70408},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2280, col: 44, offset: 69929},
+								pos:  position{line: 2300, col: 44, offset: 70414},
 								name: "SelectExpr",
 							},
 						},
@@ -16194,60 +16333,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2290, col: 1, offset: 70150},
+			pos:  position{line: 2310, col: 1, offset: 70635},
 			expr: &choiceExpr{
-				pos: position{line: 2291, col: 5, offset: 70161},
+				pos: position{line: 2311, col: 5, offset: 70646},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2291, col: 5, offset: 70161},
+						pos: position{line: 2311, col: 5, offset: 70646},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2291, col: 5, offset: 70161},
+							pos: position{line: 2311, col: 5, offset: 70646},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2291, col: 5, offset: 70161},
+									pos:  position{line: 2311, col: 5, offset: 70646},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2291, col: 7, offset: 70163},
+									pos:  position{line: 2311, col: 7, offset: 70648},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2291, col: 13, offset: 70169},
+									pos:  position{line: 2311, col: 13, offset: 70654},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2291, col: 15, offset: 70171},
+									pos:  position{line: 2311, col: 15, offset: 70656},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2292, col: 5, offset: 70207},
+						pos: position{line: 2312, col: 5, offset: 70692},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2292, col: 5, offset: 70207},
+							pos: position{line: 2312, col: 5, offset: 70692},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2292, col: 5, offset: 70207},
+									pos:  position{line: 2312, col: 5, offset: 70692},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2292, col: 7, offset: 70209},
+									pos:  position{line: 2312, col: 7, offset: 70694},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2292, col: 13, offset: 70215},
+									pos: position{line: 2312, col: 13, offset: 70700},
 									expr: &seqExpr{
-										pos: position{line: 2292, col: 14, offset: 70216},
+										pos: position{line: 2312, col: 14, offset: 70701},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2292, col: 14, offset: 70216},
+												pos:  position{line: 2312, col: 14, offset: 70701},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2292, col: 16, offset: 70218},
+												pos:  position{line: 2312, col: 16, offset: 70703},
 												name: "DISTINCT",
 											},
 										},
@@ -16263,84 +16402,84 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2295, col: 1, offset: 70270},
+			pos:  position{line: 2315, col: 1, offset: 70755},
 			expr: &choiceExpr{
-				pos: position{line: 2296, col: 5, offset: 70285},
+				pos: position{line: 2316, col: 5, offset: 70770},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2296, col: 5, offset: 70285},
+						pos:  position{line: 2316, col: 5, offset: 70770},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2296, col: 12, offset: 70292},
+						pos:  position{line: 2316, col: 12, offset: 70777},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2296, col: 20, offset: 70300},
+						pos:  position{line: 2316, col: 20, offset: 70785},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2296, col: 29, offset: 70309},
+						pos:  position{line: 2316, col: 29, offset: 70794},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2296, col: 38, offset: 70318},
+						pos:  position{line: 2316, col: 38, offset: 70803},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2297, col: 5, offset: 70332},
+						pos:  position{line: 2317, col: 5, offset: 70817},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2297, col: 13, offset: 70340},
+						pos:  position{line: 2317, col: 13, offset: 70825},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2297, col: 20, offset: 70347},
+						pos:  position{line: 2317, col: 20, offset: 70832},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2297, col: 28, offset: 70355},
+						pos:  position{line: 2317, col: 28, offset: 70840},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2297, col: 36, offset: 70363},
+						pos:  position{line: 2317, col: 36, offset: 70848},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2297, col: 44, offset: 70371},
+						pos:  position{line: 2317, col: 44, offset: 70856},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2298, col: 5, offset: 70380},
+						pos:  position{line: 2318, col: 5, offset: 70865},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2299, col: 5, offset: 70390},
+						pos:  position{line: 2319, col: 5, offset: 70875},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2300, col: 5, offset: 70400},
+						pos:  position{line: 2320, col: 5, offset: 70885},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2301, col: 5, offset: 70411},
+						pos:  position{line: 2321, col: 5, offset: 70896},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2302, col: 5, offset: 70421},
+						pos:  position{line: 2322, col: 5, offset: 70906},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2303, col: 5, offset: 70432},
+						pos:  position{line: 2323, col: 5, offset: 70917},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2304, col: 5, offset: 70441},
+						pos:  position{line: 2324, col: 5, offset: 70926},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2305, col: 5, offset: 70451},
+						pos:  position{line: 2325, col: 5, offset: 70936},
 						name: "ON",
 					},
 				},
@@ -16350,20 +16489,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2307, col: 1, offset: 70455},
+			pos:  position{line: 2327, col: 1, offset: 70940},
 			expr: &seqExpr{
-				pos: position{line: 2307, col: 14, offset: 70468},
+				pos: position{line: 2327, col: 14, offset: 70953},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2307, col: 14, offset: 70468},
+						pos:        position{line: 2327, col: 14, offset: 70953},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2307, col: 33, offset: 70487},
+						pos: position{line: 2327, col: 33, offset: 70972},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2307, col: 34, offset: 70488},
+							pos:  position{line: 2327, col: 34, offset: 70973},
 							name: "IdentifierRest",
 						},
 					},
@@ -16374,20 +16513,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2308, col: 1, offset: 70503},
+			pos:  position{line: 2328, col: 1, offset: 70988},
 			expr: &seqExpr{
-				pos: position{line: 2308, col: 14, offset: 70516},
+				pos: position{line: 2328, col: 14, offset: 71001},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2308, col: 14, offset: 70516},
+						pos:        position{line: 2328, col: 14, offset: 71001},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2308, col: 33, offset: 70535},
+						pos: position{line: 2328, col: 33, offset: 71020},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2308, col: 34, offset: 70536},
+							pos:  position{line: 2328, col: 34, offset: 71021},
 							name: "IdentifierRest",
 						},
 					},
@@ -16398,23 +16537,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2309, col: 1, offset: 70551},
+			pos:  position{line: 2329, col: 1, offset: 71036},
 			expr: &actionExpr{
-				pos: position{line: 2309, col: 14, offset: 70564},
+				pos: position{line: 2329, col: 14, offset: 71049},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2309, col: 14, offset: 70564},
+					pos: position{line: 2329, col: 14, offset: 71049},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2309, col: 14, offset: 70564},
+							pos:        position{line: 2329, col: 14, offset: 71049},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2309, col: 33, offset: 70583},
+							pos: position{line: 2329, col: 33, offset: 71068},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2309, col: 34, offset: 70584},
+								pos:  position{line: 2329, col: 34, offset: 71069},
 								name: "IdentifierRest",
 							},
 						},
@@ -16426,20 +16565,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2310, col: 1, offset: 70621},
+			pos:  position{line: 2330, col: 1, offset: 71106},
 			expr: &seqExpr{
-				pos: position{line: 2310, col: 14, offset: 70634},
+				pos: position{line: 2330, col: 14, offset: 71119},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2310, col: 14, offset: 70634},
+						pos:        position{line: 2330, col: 14, offset: 71119},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2310, col: 33, offset: 70653},
+						pos: position{line: 2330, col: 33, offset: 71138},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2310, col: 34, offset: 70654},
+							pos:  position{line: 2330, col: 34, offset: 71139},
 							name: "IdentifierRest",
 						},
 					},
@@ -16450,20 +16589,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2311, col: 1, offset: 70669},
+			pos:  position{line: 2331, col: 1, offset: 71154},
 			expr: &seqExpr{
-				pos: position{line: 2311, col: 14, offset: 70682},
+				pos: position{line: 2331, col: 14, offset: 71167},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2311, col: 14, offset: 70682},
+						pos:        position{line: 2331, col: 14, offset: 71167},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2311, col: 33, offset: 70701},
+						pos: position{line: 2331, col: 33, offset: 71186},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2311, col: 34, offset: 70702},
+							pos:  position{line: 2331, col: 34, offset: 71187},
 							name: "IdentifierRest",
 						},
 					},
@@ -16474,23 +16613,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2312, col: 1, offset: 70717},
+			pos:  position{line: 2332, col: 1, offset: 71202},
 			expr: &actionExpr{
-				pos: position{line: 2312, col: 14, offset: 70730},
+				pos: position{line: 2332, col: 14, offset: 71215},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2312, col: 14, offset: 70730},
+					pos: position{line: 2332, col: 14, offset: 71215},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2312, col: 14, offset: 70730},
+							pos:        position{line: 2332, col: 14, offset: 71215},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2312, col: 33, offset: 70749},
+							pos: position{line: 2332, col: 33, offset: 71234},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2312, col: 34, offset: 70750},
+								pos:  position{line: 2332, col: 34, offset: 71235},
 								name: "IdentifierRest",
 							},
 						},
@@ -16502,20 +16641,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2313, col: 1, offset: 70787},
+			pos:  position{line: 2333, col: 1, offset: 71272},
 			expr: &seqExpr{
-				pos: position{line: 2313, col: 14, offset: 70800},
+				pos: position{line: 2333, col: 14, offset: 71285},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2313, col: 14, offset: 70800},
+						pos:        position{line: 2333, col: 14, offset: 71285},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2313, col: 33, offset: 70819},
+						pos: position{line: 2333, col: 33, offset: 71304},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2313, col: 34, offset: 70820},
+							pos:  position{line: 2333, col: 34, offset: 71305},
 							name: "IdentifierRest",
 						},
 					},
@@ -16526,20 +16665,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2314, col: 1, offset: 70835},
+			pos:  position{line: 2334, col: 1, offset: 71320},
 			expr: &seqExpr{
-				pos: position{line: 2314, col: 14, offset: 70848},
+				pos: position{line: 2334, col: 14, offset: 71333},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2314, col: 14, offset: 70848},
+						pos:        position{line: 2334, col: 14, offset: 71333},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2314, col: 33, offset: 70867},
+						pos: position{line: 2334, col: 33, offset: 71352},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2314, col: 34, offset: 70868},
+							pos:  position{line: 2334, col: 34, offset: 71353},
 							name: "IdentifierRest",
 						},
 					},
@@ -16550,20 +16689,20 @@ var g = &grammar{
 		},
 		{
 			name: "AUTHOR",
-			pos:  position{line: 2315, col: 1, offset: 70883},
+			pos:  position{line: 2335, col: 1, offset: 71368},
 			expr: &seqExpr{
-				pos: position{line: 2315, col: 14, offset: 70896},
+				pos: position{line: 2335, col: 14, offset: 71381},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2315, col: 14, offset: 70896},
+						pos:        position{line: 2335, col: 14, offset: 71381},
 						val:        "author",
 						ignoreCase: true,
 						want:       "\"AUTHOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2315, col: 33, offset: 70915},
+						pos: position{line: 2335, col: 33, offset: 71400},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2315, col: 34, offset: 70916},
+							pos:  position{line: 2335, col: 34, offset: 71401},
 							name: "IdentifierRest",
 						},
 					},
@@ -16574,20 +16713,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2316, col: 1, offset: 70931},
+			pos:  position{line: 2336, col: 1, offset: 71416},
 			expr: &seqExpr{
-				pos: position{line: 2316, col: 14, offset: 70944},
+				pos: position{line: 2336, col: 14, offset: 71429},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2316, col: 14, offset: 70944},
+						pos:        position{line: 2336, col: 14, offset: 71429},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2316, col: 33, offset: 70963},
+						pos: position{line: 2336, col: 33, offset: 71448},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2316, col: 34, offset: 70964},
+							pos:  position{line: 2336, col: 34, offset: 71449},
 							name: "IdentifierRest",
 						},
 					},
@@ -16598,20 +16737,20 @@ var g = &grammar{
 		},
 		{
 			name: "BODY",
-			pos:  position{line: 2317, col: 1, offset: 70979},
+			pos:  position{line: 2337, col: 1, offset: 71464},
 			expr: &seqExpr{
-				pos: position{line: 2317, col: 14, offset: 70992},
+				pos: position{line: 2337, col: 14, offset: 71477},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2317, col: 14, offset: 70992},
+						pos:        position{line: 2337, col: 14, offset: 71477},
 						val:        "body",
 						ignoreCase: true,
 						want:       "\"BODY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2317, col: 33, offset: 71011},
+						pos: position{line: 2337, col: 33, offset: 71496},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2317, col: 34, offset: 71012},
+							pos:  position{line: 2337, col: 34, offset: 71497},
 							name: "IdentifierRest",
 						},
 					},
@@ -16622,20 +16761,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2318, col: 1, offset: 71027},
+			pos:  position{line: 2338, col: 1, offset: 71512},
 			expr: &seqExpr{
-				pos: position{line: 2318, col: 14, offset: 71040},
+				pos: position{line: 2338, col: 14, offset: 71525},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2318, col: 14, offset: 71040},
+						pos:        position{line: 2338, col: 14, offset: 71525},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2318, col: 33, offset: 71059},
+						pos: position{line: 2338, col: 33, offset: 71544},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2318, col: 34, offset: 71060},
+							pos:  position{line: 2338, col: 34, offset: 71545},
 							name: "IdentifierRest",
 						},
 					},
@@ -16646,20 +16785,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2319, col: 1, offset: 71075},
+			pos:  position{line: 2339, col: 1, offset: 71560},
 			expr: &seqExpr{
-				pos: position{line: 2319, col: 14, offset: 71088},
+				pos: position{line: 2339, col: 14, offset: 71573},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2319, col: 14, offset: 71088},
+						pos:        position{line: 2339, col: 14, offset: 71573},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2319, col: 33, offset: 71107},
+						pos: position{line: 2339, col: 33, offset: 71592},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2319, col: 34, offset: 71108},
+							pos:  position{line: 2339, col: 34, offset: 71593},
 							name: "IdentifierRest",
 						},
 					},
@@ -16670,20 +16809,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2320, col: 1, offset: 71123},
+			pos:  position{line: 2340, col: 1, offset: 71608},
 			expr: &seqExpr{
-				pos: position{line: 2320, col: 14, offset: 71136},
+				pos: position{line: 2340, col: 14, offset: 71621},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2320, col: 14, offset: 71136},
+						pos:        position{line: 2340, col: 14, offset: 71621},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2320, col: 33, offset: 71155},
+						pos: position{line: 2340, col: 33, offset: 71640},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2320, col: 34, offset: 71156},
+							pos:  position{line: 2340, col: 34, offset: 71641},
 							name: "IdentifierRest",
 						},
 					},
@@ -16694,20 +16833,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2321, col: 1, offset: 71171},
+			pos:  position{line: 2341, col: 1, offset: 71656},
 			expr: &seqExpr{
-				pos: position{line: 2321, col: 14, offset: 71184},
+				pos: position{line: 2341, col: 14, offset: 71669},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2321, col: 14, offset: 71184},
+						pos:        position{line: 2341, col: 14, offset: 71669},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2321, col: 33, offset: 71203},
+						pos: position{line: 2341, col: 33, offset: 71688},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2321, col: 34, offset: 71204},
+							pos:  position{line: 2341, col: 34, offset: 71689},
 							name: "IdentifierRest",
 						},
 					},
@@ -16718,20 +16857,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2322, col: 1, offset: 71219},
+			pos:  position{line: 2342, col: 1, offset: 71704},
 			expr: &seqExpr{
-				pos: position{line: 2322, col: 14, offset: 71232},
+				pos: position{line: 2342, col: 14, offset: 71717},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2322, col: 14, offset: 71232},
+						pos:        position{line: 2342, col: 14, offset: 71717},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2322, col: 33, offset: 71251},
+						pos: position{line: 2342, col: 33, offset: 71736},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2322, col: 34, offset: 71252},
+							pos:  position{line: 2342, col: 34, offset: 71737},
 							name: "IdentifierRest",
 						},
 					},
@@ -16742,20 +16881,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2323, col: 1, offset: 71267},
+			pos:  position{line: 2343, col: 1, offset: 71752},
 			expr: &seqExpr{
-				pos: position{line: 2323, col: 14, offset: 71280},
+				pos: position{line: 2343, col: 14, offset: 71765},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2323, col: 14, offset: 71280},
+						pos:        position{line: 2343, col: 14, offset: 71765},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2323, col: 33, offset: 71299},
+						pos: position{line: 2343, col: 33, offset: 71784},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2323, col: 34, offset: 71300},
+							pos:  position{line: 2343, col: 34, offset: 71785},
 							name: "IdentifierRest",
 						},
 					},
@@ -16766,20 +16905,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2324, col: 1, offset: 71315},
+			pos:  position{line: 2344, col: 1, offset: 71800},
 			expr: &seqExpr{
-				pos: position{line: 2324, col: 14, offset: 71328},
+				pos: position{line: 2344, col: 14, offset: 71813},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2324, col: 14, offset: 71328},
+						pos:        position{line: 2344, col: 14, offset: 71813},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2324, col: 33, offset: 71347},
+						pos: position{line: 2344, col: 33, offset: 71832},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2324, col: 34, offset: 71348},
+							pos:  position{line: 2344, col: 34, offset: 71833},
 							name: "IdentifierRest",
 						},
 					},
@@ -16790,23 +16929,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2325, col: 1, offset: 71363},
+			pos:  position{line: 2345, col: 1, offset: 71848},
 			expr: &actionExpr{
-				pos: position{line: 2325, col: 14, offset: 71376},
+				pos: position{line: 2345, col: 14, offset: 71861},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2325, col: 14, offset: 71376},
+					pos: position{line: 2345, col: 14, offset: 71861},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2325, col: 14, offset: 71376},
+							pos:        position{line: 2345, col: 14, offset: 71861},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2325, col: 33, offset: 71395},
+							pos: position{line: 2345, col: 33, offset: 71880},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2325, col: 34, offset: 71396},
+								pos:  position{line: 2345, col: 34, offset: 71881},
 								name: "IdentifierRest",
 							},
 						},
@@ -16818,20 +16957,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2326, col: 1, offset: 71434},
+			pos:  position{line: 2346, col: 1, offset: 71919},
 			expr: &seqExpr{
-				pos: position{line: 2326, col: 14, offset: 71447},
+				pos: position{line: 2346, col: 14, offset: 71932},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2326, col: 14, offset: 71447},
+						pos:        position{line: 2346, col: 14, offset: 71932},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2326, col: 33, offset: 71466},
+						pos: position{line: 2346, col: 33, offset: 71951},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2326, col: 34, offset: 71467},
+							pos:  position{line: 2346, col: 34, offset: 71952},
 							name: "IdentifierRest",
 						},
 					},
@@ -16842,20 +16981,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2327, col: 1, offset: 71482},
+			pos:  position{line: 2347, col: 1, offset: 71967},
 			expr: &seqExpr{
-				pos: position{line: 2327, col: 14, offset: 71495},
+				pos: position{line: 2347, col: 14, offset: 71980},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2327, col: 14, offset: 71495},
+						pos:        position{line: 2347, col: 14, offset: 71980},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2327, col: 33, offset: 71514},
+						pos: position{line: 2347, col: 33, offset: 71999},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2327, col: 34, offset: 71515},
+							pos:  position{line: 2347, col: 34, offset: 72000},
 							name: "IdentifierRest",
 						},
 					},
@@ -16866,23 +17005,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2328, col: 1, offset: 71530},
+			pos:  position{line: 2348, col: 1, offset: 72015},
 			expr: &actionExpr{
-				pos: position{line: 2328, col: 14, offset: 71543},
+				pos: position{line: 2348, col: 14, offset: 72028},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2328, col: 14, offset: 71543},
+					pos: position{line: 2348, col: 14, offset: 72028},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2328, col: 14, offset: 71543},
+							pos:        position{line: 2348, col: 14, offset: 72028},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2328, col: 33, offset: 71562},
+							pos: position{line: 2348, col: 33, offset: 72047},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2328, col: 34, offset: 71563},
+								pos:  position{line: 2348, col: 34, offset: 72048},
 								name: "IdentifierRest",
 							},
 						},
@@ -16894,20 +17033,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2329, col: 1, offset: 71601},
+			pos:  position{line: 2349, col: 1, offset: 72086},
 			expr: &seqExpr{
-				pos: position{line: 2329, col: 14, offset: 71614},
+				pos: position{line: 2349, col: 14, offset: 72099},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2329, col: 14, offset: 71614},
+						pos:        position{line: 2349, col: 14, offset: 72099},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2329, col: 33, offset: 71633},
+						pos: position{line: 2349, col: 33, offset: 72118},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2329, col: 34, offset: 71634},
+							pos:  position{line: 2349, col: 34, offset: 72119},
 							name: "IdentifierRest",
 						},
 					},
@@ -16918,20 +17057,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2330, col: 1, offset: 71649},
+			pos:  position{line: 2350, col: 1, offset: 72134},
 			expr: &seqExpr{
-				pos: position{line: 2330, col: 14, offset: 71662},
+				pos: position{line: 2350, col: 14, offset: 72147},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2330, col: 14, offset: 71662},
+						pos:        position{line: 2350, col: 14, offset: 72147},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2330, col: 33, offset: 71681},
+						pos: position{line: 2350, col: 33, offset: 72166},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2330, col: 34, offset: 71682},
+							pos:  position{line: 2350, col: 34, offset: 72167},
 							name: "IdentifierRest",
 						},
 					},
@@ -16942,20 +17081,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2331, col: 1, offset: 71698},
+			pos:  position{line: 2351, col: 1, offset: 72183},
 			expr: &seqExpr{
-				pos: position{line: 2331, col: 14, offset: 71711},
+				pos: position{line: 2351, col: 14, offset: 72196},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2331, col: 14, offset: 71711},
+						pos:        position{line: 2351, col: 14, offset: 72196},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2331, col: 33, offset: 71730},
+						pos: position{line: 2351, col: 33, offset: 72215},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2331, col: 34, offset: 71731},
+							pos:  position{line: 2351, col: 34, offset: 72216},
 							name: "IdentifierRest",
 						},
 					},
@@ -16966,20 +17105,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2332, col: 1, offset: 71746},
+			pos:  position{line: 2352, col: 1, offset: 72231},
 			expr: &seqExpr{
-				pos: position{line: 2332, col: 14, offset: 71759},
+				pos: position{line: 2352, col: 14, offset: 72244},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2332, col: 14, offset: 71759},
+						pos:        position{line: 2352, col: 14, offset: 72244},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2332, col: 33, offset: 71778},
+						pos: position{line: 2352, col: 33, offset: 72263},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2332, col: 34, offset: 71779},
+							pos:  position{line: 2352, col: 34, offset: 72264},
 							name: "IdentifierRest",
 						},
 					},
@@ -16990,20 +17129,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2333, col: 1, offset: 71794},
+			pos:  position{line: 2353, col: 1, offset: 72279},
 			expr: &seqExpr{
-				pos: position{line: 2333, col: 14, offset: 71807},
+				pos: position{line: 2353, col: 14, offset: 72292},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2333, col: 14, offset: 71807},
+						pos:        position{line: 2353, col: 14, offset: 72292},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2333, col: 33, offset: 71826},
+						pos: position{line: 2353, col: 33, offset: 72311},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2333, col: 34, offset: 71827},
+							pos:  position{line: 2353, col: 34, offset: 72312},
 							name: "IdentifierRest",
 						},
 					},
@@ -17014,20 +17153,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2334, col: 1, offset: 71842},
+			pos:  position{line: 2354, col: 1, offset: 72327},
 			expr: &seqExpr{
-				pos: position{line: 2334, col: 14, offset: 71855},
+				pos: position{line: 2354, col: 14, offset: 72340},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2334, col: 14, offset: 71855},
+						pos:        position{line: 2354, col: 14, offset: 72340},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2334, col: 33, offset: 71874},
+						pos: position{line: 2354, col: 33, offset: 72359},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2334, col: 34, offset: 71875},
+							pos:  position{line: 2354, col: 34, offset: 72360},
 							name: "IdentifierRest",
 						},
 					},
@@ -17038,20 +17177,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2335, col: 1, offset: 71890},
+			pos:  position{line: 2355, col: 1, offset: 72375},
 			expr: &seqExpr{
-				pos: position{line: 2335, col: 14, offset: 71903},
+				pos: position{line: 2355, col: 14, offset: 72388},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2335, col: 14, offset: 71903},
+						pos:        position{line: 2355, col: 14, offset: 72388},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2335, col: 33, offset: 71922},
+						pos: position{line: 2355, col: 33, offset: 72407},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2335, col: 34, offset: 71923},
+							pos:  position{line: 2355, col: 34, offset: 72408},
 							name: "IdentifierRest",
 						},
 					},
@@ -17062,20 +17201,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2336, col: 1, offset: 71938},
+			pos:  position{line: 2356, col: 1, offset: 72423},
 			expr: &seqExpr{
-				pos: position{line: 2336, col: 14, offset: 71951},
+				pos: position{line: 2356, col: 14, offset: 72436},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2336, col: 14, offset: 71951},
+						pos:        position{line: 2356, col: 14, offset: 72436},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2336, col: 33, offset: 71970},
+						pos: position{line: 2356, col: 33, offset: 72455},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2336, col: 34, offset: 71971},
+							pos:  position{line: 2356, col: 34, offset: 72456},
 							name: "IdentifierRest",
 						},
 					},
@@ -17086,20 +17225,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2337, col: 1, offset: 71986},
+			pos:  position{line: 2357, col: 1, offset: 72471},
 			expr: &seqExpr{
-				pos: position{line: 2337, col: 14, offset: 71999},
+				pos: position{line: 2357, col: 14, offset: 72484},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2337, col: 14, offset: 71999},
+						pos:        position{line: 2357, col: 14, offset: 72484},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2337, col: 33, offset: 72018},
+						pos: position{line: 2357, col: 33, offset: 72503},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2337, col: 34, offset: 72019},
+							pos:  position{line: 2357, col: 34, offset: 72504},
 							name: "IdentifierRest",
 						},
 					},
@@ -17110,20 +17249,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2338, col: 1, offset: 72034},
+			pos:  position{line: 2358, col: 1, offset: 72519},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 72047},
+				pos: position{line: 2358, col: 14, offset: 72532},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 72047},
+						pos:        position{line: 2358, col: 14, offset: 72532},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 72066},
+						pos: position{line: 2358, col: 33, offset: 72551},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 72067},
+							pos:  position{line: 2358, col: 34, offset: 72552},
 							name: "IdentifierRest",
 						},
 					},
@@ -17134,20 +17273,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2339, col: 1, offset: 72082},
+			pos:  position{line: 2359, col: 1, offset: 72567},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 72095},
+				pos: position{line: 2359, col: 14, offset: 72580},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 72095},
+						pos:        position{line: 2359, col: 14, offset: 72580},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 72114},
+						pos: position{line: 2359, col: 33, offset: 72599},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 72115},
+							pos:  position{line: 2359, col: 34, offset: 72600},
 							name: "IdentifierRest",
 						},
 					},
@@ -17158,20 +17297,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2340, col: 1, offset: 72130},
+			pos:  position{line: 2360, col: 1, offset: 72615},
 			expr: &seqExpr{
-				pos: position{line: 2340, col: 14, offset: 72143},
+				pos: position{line: 2360, col: 14, offset: 72628},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2340, col: 14, offset: 72143},
+						pos:        position{line: 2360, col: 14, offset: 72628},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2340, col: 33, offset: 72162},
+						pos: position{line: 2360, col: 33, offset: 72647},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2340, col: 34, offset: 72163},
+							pos:  position{line: 2360, col: 34, offset: 72648},
 							name: "IdentifierRest",
 						},
 					},
@@ -17182,20 +17321,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORMAT",
-			pos:  position{line: 2341, col: 1, offset: 72178},
+			pos:  position{line: 2361, col: 1, offset: 72663},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 72191},
+				pos: position{line: 2361, col: 14, offset: 72676},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 72191},
+						pos:        position{line: 2361, col: 14, offset: 72676},
 						val:        "format",
 						ignoreCase: true,
 						want:       "\"FORMAT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 72210},
+						pos: position{line: 2361, col: 33, offset: 72695},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 72211},
+							pos:  position{line: 2361, col: 34, offset: 72696},
 							name: "IdentifierRest",
 						},
 					},
@@ -17206,20 +17345,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2342, col: 1, offset: 72226},
+			pos:  position{line: 2362, col: 1, offset: 72711},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 72239},
+				pos: position{line: 2362, col: 14, offset: 72724},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 72239},
+						pos:        position{line: 2362, col: 14, offset: 72724},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 72258},
+						pos: position{line: 2362, col: 33, offset: 72743},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 72259},
+							pos:  position{line: 2362, col: 34, offset: 72744},
 							name: "IdentifierRest",
 						},
 					},
@@ -17230,20 +17369,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2343, col: 1, offset: 72274},
+			pos:  position{line: 2363, col: 1, offset: 72759},
 			expr: &seqExpr{
-				pos: position{line: 2343, col: 14, offset: 72287},
+				pos: position{line: 2363, col: 14, offset: 72772},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2343, col: 14, offset: 72287},
+						pos:        position{line: 2363, col: 14, offset: 72772},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2343, col: 33, offset: 72306},
+						pos: position{line: 2363, col: 33, offset: 72791},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2343, col: 34, offset: 72307},
+							pos:  position{line: 2363, col: 34, offset: 72792},
 							name: "IdentifierRest",
 						},
 					},
@@ -17254,20 +17393,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2344, col: 1, offset: 72322},
+			pos:  position{line: 2364, col: 1, offset: 72807},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 72335},
+				pos: position{line: 2364, col: 14, offset: 72820},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 72335},
+						pos:        position{line: 2364, col: 14, offset: 72820},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 72354},
+						pos: position{line: 2364, col: 33, offset: 72839},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 72355},
+							pos:  position{line: 2364, col: 34, offset: 72840},
 							name: "IdentifierRest",
 						},
 					},
@@ -17278,20 +17417,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2345, col: 1, offset: 72370},
+			pos:  position{line: 2365, col: 1, offset: 72855},
 			expr: &seqExpr{
-				pos: position{line: 2345, col: 14, offset: 72383},
+				pos: position{line: 2365, col: 14, offset: 72868},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2345, col: 14, offset: 72383},
+						pos:        position{line: 2365, col: 14, offset: 72868},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2345, col: 33, offset: 72402},
+						pos: position{line: 2365, col: 33, offset: 72887},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2345, col: 34, offset: 72403},
+							pos:  position{line: 2365, col: 34, offset: 72888},
 							name: "IdentifierRest",
 						},
 					},
@@ -17302,20 +17441,20 @@ var g = &grammar{
 		},
 		{
 			name: "GREP",
-			pos:  position{line: 2346, col: 1, offset: 72418},
+			pos:  position{line: 2366, col: 1, offset: 72903},
 			expr: &seqExpr{
-				pos: position{line: 2346, col: 14, offset: 72431},
+				pos: position{line: 2366, col: 14, offset: 72916},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2346, col: 14, offset: 72431},
+						pos:        position{line: 2366, col: 14, offset: 72916},
 						val:        "grep",
 						ignoreCase: true,
 						want:       "\"GREP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2346, col: 33, offset: 72450},
+						pos: position{line: 2366, col: 33, offset: 72935},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2346, col: 34, offset: 72451},
+							pos:  position{line: 2366, col: 34, offset: 72936},
 							name: "IdentifierRest",
 						},
 					},
@@ -17326,20 +17465,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2347, col: 1, offset: 72466},
+			pos:  position{line: 2367, col: 1, offset: 72951},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 72479},
+				pos: position{line: 2367, col: 14, offset: 72964},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 72479},
+						pos:        position{line: 2367, col: 14, offset: 72964},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 72498},
+						pos: position{line: 2367, col: 33, offset: 72983},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 72499},
+							pos:  position{line: 2367, col: 34, offset: 72984},
 							name: "IdentifierRest",
 						},
 					},
@@ -17350,20 +17489,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2348, col: 1, offset: 72514},
+			pos:  position{line: 2368, col: 1, offset: 72999},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 72527},
+				pos: position{line: 2368, col: 14, offset: 73012},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 72527},
+						pos:        position{line: 2368, col: 14, offset: 73012},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 72546},
+						pos: position{line: 2368, col: 33, offset: 73031},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 72547},
+							pos:  position{line: 2368, col: 34, offset: 73032},
 							name: "IdentifierRest",
 						},
 					},
@@ -17374,20 +17513,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2349, col: 1, offset: 72562},
+			pos:  position{line: 2369, col: 1, offset: 73047},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 72575},
+				pos: position{line: 2369, col: 14, offset: 73060},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 72575},
+						pos:        position{line: 2369, col: 14, offset: 73060},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 72594},
+						pos: position{line: 2369, col: 33, offset: 73079},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 72595},
+							pos:  position{line: 2369, col: 34, offset: 73080},
 							name: "IdentifierRest",
 						},
 					},
@@ -17398,20 +17537,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEADERS",
-			pos:  position{line: 2350, col: 1, offset: 72611},
+			pos:  position{line: 2370, col: 1, offset: 73096},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 72624},
+				pos: position{line: 2370, col: 14, offset: 73109},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 72624},
+						pos:        position{line: 2370, col: 14, offset: 73109},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"HEADERS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 72643},
+						pos: position{line: 2370, col: 33, offset: 73128},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 72644},
+							pos:  position{line: 2370, col: 34, offset: 73129},
 							name: "IdentifierRest",
 						},
 					},
@@ -17422,20 +17561,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2351, col: 1, offset: 72659},
+			pos:  position{line: 2371, col: 1, offset: 73144},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 72672},
+				pos: position{line: 2371, col: 14, offset: 73157},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 72672},
+						pos:        position{line: 2371, col: 14, offset: 73157},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 72691},
+						pos: position{line: 2371, col: 33, offset: 73176},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 72692},
+							pos:  position{line: 2371, col: 34, offset: 73177},
 							name: "IdentifierRest",
 						},
 					},
@@ -17446,20 +17585,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2352, col: 1, offset: 72707},
+			pos:  position{line: 2372, col: 1, offset: 73192},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 72720},
+				pos: position{line: 2372, col: 14, offset: 73205},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 72720},
+						pos:        position{line: 2372, col: 14, offset: 73205},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 72739},
+						pos: position{line: 2372, col: 33, offset: 73224},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 72740},
+							pos:  position{line: 2372, col: 34, offset: 73225},
 							name: "IdentifierRest",
 						},
 					},
@@ -17470,20 +17609,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2353, col: 1, offset: 72755},
+			pos:  position{line: 2373, col: 1, offset: 73240},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 72768},
+				pos: position{line: 2373, col: 14, offset: 73253},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 72768},
+						pos:        position{line: 2373, col: 14, offset: 73253},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 72787},
+						pos: position{line: 2373, col: 33, offset: 73272},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 72788},
+							pos:  position{line: 2373, col: 34, offset: 73273},
 							name: "IdentifierRest",
 						},
 					},
@@ -17494,20 +17633,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2354, col: 1, offset: 72803},
+			pos:  position{line: 2374, col: 1, offset: 73288},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 72816},
+				pos: position{line: 2374, col: 14, offset: 73301},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 72816},
+						pos:        position{line: 2374, col: 14, offset: 73301},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 72835},
+						pos: position{line: 2374, col: 33, offset: 73320},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 72836},
+							pos:  position{line: 2374, col: 34, offset: 73321},
 							name: "IdentifierRest",
 						},
 					},
@@ -17518,20 +17657,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2355, col: 1, offset: 72851},
+			pos:  position{line: 2375, col: 1, offset: 73336},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 72864},
+				pos: position{line: 2375, col: 14, offset: 73349},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 72864},
+						pos:        position{line: 2375, col: 14, offset: 73349},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 72883},
+						pos: position{line: 2375, col: 33, offset: 73368},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 72884},
+							pos:  position{line: 2375, col: 34, offset: 73369},
 							name: "IdentifierRest",
 						},
 					},
@@ -17542,20 +17681,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2356, col: 1, offset: 72899},
+			pos:  position{line: 2376, col: 1, offset: 73384},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 72912},
+				pos: position{line: 2376, col: 14, offset: 73397},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 72912},
+						pos:        position{line: 2376, col: 14, offset: 73397},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 72931},
+						pos: position{line: 2376, col: 33, offset: 73416},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 72932},
+							pos:  position{line: 2376, col: 34, offset: 73417},
 							name: "IdentifierRest",
 						},
 					},
@@ -17566,20 +17705,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2357, col: 1, offset: 72947},
+			pos:  position{line: 2377, col: 1, offset: 73432},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 72960},
+				pos: position{line: 2377, col: 14, offset: 73445},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 72960},
+						pos:        position{line: 2377, col: 14, offset: 73445},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 32, offset: 72978},
+						pos: position{line: 2377, col: 32, offset: 73463},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 33, offset: 72979},
+							pos:  position{line: 2377, col: 33, offset: 73464},
 							name: "IdentifierRest",
 						},
 					},
@@ -17590,20 +17729,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2358, col: 1, offset: 72994},
+			pos:  position{line: 2378, col: 1, offset: 73479},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 73007},
+				pos: position{line: 2378, col: 14, offset: 73492},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 73007},
+						pos:        position{line: 2378, col: 14, offset: 73492},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 73026},
+						pos: position{line: 2378, col: 33, offset: 73511},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 73027},
+							pos:  position{line: 2378, col: 34, offset: 73512},
 							name: "IdentifierRest",
 						},
 					},
@@ -17614,20 +17753,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2359, col: 1, offset: 73042},
+			pos:  position{line: 2379, col: 1, offset: 73527},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 73055},
+				pos: position{line: 2379, col: 14, offset: 73540},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 73055},
+						pos:        position{line: 2379, col: 14, offset: 73540},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 73074},
+						pos: position{line: 2379, col: 33, offset: 73559},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 73075},
+							pos:  position{line: 2379, col: 34, offset: 73560},
 							name: "IdentifierRest",
 						},
 					},
@@ -17638,20 +17777,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2360, col: 1, offset: 73090},
+			pos:  position{line: 2380, col: 1, offset: 73575},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 16, offset: 73105},
+				pos: position{line: 2380, col: 16, offset: 73590},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 16, offset: 73105},
+						pos:        position{line: 2380, col: 16, offset: 73590},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 73122},
+						pos: position{line: 2380, col: 33, offset: 73607},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 73123},
+							pos:  position{line: 2380, col: 34, offset: 73608},
 							name: "IdentifierRest",
 						},
 					},
@@ -17662,20 +17801,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2361, col: 1, offset: 73138},
+			pos:  position{line: 2381, col: 1, offset: 73623},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 73151},
+				pos: position{line: 2381, col: 14, offset: 73636},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 73151},
+						pos:        position{line: 2381, col: 14, offset: 73636},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 73170},
+						pos: position{line: 2381, col: 33, offset: 73655},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 73171},
+							pos:  position{line: 2381, col: 34, offset: 73656},
 							name: "IdentifierRest",
 						},
 					},
@@ -17686,20 +17825,20 @@ var g = &grammar{
 		},
 		{
 			name: "MESSAGE",
-			pos:  position{line: 2362, col: 1, offset: 73186},
+			pos:  position{line: 2382, col: 1, offset: 73671},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 73199},
+				pos: position{line: 2382, col: 14, offset: 73684},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 73199},
+						pos:        position{line: 2382, col: 14, offset: 73684},
 						val:        "message",
 						ignoreCase: true,
 						want:       "\"MESSAGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 73218},
+						pos: position{line: 2382, col: 33, offset: 73703},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 73219},
+							pos:  position{line: 2382, col: 34, offset: 73704},
 							name: "IdentifierRest",
 						},
 					},
@@ -17710,20 +17849,20 @@ var g = &grammar{
 		},
 		{
 			name: "META",
-			pos:  position{line: 2363, col: 1, offset: 73234},
+			pos:  position{line: 2383, col: 1, offset: 73719},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 73247},
+				pos: position{line: 2383, col: 14, offset: 73732},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 73247},
+						pos:        position{line: 2383, col: 14, offset: 73732},
 						val:        "meta",
 						ignoreCase: true,
 						want:       "\"META\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 73266},
+						pos: position{line: 2383, col: 33, offset: 73751},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 73267},
+							pos:  position{line: 2383, col: 34, offset: 73752},
 							name: "IdentifierRest",
 						},
 					},
@@ -17734,20 +17873,20 @@ var g = &grammar{
 		},
 		{
 			name: "METHOD",
-			pos:  position{line: 2364, col: 1, offset: 73282},
+			pos:  position{line: 2384, col: 1, offset: 73767},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 73295},
+				pos: position{line: 2384, col: 14, offset: 73780},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 73295},
+						pos:        position{line: 2384, col: 14, offset: 73780},
 						val:        "method",
 						ignoreCase: true,
 						want:       "\"METHOD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 73314},
+						pos: position{line: 2384, col: 33, offset: 73799},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 73315},
+							pos:  position{line: 2384, col: 34, offset: 73800},
 							name: "IdentifierRest",
 						},
 					},
@@ -17758,20 +17897,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2365, col: 1, offset: 73330},
+			pos:  position{line: 2385, col: 1, offset: 73815},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 73343},
+				pos: position{line: 2385, col: 14, offset: 73828},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 73343},
+						pos:        position{line: 2385, col: 14, offset: 73828},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 73362},
+						pos: position{line: 2385, col: 33, offset: 73847},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 73363},
+							pos:  position{line: 2385, col: 34, offset: 73848},
 							name: "IdentifierRest",
 						},
 					},
@@ -17782,20 +17921,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2366, col: 1, offset: 73378},
+			pos:  position{line: 2386, col: 1, offset: 73863},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 73391},
+				pos: position{line: 2386, col: 14, offset: 73876},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 73391},
+						pos:        position{line: 2386, col: 14, offset: 73876},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 73410},
+						pos: position{line: 2386, col: 33, offset: 73895},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 73411},
+							pos:  position{line: 2386, col: 34, offset: 73896},
 							name: "IdentifierRest",
 						},
 					},
@@ -17806,20 +17945,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2367, col: 1, offset: 73426},
+			pos:  position{line: 2387, col: 1, offset: 73911},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 73439},
+				pos: position{line: 2387, col: 14, offset: 73924},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 73439},
+						pos:        position{line: 2387, col: 14, offset: 73924},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 73458},
+						pos: position{line: 2387, col: 33, offset: 73943},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 73459},
+							pos:  position{line: 2387, col: 34, offset: 73944},
 							name: "IdentifierRest",
 						},
 					},
@@ -17830,20 +17969,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2368, col: 1, offset: 73474},
+			pos:  position{line: 2388, col: 1, offset: 73959},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 73487},
+				pos: position{line: 2388, col: 14, offset: 73972},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 73487},
+						pos:        position{line: 2388, col: 14, offset: 73972},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 73506},
+						pos: position{line: 2388, col: 33, offset: 73991},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 73507},
+							pos:  position{line: 2388, col: 34, offset: 73992},
 							name: "IdentifierRest",
 						},
 					},
@@ -17854,20 +17993,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2369, col: 1, offset: 73522},
+			pos:  position{line: 2389, col: 1, offset: 74007},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 73535},
+				pos: position{line: 2389, col: 14, offset: 74020},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 73535},
+						pos:        position{line: 2389, col: 14, offset: 74020},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 73554},
+						pos: position{line: 2389, col: 33, offset: 74039},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 73555},
+							pos:  position{line: 2389, col: 34, offset: 74040},
 							name: "IdentifierRest",
 						},
 					},
@@ -17878,20 +18017,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2370, col: 1, offset: 73570},
+			pos:  position{line: 2390, col: 1, offset: 74055},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 73583},
+				pos: position{line: 2390, col: 14, offset: 74068},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 73583},
+						pos:        position{line: 2390, col: 14, offset: 74068},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 73602},
+						pos: position{line: 2390, col: 33, offset: 74087},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 73603},
+							pos:  position{line: 2390, col: 34, offset: 74088},
 							name: "IdentifierRest",
 						},
 					},
@@ -17902,23 +18041,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2371, col: 1, offset: 73618},
+			pos:  position{line: 2391, col: 1, offset: 74103},
 			expr: &actionExpr{
-				pos: position{line: 2371, col: 14, offset: 73631},
+				pos: position{line: 2391, col: 14, offset: 74116},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2371, col: 14, offset: 73631},
+					pos: position{line: 2391, col: 14, offset: 74116},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2371, col: 14, offset: 73631},
+							pos:        position{line: 2391, col: 14, offset: 74116},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2371, col: 33, offset: 73650},
+							pos: position{line: 2391, col: 33, offset: 74135},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2371, col: 34, offset: 73651},
+								pos:  position{line: 2391, col: 34, offset: 74136},
 								name: "IdentifierRest",
 							},
 						},
@@ -17930,20 +18069,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2372, col: 1, offset: 73687},
+			pos:  position{line: 2392, col: 1, offset: 74172},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 73700},
+				pos: position{line: 2392, col: 14, offset: 74185},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 73700},
+						pos:        position{line: 2392, col: 14, offset: 74185},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 73719},
+						pos: position{line: 2392, col: 33, offset: 74204},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 73720},
+							pos:  position{line: 2392, col: 34, offset: 74205},
 							name: "IdentifierRest",
 						},
 					},
@@ -17954,20 +18093,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2373, col: 1, offset: 73735},
+			pos:  position{line: 2393, col: 1, offset: 74220},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 73748},
+				pos: position{line: 2393, col: 14, offset: 74233},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 73748},
+						pos:        position{line: 2393, col: 14, offset: 74233},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 73767},
+						pos: position{line: 2393, col: 33, offset: 74252},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 73768},
+							pos:  position{line: 2393, col: 34, offset: 74253},
 							name: "IdentifierRest",
 						},
 					},
@@ -17978,20 +18117,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2374, col: 1, offset: 73783},
+			pos:  position{line: 2394, col: 1, offset: 74268},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 73796},
+				pos: position{line: 2394, col: 14, offset: 74281},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 73796},
+						pos:        position{line: 2394, col: 14, offset: 74281},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 73815},
+						pos: position{line: 2394, col: 33, offset: 74300},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 73816},
+							pos:  position{line: 2394, col: 34, offset: 74301},
 							name: "IdentifierRest",
 						},
 					},
@@ -18002,20 +18141,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2375, col: 1, offset: 73831},
+			pos:  position{line: 2395, col: 1, offset: 74316},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 73844},
+				pos: position{line: 2395, col: 14, offset: 74329},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 73844},
+						pos:        position{line: 2395, col: 14, offset: 74329},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 73863},
+						pos: position{line: 2395, col: 33, offset: 74348},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 73864},
+							pos:  position{line: 2395, col: 34, offset: 74349},
 							name: "IdentifierRest",
 						},
 					},
@@ -18026,20 +18165,20 @@ var g = &grammar{
 		},
 		{
 			name: "OVER",
-			pos:  position{line: 2376, col: 1, offset: 73879},
+			pos:  position{line: 2396, col: 1, offset: 74364},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 73892},
+				pos: position{line: 2396, col: 14, offset: 74377},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 73892},
+						pos:        position{line: 2396, col: 14, offset: 74377},
 						val:        "over",
 						ignoreCase: true,
 						want:       "\"OVER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 73911},
+						pos: position{line: 2396, col: 33, offset: 74396},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 73912},
+							pos:  position{line: 2396, col: 34, offset: 74397},
 							name: "IdentifierRest",
 						},
 					},
@@ -18050,20 +18189,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2377, col: 1, offset: 73927},
+			pos:  position{line: 2397, col: 1, offset: 74412},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 73940},
+				pos: position{line: 2397, col: 14, offset: 74425},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 73940},
+						pos:        position{line: 2397, col: 14, offset: 74425},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 73959},
+						pos: position{line: 2397, col: 33, offset: 74444},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 73960},
+							pos:  position{line: 2397, col: 34, offset: 74445},
 							name: "IdentifierRest",
 						},
 					},
@@ -18074,20 +18213,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2378, col: 1, offset: 73975},
+			pos:  position{line: 2398, col: 1, offset: 74460},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 73988},
+				pos: position{line: 2398, col: 14, offset: 74473},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 73988},
+						pos:        position{line: 2398, col: 14, offset: 74473},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 74007},
+						pos: position{line: 2398, col: 33, offset: 74492},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 74008},
+							pos:  position{line: 2398, col: 34, offset: 74493},
 							name: "IdentifierRest",
 						},
 					},
@@ -18098,20 +18237,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2379, col: 1, offset: 74023},
+			pos:  position{line: 2399, col: 1, offset: 74508},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 74036},
+				pos: position{line: 2399, col: 14, offset: 74521},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 74036},
+						pos:        position{line: 2399, col: 14, offset: 74521},
 						val:        "RECURSIVE",
 						ignoreCase: false,
 						want:       "\"RECURSIVE\"",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 74055},
+						pos: position{line: 2399, col: 33, offset: 74540},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 74056},
+							pos:  position{line: 2399, col: 34, offset: 74541},
 							name: "IdentifierRest",
 						},
 					},
@@ -18122,20 +18261,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP",
-			pos:  position{line: 2380, col: 1, offset: 74071},
+			pos:  position{line: 2400, col: 1, offset: 74556},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 74084},
+				pos: position{line: 2400, col: 14, offset: 74569},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 74084},
+						pos:        position{line: 2400, col: 14, offset: 74569},
 						val:        "regexp",
 						ignoreCase: true,
 						want:       "\"REGEXP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 74103},
+						pos: position{line: 2400, col: 33, offset: 74588},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 74104},
+							pos:  position{line: 2400, col: 34, offset: 74589},
 							name: "IdentifierRest",
 						},
 					},
@@ -18146,20 +18285,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP_REPLACE",
-			pos:  position{line: 2381, col: 1, offset: 74119},
+			pos:  position{line: 2401, col: 1, offset: 74604},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 18, offset: 74136},
+				pos: position{line: 2401, col: 18, offset: 74621},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 18, offset: 74136},
+						pos:        position{line: 2401, col: 18, offset: 74621},
 						val:        "regexp_replace",
 						ignoreCase: true,
 						want:       "\"REGEXP_REPLACE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 36, offset: 74154},
+						pos: position{line: 2401, col: 36, offset: 74639},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 37, offset: 74155},
+							pos:  position{line: 2401, col: 37, offset: 74640},
 							name: "IdentifierRest",
 						},
 					},
@@ -18170,20 +18309,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2382, col: 1, offset: 74170},
+			pos:  position{line: 2402, col: 1, offset: 74655},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 74183},
+				pos: position{line: 2402, col: 14, offset: 74668},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 74183},
+						pos:        position{line: 2402, col: 14, offset: 74668},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 74202},
+						pos: position{line: 2402, col: 33, offset: 74687},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 74203},
+							pos:  position{line: 2402, col: 34, offset: 74688},
 							name: "IdentifierRest",
 						},
 					},
@@ -18194,20 +18333,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2383, col: 1, offset: 74218},
+			pos:  position{line: 2403, col: 1, offset: 74703},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 74231},
+				pos: position{line: 2403, col: 14, offset: 74716},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 74231},
+						pos:        position{line: 2403, col: 14, offset: 74716},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 74250},
+						pos: position{line: 2403, col: 33, offset: 74735},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 74251},
+							pos:  position{line: 2403, col: 34, offset: 74736},
 							name: "IdentifierRest",
 						},
 					},
@@ -18218,20 +18357,20 @@ var g = &grammar{
 		},
 		{
 			name: "SAMPLE",
-			pos:  position{line: 2384, col: 1, offset: 74266},
+			pos:  position{line: 2404, col: 1, offset: 74751},
 			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 74279},
+				pos: position{line: 2404, col: 14, offset: 74764},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 74279},
+						pos:        position{line: 2404, col: 14, offset: 74764},
 						val:        "sample",
 						ignoreCase: true,
 						want:       "\"SAMPLE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 74298},
+						pos: position{line: 2404, col: 33, offset: 74783},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 74299},
+							pos:  position{line: 2404, col: 34, offset: 74784},
 							name: "IdentifierRest",
 						},
 					},
@@ -18242,20 +18381,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2385, col: 1, offset: 74314},
+			pos:  position{line: 2405, col: 1, offset: 74799},
 			expr: &seqExpr{
-				pos: position{line: 2385, col: 14, offset: 74327},
+				pos: position{line: 2405, col: 14, offset: 74812},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2385, col: 14, offset: 74327},
+						pos:        position{line: 2405, col: 14, offset: 74812},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2385, col: 33, offset: 74346},
+						pos: position{line: 2405, col: 33, offset: 74831},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 34, offset: 74347},
+							pos:  position{line: 2405, col: 34, offset: 74832},
 							name: "IdentifierRest",
 						},
 					},
@@ -18266,20 +18405,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2386, col: 1, offset: 74362},
+			pos:  position{line: 2406, col: 1, offset: 74847},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 74375},
+				pos: position{line: 2406, col: 14, offset: 74860},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 74375},
+						pos:        position{line: 2406, col: 14, offset: 74860},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 74394},
+						pos: position{line: 2406, col: 33, offset: 74879},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 74395},
+							pos:  position{line: 2406, col: 34, offset: 74880},
 							name: "IdentifierRest",
 						},
 					},
@@ -18290,20 +18429,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2387, col: 1, offset: 74410},
+			pos:  position{line: 2407, col: 1, offset: 74895},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 74423},
+				pos: position{line: 2407, col: 14, offset: 74908},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 74423},
+						pos:        position{line: 2407, col: 14, offset: 74908},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 74442},
+						pos: position{line: 2407, col: 33, offset: 74927},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 74443},
+							pos:  position{line: 2407, col: 34, offset: 74928},
 							name: "IdentifierRest",
 						},
 					},
@@ -18314,20 +18453,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2388, col: 1, offset: 74458},
+			pos:  position{line: 2408, col: 1, offset: 74943},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 74471},
+				pos: position{line: 2408, col: 14, offset: 74956},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 74471},
+						pos:        position{line: 2408, col: 14, offset: 74956},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 74490},
+						pos: position{line: 2408, col: 33, offset: 74975},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 74491},
+							pos:  position{line: 2408, col: 34, offset: 74976},
 							name: "IdentifierRest",
 						},
 					},
@@ -18338,20 +18477,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2389, col: 1, offset: 74506},
+			pos:  position{line: 2409, col: 1, offset: 74991},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 74519},
+				pos: position{line: 2409, col: 14, offset: 75004},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 74519},
+						pos:        position{line: 2409, col: 14, offset: 75004},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 74538},
+						pos: position{line: 2409, col: 33, offset: 75023},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 74539},
+							pos:  position{line: 2409, col: 34, offset: 75024},
 							name: "IdentifierRest",
 						},
 					},
@@ -18362,20 +18501,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2390, col: 1, offset: 74554},
+			pos:  position{line: 2410, col: 1, offset: 75039},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 14, offset: 74567},
+				pos: position{line: 2410, col: 14, offset: 75052},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 14, offset: 74567},
+						pos:        position{line: 2410, col: 14, offset: 75052},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 74586},
+						pos: position{line: 2410, col: 33, offset: 75071},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 74587},
+							pos:  position{line: 2410, col: 34, offset: 75072},
 							name: "IdentifierRest",
 						},
 					},
@@ -18386,20 +18525,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2391, col: 1, offset: 74602},
+			pos:  position{line: 2411, col: 1, offset: 75087},
 			expr: &seqExpr{
-				pos: position{line: 2391, col: 14, offset: 74615},
+				pos: position{line: 2411, col: 14, offset: 75100},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2391, col: 14, offset: 74615},
+						pos:        position{line: 2411, col: 14, offset: 75100},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2391, col: 33, offset: 74634},
+						pos: position{line: 2411, col: 33, offset: 75119},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2391, col: 34, offset: 74635},
+							pos:  position{line: 2411, col: 34, offset: 75120},
 							name: "IdentifierRest",
 						},
 					},
@@ -18410,20 +18549,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2392, col: 1, offset: 74650},
+			pos:  position{line: 2412, col: 1, offset: 75135},
 			expr: &seqExpr{
-				pos: position{line: 2392, col: 14, offset: 74663},
+				pos: position{line: 2412, col: 14, offset: 75148},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2392, col: 14, offset: 74663},
+						pos:        position{line: 2412, col: 14, offset: 75148},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2392, col: 33, offset: 74682},
+						pos: position{line: 2412, col: 33, offset: 75167},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2392, col: 34, offset: 74683},
+							pos:  position{line: 2412, col: 34, offset: 75168},
 							name: "IdentifierRest",
 						},
 					},
@@ -18434,20 +18573,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2393, col: 1, offset: 74698},
+			pos:  position{line: 2413, col: 1, offset: 75183},
 			expr: &seqExpr{
-				pos: position{line: 2393, col: 14, offset: 74711},
+				pos: position{line: 2413, col: 14, offset: 75196},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2393, col: 14, offset: 74711},
+						pos:        position{line: 2413, col: 14, offset: 75196},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2393, col: 33, offset: 74730},
+						pos: position{line: 2413, col: 33, offset: 75215},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2393, col: 34, offset: 74731},
+							pos:  position{line: 2413, col: 34, offset: 75216},
 							name: "IdentifierRest",
 						},
 					},
@@ -18458,20 +18597,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAP",
-			pos:  position{line: 2394, col: 1, offset: 74747},
+			pos:  position{line: 2414, col: 1, offset: 75232},
 			expr: &seqExpr{
-				pos: position{line: 2394, col: 14, offset: 74760},
+				pos: position{line: 2414, col: 14, offset: 75245},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2394, col: 14, offset: 74760},
+						pos:        position{line: 2414, col: 14, offset: 75245},
 						val:        "tap",
 						ignoreCase: true,
 						want:       "\"TAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2394, col: 33, offset: 74779},
+						pos: position{line: 2414, col: 33, offset: 75264},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2394, col: 34, offset: 74780},
+							pos:  position{line: 2414, col: 34, offset: 75265},
 							name: "IdentifierRest",
 						},
 					},
@@ -18482,20 +18621,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2395, col: 1, offset: 74795},
+			pos:  position{line: 2415, col: 1, offset: 75280},
 			expr: &seqExpr{
-				pos: position{line: 2395, col: 14, offset: 74808},
+				pos: position{line: 2415, col: 14, offset: 75293},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2395, col: 14, offset: 74808},
+						pos:        position{line: 2415, col: 14, offset: 75293},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2395, col: 33, offset: 74827},
+						pos: position{line: 2415, col: 33, offset: 75312},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2395, col: 34, offset: 74828},
+							pos:  position{line: 2415, col: 34, offset: 75313},
 							name: "IdentifierRest",
 						},
 					},
@@ -18506,23 +18645,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2396, col: 1, offset: 74843},
+			pos:  position{line: 2416, col: 1, offset: 75328},
 			expr: &actionExpr{
-				pos: position{line: 2396, col: 14, offset: 74856},
+				pos: position{line: 2416, col: 14, offset: 75341},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2396, col: 14, offset: 74856},
+					pos: position{line: 2416, col: 14, offset: 75341},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2396, col: 14, offset: 74856},
+							pos:        position{line: 2416, col: 14, offset: 75341},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2396, col: 33, offset: 74875},
+							pos: position{line: 2416, col: 33, offset: 75360},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2396, col: 34, offset: 74876},
+								pos:  position{line: 2416, col: 34, offset: 75361},
 								name: "IdentifierRest",
 							},
 						},
@@ -18534,20 +18673,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2397, col: 1, offset: 74919},
+			pos:  position{line: 2417, col: 1, offset: 75404},
 			expr: &seqExpr{
-				pos: position{line: 2397, col: 14, offset: 74932},
+				pos: position{line: 2417, col: 14, offset: 75417},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2397, col: 14, offset: 74932},
+						pos:        position{line: 2417, col: 14, offset: 75417},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2397, col: 33, offset: 74951},
+						pos: position{line: 2417, col: 33, offset: 75436},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2397, col: 34, offset: 74952},
+							pos:  position{line: 2417, col: 34, offset: 75437},
 							name: "IdentifierRest",
 						},
 					},
@@ -18558,20 +18697,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2398, col: 1, offset: 74967},
+			pos:  position{line: 2418, col: 1, offset: 75452},
 			expr: &seqExpr{
-				pos: position{line: 2398, col: 14, offset: 74980},
+				pos: position{line: 2418, col: 14, offset: 75465},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2398, col: 14, offset: 74980},
+						pos:        position{line: 2418, col: 14, offset: 75465},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2398, col: 33, offset: 74999},
+						pos: position{line: 2418, col: 33, offset: 75484},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2398, col: 34, offset: 75000},
+							pos:  position{line: 2418, col: 34, offset: 75485},
 							name: "IdentifierRest",
 						},
 					},
@@ -18582,20 +18721,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2399, col: 1, offset: 75015},
+			pos:  position{line: 2419, col: 1, offset: 75500},
 			expr: &seqExpr{
-				pos: position{line: 2399, col: 14, offset: 75028},
+				pos: position{line: 2419, col: 14, offset: 75513},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2399, col: 14, offset: 75028},
+						pos:        position{line: 2419, col: 14, offset: 75513},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2399, col: 33, offset: 75047},
+						pos: position{line: 2419, col: 33, offset: 75532},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2399, col: 34, offset: 75048},
+							pos:  position{line: 2419, col: 34, offset: 75533},
 							name: "IdentifierRest",
 						},
 					},
@@ -18606,20 +18745,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2400, col: 1, offset: 75063},
+			pos:  position{line: 2420, col: 1, offset: 75548},
 			expr: &seqExpr{
-				pos: position{line: 2400, col: 14, offset: 75076},
+				pos: position{line: 2420, col: 14, offset: 75561},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2400, col: 14, offset: 75076},
+						pos:        position{line: 2420, col: 14, offset: 75561},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2400, col: 33, offset: 75095},
+						pos: position{line: 2420, col: 33, offset: 75580},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2400, col: 34, offset: 75096},
+							pos:  position{line: 2420, col: 34, offset: 75581},
 							name: "IdentifierRest",
 						},
 					},
@@ -18630,20 +18769,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2401, col: 1, offset: 75111},
+			pos:  position{line: 2421, col: 1, offset: 75596},
 			expr: &seqExpr{
-				pos: position{line: 2401, col: 14, offset: 75124},
+				pos: position{line: 2421, col: 14, offset: 75609},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2401, col: 14, offset: 75124},
+						pos:        position{line: 2421, col: 14, offset: 75609},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2401, col: 33, offset: 75143},
+						pos: position{line: 2421, col: 33, offset: 75628},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2401, col: 34, offset: 75144},
+							pos:  position{line: 2421, col: 34, offset: 75629},
 							name: "IdentifierRest",
 						},
 					},
@@ -18654,20 +18793,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2402, col: 1, offset: 75160},
+			pos:  position{line: 2422, col: 1, offset: 75645},
 			expr: &seqExpr{
-				pos: position{line: 2402, col: 14, offset: 75173},
+				pos: position{line: 2422, col: 14, offset: 75658},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2402, col: 14, offset: 75173},
+						pos:        position{line: 2422, col: 14, offset: 75658},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2402, col: 33, offset: 75192},
+						pos: position{line: 2422, col: 33, offset: 75677},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2402, col: 34, offset: 75193},
+							pos:  position{line: 2422, col: 34, offset: 75678},
 							name: "IdentifierRest",
 						},
 					},
@@ -18678,20 +18817,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2403, col: 1, offset: 75208},
+			pos:  position{line: 2423, col: 1, offset: 75693},
 			expr: &seqExpr{
-				pos: position{line: 2403, col: 14, offset: 75221},
+				pos: position{line: 2423, col: 14, offset: 75706},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2403, col: 14, offset: 75221},
+						pos:        position{line: 2423, col: 14, offset: 75706},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2403, col: 33, offset: 75240},
+						pos: position{line: 2423, col: 33, offset: 75725},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2403, col: 34, offset: 75241},
+							pos:  position{line: 2423, col: 34, offset: 75726},
 							name: "IdentifierRest",
 						},
 					},
@@ -18702,20 +18841,44 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2404, col: 1, offset: 75256},
+			pos:  position{line: 2424, col: 1, offset: 75741},
 			expr: &seqExpr{
-				pos: position{line: 2404, col: 14, offset: 75269},
+				pos: position{line: 2424, col: 14, offset: 75754},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2404, col: 14, offset: 75269},
+						pos:        position{line: 2424, col: 14, offset: 75754},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2404, col: 33, offset: 75288},
+						pos: position{line: 2424, col: 33, offset: 75773},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2404, col: 34, offset: 75289},
+							pos:  position{line: 2424, col: 34, offset: 75774},
+							name: "IdentifierRest",
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "VALUES",
+			pos:  position{line: 2425, col: 1, offset: 75789},
+			expr: &seqExpr{
+				pos: position{line: 2425, col: 14, offset: 75802},
+				exprs: []any{
+					&litMatcher{
+						pos:        position{line: 2425, col: 14, offset: 75802},
+						val:        "values",
+						ignoreCase: true,
+						want:       "\"VALUES\"i",
+					},
+					&notExpr{
+						pos: position{line: 2425, col: 33, offset: 75821},
+						expr: &ruleRefExpr{
+							pos:  position{line: 2425, col: 34, offset: 75822},
 							name: "IdentifierRest",
 						},
 					},
@@ -18726,20 +18889,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2405, col: 1, offset: 75304},
+			pos:  position{line: 2426, col: 1, offset: 75837},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 75317},
+				pos: position{line: 2426, col: 14, offset: 75850},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 75317},
+						pos:        position{line: 2426, col: 14, offset: 75850},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 75336},
+						pos: position{line: 2426, col: 33, offset: 75869},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 75337},
+							pos:  position{line: 2426, col: 34, offset: 75870},
 							name: "IdentifierRest",
 						},
 					},
@@ -18750,20 +18913,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2406, col: 1, offset: 75352},
+			pos:  position{line: 2427, col: 1, offset: 75885},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 75365},
+				pos: position{line: 2427, col: 14, offset: 75898},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 75365},
+						pos:        position{line: 2427, col: 14, offset: 75898},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 75384},
+						pos: position{line: 2427, col: 33, offset: 75917},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 75385},
+							pos:  position{line: 2427, col: 34, offset: 75918},
 							name: "IdentifierRest",
 						},
 					},
@@ -18774,20 +18937,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2407, col: 1, offset: 75400},
+			pos:  position{line: 2428, col: 1, offset: 75933},
 			expr: &seqExpr{
-				pos: position{line: 2407, col: 14, offset: 75413},
+				pos: position{line: 2428, col: 14, offset: 75946},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2407, col: 14, offset: 75413},
+						pos:        position{line: 2428, col: 14, offset: 75946},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2407, col: 33, offset: 75432},
+						pos: position{line: 2428, col: 33, offset: 75965},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2407, col: 34, offset: 75433},
+							pos:  position{line: 2428, col: 34, offset: 75966},
 							name: "IdentifierRest",
 						},
 					},
@@ -18798,20 +18961,20 @@ var g = &grammar{
 		},
 		{
 			name: "YIELD",
-			pos:  position{line: 2408, col: 1, offset: 75448},
+			pos:  position{line: 2429, col: 1, offset: 75981},
 			expr: &seqExpr{
-				pos: position{line: 2408, col: 14, offset: 75461},
+				pos: position{line: 2429, col: 14, offset: 75994},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2408, col: 14, offset: 75461},
+						pos:        position{line: 2429, col: 14, offset: 75994},
 						val:        "yield",
 						ignoreCase: true,
 						want:       "\"YIELD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2408, col: 33, offset: 75480},
+						pos: position{line: 2429, col: 33, offset: 76013},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2408, col: 34, offset: 75481},
+							pos:  position{line: 2429, col: 34, offset: 76014},
 							name: "IdentifierRest",
 						},
 					},
@@ -20237,7 +20400,7 @@ func (c *current) onFromElem1(entity, args, o, alias any) (any, error) {
 		elem.Ordinality = o.(*ast.Ordinality)
 	}
 	if alias != nil {
-		elem.Alias = alias.(*ast.Name)
+		elem.Alias = alias.(*ast.TableAlias)
 	}
 	return elem, nil
 
@@ -22790,14 +22953,14 @@ func (p *parser) callonSelectOp1() (any, error) {
 	return p.cur.onSelectOp1(stack["op"])
 }
 
-func (c *current) onSelectExpr9(s any) (any, error) {
+func (c *current) onSelectExpr10(s any) (any, error) {
 	return s, nil
 }
 
-func (p *parser) callonSelectExpr9() (any, error) {
+func (p *parser) callonSelectExpr10() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSelectExpr9(stack["s"])
+	return p.cur.onSelectExpr10(stack["s"])
 }
 
 func (c *current) onSelectExpr1(with, body, orderby, loff any) (any, error) {
@@ -22855,6 +23018,21 @@ func (p *parser) callonSelect1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSelect1(stack["distinct"], stack["value"], stack["selection"], stack["from"], stack["where"], stack["group"], stack["having"])
+}
+
+func (c *current) onValues1(exprs any) (any, error) {
+	return &ast.Values{
+		Kind:  "Values",
+		Exprs: sliceOf[ast.Expr](exprs),
+		Loc:   loc(c),
+	}, nil
+
+}
+
+func (p *parser) callonValues1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onValues1(stack["exprs"])
 }
 
 func (c *current) onOptDistinct2() (any, error) {
@@ -22985,7 +23163,7 @@ func (p *parser) callonCteList1() (any, error) {
 
 func (c *current) onCte1(name, m, s any) (any, error) {
 	return ast.CTE{
-		Name:         name.(string),
+		Name:         name.(*ast.ID).Name,
 		Materialized: m.(*bool),
 		Op:           s.(ast.Op),
 		Loc:          loc(c),
@@ -23300,16 +23478,51 @@ func (p *parser) callonOptAlias7() (any, error) {
 	return p.cur.onOptAlias7()
 }
 
-func (c *current) onAliasClause1(name any) (any, error) {
-	// optional column defs no types
-	return &ast.Name{Kind: "Name", Text: name.(string), Loc: loc(c)}, nil
+func (c *current) onAliasClause1(name, cols any) (any, error) {
+
+	alias := &ast.TableAlias{Kind: "TableAlias", Name: name.(string), Loc: loc(c)}
+	if cols != nil {
+		alias.Columns = cols.([]*ast.ID)
+	}
+	return alias, nil
 
 }
 
 func (p *parser) callonAliasClause1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAliasClause1(stack["name"])
+	return p.cur.onAliasClause1(stack["name"], stack["cols"])
+}
+
+func (c *current) onOptColumns10(s any) (any, error) {
+	return s, nil
+}
+
+func (p *parser) callonOptColumns10() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOptColumns10(stack["s"])
+}
+
+func (c *current) onOptColumns2(first, rest any) (any, error) {
+	return sliceOf[*ast.ID](prepend(first, rest)), nil
+
+}
+
+func (p *parser) callonOptColumns2() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOptColumns2(stack["first"], stack["rest"])
+}
+
+func (c *current) onOptColumns19() (any, error) {
+	return nil, nil
+}
+
+func (p *parser) callonOptColumns19() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOptColumns19()
 }
 
 func (c *current) onSelection7(s any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -712,7 +712,7 @@ FromElem
         elem.Ordinality = o.(*ast.Ordinality)
       }      
       if alias != nil {
-        elem.Alias = alias.(*ast.Name)
+        elem.Alias = alias.(*ast.TableAlias)
       }
       return elem, nil
     }
@@ -1951,6 +1951,7 @@ SelectExpr
     body:(
         SetOperation
       / Select
+      / Values
       / "(" __ s:SQLPipe __")"      { return s, nil }
     )
     orderby:OptOrderByClause
@@ -2010,6 +2011,15 @@ Select
       return sel, nil
     }
 
+Values
+  = VALUES _ exprs:Exprs {
+      return &ast.Values{
+          Kind: "Values",
+          Exprs: sliceOf[ast.Expr](exprs),
+          Loc: loc(c),
+      }, nil
+    }
+
 OptDistinct
   = _ ALL        { return false, nil }
   / _ DISTINCT   { return true, nil }
@@ -2045,7 +2055,7 @@ CteList = first:Cte rest:( __ "," __ cte:Cte { return cte, nil} )* {
 Cte
   = name:SQLIdentifier _ AS m:OptMaterialized __ "(" __ s:SQLPipe __ ")" {
         return ast.CTE{
-            Name: name.(string),
+            Name: name.(*ast.ID).Name,
             Materialized: m.(*bool),
             Op: s.(ast.Op),
             Loc: loc(c),
@@ -2158,9 +2168,19 @@ OptAlias
   / ""              { return nil, nil }
 
 AliasClause 
-  = (AS _)? !(SQLGuard / DeprecatedFroms) name:IdentifierName { // optional column defs no types
-      return &ast.Name{Kind: "Name", Text: name.(string), Loc: loc(c)}, nil
+  = (AS _)? !(SQLGuard / DeprecatedFroms) name:IdentifierName cols:OptColumns { 
+      alias := &ast.TableAlias{Kind: "TableAlias", Name: name.(string), Loc: loc(c)}
+      if cols != nil {
+        alias.Columns = cols.([]*ast.ID)
+      }
+      return alias, nil
     }
+
+OptColumns 
+  = "(" __ first:SQLIdentifier rest:( __ "," __ s:SQLIdentifier{ return s, nil })* __ ")" {
+        return sliceOf[*ast.ID](prepend(first,rest)), nil 
+    }
+  / "" { return nil, nil }
 
 Selection
   = first:SelectElem rest:( __ "," __ s:SelectElem{ return s, nil })* {
@@ -2402,6 +2422,7 @@ UNIQ       = "UNIQ"i            !IdentifierRest
 UNNEST     = "UNNEST"i          !IdentifierRest
 USING      = "USING"i           !IdentifierRest
 VALUE      = "VALUE"i           !IdentifierRest
+VALUES     = "VALUES"i          !IdentifierRest
 WHEN       = "WHEN"i            !IdentifierRest
 WHERE      = "WHERE"i           !IdentifierRest
 WITH       = "WITH"i            !IdentifierRest

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -2167,8 +2167,8 @@ OptAlias
   = _ a:AliasClause { return a, nil }
   / ""              { return nil, nil }
 
-AliasClause 
-  = (AS _)? !(SQLGuard / DeprecatedFroms) name:IdentifierName cols:OptColumns { 
+AliasClause
+ = (AS _)? !(SQLGuard / DeprecatedFroms) name:IdentifierName cols:Columns? {
       alias := &ast.TableAlias{Kind: "TableAlias", Name: name.(string), Loc: loc(c)}
       if cols != nil {
         alias.Columns = cols.([]*ast.ID)
@@ -2176,11 +2176,10 @@ AliasClause
       return alias, nil
     }
 
-OptColumns 
-  = "(" __ first:SQLIdentifier rest:( __ "," __ s:SQLIdentifier{ return s, nil })* __ ")" {
+Columns
+  = __ "(" __ first:SQLIdentifier rest:( __ "," __ s:SQLIdentifier{ return s, nil })* __ ")" {
         return sliceOf[*ast.ID](prepend(first,rest)), nil 
     }
-  / "" { return nil, nil }
 
 Selection
   = first:SelectElem rest:( __ "," __ s:SelectElem{ return s, nil })* {

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -3,9 +3,12 @@ package semantic
 import (
 	"errors"
 	"fmt"
+	"slices"
 
+	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/ast"
 	"github.com/brimdata/super/compiler/dag"
+	"github.com/brimdata/super/compiler/kernel"
 	"github.com/brimdata/super/order"
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/zfmt"
@@ -322,6 +325,47 @@ func (a *analyzer) semSelectValue(sel *ast.Select, sch schema, seq dag.Seq) (dag
 	return seq, &dynamicSchema{}
 }
 
+func (a *analyzer) semValues(values *ast.Values, seq dag.Seq) (dag.Seq, schema) {
+	var schema *super.TypeRecord
+	exprs := make([]dag.Expr, 0, len(values.Exprs))
+	sctx := super.NewContext()
+	for _, astExpr := range values.Exprs {
+		e := a.semExpr(astExpr)
+		val, err := kernel.EvalAtCompileTime(sctx, e)
+		if err != nil {
+			a.error(astExpr, errors.New("expressions in values clause must be constant"))
+			return seq, badSchema()
+		}
+		recType, ok := super.TypeUnder(val.Type()).(*super.TypeRecord)
+		if !ok {
+			// Turn non record values into single column tuple
+			f := &dag.Field{Kind: "Field", Name: "c0", Value: e}
+			e = &dag.RecordExpr{Kind: "RecordExpr", Elems: []dag.RecordElem{f}}
+			val, _ := kernel.EvalAtCompileTime(sctx, e)
+			recType = super.TypeUnder(val.Type()).(*super.TypeRecord)
+		}
+		if schema == nil {
+			schema = recType
+		} else if schema != recType {
+			a.error(astExpr, errors.New("values clause must contain uniformly typed values"))
+		}
+		exprs = append(exprs, e)
+	}
+	if schema == nil {
+		a.error(values, errors.New("values clause must contain uniformly typed values"))
+		return seq, badSchema()
+	}
+	columns := make([]string, 0, len(schema.Fields))
+	for _, f := range schema.Fields {
+		columns = append(columns, f.Name)
+	}
+	seq = append(seq, &dag.Yield{
+		Kind:  "Yield",
+		Exprs: exprs,
+	})
+	return seq, &anonSchema{columns}
+}
+
 func (a *analyzer) genDistinct(e dag.Expr, seq dag.Seq) dag.Seq {
 	return append(seq, &dag.Distinct{
 		Kind: "Distinct",
@@ -329,28 +373,93 @@ func (a *analyzer) genDistinct(e dag.Expr, seq dag.Seq) dag.Seq {
 	})
 }
 
-func (a *analyzer) semSQLPipe(op *ast.SQLPipe, seq dag.Seq, alias string) (dag.Seq, schema) {
+func (a *analyzer) semSQLPipe(op *ast.SQLPipe, seq dag.Seq, alias *ast.TableAlias) (dag.Seq, schema) {
 	if len(op.Ops) == 1 && isSQLOp(op.Ops[0]) {
 		seq, sch := a.semSQLOp(op.Ops[0], seq)
-		return derefSchema(sch, alias, seq)
+		outSeq, outSch, err := derefSchemaWithAlias(sch, alias, seq)
+		if err != nil {
+			a.error(op.Ops[0], err)
+		}
+		return outSeq, outSch
 	}
 	if len(seq) > 0 {
 		panic("semSQLOp: SQL pipes can't have parents")
 	}
-	return a.semSeq(op.Ops), &dynamicSchema{name: alias}
+	var name string
+	if alias != nil {
+		name = alias.Name
+		if len(alias.Columns) != 0 {
+			a.error(alias, errors.New("cannot apply aliased columns to dynamically typed data"))
+		}
+	}
+	return a.semSeq(op.Ops), &dynamicSchema{name: name}
 }
 
-func derefSchema(sch schema, alias string, seq dag.Seq) (dag.Seq, schema) {
-	e, sch := sch.deref(alias)
+func derefSchemaAs(sch schema, table string, seq dag.Seq) (dag.Seq, schema) {
+	e, sch := sch.deref(table)
 	if e != nil {
 		seq = yieldExpr(e, seq)
 	}
 	return seq, sch
 }
 
+func derefSchema(sch schema, seq dag.Seq) (dag.Seq, schema) {
+	return derefSchemaAs(sch, "", seq)
+}
+
+func derefSchemaWithAlias(insch schema, alias *ast.TableAlias, inseq dag.Seq) (dag.Seq, schema, error) {
+	var table string
+	if alias != nil {
+		table = alias.Name
+	}
+	seq, sch := derefSchemaAs(insch, table, inseq)
+	if alias == nil || len(alias.Columns) == 0 {
+		return seq, sch, nil
+	}
+	switch sch := sch.(type) {
+	case *anonSchema:
+		return mapColumns(sch.columns, alias, seq)
+	case *staticSchema:
+		return mapColumns(sch.columns, alias, seq)
+	default:
+		return seq, sch, errors.New("cannot apply column aliases to dynamically typed data")
+	}
+}
+
+func mapColumns(in []string, alias *ast.TableAlias, seq dag.Seq) (dag.Seq, schema, error) {
+	if len(alias.Columns) > len(in) {
+		return nil, nil, fmt.Errorf("cannot apply %d aliased columns in alias %q to table with %d columns", len(alias.Columns), alias.Name, len(in))
+	}
+	out := idsToStrings(alias.Columns)
+	if !slices.Equal(in, out) {
+		// Make a record expression...
+		elems := make([]dag.RecordElem, 0, len(in))
+		for k := range out {
+			elems = append(elems, &dag.Field{
+				Kind:  "Field",
+				Name:  out[k],
+				Value: &dag.This{Kind: "This", Path: []string{in[k]}},
+			})
+		}
+		seq = yieldExpr(&dag.RecordExpr{
+			Kind:  "RecordExpr",
+			Elems: elems,
+		}, seq)
+	}
+	return seq, &staticSchema{alias.Name, out}, nil
+}
+
+func idsToStrings(ids []*ast.ID) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, id.Name)
+	}
+	return out
+}
+
 func isSQLOp(op ast.Op) bool {
 	switch op.(type) {
-	case *ast.Select, *ast.SQLLimitOffset, *ast.OrderBy, *ast.SQLPipe, *ast.SQLJoin:
+	case *ast.Select, *ast.SQLLimitOffset, *ast.OrderBy, *ast.SQLPipe, *ast.SQLJoin, *ast.Values:
 		return true
 	}
 	return false
@@ -359,9 +468,11 @@ func isSQLOp(op ast.Op) bool {
 func (a *analyzer) semSQLOp(op ast.Op, seq dag.Seq) (dag.Seq, schema) {
 	switch op := op.(type) {
 	case *ast.SQLPipe:
-		return a.semSQLPipe(op, seq, "") //XXX empty string for alias?
+		return a.semSQLPipe(op, seq, nil) //XXX should alias hang off SQLPipe?
 	case *ast.Select:
 		return a.semSelect(op, seq)
+	case *ast.Values:
+		return a.semValues(op, seq)
 	case *ast.SQLJoin:
 		return a.semSQLJoin(op, seq)
 	case *ast.OrderBy:

--- a/compiler/ztests/sql/table-alias.yaml
+++ b/compiler/ztests/sql/table-alias.yaml
@@ -1,0 +1,29 @@
+script: |
+  super -z -c "select T.a,b x from (values (1,'foo'),(3,'bar')) as T(a, b)"
+  echo ===
+  super -z -c "values {x:1},{x:2}"
+  echo ===
+  super -z -c "select * from (select T.a,b x from (values (1,'foo'),(3,'bar')) as T(a, b)) as T2(c,d)"
+  echo ===
+  super -z -c "select * from (select T.a,b x from (values (1,'foo'),(3,'bar')) as T(a, b)) as T2(d)"
+  echo ===
+  super -z -c "from (values 1,2,3)"
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1,x:"foo"}
+      {a:3,x:"bar"}
+      ===
+      {x:1}
+      {x:2}
+      ===
+      {c:1,d:"foo"}
+      {c:3,d:"bar"}
+      ===
+      {d:1}
+      {d:3}
+      ===
+      {c0:1}
+      {c0:2}
+      {c0:3}

--- a/compiler/ztests/sql/table-alias.yaml
+++ b/compiler/ztests/sql/table-alias.yaml
@@ -5,7 +5,7 @@ script: |
   echo ===
   super -z -c "select * from (select T.a,b x from (values (1,'foo'),(3,'bar')) as T(a, b)) as T2(c,d)"
   echo ===
-  super -z -c "select * from (select T.a,b x from (values (1,'foo'),(3,'bar')) as T(a, b)) as T2(d)"
+  super -z -c "select * from (select T.a,b x from (values (1,'foo'),(3,'bar')) as T ( a, b)) as T2(d)"
   echo ===
   super -z -c "from (values 1,2,3)"
 

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -683,21 +683,21 @@ func (c *canon) fromElem(elem *ast.FromElem) {
 	if elem.Args != nil {
 		c.fromArgs(elem.Args)
 	}
-	c.tableAlias(elem.Alias)
+	if elem.Alias != nil {
+		c.tableAlias(elem.Alias)
+	}
 }
 
 func (c *canon) tableAlias(alias *ast.TableAlias) {
-	if alias != nil {
-		c.write("as %s", sup.QuotedName(alias.Name))
-		if len(alias.Columns) != 0 {
-			c.write(" (")
-			var comma string
-			for _, col := range alias.Columns {
-				c.write("%s%s", comma, sup.QuotedName(col.Name))
-				comma = ", "
-			}
-			c.write(")")
+	c.write("as %s", sup.QuotedName(alias.Name))
+	if len(alias.Columns) != 0 {
+		c.write(" (")
+		var comma string
+		for _, col := range alias.Columns {
+			c.write("%s%s", comma, sup.QuotedName(col.Name))
+			comma = ", "
 		}
+		c.write(")")
 	}
 }
 

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -683,8 +683,21 @@ func (c *canon) fromElem(elem *ast.FromElem) {
 	if elem.Args != nil {
 		c.fromArgs(elem.Args)
 	}
-	if elem.Alias != nil {
-		c.write(" %s", sup.QuotedName(elem.Alias.Text))
+	c.tableAlias(elem.Alias)
+}
+
+func (c *canon) tableAlias(alias *ast.TableAlias) {
+	if alias != nil {
+		c.write("as %s", sup.QuotedName(alias.Name))
+		if len(alias.Columns) != 0 {
+			c.write(" (")
+			var comma string
+			for _, col := range alias.Columns {
+				c.write("%s%s", comma, sup.QuotedName(col.Name))
+				comma = ", "
+			}
+			c.write(")")
+		}
 	}
 }
 


### PR DESCRIPTION
This commit adds support for a VALUES clause as well as an optional columns specification on table aliases.  The values listed in the values clause must all be uniformly typed.  When polymorphic data is desired, yield can be used inside of a SQL pipe instead of this values clause.  VALUES is not ANSI SQL but provides compatibility with PostgreSQL and duckdb.