### PR TITLE
fix bug with error formatting and empty texts

### DIFF
--- a/compiler/parser/ztests/syntax-error-empty.yaml
+++ b/compiler/parser/ztests/syntax-error-empty.yaml
@@ -1,0 +1,15 @@
+script: |
+  ! super compile -I query.sql -I empty.sql
+
+inputs:
+  - name: query.sql
+    data: "SELECT"
+  - name: empty.sql 
+    data: ""
+
+outputs:
+  - name: stderr
+    data: |
+      parse error in query.sql at line 1, column 7:
+      SELECT
+        === ^ ===

--- a/compiler/parser/ztests/syntax-error-eof.yaml
+++ b/compiler/parser/ztests/syntax-error-eof.yaml
@@ -1,0 +1,13 @@
+script: |
+  ! super compile -I query.sql
+
+inputs:
+  - name: query.sql
+    data: "SELECT"
+
+outputs:
+  - name: stderr
+    data: |
+      parse error in query.sql at line 1, column 7:
+      SELECT
+        === ^ ===

--- a/compiler/srcfiles/file.go
+++ b/compiler/srcfiles/file.go
@@ -38,6 +38,9 @@ func (f File) Position(pos int) Position {
 	}
 	offset := pos - f.start
 	i := searchLine(f.lines, offset)
+	if i < 0 {
+		return Position{-1, -1, -1, -1}
+	}
 	return Position{
 		Pos:    pos,
 		Offset: offset,


### PR DESCRIPTION
This commit fixes a bug where the error-formatting logic would panic while handling corner cases of empty strings for input files and -c query text when encountering a syntax error at end of input.

Closes #5957