### PR TITLE
join: Lift parent sequence into Fork path

### DIFF
--- a/compiler/semantic/analyzer.go
+++ b/compiler/semantic/analyzer.go
@@ -66,7 +66,12 @@ func HasSource(seq dag.Seq) bool {
 	case *dag.FileScan, *dag.HTTPScan, *dag.PoolScan, *dag.LakeMetaScan, *dag.PoolMetaScan, *dag.CommitMetaScan, *dag.DeleteScan, *dag.NullScan:
 		return true
 	case *dag.Fork:
-		return HasSource(op.Paths[0])
+		for _, path := range op.Paths {
+			if !HasSource(path) {
+				return false
+			}
+		}
+		return true
 	case *dag.Scope:
 		return HasSource(op.Body)
 	}

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -819,11 +819,13 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) dag.Seq {
 			Args:     a.semAssignments(o.Args),
 		}
 		if rightInput != nil {
-			par := &dag.Fork{
-				Kind:  "Fork",
-				Paths: []dag.Seq{{dag.PassOp}, rightInput},
+			if len(seq) == 0 {
+				seq = dag.Seq{dag.PassOp}
 			}
-			seq = append(seq, par)
+			return dag.Seq{
+				&dag.Fork{Kind: "Fork", Paths: []dag.Seq{seq, rightInput}},
+				join,
+			}
 		}
 		return append(seq, join)
 	case *ast.Explode:

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -549,7 +549,7 @@ func (a *analyzer) semSQLJoin(join *ast.SQLJoin, seq dag.Seq) (dag.Seq, schema) 
 	}
 	par := &dag.Fork{
 		Kind:  "Fork",
-		Paths: []dag.Seq{{dag.PassOp}, rightSeq},
+		Paths: []dag.Seq{leftSeq, rightSeq},
 	}
 	dagJoin := &dag.Join{
 		Kind:     "Join",
@@ -560,7 +560,7 @@ func (a *analyzer) semSQLJoin(join *ast.SQLJoin, seq dag.Seq) (dag.Seq, schema) 
 		RightKey: rightKey,
 		Args:     []dag.Assignment{assignment},
 	}
-	return append(append(leftSeq, par), dagJoin), sch
+	return dag.Seq{par, dagJoin}, sch
 }
 
 var badJoinCond = errors.New("bad join condition")

--- a/compiler/ztests/join-subquery.yaml
+++ b/compiler/ztests/join-subquery.yaml
@@ -11,10 +11,9 @@ outputs:
           from b
         ) on c
         ===
-        file a
-        | fork (
+        fork (
           =>
-            pass
+            file a
           =>
             file b
         )

--- a/compiler/ztests/join-yield.yaml
+++ b/compiler/ztests/join-yield.yaml
@@ -1,0 +1,15 @@
+script: |
+  super -s -c 'from input.sup
+               | join (yield {x:3,y:"a"}, {x:4,y:"b"}) on y'
+
+inputs:
+  - name: input.sup
+    data: |
+      {x:1,y:"a"}
+      {x:2,y:"b"}
+
+outputs:
+  - name: stdout
+    data: |
+      {x:1,y:"a"}
+      {x:2,y:"b"}

--- a/compiler/ztests/par-join.yaml
+++ b/compiler/ztests/par-join.yaml
@@ -4,23 +4,22 @@ script: |
   super db create -q -orderby ts test
   # At the time of writing, the where operator is necessary because a pool scan
   # is parallelized only when followed by another operator.
-  super db compile -C -P 2 "from test | join (from test | where true) on a=b" | sed -e 's/pool .*/.../'
+  super db compile -C -P 2 "from test | where true | join (from test | where true) on a=b" | sed -e 's/pool .*/.../'
 
 outputs:
   - name: stdout
     data: |
-      lister ...
-      | slicer
-      | scatter (
+      fork (
         =>
-          seqscan ...
-        =>
-          seqscan ...
-      )
-      | merge ts asc nulls last
-      | fork (
-        =>
-          pass
+          lister ...
+          | slicer
+          | scatter (
+            =>
+              seqscan ...
+            =>
+              seqscan ...
+          )
+          | merge ts asc nulls last
         =>
           lister ...
           | slicer

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -56,10 +56,9 @@ outputs:
       | yield c
       | output main
       === join
-      file file1 unordered fields a,c
-      | fork (
+      fork (
         =>
-          pass
+          file file1 unordered fields a,c
         =>
           file file2 unordered fields a,b
       )

--- a/compiler/ztests/sql/join-using.yaml
+++ b/compiler/ztests/sql/join-using.yaml
@@ -1,5 +1,4 @@
 script: |
-  # XXX The result of the first query is incorrect because of yields in forks
   super -s -I cte.spq -c 'select * from A A(x,y) join B B(x,y) using (y)'
   ! super -s -I cte.spq -c 'select * from A A(x,y) join B B(x,y) using (A.y)'
   ! super -s -I cte.spq -c 'select * from A A(x,y) join B B(x,z) using (y)'
@@ -18,8 +17,6 @@ outputs:
   - name: stdout
     data: |
       {x:3,y:"a"}
-      {x:3,y:"a"}
-      {x:4,y:"b"}
       {x:4,y:"b"}
   - name: stderr
     data: |

--- a/zfmt/ztests/decls.yaml
+++ b/zfmt/ztests/decls.yaml
@@ -57,10 +57,9 @@ outputs:
           a+b
         )
         
-        file fruit.json
-        | fork (
+        fork (
           =>
-            pass
+            file fruit.json
           =>
             file people.json
         )


### PR DESCRIPTION
This commit changes the behavior of joins with right inputs so that the semantic analyzer lifts the parent flowgraph into the created Fork operator instead of using the Pass operator. This corrects a bug when using yields on right side of join that essentially causes the join to act like a cross join.

It also changes the behavior of semantic.HasSource so that a program starting with a Fork operator and containing a mix of Sourced and non-Sourced paths will get the default or null scanner added to it.