### PR TITLE
Rework UDFs

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -318,9 +318,9 @@ func (b *Builder) compileCall(call dag.Call) (expr.Evaluator, error) {
 	// First check if call is to a user defined function, otherwise check for
 	// builtin function.
 	var fn expr.Function
-	if e, ok := b.udfs[call.Name]; ok {
+	if u, ok := b.udfs[call.Name]; ok {
 		var err error
-		if fn, err = b.compileUDFCall(call.Name, e); err != nil {
+		if fn, err = b.compileUDFCall(call.Name, u); err != nil {
 			return nil, err
 		}
 	} else {
@@ -342,16 +342,16 @@ func (b *Builder) compileCall(call dag.Call) (expr.Evaluator, error) {
 	return expr.NewCall(fn, exprs), nil
 }
 
-func (b *Builder) compileUDFCall(name string, body dag.Expr) (expr.Function, error) {
+func (b *Builder) compileUDFCall(name string, u *udf) (expr.Function, error) {
 	if fn, ok := b.compiledUDFs[name]; ok {
 		return fn, nil
 	}
-	fn := &expr.UDF{Name: name, Sctx: b.sctx()}
+	fn := expr.NewUDF(b.sctx(), name, u.params)
 	// We store compiled UDF calls here so as to avoid stack overflows on
 	// recursive calls.
 	b.compiledUDFs[name] = fn
 	var err error
-	if fn.Body, err = b.compileExpr(body); err != nil {
+	if fn.Body, err = b.compileExpr(u.expr); err != nil {
 		return nil, err
 	}
 	delete(b.compiledUDFs, name)

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -1101,22 +1101,11 @@ func (a *analyzer) semFuncDecls(decls []*ast.FuncDecl) []*dag.Func {
 		funcs = append(funcs, f)
 	}
 	for i, d := range decls {
-		funcs[i].Expr = a.semFuncBody(d, d.Params, d.Expr)
+		a.enterScope()
+		funcs[i].Expr = a.semExpr(d.Expr)
+		a.exitScope()
 	}
 	return funcs
-}
-
-func (a *analyzer) semFuncBody(d *ast.FuncDecl, params []*ast.ID, body ast.Expr) dag.Expr {
-	a.enterScope()
-	defer a.exitScope()
-	for _, p := range params {
-		if err := a.scope.DefineVar(p); err != nil {
-			// XXX Each param should be a node but now just report the error
-			// as the entire declaration.
-			a.error(d, err)
-		}
-	}
-	return a.semExpr(body)
 }
 
 func (a *analyzer) semOpDecl(d *ast.OpDecl) {

--- a/runtime/sam/expr/udf.go
+++ b/runtime/sam/expr/udf.go
@@ -1,41 +1,57 @@
 package expr
 
 import (
-	"slices"
-
 	"github.com/brimdata/super"
+	"github.com/brimdata/super/zcode"
 )
 
 const maxStackDepth = 10_000
 
 type UDF struct {
-	Body Evaluator
-	Name string
-	Sctx *super.Context
+	Body    Evaluator
+	sctx    *super.Context
+	name    string
+	fields  []super.Field
+	builder zcode.Builder
+}
+
+func NewUDF(sctx *super.Context, name string, params []string) *UDF {
+	var fields []super.Field
+	for _, p := range params {
+		fields = append(fields, super.Field{Name: p})
+	}
+	return &UDF{sctx: sctx, name: name, fields: fields}
 }
 
 func (u *UDF) Call(ectx super.Allocator, args []super.Value) super.Value {
-	stack := 1
-	if f, ok := ectx.(*frame); ok {
-		stack += f.stack
+	f, ok := ectx.(*frame)
+	if ok {
+		f.stack++
+	} else {
+		f = &frame{1}
 	}
-	if stack > maxStackDepth {
-		return u.Sctx.NewErrorf("stack overflow in function %q", u.Name)
+	if f.stack > maxStackDepth {
+		return u.sctx.NewErrorf("stack overflow in function %q", u.name)
 	}
-	// args must be cloned otherwise the values will be overwritten in
-	// recursive calls.
-	f := &frame{stack: stack, vars: slices.Clone(args)}
 	defer f.exit()
-	return u.Body.Eval(f, super.Null)
+	if len(args) == 0 {
+		return u.Body.Eval(f, super.Null)
+	}
+	u.builder.Reset()
+	for i := range args {
+		u.fields[i].Type = args[i].Type()
+		u.builder.Append(args[i].Bytes())
+	}
+	typ := u.sctx.MustLookupTypeRecord(u.fields)
+	return u.Body.Eval(f, super.NewValue(typ, u.builder.Bytes()))
 }
 
 type frame struct {
 	stack int
-	vars  []super.Value
 }
 
 func (f *frame) Vars() []super.Value {
-	return f.vars
+	return nil
 }
 
 func (f *frame) exit() {


### PR DESCRIPTION
This commit changes how udfs work so that they no longer rely on variables but instead rewrite the context value as a record with a field for every function parameter paired with its call expression.