### PR TITLE
simplify stack depth limit checking in expr Eval

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -344,11 +344,7 @@ func (b *Builder) compileUDFCall(name string, f *dag.Func) (expr.Function, error
 	if fn, ok := b.compiledUDFs[name]; ok {
 		return fn, nil
 	}
-	if b.udfStackDepth == nil {
-		b.udfStackDepth = new(int)
-		defer func() { b.udfStackDepth = nil }()
-	}
-	fn := expr.NewUDF(b.sctx(), name, f.Params, b.udfStackDepth)
+	fn := expr.NewUDF(b.sctx(), name, f.Params)
 	// We store compiled UDF calls here so as to avoid stack overflows on
 	// recursive calls.
 	b.compiledUDFs[name] = fn

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -51,17 +51,16 @@ import (
 var ErrJoinParents = errors.New("join requires two upstream parallel query paths")
 
 type Builder struct {
-	rctx          *runtime.Context
-	mctx          *super.Context
-	env           *exec.Environment
-	readers       []zio.Reader
-	progress      *zbuf.Progress
-	channels      map[string][]zbuf.Puller
-	deletes       *sync.Map
-	udfs          map[string]*dag.Func
-	compiledUDFs  map[string]*expr.UDF
-	udfStackDepth *int
-	resetters     expr.Resetters
+	rctx         *runtime.Context
+	mctx         *super.Context
+	env          *exec.Environment
+	readers      []zio.Reader
+	progress     *zbuf.Progress
+	channels     map[string][]zbuf.Puller
+	deletes      *sync.Map
+	udfs         map[string]*dag.Func
+	compiledUDFs map[string]*expr.UDF
+	resetters    expr.Resetters
 }
 
 func NewBuilder(rctx *runtime.Context, env *exec.Environment) *Builder {

--- a/runtime/sam/expr/udf.go
+++ b/runtime/sam/expr/udf.go
@@ -12,24 +12,24 @@ type UDF struct {
 	sctx       *super.Context
 	name       string
 	fields     []super.Field
-	stackDepth *int
+	stackDepth int
 	builder    zcode.Builder
 }
 
-func NewUDF(sctx *super.Context, name string, params []string, stackDepth *int) *UDF {
+func NewUDF(sctx *super.Context, name string, params []string) *UDF {
 	var fields []super.Field
 	for _, p := range params {
 		fields = append(fields, super.Field{Name: p})
 	}
-	return &UDF{sctx: sctx, name: name, fields: fields, stackDepth: stackDepth}
+	return &UDF{sctx: sctx, name: name, fields: fields}
 }
 
 func (u *UDF) Call(args []super.Value) super.Value {
-	*u.stackDepth++
-	if *u.stackDepth > maxStackDepth {
+	u.stackDepth++
+	if u.stackDepth > maxStackDepth {
 		return u.sctx.NewErrorf("stack overflow in function %q", u.name)
 	}
-	defer func() { *u.stackDepth-- }()
+	defer func() { u.stackDepth-- }()
 	if len(args) == 0 {
 		return u.Body.Eval(super.Null)
 	}


### PR DESCRIPTION
This commit simplifies the logic in the stack depth calculation by keeping the depth state in each call site instance instead of trying to share it.  So instead of tracking a global depth, we just compute a local depth for each function and halt recursion with an error when the limit is locally exceeded.