### PR TITLE
Change runtime/sam/expr.NewValueCompareFn nullsMax param to order.Nulls

### DIFF
--- a/cmd/super/internal/lakemanage/scan.go
+++ b/cmd/super/internal/lakemanage/scan.go
@@ -120,7 +120,7 @@ type runBuilder struct {
 }
 
 func newRunBuilder() *runBuilder {
-	return &runBuilder{cmp: expr.NewValueCompareFn(order.Asc, true)}
+	return &runBuilder{cmp: expr.NewValueCompareFn(order.Asc, order.NullsLast)}
 }
 
 func (r *runBuilder) overlaps(first, last super.Value) bool {

--- a/csup/zcode.go
+++ b/csup/zcode.go
@@ -30,7 +30,7 @@ type ZcodeEncoder struct {
 func NewZcodeEncoder(typ super.Type) *ZcodeEncoder {
 	return &ZcodeEncoder{
 		typ: typ,
-		cmp: expr.NewValueCompareFn(order.Asc, false),
+		cmp: expr.NewValueCompareFn(order.Asc, order.NullsFirst),
 	}
 }
 

--- a/runtime/sam/expr/extent/span.go
+++ b/runtime/sam/expr/extent/span.go
@@ -49,7 +49,7 @@ func NewGeneric(lower, upper super.Value, cmp expr.CompareFn) *Generic {
 }
 
 func NewGenericFromOrder(first, last super.Value, o order.Which) *Generic {
-	return NewGeneric(first, last, expr.NewValueCompareFn(o, o == order.Asc))
+	return NewGeneric(first, last, expr.NewValueCompareFn(o, o.NullsMax(true)))
 }
 
 func (g *Generic) In(val super.Value) bool {

--- a/runtime/sam/expr/function/compare.go
+++ b/runtime/sam/expr/function/compare.go
@@ -14,8 +14,8 @@ type Compare struct {
 
 func NewCompare(sctx *super.Context) *Compare {
 	return &Compare{
-		nullsMax: expr.NewValueCompareFn(order.Asc, true),
-		nullsMin: expr.NewValueCompareFn(order.Asc, false),
+		nullsMax: expr.NewValueCompareFn(order.Asc, order.NullsLast),
+		nullsMin: expr.NewValueCompareFn(order.Asc, order.NullsFirst),
 		sctx:     sctx,
 	}
 }

--- a/runtime/sam/expr/sort.go
+++ b/runtime/sam/expr/sort.go
@@ -95,8 +95,8 @@ func (c *Comparator) sortStableIndices(vals []super.Value) []uint32 {
 
 type CompareFn func(a, b super.Value) int
 
-func NewValueCompareFn(o order.Which, nullsMax bool) CompareFn {
-	return NewComparator(SortExpr{&This{}, o, o.NullsMax(nullsMax)}).Compare
+func NewValueCompareFn(o order.Which, n order.Nulls) CompareFn {
+	return NewComparator(SortExpr{&This{}, o, n}).Compare
 }
 
 type Comparator struct {

--- a/runtime/sam/op/aggregate/aggregate.go
+++ b/runtime/sam/op/aggregate/aggregate.go
@@ -83,7 +83,7 @@ func NewAggregator(ctx context.Context, sctx *super.Context, keyRefs, keyExprs, 
 	if nkeys > 0 && inputDir != 0 {
 		keySortExpr := expr.NewSortExpr(keyRefs[0], o, o.NullsMax(true))
 		keyCompare = expr.NewComparator(keySortExpr).WithMissingAsNull().Compare
-		valueCompare = expr.NewValueCompareFn(o, true)
+		valueCompare = expr.NewValueCompareFn(o, o.NullsMax(true))
 	}
 	var sortExprs []expr.SortExpr
 	for _, e := range keyRefs {

--- a/runtime/sam/op/join/join.go
+++ b/runtime/sam/op/join/join.go
@@ -63,7 +63,7 @@ func New(rctx *runtime.Context, anti, inner bool, left, right zbuf.Puller, leftK
 		left:        newPuller(left, ctx),
 		right:       zio.NewPeeker(newPuller(right, ctx)),
 		resetter:    resetter,
-		compare:     expr.NewValueCompareFn(o, true),
+		compare:     expr.NewValueCompareFn(o, o.NullsMax(true)),
 		cutter:      expr.NewCutter(rctx.Sctx, lhs, rhs),
 		splicer:     NewRecordSplicer(rctx.Sctx),
 	}

--- a/runtime/sam/op/meta/lister.go
+++ b/runtime/sam/op/meta/lister.go
@@ -104,7 +104,7 @@ func initObjectScan(snap commits.View, sortKey order.SortKey) []*data.Object {
 }
 
 func sortObjects(objects []*data.Object, o order.Which) {
-	cmp := expr.NewValueCompareFn(o, true)
+	cmp := expr.NewValueCompareFn(o, o.NullsMax(true))
 	lessFunc := func(a, b *data.Object) bool {
 		aFrom, aTo, bFrom, bTo := a.Min, a.Max, b.Min, b.Max
 		if o == order.Desc {

--- a/runtime/sam/op/meta/slicer.go
+++ b/runtime/sam/op/meta/slicer.go
@@ -35,8 +35,8 @@ func NewSlicer(parent zbuf.Puller, sctx *super.Context) *Slicer {
 		parent:      parent,
 		marshaler:   m,
 		unmarshaler: sup.NewBSUPUnmarshaler(),
-		//XXX check nullsmax is consistent for both dirs in lake ops
-		cmp: expr.NewValueCompareFn(order.Asc, true),
+		//XXX check that nulls position is consistent for both dirs in lake ops
+		cmp: expr.NewValueCompareFn(order.Asc, order.NullsLast),
 	}
 }
 


### PR DESCRIPTION
This makes NewValueCompareFn consistent with NewSortExpr and makes its behavior clearer at call sites.