### PR TITLE
use file extension to imply format and avoid auto-detection

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -21,6 +21,7 @@ import (
 	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/runtime/sam/expr/function"
 	"github.com/brimdata/super/sup"
+	"github.com/brimdata/super/zio"
 	"github.com/segmentio/ksuid"
 )
 
@@ -250,12 +251,7 @@ func (a *analyzer) formatArg(args ast.FromArgs) string {
 func (a *analyzer) semFile(name string, args ast.FromArgs) dag.Op {
 	format := a.formatArg(args)
 	if format == "" {
-		switch filepath.Ext(name) {
-		case ".parquet":
-			format = "parquet"
-		case ".csup":
-			format = "csup"
-		}
+		format = zio.FormatFromPath(name)
 	}
 	return &dag.FileScan{
 		Kind:   "FileScan",
@@ -297,6 +293,9 @@ func (a *analyzer) semFromURL(urlLoc ast.Node, u string, args ast.FromArgs) dag.
 	if err != nil {
 		a.error(args, err)
 		return badOp()
+	}
+	if format == "" {
+		format = zio.FormatFromPath(u)
 	}
 	return &dag.HTTPScan{
 		Kind:    "HTTPScan",

--- a/compiler/ztests/const-source.yaml
+++ b/compiler/ztests/const-source.yaml
@@ -24,7 +24,7 @@ outputs:
       (
         const FILE = "A.sup"
         
-        file A.sup
+        file A.sup format sup
         | output main
       )
       ===

--- a/compiler/ztests/sql/like-newline.yaml
+++ b/compiler/ztests/sql/like-newline.yaml
@@ -4,8 +4,8 @@ script: |
 inputs:
   - name: a.json
     data: |
-      {a:"foo bar"}
-      {a:"foo\nbar"}
+      {"a":"foo bar"}
+      {"a":"foo\nbar"}
 
 outputs:
   - name: stdout

--- a/zfmt/ztests/decls.yaml
+++ b/zfmt/ztests/decls.yaml
@@ -61,10 +61,10 @@ outputs:
         
         fork
           (
-            file fruit.json
+            file fruit.json format json
           )
           (
-            file people.json
+            file people.json format json
           )
         | inner join as {left,right} on left_key=right_key
         | values {...left,left_dest:right.right_source}

--- a/zfmt/ztests/join.yaml
+++ b/zfmt/ztests/join.yaml
@@ -20,7 +20,7 @@ outputs:
           pass
         )
         (
-          file test.sup
+          file test.sup format sup
         )
       | inner join as {left,right} on x=x
       | output main
@@ -35,7 +35,7 @@ outputs:
           pass
         )
         (
-          file test.sup
+          file test.sup format sup
         )
       | right join as {l,r} on x=x
       | output main

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -3,6 +3,7 @@ package zio
 import (
 	"context"
 	"io"
+	"path/filepath"
 	"slices"
 
 	"github.com/brimdata/super"
@@ -30,6 +31,29 @@ func Extension(format string) string {
 		return ".log"
 	case "jsup":
 		return ".ndjson"
+	default:
+		return ""
+	}
+}
+
+func FormatFromPath(path string) string {
+	switch filepath.Ext(path) {
+	case ".bsup":
+		return "bsup"
+	case ".csup":
+		return "csup"
+	case ".csv":
+		return "csv"
+	case ".json", ".ndjson", ".jsonl":
+		return "json"
+	case ".parquet":
+		return "parquet"
+	case ".sup":
+		return "sup"
+	case ".txt":
+		return "text"
+	case ".jsup":
+		return "jsup"
 	default:
 		return ""
 	}

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -44,16 +44,16 @@ func FormatFromPath(path string) string {
 		return "csup"
 	case ".csv":
 		return "csv"
-	case ".json", ".ndjson", ".jsonl":
+	case ".json", ".jsonl", ".ndjson":
 		return "json"
+	case ".jsup":
+		return "jsup"
 	case ".parquet":
 		return "parquet"
 	case ".sup":
 		return "sup"
-	case ".txt":
+	case ".text", ".txt":
 		return "text"
-	case ".jsup":
-		return "jsup"
 	default:
 		return ""
 	}


### PR DESCRIPTION
This commit changes heuristic for detecting input file (or URL) formats by first checking for known file extensions when the input path is known.  Only when this heuristic fails is autodetection employed.  This was already being done for parquet and csup files (not URLs) and this commit generalizes the approach to all support file types and includes the check for URLs.

When files are gzipped, this test fails and the autodetection logic detects the gzip and the enclosing format.  We might want to extend this approach here to gzipped files in the future, e.g., where ".json.gz" implies gzipped JSON without having to do autodetection.