### PR TITLE
Document canonical value presentation

### DIFF
--- a/docs/commands/super.md
+++ b/docs/commands/super.md
@@ -315,6 +315,41 @@ produces
 When pretty printing, colorization is enabled by default when writing to a terminal,
 and can be disabled with `-color false`.
 
+#### Canonical Value Presentation
+
+Values are stored internally based on their types as defined in the
+[data model](../formats/data-model.md), and values that are output in
+human-readable formats such SUP reflect a canonical presentation based on
+type. Therefore the output presentation of a value may not match the format
+in which it was originally expressed in a human-readable input stream or
+as a literal in a query.
+
+For example, reading this input with types `float64`, `duration`, `time`, and `string`
+
+```mdtest-command
+echo '6.00 300s 2024-08-14T12:12:51-07:00 "\u0041pple"' | super -z -
+```
+produces the output
+```mdtest-output
+6.
+5m
+2024-08-14T19:12:51Z
+"Apple"
+```
+
+When non-canonical presentation is desired, functions may be used to convert
+values to the desired presentation as a string, e.g., using the
+[`strftime` function](https://superdb.org/docs/language/functions/strftime/)
+to print a `time` value in the locale's representation
+
+```mdtest-command
+super -z -c 'yield strftime("%c", 2024-08-14T19:12:51Z)'
+```
+produces
+```mdtest-output
+"Wed Aug 14 19:12:51 2024"
+```
+
 #### Pipeline-friendly BSUP
 
 Though it's a compressed format, BSUP data is self-describing and stream-oriented


### PR DESCRIPTION
## What's Changing

This is my attempt to document how the tools present values in a canonical form in the human-readable output formats such as SUP.

## Why

When fielding community inquiry #5910 and writing up a response, I recognized that this topic might benefit from a little more coverage.

## Details

I expect that some aspects of canonical value presentation shown here would be unsurprising to most users, e.g., dropping trailing zeros in floating point values. OTOH, things like the `duration` type may be slightly less familiar to users, leading to confusion such as expressed in #5910. While docs enhancements like I'm doing here may not guarantee future users would never be confused by such things again, I figure it doesn't hurt to cover it _somewhere_, plus it gives me something in the docs to point at if similar questions from users come up in the future.