### PR TITLE
fix bug with * in select value clauses

### DIFF
--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -310,7 +310,13 @@ func (a *analyzer) semSelectValue(sel *ast.Select, sch schema, seq dag.Seq) (dag
 		if as.Label != nil {
 			a.error(sel, errors.New("SELECT VALUE cannot have AS clause in selection"))
 		}
-		exprs = append(exprs, a.semExprSchema(sch, as.Expr))
+		var e dag.Expr
+		if as.Expr == nil {
+			e = &dag.This{Kind: "This"}
+		} else {
+			e = a.semExprSchema(sch, as.Expr)
+		}
+		exprs = append(exprs, e)
 	}
 	if sel.Where != nil {
 		seq = append(seq, dag.NewFilter(a.semExprSchema(sch, sel.Where)))

--- a/compiler/ztests/sql/select-value-star.yaml
+++ b/compiler/ztests/sql/select-value-star.yaml
@@ -1,0 +1,10 @@
+spq: select value * from (yield 1,2)
+
+vector: true
+
+input: |
+  null
+
+output: |
+  1
+  2


### PR DESCRIPTION
This commit fixes a bug to handle nil expression (indicated by *) in select value clauses.  In this case, * is treated as "this".