### PR TITLE
Add another link checker exclusion due to HTTP 403

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -4,8 +4,13 @@ useGitIgnore: true
 excludedDirs:
   - node_modules
 
+ignorePatterns:
+
 # Currently not crawling links matching the following pattern due to HTTP 429 errors
 # See https://github.com/brimdata/super/pull/5887
-ignorePatterns:
   - pattern: '^https://github.com/brimdata/super/blob/main/scripts/super-cmd-perf.*$'
+
+# Not crawling the following links because of HTTP 403 (Forbidden) errors.
+# Presumably these research-oriented sites don't like being crawled.
   - pattern: '^https://dl.acm.org/doi/pdf/10.1145/984549.984551$'
+  - pattern: '^https://www.researchgate.net/publication/221325979_Union_Types_for_Semistructured_Data$'


### PR DESCRIPTION
I see that #6037 included a link checker exclusion for a site that gives an HTTP 403 (Forbidden) error when crawled. Overnight yet another 403 came up, so I've added that exclusion here as well. Everything runs clean when the link checker runs on this branch as shown [in this Actions run](https://github.com/brimdata/super/actions/runs/16349014745).