### PR TITLE
Optimize vector.NewDynamic by creating TagMap lazily

### DIFF
--- a/runtime/vam/expr/conditional.go
+++ b/runtime/vam/expr/conditional.go
@@ -67,7 +67,7 @@ func BoolMask(mask vector.Any) (*roaring.Bitmap, *roaring.Bitmap) {
 	errs := roaring.New()
 	if dynamic, ok := mask.(*vector.Dynamic); ok {
 		for i, val := range dynamic.Values {
-			boolMaskRidx(dynamic.TagMap.Reverse[i], bools, errs, val)
+			boolMaskRidx(dynamic.TagMap().Reverse[i], bools, errs, val)
 		}
 	} else {
 		boolMaskRidx(nil, bools, errs, mask)

--- a/runtime/vam/op/over.go
+++ b/runtime/vam/op/over.go
@@ -69,7 +69,7 @@ func (o *Over) Pull(done bool) (vector.Any, error) {
 func (o *Over) flatten(vec vector.Any, slot uint32) vector.Any {
 	switch vec := vector.Under(vec).(type) {
 	case *vector.Dynamic:
-		return o.flatten(vec.Values[vec.Tags[slot]], vec.TagMap.Forward[slot])
+		return o.flatten(vec.Values[vec.Tags[slot]], vec.TagMap().Forward[slot])
 	case *vector.View:
 		return o.flatten(vec.Any, vec.Index[slot])
 	case *vector.Array:

--- a/runtime/vam/op/swtich.go
+++ b/runtime/vam/op/swtich.go
@@ -80,7 +80,7 @@ func isErrorMissing(vec vector.Any, i uint32) bool {
 	vec = vector.Under(vec)
 	if dynVec, ok := vec.(*vector.Dynamic); ok {
 		vec = dynVec.Values[dynVec.Tags[i]]
-		i = dynVec.TagMap.Forward[i]
+		i = dynVec.TagMap().Forward[i]
 	}
 	errVec, ok := vec.(*vector.Error)
 	if !ok {

--- a/vector/apply.go
+++ b/vector/apply.go
@@ -38,7 +38,7 @@ func findDynamic(vecs []Any) (*Dynamic, bool) {
 
 func rip(vecs []Any, d *Dynamic) iter.Seq2[int, []Any] {
 	return func(yield func(int, []Any) bool) {
-		for i, rev := range d.TagMap.Reverse {
+		for i, rev := range d.TagMap().Reverse {
 			var newVecs []Any
 			if len(rev) > 0 {
 				for _, vec := range vecs {

--- a/vector/bool.go
+++ b/vector/bool.go
@@ -73,7 +73,7 @@ func BoolValue(vec Any, slot uint32) (bool, bool) {
 		return BoolValue(vec.Any, uint32(vec.Index[slot]))
 	case *Dynamic:
 		tag := vec.Tags[slot]
-		return BoolValue(vec.Values[tag], vec.TagMap.Forward[slot])
+		return BoolValue(vec.Values[tag], vec.TagMap().Forward[slot])
 	case *View:
 		return BoolValue(vec.Any, vec.Index[slot])
 	}

--- a/vector/dynamic.go
+++ b/vector/dynamic.go
@@ -1,6 +1,8 @@
 package vector
 
 import (
+	"sync/atomic"
+
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/zcode"
 )
@@ -10,13 +12,23 @@ import (
 type Dynamic struct {
 	Tags   []uint32
 	Values []Any
-	TagMap *TagMap
+	tagMap atomic.Pointer[TagMap]
 }
 
 var _ Any = (*Dynamic)(nil)
 
 func NewDynamic(tags []uint32, values []Any) *Dynamic {
-	return &Dynamic{Tags: tags, Values: values, TagMap: NewTagMap(tags, values)}
+	return &Dynamic{Tags: tags, Values: values}
+}
+
+func (d *Dynamic) TagMap() *TagMap {
+	if t := d.tagMap.Load(); t != nil {
+		return t
+	}
+	if t := NewTagMap(d.Tags, d.Values); d.tagMap.CompareAndSwap(nil, t) {
+		return t
+	}
+	return d.tagMap.Load()
 }
 
 func (*Dynamic) Type() super.Type {
@@ -26,7 +38,7 @@ func (*Dynamic) Type() super.Type {
 func (d *Dynamic) TypeOf(slot uint32) super.Type {
 	vals := d.Values[d.Tags[slot]]
 	if v2, ok := vals.(*Dynamic); ok {
-		return v2.TypeOf(d.TagMap.Forward[slot])
+		return v2.TypeOf(d.TagMap().Forward[slot])
 	}
 	return vals.Type()
 }
@@ -43,5 +55,5 @@ func (d *Dynamic) Len() uint32 {
 }
 
 func (d *Dynamic) Serialize(b *zcode.Builder, slot uint32) {
-	d.Values[d.Tags[slot]].Serialize(b, d.TagMap.Forward[slot])
+	d.Values[d.Tags[slot]].Serialize(b, d.TagMap().Forward[slot])
 }

--- a/vector/float.go
+++ b/vector/float.go
@@ -68,7 +68,7 @@ func FloatValue(vec Any, slot uint32) (float64, bool) {
 		return FloatValue(vec.Any, uint32(vec.Index[slot]))
 	case *Dynamic:
 		tag := vec.Tags[slot]
-		return FloatValue(vec.Values[tag], vec.TagMap.Forward[slot])
+		return FloatValue(vec.Values[tag], vec.TagMap().Forward[slot])
 	case *View:
 		return FloatValue(vec.Any, vec.Index[slot])
 	}

--- a/vector/int.go
+++ b/vector/int.go
@@ -64,7 +64,7 @@ func IntValue(vec Any, slot uint32) (int64, bool) {
 		return IntValue(vec.Any, uint32(vec.Index[slot]))
 	case *Dynamic:
 		tag := vec.Tags[slot]
-		return IntValue(vec.Values[tag], vec.TagMap.Forward[slot])
+		return IntValue(vec.Values[tag], vec.TagMap().Forward[slot])
 	case *View:
 		return IntValue(vec.Any, vec.Index[slot])
 	}

--- a/vector/uint.go
+++ b/vector/uint.go
@@ -64,7 +64,7 @@ func UintValue(vec Any, slot uint32) (uint64, bool) {
 		return UintValue(vec.Any, uint32(vec.Index[slot]))
 	case *Dynamic:
 		tag := vec.Tags[slot]
-		return UintValue(vec.Values[tag], vec.TagMap.Forward[slot])
+		return UintValue(vec.Values[tag], vec.TagMap().Forward[slot])
 	case *View:
 		return UintValue(vec.Any, vec.Index[slot])
 	}

--- a/vector/union.go
+++ b/vector/union.go
@@ -69,7 +69,7 @@ func addUnionNullsToDynamic(typ *super.TypeUnion, d *Dynamic, nulls bitvec.Bits)
 			if tags[i] != uint32(nullTag) {
 				rebuild = true
 				// If value was not previously null delete value from vector.
-				delIndexes[tags[i]] = append(delIndexes[tags[i]], d.TagMap.Forward[i])
+				delIndexes[tags[i]] = append(delIndexes[tags[i]], d.TagMap().Forward[i])
 			}
 			tags[i] = uint32(nullTag)
 			count++

--- a/vector/view.go
+++ b/vector/view.go
@@ -49,10 +49,10 @@ func Pick(val Any, index []uint32) Any {
 	case *Error:
 		return NewError(val.Typ, Pick(val.Vals, index), val.Nulls.Pick(index))
 	case *Union:
-		tags, values := viewForUnionOrDynamic(index, val.Tags, val.TagMap.Forward, val.Values)
+		tags, values := viewForUnionOrDynamic(index, val.Tags, val.TagMap().Forward, val.Values)
 		return NewUnion(val.Typ, tags, values, val.Nulls.Pick(index))
 	case *Dynamic:
-		return NewDynamic(viewForUnionOrDynamic(index, val.Tags, val.TagMap.Forward, val.Values))
+		return NewDynamic(viewForUnionOrDynamic(index, val.Tags, val.TagMap().Forward, val.Values))
 	case *View:
 		index2 := make([]uint32, len(index))
 		for k, idx := range index {


### PR DESCRIPTION
For some workloads, CPU profiling shows significant time attributable to vector.NewDynamic is spent in vector.NewTagMap.  Prior to #5194, vector.Dynamic.TagMap was initialized lazily since it isn't always needed, but the lazy behavior was removed because the implementation lacked the locking necessary for concurrent access.  Restore the lazy behavior by changing Dynamic.TagMap from a field to a method with appropriate locking inside.