### PR TITLE
Rework pkg/field.Projection to fix Paths method

### DIFF
--- a/pkg/field/projection_test.go
+++ b/pkg/field/projection_test.go
@@ -1,0 +1,31 @@
+package field
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjection(t *testing.T) {
+	cases := [][]Path{
+		{
+			Path{"a", "b"},
+		},
+		{
+			Path{"a", "b"},
+			Path{"c", "d"},
+		},
+		{
+			Path{"a", "b"},
+			Path{"a", "c"},
+		},
+		{
+			Path{"a", "b", "c"},
+			Path{"a", "b", "d"},
+		},
+	}
+	for _, c := range cases {
+		proj := NewProjection(c)
+		assert.Equal(t, c, proj.Paths(), "projection: %#v", proj)
+	}
+}


### PR DESCRIPTION
The Paths method of field.Projection returns incorrect results.  Fix it by simplifying the Projection implementation.