### PR TITLE
compiler: rename ast.JoinExpr et al. to JoinCond

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -590,7 +590,7 @@ type (
 		Style      string     `json:"style"`
 		RightInput Seq        `json:"right_input"`
 		Alias      *JoinAlias `json:"alias"`
-		Cond       JoinExpr   `json:"cond"`
+		Cond       JoinCond   `json:"cond"`
 		Loc        `json:"loc"`
 	}
 	JoinAlias struct {

--- a/compiler/ast/sql.go
+++ b/compiler/ast/sql.go
@@ -72,7 +72,7 @@ type (
 		Style string    `json:"style"`
 		Left  *FromElem `json:"left"`
 		Right *FromElem `json:"right"`
-		Cond  JoinExpr  `json:"cond"`
+		Cond  JoinCond  `json:"cond"`
 		Loc   `json:"loc"`
 	}
 	SQLCrossJoin struct {
@@ -90,26 +90,26 @@ type (
 	}
 )
 
-type JoinExpr interface {
+type JoinCond interface {
 	Node
-	joinExprNode()
+	joinCondNode()
 }
 
-type JoinOnExpr struct {
+type JoinOnCond struct {
 	Kind string `json:"kind" unpack:""`
 	Expr Expr   `json:"expr"`
 	Loc  `json:"loc"`
 }
 
-func (*JoinOnExpr) joinExprNode() {}
+func (*JoinOnCond) joinCondNode() {}
 
-type JoinUsingExpr struct {
+type JoinUsingCond struct {
 	Kind   string `json:"kind" unpack:""`
 	Fields []Expr `json:"fields"`
 	Loc    `json:"loc"`
 }
 
-func (*JoinUsingExpr) joinExprNode() {}
+func (*JoinUsingCond) joinCondNode() {}
 
 func (*SQLPipe) opNode()        {}
 func (*SQLSelect) opNode()      {}

--- a/compiler/ast/unpack.go
+++ b/compiler/ast/unpack.go
@@ -114,8 +114,8 @@ var unpacker = unpack.New(
 	SQLUnion{},
 	SQLOrderBy{},
 	SQLWith{},
-	JoinOnExpr{},
-	JoinUsingExpr{},
+	JoinOnCond{},
+	JoinUsingCond{},
 )
 
 // UnmarshalOp transforms a JSON representation of an operator into an Op.

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -650,44 +650,44 @@ var g = &grammar{
 		},
 		{
 			name: "LeanOp",
-			pos:  position{line: 85, col: 1, offset: 2077},
+			pos:  position{line: 85, col: 1, offset: 2075},
 			expr: &choiceExpr{
-				pos: position{line: 86, col: 5, offset: 2088},
+				pos: position{line: 86, col: 5, offset: 2086},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 86, col: 5, offset: 2088},
+						pos:  position{line: 86, col: 5, offset: 2086},
 						name: "Operator",
 					},
 					&actionExpr{
-						pos: position{line: 87, col: 5, offset: 2101},
+						pos: position{line: 87, col: 5, offset: 2099},
 						run: (*parser).callonLeanOp3,
 						expr: &seqExpr{
-							pos: position{line: 87, col: 5, offset: 2101},
+							pos: position{line: 87, col: 5, offset: 2099},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 87, col: 5, offset: 2101},
+									pos:        position{line: 87, col: 5, offset: 2099},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 87, col: 9, offset: 2105},
+									pos:  position{line: 87, col: 9, offset: 2103},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 87, col: 12, offset: 2108},
+									pos:   position{line: 87, col: 12, offset: 2106},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 87, col: 18, offset: 2114},
+										pos:  position{line: 87, col: 18, offset: 2112},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 87, col: 24, offset: 2120},
+									pos:  position{line: 87, col: 24, offset: 2118},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 87, col: 27, offset: 2123},
+									pos:        position{line: 87, col: 27, offset: 2121},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -696,23 +696,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 88, col: 5, offset: 2153},
+						pos: position{line: 88, col: 5, offset: 2151},
 						run: (*parser).callonLeanOp11,
 						expr: &seqExpr{
-							pos: position{line: 88, col: 5, offset: 2153},
+							pos: position{line: 88, col: 5, offset: 2151},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 88, col: 5, offset: 2153},
+									pos:   position{line: 88, col: 5, offset: 2151},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 88, col: 7, offset: 2155},
+										pos:  position{line: 88, col: 7, offset: 2153},
 										name: "OpAssignment",
 									},
 								},
 								&andExpr{
-									pos: position{line: 88, col: 20, offset: 2168},
+									pos: position{line: 88, col: 20, offset: 2166},
 									expr: &ruleRefExpr{
-										pos:  position{line: 88, col: 21, offset: 2169},
+										pos:  position{line: 88, col: 21, offset: 2167},
 										name: "EndOfOp",
 									},
 								},
@@ -720,39 +720,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 89, col: 5, offset: 2199},
+						pos: position{line: 89, col: 5, offset: 2197},
 						run: (*parser).callonLeanOp17,
 						expr: &seqExpr{
-							pos: position{line: 89, col: 5, offset: 2199},
+							pos: position{line: 89, col: 5, offset: 2197},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 89, col: 5, offset: 2199},
+									pos: position{line: 89, col: 5, offset: 2197},
 									expr: &seqExpr{
-										pos: position{line: 89, col: 7, offset: 2201},
+										pos: position{line: 89, col: 7, offset: 2199},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 89, col: 7, offset: 2201},
+												pos:  position{line: 89, col: 7, offset: 2199},
 												name: "Function",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 89, col: 16, offset: 2210},
+												pos:  position{line: 89, col: 16, offset: 2208},
 												name: "EndOfOp",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 89, col: 25, offset: 2219},
+									pos:   position{line: 89, col: 25, offset: 2217},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 89, col: 27, offset: 2221},
+										pos:  position{line: 89, col: 27, offset: 2219},
 										name: "Aggregation",
 									},
 								},
 								&andExpr{
-									pos: position{line: 89, col: 39, offset: 2233},
+									pos: position{line: 89, col: 39, offset: 2231},
 									expr: &ruleRefExpr{
-										pos:  position{line: 89, col: 40, offset: 2234},
+										pos:  position{line: 89, col: 40, offset: 2232},
 										name: "EndOfOp",
 									},
 								},
@@ -760,42 +760,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 90, col: 5, offset: 2264},
+						pos: position{line: 90, col: 5, offset: 2262},
 						run: (*parser).callonLeanOp27,
 						expr: &seqExpr{
-							pos: position{line: 90, col: 5, offset: 2264},
+							pos: position{line: 90, col: 5, offset: 2262},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 90, col: 5, offset: 2264},
+									pos: position{line: 90, col: 5, offset: 2262},
 									expr: &seqExpr{
-										pos: position{line: 90, col: 7, offset: 2266},
+										pos: position{line: 90, col: 7, offset: 2264},
 										exprs: []any{
 											&choiceExpr{
-												pos: position{line: 90, col: 8, offset: 2267},
+												pos: position{line: 90, col: 8, offset: 2265},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 90, col: 8, offset: 2267},
+														pos:  position{line: 90, col: 8, offset: 2265},
 														name: "Identifier",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 90, col: 21, offset: 2280},
+														pos:  position{line: 90, col: 21, offset: 2278},
 														name: "Literal",
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 90, col: 30, offset: 2289},
+												pos:  position{line: 90, col: 30, offset: 2287},
 												name: "__",
 											},
 											&choiceExpr{
-												pos: position{line: 90, col: 34, offset: 2293},
+												pos: position{line: 90, col: 34, offset: 2291},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 90, col: 34, offset: 2293},
+														pos:  position{line: 90, col: 34, offset: 2291},
 														name: "Pipe",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 90, col: 39, offset: 2298},
+														pos:  position{line: 90, col: 39, offset: 2296},
 														name: "EOF",
 													},
 												},
@@ -804,10 +804,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 90, col: 45, offset: 2304},
+									pos:   position{line: 90, col: 45, offset: 2302},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 90, col: 47, offset: 2306},
+										pos:  position{line: 90, col: 47, offset: 2304},
 										name: "Expr",
 									},
 								},
@@ -821,35 +821,35 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfOp",
-			pos:  position{line: 94, col: 1, offset: 2394},
+			pos:  position{line: 94, col: 1, offset: 2392},
 			expr: &seqExpr{
-				pos: position{line: 94, col: 11, offset: 2404},
+				pos: position{line: 94, col: 11, offset: 2402},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 94, col: 11, offset: 2404},
+						pos:  position{line: 94, col: 11, offset: 2402},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 94, col: 15, offset: 2408},
+						pos: position{line: 94, col: 15, offset: 2406},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 94, col: 15, offset: 2408},
+								pos:  position{line: 94, col: 15, offset: 2406},
 								name: "Pipe",
 							},
 							&litMatcher{
-								pos:        position{line: 94, col: 22, offset: 2415},
+								pos:        position{line: 94, col: 22, offset: 2413},
 								val:        ")",
 								ignoreCase: false,
 								want:       "\")\"",
 							},
 							&litMatcher{
-								pos:        position{line: 94, col: 28, offset: 2421},
+								pos:        position{line: 94, col: 28, offset: 2419},
 								val:        ";",
 								ignoreCase: false,
 								want:       "\";\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 94, col: 34, offset: 2427},
+								pos:  position{line: 94, col: 34, offset: 2425},
 								name: "EOF",
 							},
 						},
@@ -861,18 +861,18 @@ var g = &grammar{
 		},
 		{
 			name: "Pipe",
-			pos:  position{line: 95, col: 1, offset: 2432},
+			pos:  position{line: 95, col: 1, offset: 2430},
 			expr: &choiceExpr{
-				pos: position{line: 95, col: 8, offset: 2439},
+				pos: position{line: 95, col: 8, offset: 2437},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 95, col: 8, offset: 2439},
+						pos:        position{line: 95, col: 8, offset: 2437},
 						val:        "|>",
 						ignoreCase: false,
 						want:       "\"|>\"",
 					},
 					&litMatcher{
-						pos:        position{line: 95, col: 15, offset: 2446},
+						pos:        position{line: 95, col: 15, offset: 2444},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
@@ -884,49 +884,49 @@ var g = &grammar{
 		},
 		{
 			name: "ExprGuard",
-			pos:  position{line: 97, col: 1, offset: 2452},
+			pos:  position{line: 97, col: 1, offset: 2449},
 			expr: &seqExpr{
-				pos: position{line: 97, col: 13, offset: 2464},
+				pos: position{line: 97, col: 13, offset: 2461},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 97, col: 13, offset: 2464},
+						pos:  position{line: 97, col: 13, offset: 2461},
 						name: "__",
 					},
 					&choiceExpr{
-						pos: position{line: 97, col: 17, offset: 2468},
+						pos: position{line: 97, col: 17, offset: 2465},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 97, col: 17, offset: 2468},
+								pos:  position{line: 97, col: 17, offset: 2465},
 								name: "Comparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 97, col: 30, offset: 2481},
+								pos:  position{line: 97, col: 30, offset: 2478},
 								name: "AdditiveOperator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 97, col: 49, offset: 2500},
+								pos:  position{line: 97, col: 49, offset: 2497},
 								name: "MultiplicativeOperator",
 							},
 							&litMatcher{
-								pos:        position{line: 97, col: 74, offset: 2525},
+								pos:        position{line: 97, col: 74, offset: 2522},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&litMatcher{
-								pos:        position{line: 97, col: 80, offset: 2531},
+								pos:        position{line: 97, col: 80, offset: 2528},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 							&litMatcher{
-								pos:        position{line: 97, col: 86, offset: 2537},
+								pos:        position{line: 97, col: 86, offset: 2534},
 								val:        "[",
 								ignoreCase: false,
 								want:       "\"[\"",
 							},
 							&litMatcher{
-								pos:        position{line: 97, col: 92, offset: 2543},
+								pos:        position{line: 97, col: 92, offset: 2540},
 								val:        "~",
 								ignoreCase: false,
 								want:       "\"~\"",
@@ -940,68 +940,68 @@ var g = &grammar{
 		},
 		{
 			name: "Comparator",
-			pos:  position{line: 99, col: 1, offset: 2549},
+			pos:  position{line: 99, col: 1, offset: 2546},
 			expr: &choiceExpr{
-				pos: position{line: 100, col: 5, offset: 2564},
+				pos: position{line: 100, col: 5, offset: 2561},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 100, col: 5, offset: 2564},
+						pos: position{line: 100, col: 5, offset: 2561},
 						run: (*parser).callonComparator2,
 						expr: &choiceExpr{
-							pos: position{line: 100, col: 6, offset: 2565},
+							pos: position{line: 100, col: 6, offset: 2562},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 100, col: 6, offset: 2565},
+									pos:        position{line: 100, col: 6, offset: 2562},
 									val:        "==",
 									ignoreCase: false,
 									want:       "\"==\"",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 13, offset: 2572},
+									pos:        position{line: 100, col: 13, offset: 2569},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 19, offset: 2578},
+									pos:        position{line: 100, col: 19, offset: 2575},
 									val:        "!=",
 									ignoreCase: false,
 									want:       "\"!=\"",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 26, offset: 2585},
+									pos:        position{line: 100, col: 26, offset: 2582},
 									val:        "<>",
 									ignoreCase: false,
 									want:       "\"<>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 100, col: 33, offset: 2592},
+									pos:  position{line: 100, col: 33, offset: 2589},
 									name: "IN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 100, col: 38, offset: 2597},
+									pos:  position{line: 100, col: 38, offset: 2594},
 									name: "LIKE",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 45, offset: 2604},
+									pos:        position{line: 100, col: 45, offset: 2601},
 									val:        "<=",
 									ignoreCase: false,
 									want:       "\"<=\"",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 52, offset: 2611},
+									pos:        position{line: 100, col: 52, offset: 2608},
 									val:        "<",
 									ignoreCase: false,
 									want:       "\"<\"",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 58, offset: 2617},
+									pos:        position{line: 100, col: 58, offset: 2614},
 									val:        ">=",
 									ignoreCase: false,
 									want:       "\">=\"",
 								},
 								&litMatcher{
-									pos:        position{line: 100, col: 65, offset: 2624},
+									pos:        position{line: 100, col: 65, offset: 2621},
 									val:        ">",
 									ignoreCase: false,
 									want:       "\">\"",
@@ -1010,42 +1010,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 101, col: 5, offset: 2664},
+						pos: position{line: 101, col: 5, offset: 2661},
 						run: (*parser).callonComparator14,
 						expr: &seqExpr{
-							pos: position{line: 101, col: 5, offset: 2664},
+							pos: position{line: 101, col: 5, offset: 2661},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 101, col: 5, offset: 2664},
+									pos:  position{line: 101, col: 5, offset: 2661},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 101, col: 9, offset: 2668},
+									pos:  position{line: 101, col: 9, offset: 2665},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 101, col: 11, offset: 2670},
+									pos:  position{line: 101, col: 11, offset: 2667},
 									name: "LIKE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 102, col: 5, offset: 2706},
+						pos: position{line: 102, col: 5, offset: 2703},
 						run: (*parser).callonComparator19,
 						expr: &seqExpr{
-							pos: position{line: 102, col: 5, offset: 2706},
+							pos: position{line: 102, col: 5, offset: 2703},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 102, col: 5, offset: 2706},
+									pos:  position{line: 102, col: 5, offset: 2703},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 102, col: 9, offset: 2710},
+									pos:  position{line: 102, col: 9, offset: 2707},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 102, col: 11, offset: 2712},
+									pos:  position{line: 102, col: 11, offset: 2709},
 									name: "IN",
 								},
 							},
@@ -1058,28 +1058,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBoolean",
-			pos:  position{line: 104, col: 1, offset: 2741},
+			pos:  position{line: 104, col: 1, offset: 2738},
 			expr: &actionExpr{
-				pos: position{line: 105, col: 5, offset: 2759},
+				pos: position{line: 105, col: 5, offset: 2756},
 				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 105, col: 5, offset: 2759},
+					pos: position{line: 105, col: 5, offset: 2756},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 105, col: 5, offset: 2759},
+							pos:   position{line: 105, col: 5, offset: 2756},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 105, col: 11, offset: 2765},
+								pos:  position{line: 105, col: 11, offset: 2762},
 								name: "SearchAnd",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 105, col: 21, offset: 2775},
+							pos:   position{line: 105, col: 21, offset: 2772},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 105, col: 26, offset: 2780},
+								pos: position{line: 105, col: 26, offset: 2777},
 								expr: &ruleRefExpr{
-									pos:  position{line: 105, col: 26, offset: 2780},
+									pos:  position{line: 105, col: 26, offset: 2777},
 									name: "SearchOrTerm",
 								},
 							},
@@ -1092,30 +1092,30 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOrTerm",
-			pos:  position{line: 109, col: 1, offset: 2857},
+			pos:  position{line: 109, col: 1, offset: 2854},
 			expr: &actionExpr{
-				pos: position{line: 109, col: 16, offset: 2872},
+				pos: position{line: 109, col: 16, offset: 2869},
 				run: (*parser).callonSearchOrTerm1,
 				expr: &seqExpr{
-					pos: position{line: 109, col: 16, offset: 2872},
+					pos: position{line: 109, col: 16, offset: 2869},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 109, col: 16, offset: 2872},
+							pos:  position{line: 109, col: 16, offset: 2869},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 109, col: 18, offset: 2874},
+							pos:  position{line: 109, col: 18, offset: 2871},
 							name: "OR",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 109, col: 21, offset: 2877},
+							pos:  position{line: 109, col: 21, offset: 2874},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 109, col: 23, offset: 2879},
+							pos:   position{line: 109, col: 23, offset: 2876},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 109, col: 25, offset: 2881},
+								pos:  position{line: 109, col: 25, offset: 2878},
 								name: "SearchAnd",
 							},
 						},
@@ -1127,64 +1127,64 @@ var g = &grammar{
 		},
 		{
 			name: "SearchAnd",
-			pos:  position{line: 111, col: 1, offset: 2923},
+			pos:  position{line: 111, col: 1, offset: 2920},
 			expr: &actionExpr{
-				pos: position{line: 112, col: 5, offset: 2937},
+				pos: position{line: 112, col: 5, offset: 2934},
 				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 112, col: 5, offset: 2937},
+					pos: position{line: 112, col: 5, offset: 2934},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 112, col: 5, offset: 2937},
+							pos:   position{line: 112, col: 5, offset: 2934},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 112, col: 11, offset: 2943},
+								pos:  position{line: 112, col: 11, offset: 2940},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 113, col: 5, offset: 2960},
+							pos:   position{line: 113, col: 5, offset: 2957},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 113, col: 10, offset: 2965},
+								pos: position{line: 113, col: 10, offset: 2962},
 								expr: &actionExpr{
-									pos: position{line: 113, col: 11, offset: 2966},
+									pos: position{line: 113, col: 11, offset: 2963},
 									run: (*parser).callonSearchAnd7,
 									expr: &seqExpr{
-										pos: position{line: 113, col: 11, offset: 2966},
+										pos: position{line: 113, col: 11, offset: 2963},
 										exprs: []any{
 											&zeroOrOneExpr{
-												pos: position{line: 113, col: 11, offset: 2966},
+												pos: position{line: 113, col: 11, offset: 2963},
 												expr: &seqExpr{
-													pos: position{line: 113, col: 12, offset: 2967},
+													pos: position{line: 113, col: 12, offset: 2964},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 113, col: 12, offset: 2967},
+															pos:  position{line: 113, col: 12, offset: 2964},
 															name: "_",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 113, col: 14, offset: 2969},
+															pos:  position{line: 113, col: 14, offset: 2966},
 															name: "AND",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 113, col: 20, offset: 2975},
+												pos:  position{line: 113, col: 20, offset: 2972},
 												name: "_",
 											},
 											&notExpr{
-												pos: position{line: 113, col: 22, offset: 2977},
+												pos: position{line: 113, col: 22, offset: 2974},
 												expr: &ruleRefExpr{
-													pos:  position{line: 113, col: 23, offset: 2978},
+													pos:  position{line: 113, col: 23, offset: 2975},
 													name: "OR",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 113, col: 26, offset: 2981},
+												pos:   position{line: 113, col: 26, offset: 2978},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 113, col: 31, offset: 2986},
+													pos:  position{line: 113, col: 31, offset: 2983},
 													name: "SearchFactor",
 												},
 											},
@@ -1201,43 +1201,43 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 117, col: 1, offset: 3099},
+			pos:  position{line: 117, col: 1, offset: 3096},
 			expr: &choiceExpr{
-				pos: position{line: 118, col: 5, offset: 3116},
+				pos: position{line: 118, col: 5, offset: 3113},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 118, col: 5, offset: 3116},
+						pos: position{line: 118, col: 5, offset: 3113},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 118, col: 5, offset: 3116},
+							pos: position{line: 118, col: 5, offset: 3113},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 118, col: 6, offset: 3117},
+									pos: position{line: 118, col: 6, offset: 3114},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 118, col: 6, offset: 3117},
+											pos: position{line: 118, col: 6, offset: 3114},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 118, col: 6, offset: 3117},
+													pos:  position{line: 118, col: 6, offset: 3114},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 118, col: 10, offset: 3121},
+													pos:  position{line: 118, col: 10, offset: 3118},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 118, col: 14, offset: 3125},
+											pos: position{line: 118, col: 14, offset: 3122},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 118, col: 14, offset: 3125},
+													pos:        position{line: 118, col: 14, offset: 3122},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 118, col: 18, offset: 3129},
+													pos:  position{line: 118, col: 18, offset: 3126},
 													name: "__",
 												},
 											},
@@ -1245,10 +1245,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 118, col: 22, offset: 3133},
+									pos:   position{line: 118, col: 22, offset: 3130},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 118, col: 24, offset: 3135},
+										pos:  position{line: 118, col: 24, offset: 3132},
 										name: "SearchFactor",
 									},
 								},
@@ -1256,35 +1256,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 126, col: 5, offset: 3306},
+						pos: position{line: 126, col: 5, offset: 3303},
 						run: (*parser).callonSearchFactor13,
 						expr: &seqExpr{
-							pos: position{line: 126, col: 5, offset: 3306},
+							pos: position{line: 126, col: 5, offset: 3303},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 126, col: 5, offset: 3306},
+									pos:        position{line: 126, col: 5, offset: 3303},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 126, col: 9, offset: 3310},
+									pos:  position{line: 126, col: 9, offset: 3307},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 126, col: 12, offset: 3313},
+									pos:   position{line: 126, col: 12, offset: 3310},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 126, col: 17, offset: 3318},
+										pos:  position{line: 126, col: 17, offset: 3315},
 										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 126, col: 31, offset: 3332},
+									pos:  position{line: 126, col: 31, offset: 3329},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 126, col: 34, offset: 3335},
+									pos:        position{line: 126, col: 34, offset: 3332},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -1293,7 +1293,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 127, col: 5, offset: 3364},
+						pos:  position{line: 127, col: 5, offset: 3361},
 						name: "SearchExpr",
 					},
 				},
@@ -1303,53 +1303,53 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 129, col: 1, offset: 3376},
+			pos:  position{line: 129, col: 1, offset: 3373},
 			expr: &choiceExpr{
-				pos: position{line: 130, col: 5, offset: 3391},
+				pos: position{line: 130, col: 5, offset: 3388},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 130, col: 5, offset: 3391},
+						pos:  position{line: 130, col: 5, offset: 3388},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 131, col: 5, offset: 3402},
+						pos:  position{line: 131, col: 5, offset: 3399},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 132, col: 5, offset: 3411},
+						pos: position{line: 132, col: 5, offset: 3408},
 						run: (*parser).callonSearchExpr4,
 						expr: &seqExpr{
-							pos: position{line: 132, col: 5, offset: 3411},
+							pos: position{line: 132, col: 5, offset: 3408},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 132, col: 5, offset: 3411},
+									pos:   position{line: 132, col: 5, offset: 3408},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 132, col: 7, offset: 3413},
+										pos:  position{line: 132, col: 7, offset: 3410},
 										name: "SearchValue",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 132, col: 20, offset: 3426},
+									pos: position{line: 132, col: 20, offset: 3423},
 									alternatives: []any{
 										&notExpr{
-											pos: position{line: 132, col: 20, offset: 3426},
+											pos: position{line: 132, col: 20, offset: 3423},
 											expr: &ruleRefExpr{
-												pos:  position{line: 132, col: 21, offset: 3427},
+												pos:  position{line: 132, col: 21, offset: 3424},
 												name: "ExprGuard",
 											},
 										},
 										&andExpr{
-											pos: position{line: 132, col: 33, offset: 3439},
+											pos: position{line: 132, col: 33, offset: 3436},
 											expr: &seqExpr{
-												pos: position{line: 132, col: 35, offset: 3441},
+												pos: position{line: 132, col: 35, offset: 3438},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 132, col: 35, offset: 3441},
+														pos:  position{line: 132, col: 35, offset: 3438},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 132, col: 37, offset: 3443},
+														pos:  position{line: 132, col: 37, offset: 3440},
 														name: "Glob",
 													},
 												},
@@ -1361,21 +1361,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 140, col: 5, offset: 3600},
+						pos: position{line: 140, col: 5, offset: 3597},
 						run: (*parser).callonSearchExpr15,
 						expr: &seqExpr{
-							pos: position{line: 140, col: 5, offset: 3600},
+							pos: position{line: 140, col: 5, offset: 3597},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 140, col: 5, offset: 3600},
+									pos:        position{line: 140, col: 5, offset: 3597},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 140, col: 9, offset: 3604},
+									pos: position{line: 140, col: 9, offset: 3601},
 									expr: &ruleRefExpr{
-										pos:  position{line: 140, col: 10, offset: 3605},
+										pos:  position{line: 140, col: 10, offset: 3602},
 										name: "ExprGuard",
 									},
 								},
@@ -1383,7 +1383,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 143, col: 5, offset: 3713},
+						pos:  position{line: 143, col: 5, offset: 3710},
 						name: "SearchPredicate",
 					},
 				},
@@ -1393,45 +1393,45 @@ var g = &grammar{
 		},
 		{
 			name: "SearchPredicate",
-			pos:  position{line: 145, col: 1, offset: 3730},
+			pos:  position{line: 145, col: 1, offset: 3727},
 			expr: &choiceExpr{
-				pos: position{line: 146, col: 5, offset: 3750},
+				pos: position{line: 146, col: 5, offset: 3747},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 146, col: 5, offset: 3750},
+						pos: position{line: 146, col: 5, offset: 3747},
 						run: (*parser).callonSearchPredicate2,
 						expr: &seqExpr{
-							pos: position{line: 146, col: 5, offset: 3750},
+							pos: position{line: 146, col: 5, offset: 3747},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 146, col: 5, offset: 3750},
+									pos:   position{line: 146, col: 5, offset: 3747},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 146, col: 9, offset: 3754},
+										pos:  position{line: 146, col: 9, offset: 3751},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 22, offset: 3767},
+									pos:  position{line: 146, col: 22, offset: 3764},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 146, col: 25, offset: 3770},
+									pos:   position{line: 146, col: 25, offset: 3767},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 146, col: 28, offset: 3773},
+										pos:  position{line: 146, col: 28, offset: 3770},
 										name: "Comparator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 146, col: 39, offset: 3784},
+									pos:  position{line: 146, col: 39, offset: 3781},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 146, col: 42, offset: 3787},
+									pos:   position{line: 146, col: 42, offset: 3784},
 									label: "rhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 146, col: 46, offset: 3791},
+										pos:  position{line: 146, col: 46, offset: 3788},
 										name: "AdditiveExpr",
 									},
 								},
@@ -1439,13 +1439,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 155, col: 5, offset: 3991},
+						pos: position{line: 155, col: 5, offset: 3988},
 						run: (*parser).callonSearchPredicate12,
 						expr: &labeledExpr{
-							pos:   position{line: 155, col: 5, offset: 3991},
+							pos:   position{line: 155, col: 5, offset: 3988},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 155, col: 7, offset: 3993},
+								pos:  position{line: 155, col: 7, offset: 3990},
 								name: "Function",
 							},
 						},
@@ -1457,32 +1457,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 157, col: 1, offset: 4021},
+			pos:  position{line: 157, col: 1, offset: 4018},
 			expr: &choiceExpr{
-				pos: position{line: 158, col: 5, offset: 4037},
+				pos: position{line: 158, col: 5, offset: 4034},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 158, col: 5, offset: 4037},
+						pos:  position{line: 158, col: 5, offset: 4034},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 159, col: 5, offset: 4049},
+						pos: position{line: 159, col: 5, offset: 4046},
 						run: (*parser).callonSearchValue3,
 						expr: &seqExpr{
-							pos: position{line: 159, col: 5, offset: 4049},
+							pos: position{line: 159, col: 5, offset: 4046},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 159, col: 5, offset: 4049},
+									pos: position{line: 159, col: 5, offset: 4046},
 									expr: &ruleRefExpr{
-										pos:  position{line: 159, col: 6, offset: 4050},
+										pos:  position{line: 159, col: 6, offset: 4047},
 										name: "RegexpPattern",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 159, col: 20, offset: 4064},
+									pos:   position{line: 159, col: 20, offset: 4061},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 159, col: 22, offset: 4066},
+										pos:  position{line: 159, col: 22, offset: 4063},
 										name: "KeyWord",
 									},
 								},
@@ -1496,15 +1496,15 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 163, col: 1, offset: 4139},
+			pos:  position{line: 163, col: 1, offset: 4136},
 			expr: &actionExpr{
-				pos: position{line: 164, col: 5, offset: 4148},
+				pos: position{line: 164, col: 5, offset: 4145},
 				run: (*parser).callonGlob1,
 				expr: &labeledExpr{
-					pos:   position{line: 164, col: 5, offset: 4148},
+					pos:   position{line: 164, col: 5, offset: 4145},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 164, col: 13, offset: 4156},
+						pos:  position{line: 164, col: 13, offset: 4153},
 						name: "GlobPattern",
 					},
 				},
@@ -1514,15 +1514,15 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 168, col: 1, offset: 4259},
+			pos:  position{line: 168, col: 1, offset: 4256},
 			expr: &actionExpr{
-				pos: position{line: 169, col: 5, offset: 4270},
+				pos: position{line: 169, col: 5, offset: 4267},
 				run: (*parser).callonRegexp1,
 				expr: &labeledExpr{
-					pos:   position{line: 169, col: 5, offset: 4270},
+					pos:   position{line: 169, col: 5, offset: 4267},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 169, col: 13, offset: 4278},
+						pos:  position{line: 169, col: 13, offset: 4275},
 						name: "RegexpPattern",
 					},
 				},
@@ -1532,36 +1532,36 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 175, col: 1, offset: 4411},
+			pos:  position{line: 175, col: 1, offset: 4408},
 			expr: &choiceExpr{
-				pos: position{line: 176, col: 5, offset: 4427},
+				pos: position{line: 176, col: 5, offset: 4424},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 176, col: 5, offset: 4427},
+						pos: position{line: 176, col: 5, offset: 4424},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 176, col: 5, offset: 4427},
+							pos: position{line: 176, col: 5, offset: 4424},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 176, col: 5, offset: 4427},
+									pos: position{line: 176, col: 5, offset: 4424},
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 5, offset: 4427},
+										pos:  position{line: 176, col: 5, offset: 4424},
 										name: "Aggregate",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 176, col: 16, offset: 4438},
+									pos:   position{line: 176, col: 16, offset: 4435},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 21, offset: 4443},
+										pos:  position{line: 176, col: 21, offset: 4440},
 										name: "AggregateKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 176, col: 35, offset: 4457},
+									pos:   position{line: 176, col: 35, offset: 4454},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 41, offset: 4463},
+										pos:  position{line: 176, col: 41, offset: 4460},
 										name: "LimitArg",
 									},
 								},
@@ -1569,40 +1569,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 184, col: 5, offset: 4647},
+						pos: position{line: 184, col: 5, offset: 4644},
 						run: (*parser).callonAggregation10,
 						expr: &seqExpr{
-							pos: position{line: 184, col: 5, offset: 4647},
+							pos: position{line: 184, col: 5, offset: 4644},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 184, col: 5, offset: 4647},
+									pos: position{line: 184, col: 5, offset: 4644},
 									expr: &ruleRefExpr{
-										pos:  position{line: 184, col: 5, offset: 4647},
+										pos:  position{line: 184, col: 5, offset: 4644},
 										name: "Aggregate",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 184, col: 16, offset: 4658},
+									pos:   position{line: 184, col: 16, offset: 4655},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 184, col: 21, offset: 4663},
+										pos:  position{line: 184, col: 21, offset: 4660},
 										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 184, col: 36, offset: 4678},
+									pos:   position{line: 184, col: 36, offset: 4675},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 184, col: 41, offset: 4683},
+										pos: position{line: 184, col: 41, offset: 4680},
 										expr: &seqExpr{
-											pos: position{line: 184, col: 42, offset: 4684},
+											pos: position{line: 184, col: 42, offset: 4681},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 184, col: 42, offset: 4684},
+													pos:  position{line: 184, col: 42, offset: 4681},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 184, col: 44, offset: 4686},
+													pos:  position{line: 184, col: 44, offset: 4683},
 													name: "AggregateKeys",
 												},
 											},
@@ -1610,10 +1610,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 184, col: 60, offset: 4702},
+									pos:   position{line: 184, col: 60, offset: 4699},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 184, col: 66, offset: 4708},
+										pos:  position{line: 184, col: 66, offset: 4705},
 										name: "LimitArg",
 									},
 								},
@@ -1627,25 +1627,25 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregate",
-			pos:  position{line: 197, col: 1, offset: 4992},
+			pos:  position{line: 197, col: 1, offset: 4989},
 			expr: &seqExpr{
-				pos: position{line: 197, col: 13, offset: 5004},
+				pos: position{line: 197, col: 13, offset: 5001},
 				exprs: []any{
 					&choiceExpr{
-						pos: position{line: 197, col: 14, offset: 5005},
+						pos: position{line: 197, col: 14, offset: 5002},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 197, col: 14, offset: 5005},
+								pos:  position{line: 197, col: 14, offset: 5002},
 								name: "AGGREGATE",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 197, col: 26, offset: 5017},
+								pos:  position{line: 197, col: 26, offset: 5014},
 								name: "SUMMARIZE",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 197, col: 37, offset: 5028},
+						pos:  position{line: 197, col: 37, offset: 5025},
 						name: "_",
 					},
 				},
@@ -1655,42 +1655,42 @@ var g = &grammar{
 		},
 		{
 			name: "AggregateKeys",
-			pos:  position{line: 199, col: 1, offset: 5031},
+			pos:  position{line: 199, col: 1, offset: 5028},
 			expr: &actionExpr{
-				pos: position{line: 200, col: 5, offset: 5049},
+				pos: position{line: 200, col: 5, offset: 5046},
 				run: (*parser).callonAggregateKeys1,
 				expr: &seqExpr{
-					pos: position{line: 200, col: 5, offset: 5049},
+					pos: position{line: 200, col: 5, offset: 5046},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 200, col: 5, offset: 5049},
+							pos: position{line: 200, col: 5, offset: 5046},
 							expr: &seqExpr{
-								pos: position{line: 200, col: 6, offset: 5050},
+								pos: position{line: 200, col: 6, offset: 5047},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 200, col: 6, offset: 5050},
+										pos:  position{line: 200, col: 6, offset: 5047},
 										name: "GROUP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 200, col: 12, offset: 5056},
+										pos:  position{line: 200, col: 12, offset: 5053},
 										name: "_",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 16, offset: 5060},
+							pos:  position{line: 200, col: 16, offset: 5057},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 19, offset: 5063},
+							pos:  position{line: 200, col: 19, offset: 5060},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 200, col: 21, offset: 5065},
+							pos:   position{line: 200, col: 21, offset: 5062},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 200, col: 29, offset: 5073},
+								pos:  position{line: 200, col: 29, offset: 5070},
 								name: "Assignments",
 							},
 						},
@@ -1702,43 +1702,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 202, col: 1, offset: 5110},
+			pos:  position{line: 202, col: 1, offset: 5107},
 			expr: &choiceExpr{
-				pos: position{line: 203, col: 5, offset: 5123},
+				pos: position{line: 203, col: 5, offset: 5120},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 203, col: 5, offset: 5123},
+						pos: position{line: 203, col: 5, offset: 5120},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 203, col: 5, offset: 5123},
+							pos: position{line: 203, col: 5, offset: 5120},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 203, col: 5, offset: 5123},
+									pos:  position{line: 203, col: 5, offset: 5120},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 203, col: 7, offset: 5125},
+									pos:  position{line: 203, col: 7, offset: 5122},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 203, col: 12, offset: 5130},
+									pos:  position{line: 203, col: 12, offset: 5127},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 203, col: 14, offset: 5132},
+									pos:        position{line: 203, col: 14, offset: 5129},
 									val:        "-limit",
 									ignoreCase: false,
 									want:       "\"-limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 203, col: 23, offset: 5141},
+									pos:  position{line: 203, col: 23, offset: 5138},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 203, col: 25, offset: 5143},
+									pos:   position{line: 203, col: 25, offset: 5140},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 203, col: 31, offset: 5149},
+										pos:  position{line: 203, col: 31, offset: 5146},
 										name: "UInt",
 									},
 								},
@@ -1746,10 +1746,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 204, col: 5, offset: 5180},
+						pos: position{line: 204, col: 5, offset: 5177},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 204, col: 5, offset: 5180},
+							pos:        position{line: 204, col: 5, offset: 5177},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -1762,43 +1762,43 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignment",
-			pos:  position{line: 206, col: 1, offset: 5202},
+			pos:  position{line: 206, col: 1, offset: 5199},
 			expr: &choiceExpr{
-				pos: position{line: 207, col: 5, offset: 5220},
+				pos: position{line: 207, col: 5, offset: 5217},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 207, col: 5, offset: 5220},
+						pos: position{line: 207, col: 5, offset: 5217},
 						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 207, col: 5, offset: 5220},
+							pos: position{line: 207, col: 5, offset: 5217},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 207, col: 5, offset: 5220},
+									pos:   position{line: 207, col: 5, offset: 5217},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 207, col: 10, offset: 5225},
+										pos:  position{line: 207, col: 10, offset: 5222},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 15, offset: 5230},
+									pos:  position{line: 207, col: 15, offset: 5227},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 207, col: 18, offset: 5233},
+									pos:        position{line: 207, col: 18, offset: 5230},
 									val:        ":=",
 									ignoreCase: false,
 									want:       "\":=\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 23, offset: 5238},
+									pos:  position{line: 207, col: 23, offset: 5235},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 207, col: 26, offset: 5241},
+									pos:   position{line: 207, col: 26, offset: 5238},
 									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 207, col: 30, offset: 5245},
+										pos:  position{line: 207, col: 30, offset: 5242},
 										name: "Agg",
 									},
 								},
@@ -1806,13 +1806,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 210, col: 5, offset: 5363},
+						pos: position{line: 210, col: 5, offset: 5360},
 						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 210, col: 5, offset: 5363},
+							pos:   position{line: 210, col: 5, offset: 5360},
 							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 210, col: 9, offset: 5367},
+								pos:  position{line: 210, col: 9, offset: 5364},
 								name: "Agg",
 							},
 						},
@@ -1824,42 +1824,42 @@ var g = &grammar{
 		},
 		{
 			name: "Agg",
-			pos:  position{line: 214, col: 1, offset: 5462},
+			pos:  position{line: 214, col: 1, offset: 5459},
 			expr: &choiceExpr{
-				pos: position{line: 215, col: 5, offset: 5470},
+				pos: position{line: 215, col: 5, offset: 5467},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 215, col: 5, offset: 5470},
+						pos: position{line: 215, col: 5, offset: 5467},
 						run: (*parser).callonAgg2,
 						expr: &seqExpr{
-							pos: position{line: 215, col: 5, offset: 5470},
+							pos: position{line: 215, col: 5, offset: 5467},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 215, col: 5, offset: 5470},
+									pos: position{line: 215, col: 5, offset: 5467},
 									expr: &ruleRefExpr{
-										pos:  position{line: 215, col: 6, offset: 5471},
+										pos:  position{line: 215, col: 6, offset: 5468},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 215, col: 16, offset: 5481},
+									pos:   position{line: 215, col: 16, offset: 5478},
 									label: "aggDistinct",
 									expr: &ruleRefExpr{
-										pos:  position{line: 215, col: 28, offset: 5493},
+										pos:  position{line: 215, col: 28, offset: 5490},
 										name: "AggDistinct",
 									},
 								},
 								&notExpr{
-									pos: position{line: 215, col: 40, offset: 5505},
+									pos: position{line: 215, col: 40, offset: 5502},
 									expr: &seqExpr{
-										pos: position{line: 215, col: 42, offset: 5507},
+										pos: position{line: 215, col: 42, offset: 5504},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 215, col: 42, offset: 5507},
+												pos:  position{line: 215, col: 42, offset: 5504},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 215, col: 45, offset: 5510},
+												pos:        position{line: 215, col: 45, offset: 5507},
 												val:        ".",
 												ignoreCase: false,
 												want:       "\".\"",
@@ -1868,12 +1868,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 215, col: 50, offset: 5515},
+									pos:   position{line: 215, col: 50, offset: 5512},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 215, col: 56, offset: 5521},
+										pos: position{line: 215, col: 56, offset: 5518},
 										expr: &ruleRefExpr{
-											pos:  position{line: 215, col: 56, offset: 5521},
+											pos:  position{line: 215, col: 56, offset: 5518},
 											name: "WhereClause",
 										},
 									},
@@ -1882,54 +1882,54 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 223, col: 5, offset: 5696},
+						pos: position{line: 223, col: 5, offset: 5693},
 						run: (*parser).callonAgg15,
 						expr: &seqExpr{
-							pos: position{line: 223, col: 5, offset: 5696},
+							pos: position{line: 223, col: 5, offset: 5693},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 223, col: 5, offset: 5696},
+									pos: position{line: 223, col: 5, offset: 5693},
 									expr: &ruleRefExpr{
-										pos:  position{line: 223, col: 6, offset: 5697},
+										pos:  position{line: 223, col: 6, offset: 5694},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 223, col: 16, offset: 5707},
+									pos:   position{line: 223, col: 16, offset: 5704},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 223, col: 21, offset: 5712},
+										pos:  position{line: 223, col: 21, offset: 5709},
 										name: "AggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 29, offset: 5720},
+									pos:  position{line: 223, col: 29, offset: 5717},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 223, col: 32, offset: 5723},
+									pos:        position{line: 223, col: 32, offset: 5720},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 36, offset: 5727},
+									pos:  position{line: 223, col: 36, offset: 5724},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 223, col: 39, offset: 5730},
+									pos:   position{line: 223, col: 39, offset: 5727},
 									label: "expr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 223, col: 44, offset: 5735},
+										pos: position{line: 223, col: 44, offset: 5732},
 										expr: &choiceExpr{
-											pos: position{line: 223, col: 45, offset: 5736},
+											pos: position{line: 223, col: 45, offset: 5733},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 223, col: 45, offset: 5736},
+													pos:  position{line: 223, col: 45, offset: 5733},
 													name: "UnnestExpr",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 223, col: 58, offset: 5749},
+													pos:  position{line: 223, col: 58, offset: 5746},
 													name: "Expr",
 												},
 											},
@@ -1937,26 +1937,26 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 65, offset: 5756},
+									pos:  position{line: 223, col: 65, offset: 5753},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 223, col: 68, offset: 5759},
+									pos:        position{line: 223, col: 68, offset: 5756},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&notExpr{
-									pos: position{line: 223, col: 72, offset: 5763},
+									pos: position{line: 223, col: 72, offset: 5760},
 									expr: &seqExpr{
-										pos: position{line: 223, col: 74, offset: 5765},
+										pos: position{line: 223, col: 74, offset: 5762},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 223, col: 74, offset: 5765},
+												pos:  position{line: 223, col: 74, offset: 5762},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 223, col: 77, offset: 5768},
+												pos:        position{line: 223, col: 77, offset: 5765},
 												val:        ".",
 												ignoreCase: false,
 												want:       "\".\"",
@@ -1965,12 +1965,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 223, col: 82, offset: 5773},
+									pos:   position{line: 223, col: 82, offset: 5770},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 223, col: 88, offset: 5779},
+										pos: position{line: 223, col: 88, offset: 5776},
 										expr: &ruleRefExpr{
-											pos:  position{line: 223, col: 88, offset: 5779},
+											pos:  position{line: 223, col: 88, offset: 5776},
 											name: "WhereClause",
 										},
 									},
@@ -1979,13 +1979,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 237, col: 5, offset: 6069},
+						pos: position{line: 237, col: 5, offset: 6066},
 						run: (*parser).callonAgg38,
 						expr: &labeledExpr{
-							pos:   position{line: 237, col: 5, offset: 6069},
+							pos:   position{line: 237, col: 5, offset: 6066},
 							label: "cs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 237, col: 8, offset: 6072},
+								pos:  position{line: 237, col: 8, offset: 6069},
 								name: "CountStar",
 							},
 						},
@@ -1997,73 +1997,73 @@ var g = &grammar{
 		},
 		{
 			name: "AggDistinct",
-			pos:  position{line: 245, col: 1, offset: 6210},
+			pos:  position{line: 245, col: 1, offset: 6207},
 			expr: &actionExpr{
-				pos: position{line: 246, col: 5, offset: 6226},
+				pos: position{line: 246, col: 5, offset: 6223},
 				run: (*parser).callonAggDistinct1,
 				expr: &seqExpr{
-					pos: position{line: 246, col: 5, offset: 6226},
+					pos: position{line: 246, col: 5, offset: 6223},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 246, col: 5, offset: 6226},
+							pos: position{line: 246, col: 5, offset: 6223},
 							expr: &ruleRefExpr{
-								pos:  position{line: 246, col: 6, offset: 6227},
+								pos:  position{line: 246, col: 6, offset: 6224},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 246, col: 16, offset: 6237},
+							pos:   position{line: 246, col: 16, offset: 6234},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 246, col: 21, offset: 6242},
+								pos:  position{line: 246, col: 21, offset: 6239},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 29, offset: 6250},
+							pos:  position{line: 246, col: 29, offset: 6247},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 246, col: 32, offset: 6253},
+							pos:        position{line: 246, col: 32, offset: 6250},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 36, offset: 6257},
+							pos:  position{line: 246, col: 36, offset: 6254},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 39, offset: 6260},
+							pos:  position{line: 246, col: 39, offset: 6257},
 							name: "DISTINCT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 48, offset: 6269},
+							pos:  position{line: 246, col: 48, offset: 6266},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 246, col: 50, offset: 6271},
+							pos:   position{line: 246, col: 50, offset: 6268},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 246, col: 56, offset: 6277},
+								pos: position{line: 246, col: 56, offset: 6274},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 246, col: 56, offset: 6277},
+										pos:  position{line: 246, col: 56, offset: 6274},
 										name: "UnnestExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 246, col: 69, offset: 6290},
+										pos:  position{line: 246, col: 69, offset: 6287},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 75, offset: 6296},
+							pos:  position{line: 246, col: 75, offset: 6293},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 246, col: 78, offset: 6299},
+							pos:        position{line: 246, col: 78, offset: 6296},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2076,20 +2076,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 256, col: 1, offset: 6484},
+			pos:  position{line: 256, col: 1, offset: 6481},
 			expr: &choiceExpr{
-				pos: position{line: 257, col: 5, offset: 6496},
+				pos: position{line: 257, col: 5, offset: 6493},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 5, offset: 6496},
+						pos:  position{line: 257, col: 5, offset: 6493},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 258, col: 5, offset: 6515},
+						pos:  position{line: 258, col: 5, offset: 6512},
 						name: "AND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 259, col: 5, offset: 6523},
+						pos:  position{line: 259, col: 5, offset: 6520},
 						name: "OR",
 					},
 				},
@@ -2099,30 +2099,30 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 261, col: 1, offset: 6527},
+			pos:  position{line: 261, col: 1, offset: 6524},
 			expr: &actionExpr{
-				pos: position{line: 261, col: 15, offset: 6541},
+				pos: position{line: 261, col: 15, offset: 6538},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 261, col: 15, offset: 6541},
+					pos: position{line: 261, col: 15, offset: 6538},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 261, col: 15, offset: 6541},
+							pos:  position{line: 261, col: 15, offset: 6538},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 261, col: 17, offset: 6543},
+							pos:  position{line: 261, col: 17, offset: 6540},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 261, col: 23, offset: 6549},
+							pos:  position{line: 261, col: 23, offset: 6546},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 261, col: 25, offset: 6551},
+							pos:   position{line: 261, col: 25, offset: 6548},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 261, col: 30, offset: 6556},
+								pos:  position{line: 261, col: 30, offset: 6553},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -2134,45 +2134,45 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 263, col: 1, offset: 6592},
+			pos:  position{line: 263, col: 1, offset: 6589},
 			expr: &actionExpr{
-				pos: position{line: 264, col: 5, offset: 6611},
+				pos: position{line: 264, col: 5, offset: 6608},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 264, col: 5, offset: 6611},
+					pos: position{line: 264, col: 5, offset: 6608},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 264, col: 5, offset: 6611},
+							pos:   position{line: 264, col: 5, offset: 6608},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 264, col: 11, offset: 6617},
+								pos:  position{line: 264, col: 11, offset: 6614},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 264, col: 25, offset: 6631},
+							pos:   position{line: 264, col: 25, offset: 6628},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 264, col: 30, offset: 6636},
+								pos: position{line: 264, col: 30, offset: 6633},
 								expr: &seqExpr{
-									pos: position{line: 264, col: 31, offset: 6637},
+									pos: position{line: 264, col: 31, offset: 6634},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 264, col: 31, offset: 6637},
+											pos:  position{line: 264, col: 31, offset: 6634},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 264, col: 34, offset: 6640},
+											pos:        position{line: 264, col: 34, offset: 6637},
 											val:        ",",
 											ignoreCase: false,
 											want:       "\",\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 264, col: 38, offset: 6644},
+											pos:  position{line: 264, col: 38, offset: 6641},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 264, col: 41, offset: 6647},
+											pos:  position{line: 264, col: 41, offset: 6644},
 											name: "AggAssignment",
 										},
 									},
@@ -2187,43 +2187,43 @@ var g = &grammar{
 		},
 		{
 			name: "CountStar",
-			pos:  position{line: 272, col: 1, offset: 6821},
+			pos:  position{line: 272, col: 1, offset: 6818},
 			expr: &actionExpr{
-				pos: position{line: 272, col: 13, offset: 6833},
+				pos: position{line: 272, col: 13, offset: 6830},
 				run: (*parser).callonCountStar1,
 				expr: &seqExpr{
-					pos: position{line: 272, col: 13, offset: 6833},
+					pos: position{line: 272, col: 13, offset: 6830},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 272, col: 13, offset: 6833},
+							pos:  position{line: 272, col: 13, offset: 6830},
 							name: "COUNT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 272, col: 19, offset: 6839},
+							pos:  position{line: 272, col: 19, offset: 6836},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 272, col: 22, offset: 6842},
+							pos:        position{line: 272, col: 22, offset: 6839},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 272, col: 26, offset: 6846},
+							pos:  position{line: 272, col: 26, offset: 6843},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 272, col: 29, offset: 6849},
+							pos:        position{line: 272, col: 29, offset: 6846},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 272, col: 33, offset: 6853},
+							pos:  position{line: 272, col: 33, offset: 6850},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 272, col: 36, offset: 6856},
+							pos:        position{line: 272, col: 36, offset: 6853},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2236,28 +2236,28 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 282, col: 1, offset: 7050},
+			pos:  position{line: 282, col: 1, offset: 7047},
 			expr: &choiceExpr{
-				pos: position{line: 283, col: 5, offset: 7063},
+				pos: position{line: 283, col: 5, offset: 7060},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 283, col: 5, offset: 7063},
+						pos: position{line: 283, col: 5, offset: 7060},
 						run: (*parser).callonOperator2,
 						expr: &seqExpr{
-							pos: position{line: 283, col: 5, offset: 7063},
+							pos: position{line: 283, col: 5, offset: 7060},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 283, col: 5, offset: 7063},
+									pos:   position{line: 283, col: 5, offset: 7060},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 283, col: 8, offset: 7066},
+										pos:  position{line: 283, col: 8, offset: 7063},
 										name: "SelectOp",
 									},
 								},
 								&andExpr{
-									pos: position{line: 283, col: 17, offset: 7075},
+									pos: position{line: 283, col: 17, offset: 7072},
 									expr: &ruleRefExpr{
-										pos:  position{line: 283, col: 18, offset: 7076},
+										pos:  position{line: 283, col: 18, offset: 7073},
 										name: "EndOfOp",
 									},
 								},
@@ -2265,119 +2265,119 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 284, col: 5, offset: 7107},
+						pos:  position{line: 284, col: 5, offset: 7104},
 						name: "ForkOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 285, col: 5, offset: 7118},
+						pos:  position{line: 285, col: 5, offset: 7115},
 						name: "SwitchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 286, col: 5, offset: 7132},
+						pos:  position{line: 286, col: 5, offset: 7128},
 						name: "SearchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 5, offset: 7145},
+						pos:  position{line: 287, col: 5, offset: 7141},
 						name: "AssertOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 288, col: 5, offset: 7158},
+						pos:  position{line: 288, col: 5, offset: 7154},
 						name: "SortOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 289, col: 5, offset: 7169},
+						pos:  position{line: 289, col: 5, offset: 7165},
 						name: "TopOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 290, col: 5, offset: 7179},
+						pos:  position{line: 290, col: 5, offset: 7175},
 						name: "CutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 5, offset: 7189},
+						pos:  position{line: 291, col: 5, offset: 7185},
 						name: "DistinctOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 292, col: 5, offset: 7204},
+						pos:  position{line: 292, col: 5, offset: 7200},
 						name: "DropOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 5, offset: 7215},
+						pos:  position{line: 293, col: 5, offset: 7211},
 						name: "HeadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 5, offset: 7226},
+						pos:  position{line: 294, col: 5, offset: 7222},
 						name: "TailOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 5, offset: 7237},
+						pos:  position{line: 295, col: 5, offset: 7233},
 						name: "SkipOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 296, col: 5, offset: 7248},
+						pos:  position{line: 296, col: 5, offset: 7244},
 						name: "WhereOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 297, col: 5, offset: 7260},
+						pos:  position{line: 297, col: 5, offset: 7256},
 						name: "UniqOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 298, col: 5, offset: 7271},
+						pos:  position{line: 298, col: 5, offset: 7267},
 						name: "PutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 299, col: 5, offset: 7281},
+						pos:  position{line: 299, col: 5, offset: 7277},
 						name: "RenameOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 300, col: 5, offset: 7294},
+						pos:  position{line: 300, col: 5, offset: 7290},
 						name: "FuseOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 301, col: 5, offset: 7305},
+						pos:  position{line: 301, col: 5, offset: 7301},
 						name: "ShapeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 302, col: 5, offset: 7317},
+						pos:  position{line: 302, col: 5, offset: 7313},
 						name: "JoinOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 5, offset: 7328},
+						pos:  position{line: 303, col: 5, offset: 7324},
 						name: "ShapesOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 304, col: 5, offset: 7341},
+						pos:  position{line: 304, col: 5, offset: 7337},
 						name: "FromOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 305, col: 5, offset: 7352},
+						pos:  position{line: 305, col: 5, offset: 7348},
 						name: "PassOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 306, col: 5, offset: 7363},
+						pos:  position{line: 306, col: 5, offset: 7359},
 						name: "ExplodeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 307, col: 5, offset: 7377},
+						pos:  position{line: 307, col: 5, offset: 7373},
 						name: "MergeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 308, col: 5, offset: 7389},
+						pos:  position{line: 308, col: 5, offset: 7385},
 						name: "UnnestOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 5, offset: 7402},
+						pos:  position{line: 309, col: 5, offset: 7398},
 						name: "ValuesOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 5, offset: 7415},
+						pos:  position{line: 310, col: 5, offset: 7411},
 						name: "LoadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 5, offset: 7426},
+						pos:  position{line: 311, col: 5, offset: 7422},
 						name: "OutputOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 312, col: 5, offset: 7439},
+						pos:  position{line: 312, col: 5, offset: 7435},
 						name: "DebugOp",
 					},
 				},
@@ -2387,37 +2387,37 @@ var g = &grammar{
 		},
 		{
 			name: "ForkOp",
-			pos:  position{line: 314, col: 2, offset: 7449},
+			pos:  position{line: 314, col: 2, offset: 7445},
 			expr: &actionExpr{
-				pos: position{line: 315, col: 4, offset: 7461},
+				pos: position{line: 315, col: 4, offset: 7457},
 				run: (*parser).callonForkOp1,
 				expr: &seqExpr{
-					pos: position{line: 315, col: 4, offset: 7461},
+					pos: position{line: 315, col: 4, offset: 7457},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 315, col: 4, offset: 7461},
+							pos:  position{line: 315, col: 4, offset: 7457},
 							name: "FORK",
 						},
 						&labeledExpr{
-							pos:   position{line: 315, col: 9, offset: 7466},
+							pos:   position{line: 315, col: 9, offset: 7462},
 							label: "paths",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 315, col: 15, offset: 7472},
+								pos: position{line: 315, col: 15, offset: 7468},
 								expr: &actionExpr{
-									pos: position{line: 315, col: 17, offset: 7474},
+									pos: position{line: 315, col: 17, offset: 7470},
 									run: (*parser).callonForkOp6,
 									expr: &seqExpr{
-										pos: position{line: 315, col: 17, offset: 7474},
+										pos: position{line: 315, col: 17, offset: 7470},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 315, col: 17, offset: 7474},
+												pos:  position{line: 315, col: 17, offset: 7470},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 315, col: 20, offset: 7477},
+												pos:   position{line: 315, col: 20, offset: 7473},
 												label: "path",
 												expr: &ruleRefExpr{
-													pos:  position{line: 315, col: 25, offset: 7482},
+													pos:  position{line: 315, col: 25, offset: 7478},
 													name: "ScopeBody",
 												},
 											},
@@ -2434,31 +2434,31 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchOp",
-			pos:  position{line: 327, col: 1, offset: 7760},
+			pos:  position{line: 327, col: 1, offset: 7756},
 			expr: &choiceExpr{
-				pos: position{line: 328, col: 5, offset: 7773},
+				pos: position{line: 328, col: 5, offset: 7769},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 328, col: 5, offset: 7773},
+						pos: position{line: 328, col: 5, offset: 7769},
 						run: (*parser).callonSwitchOp2,
 						expr: &seqExpr{
-							pos: position{line: 328, col: 5, offset: 7773},
+							pos: position{line: 328, col: 5, offset: 7769},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 328, col: 5, offset: 7773},
+									pos:  position{line: 328, col: 5, offset: 7769},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 328, col: 12, offset: 7780},
+									pos:  position{line: 328, col: 12, offset: 7776},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 328, col: 14, offset: 7782},
+									pos:   position{line: 328, col: 14, offset: 7778},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 328, col: 20, offset: 7788},
+										pos: position{line: 328, col: 20, offset: 7784},
 										expr: &ruleRefExpr{
-											pos:  position{line: 328, col: 20, offset: 7788},
+											pos:  position{line: 328, col: 20, offset: 7784},
 											name: "SwitchPath",
 										},
 									},
@@ -2467,38 +2467,38 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 335, col: 5, offset: 7943},
+						pos: position{line: 335, col: 5, offset: 7939},
 						run: (*parser).callonSwitchOp9,
 						expr: &seqExpr{
-							pos: position{line: 335, col: 5, offset: 7943},
+							pos: position{line: 335, col: 5, offset: 7939},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 335, col: 5, offset: 7943},
+									pos:  position{line: 335, col: 5, offset: 7939},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 335, col: 12, offset: 7950},
+									pos:  position{line: 335, col: 12, offset: 7946},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 335, col: 14, offset: 7952},
+									pos:   position{line: 335, col: 14, offset: 7948},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 335, col: 19, offset: 7957},
+										pos:  position{line: 335, col: 19, offset: 7953},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 335, col: 24, offset: 7962},
+									pos:  position{line: 335, col: 24, offset: 7958},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 335, col: 26, offset: 7964},
+									pos:   position{line: 335, col: 26, offset: 7960},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 335, col: 32, offset: 7970},
+										pos: position{line: 335, col: 32, offset: 7966},
 										expr: &ruleRefExpr{
-											pos:  position{line: 335, col: 32, offset: 7970},
+											pos:  position{line: 335, col: 32, offset: 7966},
 											name: "SwitchPath",
 										},
 									},
@@ -2513,34 +2513,34 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchPath",
-			pos:  position{line: 344, col: 1, offset: 8155},
+			pos:  position{line: 344, col: 1, offset: 8151},
 			expr: &actionExpr{
-				pos: position{line: 345, col: 5, offset: 8170},
+				pos: position{line: 345, col: 5, offset: 8166},
 				run: (*parser).callonSwitchPath1,
 				expr: &seqExpr{
-					pos: position{line: 345, col: 5, offset: 8170},
+					pos: position{line: 345, col: 5, offset: 8166},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 345, col: 5, offset: 8170},
+							pos:  position{line: 345, col: 5, offset: 8166},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 345, col: 8, offset: 8173},
+							pos:   position{line: 345, col: 8, offset: 8169},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 345, col: 13, offset: 8178},
+								pos:  position{line: 345, col: 13, offset: 8174},
 								name: "Case",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 345, col: 18, offset: 8183},
+							pos:  position{line: 345, col: 18, offset: 8179},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 345, col: 21, offset: 8186},
+							pos:   position{line: 345, col: 21, offset: 8182},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 345, col: 26, offset: 8191},
+								pos:  position{line: 345, col: 26, offset: 8187},
 								name: "ScopeBody",
 							},
 						},
@@ -2552,29 +2552,29 @@ var g = &grammar{
 		},
 		{
 			name: "Case",
-			pos:  position{line: 353, col: 1, offset: 8343},
+			pos:  position{line: 353, col: 1, offset: 8339},
 			expr: &choiceExpr{
-				pos: position{line: 354, col: 5, offset: 8352},
+				pos: position{line: 354, col: 5, offset: 8348},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 354, col: 5, offset: 8352},
+						pos: position{line: 354, col: 5, offset: 8348},
 						run: (*parser).callonCase2,
 						expr: &seqExpr{
-							pos: position{line: 354, col: 5, offset: 8352},
+							pos: position{line: 354, col: 5, offset: 8348},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 354, col: 5, offset: 8352},
+									pos:  position{line: 354, col: 5, offset: 8348},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 354, col: 10, offset: 8357},
+									pos:  position{line: 354, col: 10, offset: 8353},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 354, col: 12, offset: 8359},
+									pos:   position{line: 354, col: 12, offset: 8355},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 354, col: 17, offset: 8364},
+										pos:  position{line: 354, col: 17, offset: 8360},
 										name: "Expr",
 									},
 								},
@@ -2582,10 +2582,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 355, col: 5, offset: 8394},
+						pos: position{line: 355, col: 5, offset: 8390},
 						run: (*parser).callonCase8,
 						expr: &ruleRefExpr{
-							pos:  position{line: 355, col: 5, offset: 8394},
+							pos:  position{line: 355, col: 5, offset: 8390},
 							name: "DEFAULT",
 						},
 					},
@@ -2596,40 +2596,40 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOp",
-			pos:  position{line: 357, col: 1, offset: 8423},
+			pos:  position{line: 357, col: 1, offset: 8419},
 			expr: &actionExpr{
-				pos: position{line: 358, col: 5, offset: 8436},
+				pos: position{line: 358, col: 5, offset: 8432},
 				run: (*parser).callonSearchOp1,
 				expr: &seqExpr{
-					pos: position{line: 358, col: 5, offset: 8436},
+					pos: position{line: 358, col: 5, offset: 8432},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 358, col: 6, offset: 8437},
+							pos: position{line: 358, col: 6, offset: 8433},
 							alternatives: []any{
 								&seqExpr{
-									pos: position{line: 358, col: 6, offset: 8437},
+									pos: position{line: 358, col: 6, offset: 8433},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 6, offset: 8437},
+											pos:  position{line: 358, col: 6, offset: 8433},
 											name: "SEARCH",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 13, offset: 8444},
+											pos:  position{line: 358, col: 13, offset: 8440},
 											name: "_",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 358, col: 17, offset: 8448},
+									pos: position{line: 358, col: 17, offset: 8444},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 358, col: 17, offset: 8448},
+											pos:        position{line: 358, col: 17, offset: 8444},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 21, offset: 8452},
+											pos:  position{line: 358, col: 21, offset: 8448},
 											name: "__",
 										},
 									},
@@ -2637,10 +2637,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 358, col: 25, offset: 8456},
+							pos:   position{line: 358, col: 25, offset: 8452},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 358, col: 30, offset: 8461},
+								pos:  position{line: 358, col: 30, offset: 8457},
 								name: "SearchBoolean",
 							},
 						},
@@ -2652,32 +2652,32 @@ var g = &grammar{
 		},
 		{
 			name: "AssertOp",
-			pos:  position{line: 362, col: 1, offset: 8561},
+			pos:  position{line: 362, col: 1, offset: 8557},
 			expr: &actionExpr{
-				pos: position{line: 363, col: 5, offset: 8574},
+				pos: position{line: 363, col: 5, offset: 8570},
 				run: (*parser).callonAssertOp1,
 				expr: &seqExpr{
-					pos: position{line: 363, col: 5, offset: 8574},
+					pos: position{line: 363, col: 5, offset: 8570},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 363, col: 5, offset: 8574},
+							pos:  position{line: 363, col: 5, offset: 8570},
 							name: "ASSERT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 363, col: 12, offset: 8581},
+							pos:  position{line: 363, col: 12, offset: 8577},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 363, col: 14, offset: 8583},
+							pos:   position{line: 363, col: 14, offset: 8579},
 							label: "expr",
 							expr: &actionExpr{
-								pos: position{line: 363, col: 20, offset: 8589},
+								pos: position{line: 363, col: 20, offset: 8585},
 								run: (*parser).callonAssertOp6,
 								expr: &labeledExpr{
-									pos:   position{line: 363, col: 20, offset: 8589},
+									pos:   position{line: 363, col: 20, offset: 8585},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 22, offset: 8591},
+										pos:  position{line: 363, col: 22, offset: 8587},
 										name: "Expr",
 									},
 								},
@@ -2691,33 +2691,33 @@ var g = &grammar{
 		},
 		{
 			name: "SortOp",
-			pos:  position{line: 372, col: 1, offset: 8821},
+			pos:  position{line: 372, col: 1, offset: 8817},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 8832},
+				pos: position{line: 373, col: 5, offset: 8828},
 				run: (*parser).callonSortOp1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 5, offset: 8832},
+					pos: position{line: 373, col: 5, offset: 8828},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 373, col: 6, offset: 8833},
+							pos: position{line: 373, col: 6, offset: 8829},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 373, col: 6, offset: 8833},
+									pos:  position{line: 373, col: 6, offset: 8829},
 									name: "SORT",
 								},
 								&seqExpr{
-									pos: position{line: 373, col: 13, offset: 8840},
+									pos: position{line: 373, col: 13, offset: 8836},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 373, col: 13, offset: 8840},
+											pos:  position{line: 373, col: 13, offset: 8836},
 											name: "ORDER",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 373, col: 19, offset: 8846},
+											pos:  position{line: 373, col: 19, offset: 8842},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 373, col: 21, offset: 8848},
+											pos:  position{line: 373, col: 21, offset: 8844},
 											name: "BY",
 										},
 									},
@@ -2725,40 +2725,40 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 373, col: 25, offset: 8852},
+							pos: position{line: 373, col: 25, offset: 8848},
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 26, offset: 8853},
+								pos:  position{line: 373, col: 26, offset: 8849},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 31, offset: 8858},
+							pos:   position{line: 373, col: 31, offset: 8854},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 36, offset: 8863},
+								pos:  position{line: 373, col: 36, offset: 8859},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 45, offset: 8872},
+							pos:   position{line: 373, col: 45, offset: 8868},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 373, col: 51, offset: 8878},
+								pos: position{line: 373, col: 51, offset: 8874},
 								expr: &actionExpr{
-									pos: position{line: 373, col: 52, offset: 8879},
+									pos: position{line: 373, col: 52, offset: 8875},
 									run: (*parser).callonSortOp15,
 									expr: &seqExpr{
-										pos: position{line: 373, col: 52, offset: 8879},
+										pos: position{line: 373, col: 52, offset: 8875},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 373, col: 52, offset: 8879},
+												pos:  position{line: 373, col: 52, offset: 8875},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 373, col: 55, offset: 8882},
+												pos:   position{line: 373, col: 55, offset: 8878},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 373, col: 57, offset: 8884},
+													pos:  position{line: 373, col: 57, offset: 8880},
 													name: "OrderByList",
 												},
 											},
@@ -2775,30 +2775,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 388, col: 1, offset: 9194},
+			pos:  position{line: 388, col: 1, offset: 9190},
 			expr: &actionExpr{
-				pos: position{line: 388, col: 12, offset: 9205},
+				pos: position{line: 388, col: 12, offset: 9201},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 388, col: 12, offset: 9205},
+					pos:   position{line: 388, col: 12, offset: 9201},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 388, col: 17, offset: 9210},
+						pos: position{line: 388, col: 17, offset: 9206},
 						expr: &actionExpr{
-							pos: position{line: 388, col: 18, offset: 9211},
+							pos: position{line: 388, col: 18, offset: 9207},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 388, col: 18, offset: 9211},
+								pos: position{line: 388, col: 18, offset: 9207},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 388, col: 18, offset: 9211},
+										pos:  position{line: 388, col: 18, offset: 9207},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 388, col: 20, offset: 9213},
+										pos:   position{line: 388, col: 20, offset: 9209},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 388, col: 22, offset: 9215},
+											pos:  position{line: 388, col: 22, offset: 9211},
 											name: "SortArg",
 										},
 									},
@@ -2813,12 +2813,12 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 390, col: 1, offset: 9272},
+			pos:  position{line: 390, col: 1, offset: 9268},
 			expr: &actionExpr{
-				pos: position{line: 391, col: 5, offset: 9284},
+				pos: position{line: 391, col: 5, offset: 9280},
 				run: (*parser).callonSortArg1,
 				expr: &litMatcher{
-					pos:        position{line: 391, col: 5, offset: 9284},
+					pos:        position{line: 391, col: 5, offset: 9280},
 					val:        "-r",
 					ignoreCase: false,
 					want:       "\"-r\"",
@@ -2829,52 +2829,52 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 393, col: 1, offset: 9348},
+			pos:  position{line: 393, col: 1, offset: 9344},
 			expr: &actionExpr{
-				pos: position{line: 394, col: 5, offset: 9358},
+				pos: position{line: 394, col: 5, offset: 9354},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 394, col: 5, offset: 9358},
+					pos: position{line: 394, col: 5, offset: 9354},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 5, offset: 9358},
+							pos:  position{line: 394, col: 5, offset: 9354},
 							name: "TOP",
 						},
 						&andExpr{
-							pos: position{line: 394, col: 9, offset: 9362},
+							pos: position{line: 394, col: 9, offset: 9358},
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 10, offset: 9363},
+								pos:  position{line: 394, col: 10, offset: 9359},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 15, offset: 9368},
+							pos:   position{line: 394, col: 15, offset: 9364},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 20, offset: 9373},
+								pos:  position{line: 394, col: 20, offset: 9369},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 29, offset: 9382},
+							pos:   position{line: 394, col: 29, offset: 9378},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 394, col: 35, offset: 9388},
+								pos: position{line: 394, col: 35, offset: 9384},
 								expr: &actionExpr{
-									pos: position{line: 394, col: 36, offset: 9389},
+									pos: position{line: 394, col: 36, offset: 9385},
 									run: (*parser).callonTopOp10,
 									expr: &seqExpr{
-										pos: position{line: 394, col: 36, offset: 9389},
+										pos: position{line: 394, col: 36, offset: 9385},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 394, col: 36, offset: 9389},
+												pos:  position{line: 394, col: 36, offset: 9385},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 394, col: 38, offset: 9391},
+												pos:   position{line: 394, col: 38, offset: 9387},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 394, col: 40, offset: 9393},
+													pos:  position{line: 394, col: 40, offset: 9389},
 													name: "Expr",
 												},
 											},
@@ -2884,25 +2884,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 65, offset: 9418},
+							pos:   position{line: 394, col: 65, offset: 9414},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 394, col: 71, offset: 9424},
+								pos: position{line: 394, col: 71, offset: 9420},
 								expr: &actionExpr{
-									pos: position{line: 394, col: 72, offset: 9425},
+									pos: position{line: 394, col: 72, offset: 9421},
 									run: (*parser).callonTopOp17,
 									expr: &seqExpr{
-										pos: position{line: 394, col: 72, offset: 9425},
+										pos: position{line: 394, col: 72, offset: 9421},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 394, col: 72, offset: 9425},
+												pos:  position{line: 394, col: 72, offset: 9421},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 394, col: 74, offset: 9427},
+												pos:   position{line: 394, col: 74, offset: 9423},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 394, col: 76, offset: 9429},
+													pos:  position{line: 394, col: 76, offset: 9425},
 													name: "OrderByList",
 												},
 											},
@@ -2919,26 +2919,26 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 412, col: 1, offset: 9809},
+			pos:  position{line: 412, col: 1, offset: 9805},
 			expr: &actionExpr{
-				pos: position{line: 413, col: 5, offset: 9819},
+				pos: position{line: 413, col: 5, offset: 9815},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 413, col: 5, offset: 9819},
+					pos: position{line: 413, col: 5, offset: 9815},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 5, offset: 9819},
+							pos:  position{line: 413, col: 5, offset: 9815},
 							name: "CUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 9, offset: 9823},
+							pos:  position{line: 413, col: 9, offset: 9819},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 11, offset: 9825},
+							pos:   position{line: 413, col: 11, offset: 9821},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 16, offset: 9830},
+								pos:  position{line: 413, col: 16, offset: 9826},
 								name: "Assignments",
 							},
 						},
@@ -2950,26 +2950,26 @@ var g = &grammar{
 		},
 		{
 			name: "DistinctOp",
-			pos:  position{line: 421, col: 1, offset: 9974},
+			pos:  position{line: 421, col: 1, offset: 9970},
 			expr: &actionExpr{
-				pos: position{line: 422, col: 5, offset: 9989},
+				pos: position{line: 422, col: 5, offset: 9985},
 				run: (*parser).callonDistinctOp1,
 				expr: &seqExpr{
-					pos: position{line: 422, col: 5, offset: 9989},
+					pos: position{line: 422, col: 5, offset: 9985},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 422, col: 5, offset: 9989},
+							pos:  position{line: 422, col: 5, offset: 9985},
 							name: "DISTINCT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 422, col: 14, offset: 9998},
+							pos:  position{line: 422, col: 14, offset: 9994},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 422, col: 16, offset: 10000},
+							pos:   position{line: 422, col: 16, offset: 9996},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 422, col: 18, offset: 10002},
+								pos:  position{line: 422, col: 18, offset: 9998},
 								name: "Expr",
 							},
 						},
@@ -2981,26 +2981,26 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 430, col: 1, offset: 10138},
+			pos:  position{line: 430, col: 1, offset: 10134},
 			expr: &actionExpr{
-				pos: position{line: 431, col: 5, offset: 10149},
+				pos: position{line: 431, col: 5, offset: 10145},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 431, col: 5, offset: 10149},
+					pos: position{line: 431, col: 5, offset: 10145},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 431, col: 5, offset: 10149},
+							pos:  position{line: 431, col: 5, offset: 10145},
 							name: "DROP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 431, col: 10, offset: 10154},
+							pos:  position{line: 431, col: 10, offset: 10150},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 431, col: 12, offset: 10156},
+							pos:   position{line: 431, col: 12, offset: 10152},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 431, col: 17, offset: 10161},
+								pos:  position{line: 431, col: 17, offset: 10157},
 								name: "Lvals",
 							},
 						},
@@ -3012,45 +3012,45 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 439, col: 1, offset: 10301},
+			pos:  position{line: 439, col: 1, offset: 10297},
 			expr: &choiceExpr{
-				pos: position{line: 440, col: 5, offset: 10312},
+				pos: position{line: 440, col: 5, offset: 10308},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 440, col: 5, offset: 10312},
+						pos: position{line: 440, col: 5, offset: 10308},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 440, col: 5, offset: 10312},
+							pos: position{line: 440, col: 5, offset: 10308},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 440, col: 6, offset: 10313},
+									pos: position{line: 440, col: 6, offset: 10309},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 6, offset: 10313},
+											pos:  position{line: 440, col: 6, offset: 10309},
 											name: "HEAD",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 13, offset: 10320},
+											pos:  position{line: 440, col: 13, offset: 10316},
 											name: "LIMIT",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 440, col: 20, offset: 10327},
+									pos:  position{line: 440, col: 20, offset: 10323},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 440, col: 22, offset: 10329},
+									pos: position{line: 440, col: 22, offset: 10325},
 									expr: &ruleRefExpr{
-										pos:  position{line: 440, col: 23, offset: 10330},
+										pos:  position{line: 440, col: 23, offset: 10326},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 440, col: 31, offset: 10338},
+									pos:   position{line: 440, col: 31, offset: 10334},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 440, col: 37, offset: 10344},
+										pos:  position{line: 440, col: 37, offset: 10340},
 										name: "Expr",
 									},
 								},
@@ -3058,26 +3058,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 447, col: 5, offset: 10474},
+						pos: position{line: 447, col: 5, offset: 10470},
 						run: (*parser).callonHeadOp12,
 						expr: &seqExpr{
-							pos: position{line: 447, col: 5, offset: 10474},
+							pos: position{line: 447, col: 5, offset: 10470},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 447, col: 5, offset: 10474},
+									pos:  position{line: 447, col: 5, offset: 10470},
 									name: "HEAD",
 								},
 								&notExpr{
-									pos: position{line: 447, col: 10, offset: 10479},
+									pos: position{line: 447, col: 10, offset: 10475},
 									expr: &seqExpr{
-										pos: position{line: 447, col: 12, offset: 10481},
+										pos: position{line: 447, col: 12, offset: 10477},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 447, col: 12, offset: 10481},
+												pos:  position{line: 447, col: 12, offset: 10477},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 447, col: 15, offset: 10484},
+												pos:        position{line: 447, col: 15, offset: 10480},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3086,9 +3086,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 447, col: 20, offset: 10489},
+									pos: position{line: 447, col: 20, offset: 10485},
 									expr: &ruleRefExpr{
-										pos:  position{line: 447, col: 21, offset: 10490},
+										pos:  position{line: 447, col: 21, offset: 10486},
 										name: "EOKW",
 									},
 								},
@@ -3102,36 +3102,36 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 454, col: 1, offset: 10584},
+			pos:  position{line: 454, col: 1, offset: 10580},
 			expr: &choiceExpr{
-				pos: position{line: 455, col: 5, offset: 10595},
+				pos: position{line: 455, col: 5, offset: 10591},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 455, col: 5, offset: 10595},
+						pos: position{line: 455, col: 5, offset: 10591},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 455, col: 5, offset: 10595},
+							pos: position{line: 455, col: 5, offset: 10591},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 455, col: 5, offset: 10595},
+									pos:  position{line: 455, col: 5, offset: 10591},
 									name: "TAIL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 455, col: 10, offset: 10600},
+									pos:  position{line: 455, col: 10, offset: 10596},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 455, col: 12, offset: 10602},
+									pos: position{line: 455, col: 12, offset: 10598},
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 13, offset: 10603},
+										pos:  position{line: 455, col: 13, offset: 10599},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 455, col: 21, offset: 10611},
+									pos:   position{line: 455, col: 21, offset: 10607},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 27, offset: 10617},
+										pos:  position{line: 455, col: 27, offset: 10613},
 										name: "Expr",
 									},
 								},
@@ -3139,26 +3139,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 462, col: 5, offset: 10747},
+						pos: position{line: 462, col: 5, offset: 10743},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 462, col: 5, offset: 10747},
+							pos: position{line: 462, col: 5, offset: 10743},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 462, col: 5, offset: 10747},
+									pos:  position{line: 462, col: 5, offset: 10743},
 									name: "TAIL",
 								},
 								&notExpr{
-									pos: position{line: 462, col: 10, offset: 10752},
+									pos: position{line: 462, col: 10, offset: 10748},
 									expr: &seqExpr{
-										pos: position{line: 462, col: 12, offset: 10754},
+										pos: position{line: 462, col: 12, offset: 10750},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 462, col: 12, offset: 10754},
+												pos:  position{line: 462, col: 12, offset: 10750},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 462, col: 15, offset: 10757},
+												pos:        position{line: 462, col: 15, offset: 10753},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3167,9 +3167,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 462, col: 20, offset: 10762},
+									pos: position{line: 462, col: 20, offset: 10758},
 									expr: &ruleRefExpr{
-										pos:  position{line: 462, col: 21, offset: 10763},
+										pos:  position{line: 462, col: 21, offset: 10759},
 										name: "EOKW",
 									},
 								},
@@ -3183,26 +3183,26 @@ var g = &grammar{
 		},
 		{
 			name: "SkipOp",
-			pos:  position{line: 469, col: 1, offset: 10857},
+			pos:  position{line: 469, col: 1, offset: 10853},
 			expr: &actionExpr{
-				pos: position{line: 470, col: 5, offset: 10868},
+				pos: position{line: 470, col: 5, offset: 10864},
 				run: (*parser).callonSkipOp1,
 				expr: &seqExpr{
-					pos: position{line: 470, col: 5, offset: 10868},
+					pos: position{line: 470, col: 5, offset: 10864},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 470, col: 5, offset: 10868},
+							pos:  position{line: 470, col: 5, offset: 10864},
 							name: "SKIP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 470, col: 10, offset: 10873},
+							pos:  position{line: 470, col: 10, offset: 10869},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 470, col: 12, offset: 10875},
+							pos:   position{line: 470, col: 12, offset: 10871},
 							label: "count",
 							expr: &ruleRefExpr{
-								pos:  position{line: 470, col: 18, offset: 10881},
+								pos:  position{line: 470, col: 18, offset: 10877},
 								name: "Expr",
 							},
 						},
@@ -3214,26 +3214,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 478, col: 1, offset: 11008},
+			pos:  position{line: 478, col: 1, offset: 11004},
 			expr: &actionExpr{
-				pos: position{line: 479, col: 5, offset: 11020},
+				pos: position{line: 479, col: 5, offset: 11016},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 479, col: 5, offset: 11020},
+					pos: position{line: 479, col: 5, offset: 11016},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 479, col: 5, offset: 11020},
+							pos:  position{line: 479, col: 5, offset: 11016},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 479, col: 11, offset: 11026},
+							pos:  position{line: 479, col: 11, offset: 11022},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 479, col: 13, offset: 11028},
+							pos:   position{line: 479, col: 13, offset: 11024},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 479, col: 18, offset: 11033},
+								pos:  position{line: 479, col: 18, offset: 11029},
 								name: "Expr",
 							},
 						},
@@ -3245,26 +3245,26 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 487, col: 1, offset: 11160},
+			pos:  position{line: 487, col: 1, offset: 11156},
 			expr: &choiceExpr{
-				pos: position{line: 488, col: 5, offset: 11171},
+				pos: position{line: 488, col: 5, offset: 11167},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 488, col: 5, offset: 11171},
+						pos: position{line: 488, col: 5, offset: 11167},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 488, col: 5, offset: 11171},
+							pos: position{line: 488, col: 5, offset: 11167},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 488, col: 5, offset: 11171},
+									pos:  position{line: 488, col: 5, offset: 11167},
 									name: "UNIQ",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 488, col: 10, offset: 11176},
+									pos:  position{line: 488, col: 10, offset: 11172},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 488, col: 12, offset: 11178},
+									pos:        position{line: 488, col: 12, offset: 11174},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3273,26 +3273,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 491, col: 5, offset: 11263},
+						pos: position{line: 491, col: 5, offset: 11259},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 491, col: 5, offset: 11263},
+							pos: position{line: 491, col: 5, offset: 11259},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 491, col: 5, offset: 11263},
+									pos:  position{line: 491, col: 5, offset: 11259},
 									name: "UNIQ",
 								},
 								&notExpr{
-									pos: position{line: 491, col: 10, offset: 11268},
+									pos: position{line: 491, col: 10, offset: 11264},
 									expr: &seqExpr{
-										pos: position{line: 491, col: 12, offset: 11270},
+										pos: position{line: 491, col: 12, offset: 11266},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 491, col: 12, offset: 11270},
+												pos:  position{line: 491, col: 12, offset: 11266},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 491, col: 15, offset: 11273},
+												pos:        position{line: 491, col: 15, offset: 11269},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3301,9 +3301,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 491, col: 20, offset: 11278},
+									pos: position{line: 491, col: 20, offset: 11274},
 									expr: &ruleRefExpr{
-										pos:  position{line: 491, col: 21, offset: 11279},
+										pos:  position{line: 491, col: 21, offset: 11275},
 										name: "EOKW",
 									},
 								},
@@ -3317,26 +3317,26 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 495, col: 1, offset: 11348},
+			pos:  position{line: 495, col: 1, offset: 11344},
 			expr: &actionExpr{
-				pos: position{line: 496, col: 5, offset: 11358},
+				pos: position{line: 496, col: 5, offset: 11354},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 496, col: 5, offset: 11358},
+					pos: position{line: 496, col: 5, offset: 11354},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 496, col: 5, offset: 11358},
+							pos:  position{line: 496, col: 5, offset: 11354},
 							name: "PUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 496, col: 9, offset: 11362},
+							pos:  position{line: 496, col: 9, offset: 11358},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 496, col: 11, offset: 11364},
+							pos:   position{line: 496, col: 11, offset: 11360},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 496, col: 16, offset: 11369},
+								pos:  position{line: 496, col: 16, offset: 11365},
 								name: "Assignments",
 							},
 						},
@@ -3348,59 +3348,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 504, col: 1, offset: 11519},
+			pos:  position{line: 504, col: 1, offset: 11515},
 			expr: &actionExpr{
-				pos: position{line: 505, col: 5, offset: 11532},
+				pos: position{line: 505, col: 5, offset: 11528},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 505, col: 5, offset: 11532},
+					pos: position{line: 505, col: 5, offset: 11528},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 505, col: 5, offset: 11532},
+							pos:  position{line: 505, col: 5, offset: 11528},
 							name: "RENAME",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 505, col: 12, offset: 11539},
+							pos:  position{line: 505, col: 12, offset: 11535},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 505, col: 14, offset: 11541},
+							pos:   position{line: 505, col: 14, offset: 11537},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 505, col: 20, offset: 11547},
+								pos:  position{line: 505, col: 20, offset: 11543},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 505, col: 31, offset: 11558},
+							pos:   position{line: 505, col: 31, offset: 11554},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 505, col: 36, offset: 11563},
+								pos: position{line: 505, col: 36, offset: 11559},
 								expr: &actionExpr{
-									pos: position{line: 505, col: 37, offset: 11564},
+									pos: position{line: 505, col: 37, offset: 11560},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 505, col: 37, offset: 11564},
+										pos: position{line: 505, col: 37, offset: 11560},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 505, col: 37, offset: 11564},
+												pos:  position{line: 505, col: 37, offset: 11560},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 505, col: 40, offset: 11567},
+												pos:        position{line: 505, col: 40, offset: 11563},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 505, col: 44, offset: 11571},
+												pos:  position{line: 505, col: 44, offset: 11567},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 505, col: 47, offset: 11574},
+												pos:   position{line: 505, col: 47, offset: 11570},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 505, col: 50, offset: 11577},
+													pos:  position{line: 505, col: 50, offset: 11573},
 													name: "Assignment",
 												},
 											},
@@ -3417,28 +3417,28 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 518, col: 1, offset: 12042},
+			pos:  position{line: 518, col: 1, offset: 12038},
 			expr: &actionExpr{
-				pos: position{line: 519, col: 5, offset: 12053},
+				pos: position{line: 519, col: 5, offset: 12049},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 519, col: 5, offset: 12053},
+					pos: position{line: 519, col: 5, offset: 12049},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 519, col: 5, offset: 12053},
+							pos:  position{line: 519, col: 5, offset: 12049},
 							name: "FUSE",
 						},
 						&notExpr{
-							pos: position{line: 519, col: 10, offset: 12058},
+							pos: position{line: 519, col: 10, offset: 12054},
 							expr: &seqExpr{
-								pos: position{line: 519, col: 12, offset: 12060},
+								pos: position{line: 519, col: 12, offset: 12056},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 519, col: 12, offset: 12060},
+										pos:  position{line: 519, col: 12, offset: 12056},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 519, col: 15, offset: 12063},
+										pos:        position{line: 519, col: 15, offset: 12059},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3447,9 +3447,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 519, col: 20, offset: 12068},
+							pos: position{line: 519, col: 20, offset: 12064},
 							expr: &ruleRefExpr{
-								pos:  position{line: 519, col: 21, offset: 12069},
+								pos:  position{line: 519, col: 21, offset: 12065},
 								name: "EOKW",
 							},
 						},
@@ -3461,28 +3461,28 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 523, col: 1, offset: 12138},
+			pos:  position{line: 523, col: 1, offset: 12134},
 			expr: &actionExpr{
-				pos: position{line: 524, col: 5, offset: 12150},
+				pos: position{line: 524, col: 5, offset: 12146},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 524, col: 5, offset: 12150},
+					pos: position{line: 524, col: 5, offset: 12146},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 524, col: 5, offset: 12150},
+							pos:  position{line: 524, col: 5, offset: 12146},
 							name: "SHAPE",
 						},
 						&notExpr{
-							pos: position{line: 524, col: 11, offset: 12156},
+							pos: position{line: 524, col: 11, offset: 12152},
 							expr: &seqExpr{
-								pos: position{line: 524, col: 13, offset: 12158},
+								pos: position{line: 524, col: 13, offset: 12154},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 524, col: 13, offset: 12158},
+										pos:  position{line: 524, col: 13, offset: 12154},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 524, col: 16, offset: 12161},
+										pos:        position{line: 524, col: 16, offset: 12157},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3491,9 +3491,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 524, col: 21, offset: 12166},
+							pos: position{line: 524, col: 21, offset: 12162},
 							expr: &ruleRefExpr{
-								pos:  position{line: 524, col: 22, offset: 12167},
+								pos:  position{line: 524, col: 22, offset: 12163},
 								name: "EOKW",
 							},
 						},
@@ -3505,51 +3505,51 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 528, col: 1, offset: 12238},
+			pos:  position{line: 528, col: 1, offset: 12234},
 			expr: &actionExpr{
-				pos: position{line: 529, col: 5, offset: 12249},
+				pos: position{line: 529, col: 5, offset: 12245},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 529, col: 5, offset: 12249},
+					pos: position{line: 529, col: 5, offset: 12245},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 529, col: 5, offset: 12249},
+							pos:   position{line: 529, col: 5, offset: 12245},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 529, col: 11, offset: 12255},
+								pos:  position{line: 529, col: 11, offset: 12251},
 								name: "JoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 529, col: 21, offset: 12265},
+							pos:  position{line: 529, col: 21, offset: 12261},
 							name: "JOIN",
 						},
 						&labeledExpr{
-							pos:   position{line: 529, col: 26, offset: 12270},
+							pos:   position{line: 529, col: 26, offset: 12266},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 529, col: 37, offset: 12281},
+								pos:  position{line: 529, col: 37, offset: 12277},
 								name: "JoinRightInput",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 529, col: 52, offset: 12296},
+							pos:   position{line: 529, col: 52, offset: 12292},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 529, col: 58, offset: 12302},
+								pos:  position{line: 529, col: 58, offset: 12298},
 								name: "OptJoinAlias",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 529, col: 71, offset: 12315},
+							pos:  position{line: 529, col: 71, offset: 12311},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 529, col: 73, offset: 12317},
+							pos:   position{line: 529, col: 73, offset: 12313},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 529, col: 75, offset: 12319},
-								name: "JoinExpr",
+								pos:  position{line: 529, col: 75, offset: 12315},
+								name: "JoinCond",
 							},
 						},
 					},
@@ -3560,83 +3560,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 545, col: 1, offset: 12654},
+			pos:  position{line: 545, col: 1, offset: 12650},
 			expr: &choiceExpr{
-				pos: position{line: 546, col: 5, offset: 12668},
+				pos: position{line: 546, col: 5, offset: 12664},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 546, col: 5, offset: 12668},
+						pos: position{line: 546, col: 5, offset: 12664},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 546, col: 5, offset: 12668},
+							pos: position{line: 546, col: 5, offset: 12664},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 5, offset: 12668},
+									pos:  position{line: 546, col: 5, offset: 12664},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 10, offset: 12673},
+									pos:  position{line: 546, col: 10, offset: 12669},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 12703},
+						pos: position{line: 547, col: 5, offset: 12699},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 5, offset: 12703},
+							pos: position{line: 547, col: 5, offset: 12699},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 5, offset: 12703},
+									pos:  position{line: 547, col: 5, offset: 12699},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 11, offset: 12709},
+									pos:  position{line: 547, col: 11, offset: 12705},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 12739},
+						pos: position{line: 548, col: 5, offset: 12735},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 548, col: 5, offset: 12739},
+							pos: position{line: 548, col: 5, offset: 12735},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 5, offset: 12739},
+									pos:  position{line: 548, col: 5, offset: 12735},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 548, col: 11, offset: 12745},
+									pos:  position{line: 548, col: 11, offset: 12741},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 549, col: 5, offset: 12774},
+						pos: position{line: 549, col: 5, offset: 12770},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 549, col: 5, offset: 12774},
+							pos: position{line: 549, col: 5, offset: 12770},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 549, col: 5, offset: 12774},
+									pos:  position{line: 549, col: 5, offset: 12770},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 549, col: 11, offset: 12780},
+									pos:  position{line: 549, col: 11, offset: 12776},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 550, col: 5, offset: 12810},
+						pos: position{line: 550, col: 5, offset: 12806},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 550, col: 5, offset: 12810},
+							pos:        position{line: 550, col: 5, offset: 12806},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3649,33 +3649,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptJoinAlias",
-			pos:  position{line: 552, col: 1, offset: 12838},
+			pos:  position{line: 552, col: 1, offset: 12834},
 			expr: &choiceExpr{
-				pos: position{line: 553, col: 5, offset: 12855},
+				pos: position{line: 553, col: 5, offset: 12851},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 553, col: 5, offset: 12855},
+						pos: position{line: 553, col: 5, offset: 12851},
 						run: (*parser).callonOptJoinAlias2,
 						expr: &seqExpr{
-							pos: position{line: 553, col: 5, offset: 12855},
+							pos: position{line: 553, col: 5, offset: 12851},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 5, offset: 12855},
+									pos:  position{line: 553, col: 5, offset: 12851},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 7, offset: 12857},
+									pos:  position{line: 553, col: 7, offset: 12853},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 553, col: 10, offset: 12860},
+									pos:  position{line: 553, col: 10, offset: 12856},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 553, col: 12, offset: 12862},
+									pos:   position{line: 553, col: 12, offset: 12858},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 553, col: 14, offset: 12864},
+										pos:  position{line: 553, col: 14, offset: 12860},
 										name: "JoinAlias",
 									},
 								},
@@ -3683,10 +3683,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 12896},
+						pos: position{line: 554, col: 5, offset: 12892},
 						run: (*parser).callonOptJoinAlias9,
 						expr: &litMatcher{
-							pos:        position{line: 554, col: 5, offset: 12896},
+							pos:        position{line: 554, col: 5, offset: 12892},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3699,59 +3699,59 @@ var g = &grammar{
 		},
 		{
 			name: "JoinAlias",
-			pos:  position{line: 556, col: 1, offset: 12920},
+			pos:  position{line: 556, col: 1, offset: 12916},
 			expr: &actionExpr{
-				pos: position{line: 557, col: 5, offset: 12934},
+				pos: position{line: 557, col: 5, offset: 12930},
 				run: (*parser).callonJoinAlias1,
 				expr: &seqExpr{
-					pos: position{line: 557, col: 5, offset: 12934},
+					pos: position{line: 557, col: 5, offset: 12930},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 557, col: 5, offset: 12934},
+							pos:        position{line: 557, col: 5, offset: 12930},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 557, col: 9, offset: 12938},
+							pos:  position{line: 557, col: 9, offset: 12934},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 557, col: 12, offset: 12941},
+							pos:   position{line: 557, col: 12, offset: 12937},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 557, col: 17, offset: 12946},
+								pos:  position{line: 557, col: 17, offset: 12942},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 557, col: 28, offset: 12957},
+							pos:  position{line: 557, col: 28, offset: 12953},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 557, col: 31, offset: 12960},
+							pos:        position{line: 557, col: 31, offset: 12956},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 557, col: 35, offset: 12964},
+							pos:  position{line: 557, col: 35, offset: 12960},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 557, col: 38, offset: 12967},
+							pos:   position{line: 557, col: 38, offset: 12963},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 557, col: 44, offset: 12973},
+								pos:  position{line: 557, col: 44, offset: 12969},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 557, col: 55, offset: 12984},
+							pos:  position{line: 557, col: 55, offset: 12980},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 557, col: 58, offset: 12987},
+							pos:        position{line: 557, col: 58, offset: 12983},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -3764,44 +3764,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 565, col: 1, offset: 13125},
+			pos:  position{line: 565, col: 1, offset: 13121},
 			expr: &choiceExpr{
-				pos: position{line: 566, col: 5, offset: 13144},
+				pos: position{line: 566, col: 5, offset: 13140},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 566, col: 5, offset: 13144},
+						pos: position{line: 566, col: 5, offset: 13140},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 566, col: 5, offset: 13144},
+							pos: position{line: 566, col: 5, offset: 13140},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 566, col: 5, offset: 13144},
+									pos:  position{line: 566, col: 5, offset: 13140},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 566, col: 8, offset: 13147},
+									pos:        position{line: 566, col: 8, offset: 13143},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 566, col: 12, offset: 13151},
+									pos:  position{line: 566, col: 12, offset: 13147},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 566, col: 15, offset: 13154},
+									pos:   position{line: 566, col: 15, offset: 13150},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 566, col: 17, offset: 13156},
+										pos:  position{line: 566, col: 17, offset: 13152},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 566, col: 21, offset: 13160},
+									pos:  position{line: 566, col: 21, offset: 13156},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 566, col: 24, offset: 13163},
+									pos:        position{line: 566, col: 24, offset: 13159},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3810,10 +3810,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 567, col: 5, offset: 13189},
+						pos: position{line: 567, col: 5, offset: 13185},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 567, col: 5, offset: 13189},
+							pos:        position{line: 567, col: 5, offset: 13185},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3826,44 +3826,44 @@ var g = &grammar{
 		},
 		{
 			name: "ShapesOp",
-			pos:  position{line: 569, col: 1, offset: 13213},
+			pos:  position{line: 569, col: 1, offset: 13209},
 			expr: &actionExpr{
-				pos: position{line: 570, col: 5, offset: 13226},
+				pos: position{line: 570, col: 5, offset: 13222},
 				run: (*parser).callonShapesOp1,
 				expr: &seqExpr{
-					pos: position{line: 570, col: 5, offset: 13226},
+					pos: position{line: 570, col: 5, offset: 13222},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 570, col: 5, offset: 13226},
+							pos:  position{line: 570, col: 5, offset: 13222},
 							name: "SHAPES",
 						},
 						&andExpr{
-							pos: position{line: 570, col: 12, offset: 13233},
+							pos: position{line: 570, col: 12, offset: 13229},
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 13, offset: 13234},
+								pos:  position{line: 570, col: 13, offset: 13230},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 570, col: 18, offset: 13239},
+							pos:   position{line: 570, col: 18, offset: 13235},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 570, col: 23, offset: 13244},
+								pos: position{line: 570, col: 23, offset: 13240},
 								expr: &actionExpr{
-									pos: position{line: 570, col: 24, offset: 13245},
+									pos: position{line: 570, col: 24, offset: 13241},
 									run: (*parser).callonShapesOp8,
 									expr: &seqExpr{
-										pos: position{line: 570, col: 24, offset: 13245},
+										pos: position{line: 570, col: 24, offset: 13241},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 570, col: 24, offset: 13245},
+												pos:  position{line: 570, col: 24, offset: 13241},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 570, col: 26, offset: 13247},
+												pos:   position{line: 570, col: 26, offset: 13243},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 570, col: 28, offset: 13249},
+													pos:  position{line: 570, col: 28, offset: 13245},
 													name: "Lval",
 												},
 											},
@@ -3880,28 +3880,28 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 583, col: 1, offset: 13688},
+			pos:  position{line: 583, col: 1, offset: 13684},
 			expr: &actionExpr{
-				pos: position{line: 584, col: 5, offset: 13705},
+				pos: position{line: 584, col: 5, offset: 13701},
 				run: (*parser).callonOpAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 584, col: 5, offset: 13705},
+					pos: position{line: 584, col: 5, offset: 13701},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 584, col: 5, offset: 13705},
+							pos: position{line: 584, col: 5, offset: 13701},
 							expr: &seqExpr{
-								pos: position{line: 584, col: 7, offset: 13707},
+								pos: position{line: 584, col: 7, offset: 13703},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 584, col: 7, offset: 13707},
+										pos:  position{line: 584, col: 7, offset: 13703},
 										name: "Lval",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 584, col: 12, offset: 13712},
+										pos:  position{line: 584, col: 12, offset: 13708},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 584, col: 15, offset: 13715},
+										pos:        position{line: 584, col: 15, offset: 13711},
 										val:        ":=",
 										ignoreCase: false,
 										want:       "\":=\"",
@@ -3910,10 +3910,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 584, col: 21, offset: 13721},
+							pos:   position{line: 584, col: 21, offset: 13717},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 584, col: 23, offset: 13723},
+								pos:  position{line: 584, col: 23, offset: 13719},
 								name: "Assignments",
 							},
 						},
@@ -3925,36 +3925,36 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 592, col: 1, offset: 13895},
+			pos:  position{line: 592, col: 1, offset: 13891},
 			expr: &actionExpr{
-				pos: position{line: 593, col: 5, offset: 13906},
+				pos: position{line: 593, col: 5, offset: 13902},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 593, col: 5, offset: 13906},
+					pos: position{line: 593, col: 5, offset: 13902},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 593, col: 5, offset: 13906},
+							pos:  position{line: 593, col: 5, offset: 13902},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 593, col: 10, offset: 13911},
+							pos:  position{line: 593, col: 10, offset: 13907},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 593, col: 12, offset: 13913},
+							pos:   position{line: 593, col: 12, offset: 13909},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 593, col: 17, offset: 13918},
+								pos:  position{line: 593, col: 17, offset: 13914},
 								name: "Text",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 593, col: 22, offset: 13923},
+							pos:   position{line: 593, col: 22, offset: 13919},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 593, col: 27, offset: 13928},
+								pos: position{line: 593, col: 27, offset: 13924},
 								expr: &ruleRefExpr{
-									pos:  position{line: 593, col: 27, offset: 13928},
+									pos:  position{line: 593, col: 27, offset: 13924},
 									name: "CommitishOpArgs",
 								},
 							},
@@ -3967,26 +3967,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 602, col: 1, offset: 14106},
+			pos:  position{line: 602, col: 1, offset: 14102},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 5, offset: 14119},
+				pos: position{line: 603, col: 5, offset: 14115},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 603, col: 5, offset: 14119},
+					pos: position{line: 603, col: 5, offset: 14115},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 603, col: 5, offset: 14119},
+							pos:  position{line: 603, col: 5, offset: 14115},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 603, col: 12, offset: 14126},
+							pos:  position{line: 603, col: 12, offset: 14122},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 603, col: 14, offset: 14128},
+							pos:   position{line: 603, col: 14, offset: 14124},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 603, col: 19, offset: 14133},
+								pos:  position{line: 603, col: 19, offset: 14129},
 								name: "Identifier",
 							},
 						},
@@ -3998,44 +3998,44 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 611, col: 1, offset: 14267},
+			pos:  position{line: 611, col: 1, offset: 14263},
 			expr: &actionExpr{
-				pos: position{line: 612, col: 5, offset: 14279},
+				pos: position{line: 612, col: 5, offset: 14275},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 612, col: 5, offset: 14279},
+					pos: position{line: 612, col: 5, offset: 14275},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 612, col: 5, offset: 14279},
+							pos:  position{line: 612, col: 5, offset: 14275},
 							name: "DEBUG",
 						},
 						&andExpr{
-							pos: position{line: 612, col: 11, offset: 14285},
+							pos: position{line: 612, col: 11, offset: 14281},
 							expr: &ruleRefExpr{
-								pos:  position{line: 612, col: 12, offset: 14286},
+								pos:  position{line: 612, col: 12, offset: 14282},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 612, col: 17, offset: 14291},
+							pos:   position{line: 612, col: 17, offset: 14287},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 612, col: 22, offset: 14296},
+								pos: position{line: 612, col: 22, offset: 14292},
 								expr: &actionExpr{
-									pos: position{line: 612, col: 23, offset: 14297},
+									pos: position{line: 612, col: 23, offset: 14293},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 612, col: 23, offset: 14297},
+										pos: position{line: 612, col: 23, offset: 14293},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 612, col: 23, offset: 14297},
+												pos:  position{line: 612, col: 23, offset: 14293},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 612, col: 25, offset: 14299},
+												pos:   position{line: 612, col: 25, offset: 14295},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 612, col: 27, offset: 14301},
+													pos:  position{line: 612, col: 27, offset: 14297},
 													name: "Expr",
 												},
 											},
@@ -4052,26 +4052,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 623, col: 1, offset: 14494},
+			pos:  position{line: 623, col: 1, offset: 14490},
 			expr: &actionExpr{
-				pos: position{line: 624, col: 5, offset: 14505},
+				pos: position{line: 624, col: 5, offset: 14501},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 624, col: 5, offset: 14505},
+					pos: position{line: 624, col: 5, offset: 14501},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 624, col: 5, offset: 14505},
+							pos:  position{line: 624, col: 5, offset: 14501},
 							name: "FROM",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 624, col: 10, offset: 14510},
+							pos:  position{line: 624, col: 10, offset: 14506},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 624, col: 12, offset: 14512},
+							pos:   position{line: 624, col: 12, offset: 14508},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 624, col: 18, offset: 14518},
+								pos:  position{line: 624, col: 18, offset: 14514},
 								name: "FromElems",
 							},
 						},
@@ -4083,51 +4083,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 632, col: 1, offset: 14661},
+			pos:  position{line: 632, col: 1, offset: 14657},
 			expr: &actionExpr{
-				pos: position{line: 633, col: 5, offset: 14675},
+				pos: position{line: 633, col: 5, offset: 14671},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 633, col: 5, offset: 14675},
+					pos: position{line: 633, col: 5, offset: 14671},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 633, col: 5, offset: 14675},
+							pos:   position{line: 633, col: 5, offset: 14671},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 11, offset: 14681},
+								pos:  position{line: 633, col: 11, offset: 14677},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 633, col: 20, offset: 14690},
+							pos:   position{line: 633, col: 20, offset: 14686},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 633, col: 25, offset: 14695},
+								pos: position{line: 633, col: 25, offset: 14691},
 								expr: &actionExpr{
-									pos: position{line: 633, col: 27, offset: 14697},
+									pos: position{line: 633, col: 27, offset: 14693},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 633, col: 27, offset: 14697},
+										pos: position{line: 633, col: 27, offset: 14693},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 633, col: 27, offset: 14697},
+												pos:  position{line: 633, col: 27, offset: 14693},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 633, col: 30, offset: 14700},
+												pos:        position{line: 633, col: 30, offset: 14696},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 633, col: 34, offset: 14704},
+												pos:  position{line: 633, col: 34, offset: 14700},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 633, col: 37, offset: 14707},
+												pos:   position{line: 633, col: 37, offset: 14703},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 633, col: 42, offset: 14712},
+													pos:  position{line: 633, col: 42, offset: 14708},
 													name: "FromElem",
 												},
 											},
@@ -4144,45 +4144,45 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 637, col: 1, offset: 14796},
+			pos:  position{line: 637, col: 1, offset: 14788},
 			expr: &actionExpr{
-				pos: position{line: 638, col: 5, offset: 14809},
+				pos: position{line: 638, col: 5, offset: 14801},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 638, col: 5, offset: 14809},
+					pos: position{line: 638, col: 5, offset: 14801},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 638, col: 5, offset: 14809},
+							pos:   position{line: 638, col: 5, offset: 14801},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 12, offset: 14816},
+								pos:  position{line: 638, col: 12, offset: 14808},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 638, col: 23, offset: 14827},
+							pos:   position{line: 638, col: 23, offset: 14819},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 638, col: 28, offset: 14832},
+								pos: position{line: 638, col: 28, offset: 14824},
 								expr: &ruleRefExpr{
-									pos:  position{line: 638, col: 28, offset: 14832},
+									pos:  position{line: 638, col: 28, offset: 14824},
 									name: "CommitishOpArgs",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 638, col: 45, offset: 14849},
+							pos:   position{line: 638, col: 45, offset: 14841},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 47, offset: 14851},
+								pos:  position{line: 638, col: 47, offset: 14843},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 638, col: 61, offset: 14865},
+							pos:   position{line: 638, col: 61, offset: 14857},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 67, offset: 14871},
+								pos:  position{line: 638, col: 67, offset: 14863},
 								name: "OptAlias",
 							},
 						},
@@ -4194,34 +4194,34 @@ var g = &grammar{
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 656, col: 1, offset: 15270},
+			pos:  position{line: 656, col: 1, offset: 15256},
 			expr: &choiceExpr{
-				pos: position{line: 657, col: 5, offset: 15285},
+				pos: position{line: 657, col: 5, offset: 15271},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 657, col: 5, offset: 15285},
+						pos:  position{line: 657, col: 5, offset: 15271},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 658, col: 5, offset: 15296},
+						pos:  position{line: 658, col: 5, offset: 15282},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 15305},
+						pos: position{line: 659, col: 5, offset: 15291},
 						run: (*parser).callonFromEntity4,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 15305},
+							pos: position{line: 659, col: 5, offset: 15291},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 659, col: 5, offset: 15305},
+									pos:        position{line: 659, col: 5, offset: 15291},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 659, col: 9, offset: 15309},
+									pos: position{line: 659, col: 9, offset: 15295},
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 10, offset: 15310},
+										pos:  position{line: 659, col: 10, offset: 15296},
 										name: "ExprGuard",
 									},
 								},
@@ -4229,43 +4229,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 15391},
+						pos: position{line: 660, col: 5, offset: 15377},
 						run: (*parser).callonFromEntity9,
 						expr: &seqExpr{
-							pos: position{line: 660, col: 5, offset: 15391},
+							pos: position{line: 660, col: 5, offset: 15377},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 660, col: 5, offset: 15391},
+									pos:  position{line: 660, col: 5, offset: 15377},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 660, col: 10, offset: 15396},
+									pos:  position{line: 660, col: 10, offset: 15382},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 660, col: 13, offset: 15399},
+									pos:        position{line: 660, col: 13, offset: 15385},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 660, col: 17, offset: 15403},
+									pos:  position{line: 660, col: 17, offset: 15389},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 660, col: 20, offset: 15406},
+									pos:   position{line: 660, col: 20, offset: 15392},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 660, col: 22, offset: 15408},
+										pos:  position{line: 660, col: 22, offset: 15394},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 660, col: 27, offset: 15413},
+									pos:  position{line: 660, col: 27, offset: 15399},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 660, col: 30, offset: 15416},
+									pos:        position{line: 660, col: 30, offset: 15402},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4274,35 +4274,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 667, col: 5, offset: 15552},
+						pos: position{line: 667, col: 5, offset: 15538},
 						run: (*parser).callonFromEntity19,
 						expr: &labeledExpr{
-							pos:   position{line: 667, col: 5, offset: 15552},
+							pos:   position{line: 667, col: 5, offset: 15538},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 667, col: 10, offset: 15557},
+								pos:  position{line: 667, col: 10, offset: 15543},
 								name: "ColonText",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 15699},
+						pos: position{line: 674, col: 5, offset: 15685},
 						run: (*parser).callonFromEntity22,
 						expr: &seqExpr{
-							pos: position{line: 674, col: 5, offset: 15699},
+							pos: position{line: 674, col: 5, offset: 15685},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 674, col: 5, offset: 15699},
+									pos:   position{line: 674, col: 5, offset: 15685},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 674, col: 10, offset: 15704},
+										pos:  position{line: 674, col: 10, offset: 15690},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 674, col: 24, offset: 15718},
+									pos: position{line: 674, col: 24, offset: 15704},
 									expr: &ruleRefExpr{
-										pos:  position{line: 674, col: 25, offset: 15719},
+										pos:  position{line: 674, col: 25, offset: 15705},
 										name: "AliasClause",
 									},
 								},
@@ -4310,35 +4310,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 675, col: 5, offset: 15754},
+						pos: position{line: 675, col: 5, offset: 15740},
 						run: (*parser).callonFromEntity28,
 						expr: &seqExpr{
-							pos: position{line: 675, col: 5, offset: 15754},
+							pos: position{line: 675, col: 5, offset: 15740},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 675, col: 5, offset: 15754},
+									pos:        position{line: 675, col: 5, offset: 15740},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 675, col: 9, offset: 15758},
+									pos:  position{line: 675, col: 9, offset: 15744},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 675, col: 12, offset: 15761},
+									pos:   position{line: 675, col: 12, offset: 15747},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 675, col: 17, offset: 15766},
+										pos:  position{line: 675, col: 17, offset: 15752},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 675, col: 31, offset: 15780},
+									pos:  position{line: 675, col: 31, offset: 15766},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 675, col: 34, offset: 15783},
+									pos:        position{line: 675, col: 34, offset: 15769},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4347,35 +4347,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 676, col: 5, offset: 15812},
+						pos: position{line: 676, col: 5, offset: 15798},
 						run: (*parser).callonFromEntity36,
 						expr: &seqExpr{
-							pos: position{line: 676, col: 5, offset: 15812},
+							pos: position{line: 676, col: 5, offset: 15798},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 676, col: 5, offset: 15812},
+									pos:        position{line: 676, col: 5, offset: 15798},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 676, col: 9, offset: 15816},
+									pos:  position{line: 676, col: 9, offset: 15802},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 676, col: 12, offset: 15819},
+									pos:   position{line: 676, col: 12, offset: 15805},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 676, col: 14, offset: 15821},
+										pos:  position{line: 676, col: 14, offset: 15807},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 676, col: 22, offset: 15829},
+									pos:  position{line: 676, col: 22, offset: 15815},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 676, col: 25, offset: 15832},
+									pos:        position{line: 676, col: 25, offset: 15818},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4384,7 +4384,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 679, col: 5, offset: 15868},
+						pos:  position{line: 679, col: 5, offset: 15854},
 						name: "Text",
 					},
 				},
@@ -4394,34 +4394,34 @@ var g = &grammar{
 		},
 		{
 			name: "Text",
-			pos:  position{line: 682, col: 1, offset: 15942},
+			pos:  position{line: 682, col: 1, offset: 15928},
 			expr: &actionExpr{
-				pos: position{line: 683, col: 4, offset: 15950},
+				pos: position{line: 683, col: 4, offset: 15936},
 				run: (*parser).callonText1,
 				expr: &labeledExpr{
-					pos:   position{line: 683, col: 4, offset: 15950},
+					pos:   position{line: 683, col: 4, offset: 15936},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 683, col: 7, offset: 15953},
+						pos: position{line: 683, col: 7, offset: 15939},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 683, col: 7, offset: 15953},
+								pos:  position{line: 683, col: 7, offset: 15939},
 								name: "UnquotedURL",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 683, col: 21, offset: 15967},
+								pos:  position{line: 683, col: 21, offset: 15953},
 								name: "TextChars",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 683, col: 33, offset: 15979},
+								pos:  position{line: 683, col: 33, offset: 15965},
 								name: "KSUID",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 683, col: 41, offset: 15987},
+								pos:  position{line: 683, col: 41, offset: 15973},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 683, col: 62, offset: 16008},
+								pos:  position{line: 683, col: 62, offset: 15994},
 								name: "SingleQuotedString",
 							},
 						},
@@ -4433,30 +4433,30 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 687, col: 1, offset: 16108},
+			pos:  position{line: 687, col: 1, offset: 16094},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 15, offset: 16122},
+				pos: position{line: 687, col: 15, offset: 16108},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 687, col: 15, offset: 16122},
+					pos: position{line: 687, col: 15, offset: 16108},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 687, col: 16, offset: 16123},
+							pos: position{line: 687, col: 16, offset: 16109},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 687, col: 16, offset: 16123},
+									pos:        position{line: 687, col: 16, offset: 16109},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 687, col: 28, offset: 16135},
+									pos:        position{line: 687, col: 28, offset: 16121},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 687, col: 41, offset: 16148},
+									pos:        position{line: 687, col: 41, offset: 16134},
 									val:        "s3://",
 									ignoreCase: false,
 									want:       "\"s3://\"",
@@ -4464,9 +4464,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 687, col: 50, offset: 16157},
+							pos: position{line: 687, col: 50, offset: 16143},
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 50, offset: 16157},
+								pos:  position{line: 687, col: 50, offset: 16143},
 								name: "URLChar",
 							},
 						},
@@ -4478,9 +4478,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 689, col: 1, offset: 16198},
+			pos:  position{line: 689, col: 1, offset: 16184},
 			expr: &charClassMatcher{
-				pos:        position{line: 689, col: 11, offset: 16208},
+				pos:        position{line: 689, col: 11, offset: 16194},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -4492,27 +4492,27 @@ var g = &grammar{
 		},
 		{
 			name: "TextChars",
-			pos:  position{line: 691, col: 1, offset: 16255},
+			pos:  position{line: 691, col: 1, offset: 16241},
 			expr: &actionExpr{
-				pos: position{line: 692, col: 5, offset: 16269},
+				pos: position{line: 692, col: 5, offset: 16255},
 				run: (*parser).callonTextChars1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 692, col: 5, offset: 16269},
+					pos: position{line: 692, col: 5, offset: 16255},
 					expr: &choiceExpr{
-						pos: position{line: 692, col: 6, offset: 16270},
+						pos: position{line: 692, col: 6, offset: 16256},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 692, col: 6, offset: 16270},
+								pos:  position{line: 692, col: 6, offset: 16256},
 								name: "IdentifierRest",
 							},
 							&litMatcher{
-								pos:        position{line: 692, col: 23, offset: 16287},
+								pos:        position{line: 692, col: 23, offset: 16273},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 692, col: 29, offset: 16293},
+								pos:        position{line: 692, col: 29, offset: 16279},
 								val:        "/",
 								ignoreCase: false,
 								want:       "\"/\"",
@@ -4526,40 +4526,40 @@ var g = &grammar{
 		},
 		{
 			name: "CommitishOpArgs",
-			pos:  position{line: 694, col: 1, offset: 16331},
+			pos:  position{line: 694, col: 1, offset: 16317},
 			expr: &choiceExpr{
-				pos: position{line: 695, col: 5, offset: 16351},
+				pos: position{line: 695, col: 5, offset: 16337},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 16351},
+						pos: position{line: 695, col: 5, offset: 16337},
 						run: (*parser).callonCommitishOpArgs2,
 						expr: &seqExpr{
-							pos: position{line: 695, col: 5, offset: 16351},
+							pos: position{line: 695, col: 5, offset: 16337},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 695, col: 5, offset: 16351},
+									pos:  position{line: 695, col: 5, offset: 16337},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 695, col: 8, offset: 16354},
+									pos:   position{line: 695, col: 8, offset: 16340},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 695, col: 15, offset: 16361},
+										pos: position{line: 695, col: 15, offset: 16347},
 										expr: &ruleRefExpr{
-											pos:  position{line: 695, col: 15, offset: 16361},
+											pos:  position{line: 695, col: 15, offset: 16347},
 											name: "MetaCommitish",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 695, col: 30, offset: 16376},
+									pos:  position{line: 695, col: 30, offset: 16362},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 695, col: 33, offset: 16379},
+									pos:   position{line: 695, col: 33, offset: 16365},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 695, col: 38, offset: 16384},
+										pos:  position{line: 695, col: 38, offset: 16370},
 										name: "OpArgs",
 									},
 								},
@@ -4567,20 +4567,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 16514},
+						pos: position{line: 701, col: 5, offset: 16500},
 						run: (*parser).callonCommitishOpArgs11,
 						expr: &seqExpr{
-							pos: position{line: 701, col: 5, offset: 16514},
+							pos: position{line: 701, col: 5, offset: 16500},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 701, col: 5, offset: 16514},
+									pos:  position{line: 701, col: 5, offset: 16500},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 701, col: 8, offset: 16517},
+									pos:   position{line: 701, col: 8, offset: 16503},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 15, offset: 16524},
+										pos:  position{line: 701, col: 15, offset: 16510},
 										name: "MetaCommitish",
 									},
 								},
@@ -4594,31 +4594,31 @@ var g = &grammar{
 		},
 		{
 			name: "MetaCommitish",
-			pos:  position{line: 703, col: 1, offset: 16562},
+			pos:  position{line: 703, col: 1, offset: 16548},
 			expr: &choiceExpr{
-				pos: position{line: 704, col: 5, offset: 16580},
+				pos: position{line: 704, col: 5, offset: 16566},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 704, col: 5, offset: 16580},
+						pos: position{line: 704, col: 5, offset: 16566},
 						run: (*parser).callonMetaCommitish2,
 						expr: &seqExpr{
-							pos: position{line: 704, col: 5, offset: 16580},
+							pos: position{line: 704, col: 5, offset: 16566},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 704, col: 5, offset: 16580},
+									pos:   position{line: 704, col: 5, offset: 16566},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 704, col: 12, offset: 16587},
+										pos:  position{line: 704, col: 12, offset: 16573},
 										name: "Commitish",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 704, col: 22, offset: 16597},
+									pos:   position{line: 704, col: 22, offset: 16583},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 704, col: 27, offset: 16602},
+										pos: position{line: 704, col: 27, offset: 16588},
 										expr: &ruleRefExpr{
-											pos:  position{line: 704, col: 27, offset: 16602},
+											pos:  position{line: 704, col: 27, offset: 16588},
 											name: "ColonText",
 										},
 									},
@@ -4627,13 +4627,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 711, col: 5, offset: 16826},
+						pos: position{line: 711, col: 5, offset: 16812},
 						run: (*parser).callonMetaCommitish9,
 						expr: &labeledExpr{
-							pos:   position{line: 711, col: 5, offset: 16826},
+							pos:   position{line: 711, col: 5, offset: 16812},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 711, col: 10, offset: 16831},
+								pos:  position{line: 711, col: 10, offset: 16817},
 								name: "ColonText",
 							},
 						},
@@ -4645,24 +4645,24 @@ var g = &grammar{
 		},
 		{
 			name: "Commitish",
-			pos:  position{line: 715, col: 1, offset: 16956},
+			pos:  position{line: 715, col: 1, offset: 16941},
 			expr: &actionExpr{
-				pos: position{line: 716, col: 5, offset: 16970},
+				pos: position{line: 716, col: 5, offset: 16955},
 				run: (*parser).callonCommitish1,
 				expr: &seqExpr{
-					pos: position{line: 716, col: 5, offset: 16970},
+					pos: position{line: 716, col: 5, offset: 16955},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 716, col: 5, offset: 16970},
+							pos:        position{line: 716, col: 5, offset: 16955},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 716, col: 9, offset: 16974},
+							pos:   position{line: 716, col: 9, offset: 16959},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 716, col: 14, offset: 16979},
+								pos:  position{line: 716, col: 14, offset: 16964},
 								name: "CommitText",
 							},
 						},
@@ -4674,22 +4674,22 @@ var g = &grammar{
 		},
 		{
 			name: "CommitText",
-			pos:  position{line: 720, col: 1, offset: 17114},
+			pos:  position{line: 720, col: 1, offset: 17099},
 			expr: &choiceExpr{
-				pos: position{line: 721, col: 5, offset: 17129},
+				pos: position{line: 721, col: 5, offset: 17114},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 721, col: 5, offset: 17129},
+						pos:  position{line: 721, col: 5, offset: 17114},
 						name: "Name",
 					},
 					&actionExpr{
-						pos: position{line: 722, col: 5, offset: 17138},
+						pos: position{line: 722, col: 5, offset: 17123},
 						run: (*parser).callonCommitText3,
 						expr: &labeledExpr{
-							pos:   position{line: 722, col: 5, offset: 17138},
+							pos:   position{line: 722, col: 5, offset: 17123},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 722, col: 7, offset: 17140},
+								pos:  position{line: 722, col: 7, offset: 17125},
 								name: "KSUID",
 							},
 						},
@@ -4701,40 +4701,40 @@ var g = &grammar{
 		},
 		{
 			name: "OpArg",
-			pos:  position{line: 724, col: 1, offset: 17215},
+			pos:  position{line: 724, col: 1, offset: 17200},
 			expr: &choiceExpr{
-				pos: position{line: 725, col: 5, offset: 17225},
+				pos: position{line: 725, col: 5, offset: 17210},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 725, col: 5, offset: 17225},
+						pos: position{line: 725, col: 5, offset: 17210},
 						run: (*parser).callonOpArg2,
 						expr: &seqExpr{
-							pos: position{line: 725, col: 5, offset: 17225},
+							pos: position{line: 725, col: 5, offset: 17210},
 							exprs: []any{
 								&andExpr{
-									pos: position{line: 725, col: 5, offset: 17225},
+									pos: position{line: 725, col: 5, offset: 17210},
 									expr: &ruleRefExpr{
-										pos:  position{line: 725, col: 6, offset: 17226},
+										pos:  position{line: 725, col: 6, offset: 17211},
 										name: "ArgNameExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 725, col: 18, offset: 17238},
+									pos:   position{line: 725, col: 18, offset: 17223},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 725, col: 22, offset: 17242},
+										pos:  position{line: 725, col: 22, offset: 17227},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 725, col: 30, offset: 17250},
+									pos:  position{line: 725, col: 30, offset: 17235},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 725, col: 32, offset: 17252},
+									pos:   position{line: 725, col: 32, offset: 17237},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 725, col: 34, offset: 17254},
+										pos:  position{line: 725, col: 34, offset: 17239},
 										name: "Expr",
 									},
 								},
@@ -4742,28 +4742,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 726, col: 5, offset: 17361},
+						pos: position{line: 726, col: 5, offset: 17346},
 						run: (*parser).callonOpArg11,
 						expr: &seqExpr{
-							pos: position{line: 726, col: 5, offset: 17361},
+							pos: position{line: 726, col: 5, offset: 17346},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 726, col: 5, offset: 17361},
+									pos:   position{line: 726, col: 5, offset: 17346},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 726, col: 9, offset: 17365},
+										pos:  position{line: 726, col: 9, offset: 17350},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 726, col: 17, offset: 17373},
+									pos:  position{line: 726, col: 17, offset: 17358},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 726, col: 19, offset: 17375},
+									pos:   position{line: 726, col: 19, offset: 17360},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 726, col: 21, offset: 17377},
+										pos:  position{line: 726, col: 21, offset: 17362},
 										name: "Text",
 									},
 								},
@@ -4777,51 +4777,51 @@ var g = &grammar{
 		},
 		{
 			name: "OpArgs",
-			pos:  position{line: 728, col: 1, offset: 17482},
+			pos:  position{line: 728, col: 1, offset: 17467},
 			expr: &actionExpr{
-				pos: position{line: 729, col: 5, offset: 17493},
+				pos: position{line: 729, col: 5, offset: 17478},
 				run: (*parser).callonOpArgs1,
 				expr: &seqExpr{
-					pos: position{line: 729, col: 5, offset: 17493},
+					pos: position{line: 729, col: 5, offset: 17478},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 729, col: 5, offset: 17493},
+							pos:        position{line: 729, col: 5, offset: 17478},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 729, col: 9, offset: 17497},
+							pos:  position{line: 729, col: 9, offset: 17482},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 729, col: 12, offset: 17500},
+							pos:   position{line: 729, col: 12, offset: 17485},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 729, col: 18, offset: 17506},
+								pos:  position{line: 729, col: 18, offset: 17491},
 								name: "OpArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 729, col: 24, offset: 17512},
+							pos:   position{line: 729, col: 24, offset: 17497},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 729, col: 29, offset: 17517},
+								pos: position{line: 729, col: 29, offset: 17502},
 								expr: &actionExpr{
-									pos: position{line: 729, col: 30, offset: 17518},
+									pos: position{line: 729, col: 30, offset: 17503},
 									run: (*parser).callonOpArgs9,
 									expr: &seqExpr{
-										pos: position{line: 729, col: 30, offset: 17518},
+										pos: position{line: 729, col: 30, offset: 17503},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 729, col: 30, offset: 17518},
+												pos:  position{line: 729, col: 30, offset: 17503},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 729, col: 32, offset: 17520},
+												pos:   position{line: 729, col: 32, offset: 17505},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 729, col: 34, offset: 17522},
+													pos:  position{line: 729, col: 34, offset: 17507},
 													name: "OpArg",
 												},
 											},
@@ -4831,11 +4831,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 729, col: 60, offset: 17548},
+							pos:  position{line: 729, col: 60, offset: 17533},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 729, col: 63, offset: 17551},
+							pos:        position{line: 729, col: 63, offset: 17536},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -4848,14 +4848,14 @@ var g = &grammar{
 		},
 		{
 			name: "ArgName",
-			pos:  position{line: 733, col: 1, offset: 17603},
+			pos:  position{line: 733, col: 1, offset: 17588},
 			expr: &actionExpr{
-				pos: position{line: 733, col: 11, offset: 17613},
+				pos: position{line: 733, col: 11, offset: 17598},
 				run: (*parser).callonArgName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 733, col: 11, offset: 17613},
+					pos: position{line: 733, col: 11, offset: 17598},
 					expr: &ruleRefExpr{
-						pos:  position{line: 733, col: 11, offset: 17613},
+						pos:  position{line: 733, col: 11, offset: 17598},
 						name: "UnicodeLetter",
 					},
 				},
@@ -4865,20 +4865,20 @@ var g = &grammar{
 		},
 		{
 			name: "ArgNameExpr",
-			pos:  position{line: 735, col: 1, offset: 17660},
+			pos:  position{line: 735, col: 1, offset: 17645},
 			expr: &seqExpr{
-				pos: position{line: 736, col: 5, offset: 17676},
+				pos: position{line: 736, col: 5, offset: 17661},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 736, col: 5, offset: 17676},
+						pos:        position{line: 736, col: 5, offset: 17661},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"headers\"i",
 					},
 					&notExpr{
-						pos: position{line: 736, col: 16, offset: 17687},
+						pos: position{line: 736, col: 16, offset: 17672},
 						expr: &ruleRefExpr{
-							pos:  position{line: 736, col: 17, offset: 17688},
+							pos:  position{line: 736, col: 17, offset: 17673},
 							name: "UnicodeLetter",
 						},
 					},
@@ -4889,30 +4889,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 739, col: 1, offset: 17736},
+			pos:  position{line: 739, col: 1, offset: 17721},
 			expr: &actionExpr{
-				pos: position{line: 740, col: 5, offset: 17747},
+				pos: position{line: 740, col: 5, offset: 17732},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 740, col: 5, offset: 17747},
+					pos: position{line: 740, col: 5, offset: 17732},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 740, col: 5, offset: 17747},
+							pos:  position{line: 740, col: 5, offset: 17732},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 740, col: 7, offset: 17749},
+							pos:  position{line: 740, col: 7, offset: 17734},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 740, col: 10, offset: 17752},
+							pos:  position{line: 740, col: 10, offset: 17737},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 740, col: 12, offset: 17754},
+							pos:   position{line: 740, col: 12, offset: 17739},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 740, col: 15, offset: 17757},
+								pos:  position{line: 740, col: 15, offset: 17742},
 								name: "KSUID",
 							},
 						},
@@ -4924,14 +4924,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 743, col: 1, offset: 17823},
+			pos:  position{line: 743, col: 1, offset: 17808},
 			expr: &actionExpr{
-				pos: position{line: 743, col: 9, offset: 17831},
+				pos: position{line: 743, col: 9, offset: 17816},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 743, col: 9, offset: 17831},
+					pos: position{line: 743, col: 9, offset: 17816},
 					expr: &charClassMatcher{
-						pos:        position{line: 743, col: 10, offset: 17832},
+						pos:        position{line: 743, col: 10, offset: 17817},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -4944,24 +4944,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonText",
-			pos:  position{line: 745, col: 1, offset: 17878},
+			pos:  position{line: 745, col: 1, offset: 17863},
 			expr: &actionExpr{
-				pos: position{line: 746, col: 5, offset: 17892},
+				pos: position{line: 746, col: 5, offset: 17877},
 				run: (*parser).callonColonText1,
 				expr: &seqExpr{
-					pos: position{line: 746, col: 5, offset: 17892},
+					pos: position{line: 746, col: 5, offset: 17877},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 746, col: 5, offset: 17892},
+							pos:        position{line: 746, col: 5, offset: 17877},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 746, col: 9, offset: 17896},
+							pos:   position{line: 746, col: 9, offset: 17881},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 746, col: 11, offset: 17898},
+								pos:  position{line: 746, col: 11, offset: 17883},
 								name: "Text",
 							},
 						},
@@ -4973,28 +4973,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 748, col: 1, offset: 17922},
+			pos:  position{line: 748, col: 1, offset: 17907},
 			expr: &actionExpr{
-				pos: position{line: 749, col: 5, offset: 17933},
+				pos: position{line: 749, col: 5, offset: 17918},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 749, col: 5, offset: 17933},
+					pos: position{line: 749, col: 5, offset: 17918},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 749, col: 5, offset: 17933},
+							pos:  position{line: 749, col: 5, offset: 17918},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 749, col: 10, offset: 17938},
+							pos: position{line: 749, col: 10, offset: 17923},
 							expr: &seqExpr{
-								pos: position{line: 749, col: 12, offset: 17940},
+								pos: position{line: 749, col: 12, offset: 17925},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 749, col: 12, offset: 17940},
+										pos:  position{line: 749, col: 12, offset: 17925},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 749, col: 15, offset: 17943},
+										pos:        position{line: 749, col: 15, offset: 17928},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5003,9 +5003,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 749, col: 20, offset: 17948},
+							pos: position{line: 749, col: 20, offset: 17933},
 							expr: &ruleRefExpr{
-								pos:  position{line: 749, col: 21, offset: 17949},
+								pos:  position{line: 749, col: 21, offset: 17934},
 								name: "EOKW",
 							},
 						},
@@ -5017,44 +5017,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 755, col: 1, offset: 18140},
+			pos:  position{line: 755, col: 1, offset: 18125},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 18154},
+				pos: position{line: 756, col: 5, offset: 18139},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 756, col: 5, offset: 18154},
+					pos: position{line: 756, col: 5, offset: 18139},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 5, offset: 18154},
+							pos:  position{line: 756, col: 5, offset: 18139},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 13, offset: 18162},
+							pos:  position{line: 756, col: 13, offset: 18147},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 15, offset: 18164},
+							pos:   position{line: 756, col: 15, offset: 18149},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 20, offset: 18169},
+								pos:  position{line: 756, col: 20, offset: 18154},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 26, offset: 18175},
+							pos:   position{line: 756, col: 26, offset: 18160},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 30, offset: 18179},
+								pos:  position{line: 756, col: 30, offset: 18164},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 38, offset: 18187},
+							pos:   position{line: 756, col: 38, offset: 18172},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 756, col: 41, offset: 18190},
+								pos: position{line: 756, col: 41, offset: 18175},
 								expr: &ruleRefExpr{
-									pos:  position{line: 756, col: 41, offset: 18190},
+									pos:  position{line: 756, col: 41, offset: 18175},
 									name: "AsArg",
 								},
 							},
@@ -5067,26 +5067,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 769, col: 1, offset: 18432},
+			pos:  position{line: 769, col: 1, offset: 18417},
 			expr: &actionExpr{
-				pos: position{line: 770, col: 5, offset: 18444},
+				pos: position{line: 770, col: 5, offset: 18429},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 770, col: 5, offset: 18444},
+					pos: position{line: 770, col: 5, offset: 18429},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 770, col: 5, offset: 18444},
+							pos:  position{line: 770, col: 5, offset: 18429},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 770, col: 11, offset: 18450},
+							pos:  position{line: 770, col: 11, offset: 18435},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 770, col: 13, offset: 18452},
+							pos:   position{line: 770, col: 13, offset: 18437},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 770, col: 19, offset: 18458},
+								pos:  position{line: 770, col: 19, offset: 18443},
 								name: "OrderByList",
 							},
 						},
@@ -5098,59 +5098,59 @@ var g = &grammar{
 		},
 		{
 			name: "UnnestOp",
-			pos:  position{line: 778, col: 1, offset: 18600},
+			pos:  position{line: 778, col: 1, offset: 18585},
 			expr: &actionExpr{
-				pos: position{line: 779, col: 6, offset: 18614},
+				pos: position{line: 779, col: 6, offset: 18599},
 				run: (*parser).callonUnnestOp1,
 				expr: &seqExpr{
-					pos: position{line: 779, col: 6, offset: 18614},
+					pos: position{line: 779, col: 6, offset: 18599},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 6, offset: 18614},
+							pos:  position{line: 779, col: 6, offset: 18599},
 							name: "UNNEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 13, offset: 18621},
+							pos:  position{line: 779, col: 13, offset: 18606},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 779, col: 15, offset: 18623},
+							pos:   position{line: 779, col: 15, offset: 18608},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 779, col: 17, offset: 18625},
+								pos:  position{line: 779, col: 17, offset: 18610},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 779, col: 22, offset: 18630},
+							pos:   position{line: 779, col: 22, offset: 18615},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 779, col: 27, offset: 18635},
+								pos: position{line: 779, col: 27, offset: 18620},
 								expr: &actionExpr{
-									pos: position{line: 779, col: 28, offset: 18636},
+									pos: position{line: 779, col: 28, offset: 18621},
 									run: (*parser).callonUnnestOp9,
 									expr: &seqExpr{
-										pos: position{line: 779, col: 28, offset: 18636},
+										pos: position{line: 779, col: 28, offset: 18621},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 779, col: 28, offset: 18636},
+												pos:  position{line: 779, col: 28, offset: 18621},
 												name: "_",
 											},
 											&litMatcher{
-												pos:        position{line: 779, col: 30, offset: 18638},
+												pos:        position{line: 779, col: 30, offset: 18623},
 												val:        "into",
 												ignoreCase: true,
 												want:       "\"into\"i",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 779, col: 38, offset: 18646},
+												pos:  position{line: 779, col: 38, offset: 18631},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 779, col: 40, offset: 18648},
+												pos:   position{line: 779, col: 40, offset: 18633},
 												label: "body",
 												expr: &ruleRefExpr{
-													pos:  position{line: 779, col: 45, offset: 18653},
+													pos:  position{line: 779, col: 45, offset: 18638},
 													name: "ScopeBody",
 												},
 											},
@@ -5167,30 +5167,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 791, col: 1, offset: 18890},
+			pos:  position{line: 791, col: 1, offset: 18875},
 			expr: &actionExpr{
-				pos: position{line: 792, col: 5, offset: 18902},
+				pos: position{line: 792, col: 5, offset: 18887},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 792, col: 5, offset: 18902},
+					pos: position{line: 792, col: 5, offset: 18887},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 5, offset: 18902},
+							pos:  position{line: 792, col: 5, offset: 18887},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 7, offset: 18904},
+							pos:  position{line: 792, col: 7, offset: 18889},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 792, col: 10, offset: 18907},
+							pos:  position{line: 792, col: 10, offset: 18892},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 792, col: 12, offset: 18909},
+							pos:   position{line: 792, col: 12, offset: 18894},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 792, col: 16, offset: 18913},
+								pos:  position{line: 792, col: 16, offset: 18898},
 								name: "Type",
 							},
 						},
@@ -5202,30 +5202,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 794, col: 1, offset: 18939},
+			pos:  position{line: 794, col: 1, offset: 18924},
 			expr: &actionExpr{
-				pos: position{line: 795, col: 5, offset: 18949},
+				pos: position{line: 795, col: 5, offset: 18934},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 795, col: 5, offset: 18949},
+					pos: position{line: 795, col: 5, offset: 18934},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 5, offset: 18949},
+							pos:  position{line: 795, col: 5, offset: 18934},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 7, offset: 18951},
+							pos:  position{line: 795, col: 7, offset: 18936},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 10, offset: 18954},
+							pos:  position{line: 795, col: 10, offset: 18939},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 12, offset: 18956},
+							pos:   position{line: 795, col: 12, offset: 18941},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 16, offset: 18960},
+								pos:  position{line: 795, col: 16, offset: 18945},
 								name: "Lval",
 							},
 						},
@@ -5237,9 +5237,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 799, col: 1, offset: 19011},
+			pos:  position{line: 799, col: 1, offset: 18996},
 			expr: &ruleRefExpr{
-				pos:  position{line: 799, col: 8, offset: 19018},
+				pos:  position{line: 799, col: 8, offset: 19003},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5247,51 +5247,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 801, col: 1, offset: 19029},
+			pos:  position{line: 801, col: 1, offset: 19014},
 			expr: &actionExpr{
-				pos: position{line: 802, col: 5, offset: 19039},
+				pos: position{line: 802, col: 5, offset: 19024},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 802, col: 5, offset: 19039},
+					pos: position{line: 802, col: 5, offset: 19024},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 802, col: 5, offset: 19039},
+							pos:   position{line: 802, col: 5, offset: 19024},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 802, col: 11, offset: 19045},
+								pos:  position{line: 802, col: 11, offset: 19030},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 802, col: 16, offset: 19050},
+							pos:   position{line: 802, col: 16, offset: 19035},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 802, col: 21, offset: 19055},
+								pos: position{line: 802, col: 21, offset: 19040},
 								expr: &actionExpr{
-									pos: position{line: 802, col: 22, offset: 19056},
+									pos: position{line: 802, col: 22, offset: 19041},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 802, col: 22, offset: 19056},
+										pos: position{line: 802, col: 22, offset: 19041},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 802, col: 22, offset: 19056},
+												pos:  position{line: 802, col: 22, offset: 19041},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 802, col: 25, offset: 19059},
+												pos:        position{line: 802, col: 25, offset: 19044},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 802, col: 29, offset: 19063},
+												pos:  position{line: 802, col: 29, offset: 19048},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 802, col: 32, offset: 19066},
+												pos:   position{line: 802, col: 32, offset: 19051},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 802, col: 37, offset: 19071},
+													pos:  position{line: 802, col: 37, offset: 19056},
 													name: "Lval",
 												},
 											},
@@ -5308,51 +5308,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 806, col: 1, offset: 19147},
+			pos:  position{line: 806, col: 1, offset: 19132},
 			expr: &actionExpr{
-				pos: position{line: 807, col: 5, offset: 19163},
+				pos: position{line: 807, col: 5, offset: 19148},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 807, col: 5, offset: 19163},
+					pos: position{line: 807, col: 5, offset: 19148},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 807, col: 5, offset: 19163},
+							pos:   position{line: 807, col: 5, offset: 19148},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 807, col: 11, offset: 19169},
+								pos:  position{line: 807, col: 11, offset: 19154},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 807, col: 22, offset: 19180},
+							pos:   position{line: 807, col: 22, offset: 19165},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 807, col: 27, offset: 19185},
+								pos: position{line: 807, col: 27, offset: 19170},
 								expr: &actionExpr{
-									pos: position{line: 807, col: 28, offset: 19186},
+									pos: position{line: 807, col: 28, offset: 19171},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 807, col: 28, offset: 19186},
+										pos: position{line: 807, col: 28, offset: 19171},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 807, col: 28, offset: 19186},
+												pos:  position{line: 807, col: 28, offset: 19171},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 807, col: 31, offset: 19189},
+												pos:        position{line: 807, col: 31, offset: 19174},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 807, col: 35, offset: 19193},
+												pos:  position{line: 807, col: 35, offset: 19178},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 807, col: 38, offset: 19196},
+												pos:   position{line: 807, col: 38, offset: 19181},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 807, col: 40, offset: 19198},
+													pos:  position{line: 807, col: 40, offset: 19183},
 													name: "Assignment",
 												},
 											},
@@ -5369,38 +5369,38 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 811, col: 1, offset: 19273},
+			pos:  position{line: 811, col: 1, offset: 19258},
 			expr: &actionExpr{
-				pos: position{line: 812, col: 5, offset: 19288},
+				pos: position{line: 812, col: 5, offset: 19273},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 812, col: 5, offset: 19288},
+					pos: position{line: 812, col: 5, offset: 19273},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 812, col: 5, offset: 19288},
+							pos:   position{line: 812, col: 5, offset: 19273},
 							label: "lhs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 812, col: 9, offset: 19292},
+								pos: position{line: 812, col: 9, offset: 19277},
 								expr: &actionExpr{
-									pos: position{line: 812, col: 10, offset: 19293},
+									pos: position{line: 812, col: 10, offset: 19278},
 									run: (*parser).callonAssignment5,
 									expr: &seqExpr{
-										pos: position{line: 812, col: 10, offset: 19293},
+										pos: position{line: 812, col: 10, offset: 19278},
 										exprs: []any{
 											&labeledExpr{
-												pos:   position{line: 812, col: 10, offset: 19293},
+												pos:   position{line: 812, col: 10, offset: 19278},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 812, col: 15, offset: 19298},
+													pos:  position{line: 812, col: 15, offset: 19283},
 													name: "Lval",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 812, col: 20, offset: 19303},
+												pos:  position{line: 812, col: 20, offset: 19288},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 812, col: 23, offset: 19306},
+												pos:        position{line: 812, col: 23, offset: 19291},
 												val:        ":=",
 												ignoreCase: false,
 												want:       "\":=\"",
@@ -5411,14 +5411,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 812, col: 51, offset: 19334},
+							pos:  position{line: 812, col: 51, offset: 19319},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 812, col: 54, offset: 19337},
+							pos:   position{line: 812, col: 54, offset: 19322},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 812, col: 58, offset: 19341},
+								pos:  position{line: 812, col: 58, offset: 19326},
 								name: "Expr",
 							},
 						},
@@ -5430,9 +5430,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 824, col: 1, offset: 19555},
+			pos:  position{line: 824, col: 1, offset: 19540},
 			expr: &ruleRefExpr{
-				pos:  position{line: 824, col: 8, offset: 19562},
+				pos:  position{line: 824, col: 8, offset: 19547},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -5440,63 +5440,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 826, col: 1, offset: 19579},
+			pos:  position{line: 826, col: 1, offset: 19564},
 			expr: &actionExpr{
-				pos: position{line: 827, col: 5, offset: 19599},
+				pos: position{line: 827, col: 5, offset: 19584},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 827, col: 5, offset: 19599},
+					pos: position{line: 827, col: 5, offset: 19584},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 827, col: 5, offset: 19599},
+							pos:   position{line: 827, col: 5, offset: 19584},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 827, col: 10, offset: 19604},
+								pos:  position{line: 827, col: 10, offset: 19589},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 827, col: 24, offset: 19618},
+							pos:   position{line: 827, col: 24, offset: 19603},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 827, col: 28, offset: 19622},
+								pos: position{line: 827, col: 28, offset: 19607},
 								expr: &seqExpr{
-									pos: position{line: 827, col: 29, offset: 19623},
+									pos: position{line: 827, col: 29, offset: 19608},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 827, col: 29, offset: 19623},
+											pos:  position{line: 827, col: 29, offset: 19608},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 827, col: 32, offset: 19626},
+											pos:        position{line: 827, col: 32, offset: 19611},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 827, col: 36, offset: 19630},
+											pos:  position{line: 827, col: 36, offset: 19615},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 827, col: 39, offset: 19633},
+											pos:  position{line: 827, col: 39, offset: 19618},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 827, col: 44, offset: 19638},
+											pos:  position{line: 827, col: 44, offset: 19623},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 827, col: 47, offset: 19641},
+											pos:        position{line: 827, col: 47, offset: 19626},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 827, col: 51, offset: 19645},
+											pos:  position{line: 827, col: 51, offset: 19630},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 827, col: 54, offset: 19648},
+											pos:  position{line: 827, col: 54, offset: 19633},
 											name: "Expr",
 										},
 									},
@@ -5511,53 +5511,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 841, col: 1, offset: 19969},
+			pos:  position{line: 841, col: 1, offset: 19954},
 			expr: &actionExpr{
-				pos: position{line: 842, col: 5, offset: 19987},
+				pos: position{line: 842, col: 5, offset: 19972},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 842, col: 5, offset: 19987},
+					pos: position{line: 842, col: 5, offset: 19972},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 842, col: 5, offset: 19987},
+							pos:   position{line: 842, col: 5, offset: 19972},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 11, offset: 19993},
+								pos:  position{line: 842, col: 11, offset: 19978},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 843, col: 5, offset: 20012},
+							pos:   position{line: 843, col: 5, offset: 19997},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 843, col: 10, offset: 20017},
+								pos: position{line: 843, col: 10, offset: 20002},
 								expr: &actionExpr{
-									pos: position{line: 843, col: 11, offset: 20018},
+									pos: position{line: 843, col: 11, offset: 20003},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 843, col: 11, offset: 20018},
+										pos: position{line: 843, col: 11, offset: 20003},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 843, col: 11, offset: 20018},
+												pos:  position{line: 843, col: 11, offset: 20003},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 843, col: 14, offset: 20021},
+												pos:   position{line: 843, col: 14, offset: 20006},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 843, col: 17, offset: 20024},
+													pos:  position{line: 843, col: 17, offset: 20009},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 843, col: 20, offset: 20027},
+												pos:  position{line: 843, col: 20, offset: 20012},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 843, col: 23, offset: 20030},
+												pos:   position{line: 843, col: 23, offset: 20015},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 843, col: 28, offset: 20035},
+													pos:  position{line: 843, col: 28, offset: 20020},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -5574,53 +5574,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 847, col: 1, offset: 20149},
+			pos:  position{line: 847, col: 1, offset: 20134},
 			expr: &actionExpr{
-				pos: position{line: 848, col: 5, offset: 20168},
+				pos: position{line: 848, col: 5, offset: 20153},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 848, col: 5, offset: 20168},
+					pos: position{line: 848, col: 5, offset: 20153},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 848, col: 5, offset: 20168},
+							pos:   position{line: 848, col: 5, offset: 20153},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 11, offset: 20174},
+								pos:  position{line: 848, col: 11, offset: 20159},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 849, col: 5, offset: 20186},
+							pos:   position{line: 849, col: 5, offset: 20171},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 849, col: 10, offset: 20191},
+								pos: position{line: 849, col: 10, offset: 20176},
 								expr: &actionExpr{
-									pos: position{line: 849, col: 11, offset: 20192},
+									pos: position{line: 849, col: 11, offset: 20177},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 849, col: 11, offset: 20192},
+										pos: position{line: 849, col: 11, offset: 20177},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 849, col: 11, offset: 20192},
+												pos:  position{line: 849, col: 11, offset: 20177},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 849, col: 14, offset: 20195},
+												pos:   position{line: 849, col: 14, offset: 20180},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 849, col: 17, offset: 20198},
+													pos:  position{line: 849, col: 17, offset: 20183},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 849, col: 21, offset: 20202},
+												pos:  position{line: 849, col: 21, offset: 20187},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 849, col: 24, offset: 20205},
+												pos:   position{line: 849, col: 24, offset: 20190},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 849, col: 29, offset: 20210},
+													pos:  position{line: 849, col: 29, offset: 20195},
 													name: "NotExpr",
 												},
 											},
@@ -5637,43 +5637,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 853, col: 1, offset: 20317},
+			pos:  position{line: 853, col: 1, offset: 20302},
 			expr: &choiceExpr{
-				pos: position{line: 854, col: 5, offset: 20329},
+				pos: position{line: 854, col: 5, offset: 20314},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 854, col: 5, offset: 20329},
+						pos: position{line: 854, col: 5, offset: 20314},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 854, col: 5, offset: 20329},
+							pos: position{line: 854, col: 5, offset: 20314},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 854, col: 6, offset: 20330},
+									pos: position{line: 854, col: 6, offset: 20315},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 854, col: 6, offset: 20330},
+											pos: position{line: 854, col: 6, offset: 20315},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 854, col: 6, offset: 20330},
+													pos:  position{line: 854, col: 6, offset: 20315},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 854, col: 10, offset: 20334},
+													pos:  position{line: 854, col: 10, offset: 20319},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 854, col: 14, offset: 20338},
+											pos: position{line: 854, col: 14, offset: 20323},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 854, col: 14, offset: 20338},
+													pos:        position{line: 854, col: 14, offset: 20323},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 854, col: 18, offset: 20342},
+													pos:  position{line: 854, col: 18, offset: 20327},
 													name: "__",
 												},
 											},
@@ -5681,10 +5681,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 854, col: 22, offset: 20346},
+									pos:   position{line: 854, col: 22, offset: 20331},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 854, col: 24, offset: 20348},
+										pos:  position{line: 854, col: 24, offset: 20333},
 										name: "NotExpr",
 									},
 								},
@@ -5692,7 +5692,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 862, col: 5, offset: 20514},
+						pos:  position{line: 862, col: 5, offset: 20499},
 						name: "BetweenExpr",
 					},
 				},
@@ -5702,42 +5702,42 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 864, col: 1, offset: 20529},
+			pos:  position{line: 864, col: 1, offset: 20512},
 			expr: &choiceExpr{
-				pos: position{line: 865, col: 5, offset: 20545},
+				pos: position{line: 865, col: 5, offset: 20528},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 865, col: 5, offset: 20545},
+						pos: position{line: 865, col: 5, offset: 20528},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 865, col: 5, offset: 20545},
+							pos: position{line: 865, col: 5, offset: 20528},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 865, col: 5, offset: 20545},
+									pos:   position{line: 865, col: 5, offset: 20528},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 865, col: 10, offset: 20550},
+										pos:  position{line: 865, col: 10, offset: 20533},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 865, col: 25, offset: 20565},
+									pos:  position{line: 865, col: 25, offset: 20548},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 865, col: 27, offset: 20567},
+									pos:   position{line: 865, col: 27, offset: 20550},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 865, col: 31, offset: 20571},
+										pos: position{line: 865, col: 31, offset: 20554},
 										expr: &seqExpr{
-											pos: position{line: 865, col: 32, offset: 20572},
+											pos: position{line: 865, col: 32, offset: 20555},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 865, col: 32, offset: 20572},
+													pos:  position{line: 865, col: 32, offset: 20555},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 865, col: 36, offset: 20576},
+													pos:  position{line: 865, col: 36, offset: 20559},
 													name: "_",
 												},
 											},
@@ -5745,38 +5745,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 865, col: 40, offset: 20580},
+									pos:  position{line: 865, col: 40, offset: 20563},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 865, col: 48, offset: 20588},
+									pos:  position{line: 865, col: 48, offset: 20571},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 865, col: 50, offset: 20590},
+									pos:   position{line: 865, col: 50, offset: 20573},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 865, col: 56, offset: 20596},
+										pos:  position{line: 865, col: 56, offset: 20579},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 865, col: 68, offset: 20608},
+									pos:  position{line: 865, col: 68, offset: 20591},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 865, col: 70, offset: 20610},
+									pos:  position{line: 865, col: 70, offset: 20593},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 865, col: 74, offset: 20614},
+									pos:  position{line: 865, col: 74, offset: 20597},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 865, col: 76, offset: 20616},
+									pos:   position{line: 865, col: 76, offset: 20599},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 865, col: 82, offset: 20622},
+										pos:  position{line: 865, col: 82, offset: 20605},
 										name: "BetweenExpr",
 									},
 								},
@@ -5784,7 +5784,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 875, col: 5, offset: 20854},
+						pos:  position{line: 875, col: 5, offset: 20837},
 						name: "ComparisonExpr",
 					},
 				},
@@ -5794,46 +5794,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 877, col: 1, offset: 20870},
+			pos:  position{line: 877, col: 1, offset: 20853},
 			expr: &choiceExpr{
-				pos: position{line: 878, col: 5, offset: 20889},
+				pos: position{line: 878, col: 5, offset: 20872},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 878, col: 5, offset: 20889},
+						pos: position{line: 878, col: 5, offset: 20872},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 878, col: 5, offset: 20889},
+							pos: position{line: 878, col: 5, offset: 20872},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 878, col: 5, offset: 20889},
+									pos:   position{line: 878, col: 5, offset: 20872},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 878, col: 10, offset: 20894},
+										pos:  position{line: 878, col: 10, offset: 20877},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 878, col: 23, offset: 20907},
+									pos:  position{line: 878, col: 23, offset: 20890},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 878, col: 25, offset: 20909},
+									pos:  position{line: 878, col: 25, offset: 20892},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 878, col: 28, offset: 20912},
+									pos:   position{line: 878, col: 28, offset: 20895},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 878, col: 32, offset: 20916},
+										pos: position{line: 878, col: 32, offset: 20899},
 										expr: &seqExpr{
-											pos: position{line: 878, col: 33, offset: 20917},
+											pos: position{line: 878, col: 33, offset: 20900},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 878, col: 33, offset: 20917},
+													pos:  position{line: 878, col: 33, offset: 20900},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 878, col: 35, offset: 20919},
+													pos:  position{line: 878, col: 35, offset: 20902},
 													name: "NOT",
 												},
 											},
@@ -5841,82 +5841,82 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 878, col: 41, offset: 20925},
+									pos:  position{line: 878, col: 41, offset: 20908},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 878, col: 43, offset: 20927},
+									pos:  position{line: 878, col: 43, offset: 20910},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 886, col: 5, offset: 21095},
+						pos: position{line: 886, col: 5, offset: 21075},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 886, col: 5, offset: 21095},
+							pos: position{line: 886, col: 5, offset: 21075},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 886, col: 5, offset: 21095},
+									pos:   position{line: 886, col: 5, offset: 21075},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 886, col: 9, offset: 21099},
+										pos:  position{line: 886, col: 9, offset: 21079},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 886, col: 22, offset: 21112},
+									pos:   position{line: 886, col: 22, offset: 21092},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 886, col: 31, offset: 21121},
+										pos: position{line: 886, col: 31, offset: 21101},
 										expr: &choiceExpr{
-											pos: position{line: 886, col: 32, offset: 21122},
+											pos: position{line: 886, col: 32, offset: 21102},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 886, col: 32, offset: 21122},
+													pos: position{line: 886, col: 32, offset: 21102},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 886, col: 32, offset: 21122},
+															pos:  position{line: 886, col: 32, offset: 21102},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 886, col: 35, offset: 21125},
+															pos:  position{line: 886, col: 35, offset: 21105},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 886, col: 46, offset: 21136},
+															pos:  position{line: 886, col: 46, offset: 21116},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 886, col: 49, offset: 21139},
+															pos:  position{line: 886, col: 49, offset: 21119},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 886, col: 64, offset: 21154},
+													pos: position{line: 886, col: 64, offset: 21134},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 886, col: 64, offset: 21154},
+															pos:  position{line: 886, col: 64, offset: 21134},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 886, col: 68, offset: 21158},
+															pos: position{line: 886, col: 68, offset: 21138},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 886, col: 68, offset: 21158},
+																pos:        position{line: 886, col: 68, offset: 21138},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 886, col: 104, offset: 21194},
+															pos:  position{line: 886, col: 104, offset: 21174},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 886, col: 107, offset: 21197},
+															pos:  position{line: 886, col: 107, offset: 21177},
 															name: "Regexp",
 														},
 													},
@@ -5935,53 +5935,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 899, col: 1, offset: 21483},
+			pos:  position{line: 899, col: 1, offset: 21462},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 21500},
+				pos: position{line: 900, col: 5, offset: 21479},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 21500},
+					pos: position{line: 900, col: 5, offset: 21479},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 21500},
+							pos:   position{line: 900, col: 5, offset: 21479},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 11, offset: 21506},
+								pos:  position{line: 900, col: 11, offset: 21485},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 901, col: 5, offset: 21529},
+							pos:   position{line: 901, col: 5, offset: 21508},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 901, col: 10, offset: 21534},
+								pos: position{line: 901, col: 10, offset: 21513},
 								expr: &actionExpr{
-									pos: position{line: 901, col: 11, offset: 21535},
+									pos: position{line: 901, col: 11, offset: 21514},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 901, col: 11, offset: 21535},
+										pos: position{line: 901, col: 11, offset: 21514},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 11, offset: 21535},
+												pos:  position{line: 901, col: 11, offset: 21514},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 901, col: 14, offset: 21538},
+												pos:   position{line: 901, col: 14, offset: 21517},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 901, col: 17, offset: 21541},
+													pos:  position{line: 901, col: 17, offset: 21520},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 34, offset: 21558},
+												pos:  position{line: 901, col: 34, offset: 21537},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 901, col: 37, offset: 21561},
+												pos:   position{line: 901, col: 37, offset: 21540},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 901, col: 42, offset: 21566},
+													pos:  position{line: 901, col: 42, offset: 21545},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5998,21 +5998,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 905, col: 1, offset: 21684},
+			pos:  position{line: 905, col: 1, offset: 21663},
 			expr: &actionExpr{
-				pos: position{line: 905, col: 20, offset: 21703},
+				pos: position{line: 905, col: 20, offset: 21682},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 905, col: 21, offset: 21704},
+					pos: position{line: 905, col: 21, offset: 21683},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 905, col: 21, offset: 21704},
+							pos:        position{line: 905, col: 21, offset: 21683},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 905, col: 27, offset: 21710},
+							pos:        position{line: 905, col: 27, offset: 21689},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6025,53 +6025,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 907, col: 1, offset: 21747},
+			pos:  position{line: 907, col: 1, offset: 21726},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 5, offset: 21770},
+				pos: position{line: 908, col: 5, offset: 21749},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 908, col: 5, offset: 21770},
+					pos: position{line: 908, col: 5, offset: 21749},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 908, col: 5, offset: 21770},
+							pos:   position{line: 908, col: 5, offset: 21749},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 908, col: 11, offset: 21776},
+								pos:  position{line: 908, col: 11, offset: 21755},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 5, offset: 21791},
+							pos:   position{line: 909, col: 5, offset: 21770},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 909, col: 10, offset: 21796},
+								pos: position{line: 909, col: 10, offset: 21775},
 								expr: &actionExpr{
-									pos: position{line: 909, col: 11, offset: 21797},
+									pos: position{line: 909, col: 11, offset: 21776},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 909, col: 11, offset: 21797},
+										pos: position{line: 909, col: 11, offset: 21776},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 909, col: 11, offset: 21797},
+												pos:  position{line: 909, col: 11, offset: 21776},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 909, col: 14, offset: 21800},
+												pos:   position{line: 909, col: 14, offset: 21779},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 909, col: 17, offset: 21803},
+													pos:  position{line: 909, col: 17, offset: 21782},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 909, col: 40, offset: 21826},
+												pos:  position{line: 909, col: 40, offset: 21805},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 909, col: 43, offset: 21829},
+												pos:   position{line: 909, col: 43, offset: 21808},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 909, col: 48, offset: 21834},
+													pos:  position{line: 909, col: 48, offset: 21813},
 													name: "ConcatExpr",
 												},
 											},
@@ -6088,27 +6088,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 913, col: 1, offset: 21944},
+			pos:  position{line: 913, col: 1, offset: 21923},
 			expr: &actionExpr{
-				pos: position{line: 913, col: 26, offset: 21969},
+				pos: position{line: 913, col: 26, offset: 21948},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 913, col: 27, offset: 21970},
+					pos: position{line: 913, col: 27, offset: 21949},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 913, col: 27, offset: 21970},
+							pos:        position{line: 913, col: 27, offset: 21949},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 913, col: 33, offset: 21976},
+							pos:        position{line: 913, col: 33, offset: 21955},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 913, col: 39, offset: 21982},
+							pos:        position{line: 913, col: 39, offset: 21961},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6121,51 +6121,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 915, col: 1, offset: 22019},
+			pos:  position{line: 915, col: 1, offset: 21998},
 			expr: &actionExpr{
-				pos: position{line: 916, col: 5, offset: 22035},
+				pos: position{line: 916, col: 5, offset: 22013},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 916, col: 5, offset: 22035},
+					pos: position{line: 916, col: 5, offset: 22013},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 916, col: 5, offset: 22035},
+							pos:   position{line: 916, col: 5, offset: 22013},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 916, col: 11, offset: 22041},
+								pos:  position{line: 916, col: 11, offset: 22019},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 917, col: 5, offset: 22062},
+							pos:   position{line: 917, col: 5, offset: 22040},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 917, col: 10, offset: 22067},
+								pos: position{line: 917, col: 10, offset: 22045},
 								expr: &actionExpr{
-									pos: position{line: 917, col: 11, offset: 22068},
+									pos: position{line: 917, col: 11, offset: 22046},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 917, col: 11, offset: 22068},
+										pos: position{line: 917, col: 11, offset: 22046},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 917, col: 11, offset: 22068},
+												pos:  position{line: 917, col: 11, offset: 22046},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 917, col: 14, offset: 22071},
+												pos:        position{line: 917, col: 14, offset: 22049},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 917, col: 19, offset: 22076},
+												pos:  position{line: 917, col: 19, offset: 22054},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 917, col: 22, offset: 22079},
+												pos:   position{line: 917, col: 22, offset: 22057},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 917, col: 27, offset: 22084},
+													pos:  position{line: 917, col: 27, offset: 22062},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6182,40 +6182,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 921, col: 1, offset: 22202},
+			pos:  position{line: 921, col: 1, offset: 22180},
 			expr: &choiceExpr{
-				pos: position{line: 922, col: 5, offset: 22223},
+				pos: position{line: 922, col: 5, offset: 22201},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 922, col: 5, offset: 22223},
+						pos: position{line: 922, col: 5, offset: 22201},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 922, col: 5, offset: 22223},
+							pos: position{line: 922, col: 5, offset: 22201},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 922, col: 5, offset: 22223},
+									pos: position{line: 922, col: 5, offset: 22201},
 									expr: &ruleRefExpr{
-										pos:  position{line: 922, col: 6, offset: 22224},
+										pos:  position{line: 922, col: 6, offset: 22202},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 922, col: 14, offset: 22232},
+									pos:   position{line: 922, col: 14, offset: 22210},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 922, col: 17, offset: 22235},
+										pos:  position{line: 922, col: 17, offset: 22213},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 31, offset: 22249},
+									pos:  position{line: 922, col: 31, offset: 22227},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 922, col: 34, offset: 22252},
+									pos:   position{line: 922, col: 34, offset: 22230},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 922, col: 36, offset: 22254},
+										pos:  position{line: 922, col: 36, offset: 22232},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6223,7 +6223,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 931, col: 5, offset: 22438},
+						pos:  position{line: 931, col: 5, offset: 22416},
 						name: "ColonCast",
 					},
 				},
@@ -6233,21 +6233,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 933, col: 1, offset: 22449},
+			pos:  position{line: 933, col: 1, offset: 22427},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 17, offset: 22465},
+				pos: position{line: 933, col: 17, offset: 22443},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 933, col: 18, offset: 22466},
+					pos: position{line: 933, col: 18, offset: 22444},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 933, col: 18, offset: 22466},
+							pos:        position{line: 933, col: 18, offset: 22444},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 933, col: 24, offset: 22472},
+							pos:        position{line: 933, col: 24, offset: 22450},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6260,58 +6260,58 @@ var g = &grammar{
 		},
 		{
 			name: "ColonCast",
-			pos:  position{line: 935, col: 1, offset: 22509},
+			pos:  position{line: 935, col: 1, offset: 22487},
 			expr: &actionExpr{
-				pos: position{line: 936, col: 5, offset: 22523},
+				pos: position{line: 936, col: 5, offset: 22501},
 				run: (*parser).callonColonCast1,
 				expr: &seqExpr{
-					pos: position{line: 936, col: 5, offset: 22523},
+					pos: position{line: 936, col: 5, offset: 22501},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 936, col: 5, offset: 22523},
+							pos:   position{line: 936, col: 5, offset: 22501},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 936, col: 11, offset: 22529},
+								pos:  position{line: 936, col: 11, offset: 22507},
 								name: "DerefExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 937, col: 5, offset: 22543},
+							pos:   position{line: 937, col: 5, offset: 22521},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 937, col: 10, offset: 22548},
+								pos: position{line: 937, col: 10, offset: 22526},
 								expr: &actionExpr{
-									pos: position{line: 937, col: 11, offset: 22549},
+									pos: position{line: 937, col: 11, offset: 22527},
 									run: (*parser).callonColonCast7,
 									expr: &seqExpr{
-										pos: position{line: 937, col: 11, offset: 22549},
+										pos: position{line: 937, col: 11, offset: 22527},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 937, col: 11, offset: 22549},
+												pos:  position{line: 937, col: 11, offset: 22527},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 937, col: 14, offset: 22552},
+												pos:        position{line: 937, col: 14, offset: 22530},
 												val:        "::",
 												ignoreCase: false,
 												want:       "\"::\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 937, col: 19, offset: 22557},
+												pos:  position{line: 937, col: 19, offset: 22535},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 937, col: 22, offset: 22560},
+												pos:   position{line: 937, col: 22, offset: 22538},
 												label: "expr",
 												expr: &choiceExpr{
-													pos: position{line: 937, col: 28, offset: 22566},
+													pos: position{line: 937, col: 28, offset: 22544},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 937, col: 28, offset: 22566},
+															pos:  position{line: 937, col: 28, offset: 22544},
 															name: "TypeAsValue",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 937, col: 42, offset: 22580},
+															pos:  position{line: 937, col: 42, offset: 22558},
 															name: "DerefExpr",
 														},
 													},
@@ -6330,73 +6330,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 941, col: 1, offset: 22690},
+			pos:  position{line: 941, col: 1, offset: 22668},
 			expr: &choiceExpr{
-				pos: position{line: 942, col: 5, offset: 22704},
+				pos: position{line: 942, col: 5, offset: 22682},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 942, col: 5, offset: 22704},
+						pos: position{line: 942, col: 5, offset: 22682},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 942, col: 5, offset: 22704},
+							pos: position{line: 942, col: 5, offset: 22682},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 942, col: 5, offset: 22704},
+									pos:   position{line: 942, col: 5, offset: 22682},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 10, offset: 22709},
+										pos:  position{line: 942, col: 10, offset: 22687},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 20, offset: 22719},
+									pos:        position{line: 942, col: 20, offset: 22697},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 24, offset: 22723},
+									pos:  position{line: 942, col: 24, offset: 22701},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 942, col: 27, offset: 22726},
+									pos:   position{line: 942, col: 27, offset: 22704},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 32, offset: 22731},
+										pos:  position{line: 942, col: 32, offset: 22709},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 45, offset: 22744},
+									pos:  position{line: 942, col: 45, offset: 22722},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 48, offset: 22747},
+									pos:        position{line: 942, col: 48, offset: 22725},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 52, offset: 22751},
+									pos:  position{line: 942, col: 52, offset: 22729},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 942, col: 55, offset: 22754},
+									pos:   position{line: 942, col: 55, offset: 22732},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 942, col: 58, offset: 22757},
+										pos: position{line: 942, col: 58, offset: 22735},
 										expr: &ruleRefExpr{
-											pos:  position{line: 942, col: 58, offset: 22757},
+											pos:  position{line: 942, col: 58, offset: 22735},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 72, offset: 22771},
+									pos:  position{line: 942, col: 72, offset: 22749},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 75, offset: 22774},
+									pos:        position{line: 942, col: 75, offset: 22752},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6405,49 +6405,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 954, col: 5, offset: 23013},
+						pos: position{line: 954, col: 5, offset: 22991},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 954, col: 5, offset: 23013},
+							pos: position{line: 954, col: 5, offset: 22991},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 954, col: 5, offset: 23013},
+									pos:   position{line: 954, col: 5, offset: 22991},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 954, col: 10, offset: 23018},
+										pos:  position{line: 954, col: 10, offset: 22996},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 954, col: 20, offset: 23028},
+									pos:        position{line: 954, col: 20, offset: 23006},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 24, offset: 23032},
+									pos:  position{line: 954, col: 24, offset: 23010},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 954, col: 27, offset: 23035},
+									pos:        position{line: 954, col: 27, offset: 23013},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 31, offset: 23039},
+									pos:  position{line: 954, col: 31, offset: 23017},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 954, col: 34, offset: 23042},
+									pos:   position{line: 954, col: 34, offset: 23020},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 954, col: 37, offset: 23045},
+										pos:  position{line: 954, col: 37, offset: 23023},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 954, col: 50, offset: 23058},
+									pos:        position{line: 954, col: 50, offset: 23036},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6456,35 +6456,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 962, col: 5, offset: 23222},
+						pos: position{line: 962, col: 5, offset: 23200},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 962, col: 5, offset: 23222},
+							pos: position{line: 962, col: 5, offset: 23200},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 962, col: 5, offset: 23222},
+									pos:   position{line: 962, col: 5, offset: 23200},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 962, col: 10, offset: 23227},
+										pos:  position{line: 962, col: 10, offset: 23205},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 962, col: 20, offset: 23237},
+									pos:        position{line: 962, col: 20, offset: 23215},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 962, col: 24, offset: 23241},
+									pos:   position{line: 962, col: 24, offset: 23219},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 962, col: 30, offset: 23247},
+										pos:  position{line: 962, col: 30, offset: 23225},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 962, col: 35, offset: 23252},
+									pos:        position{line: 962, col: 35, offset: 23230},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6493,30 +6493,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 970, col: 5, offset: 23422},
+						pos: position{line: 970, col: 5, offset: 23400},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 970, col: 5, offset: 23422},
+							pos: position{line: 970, col: 5, offset: 23400},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 970, col: 5, offset: 23422},
+									pos:   position{line: 970, col: 5, offset: 23400},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 10, offset: 23427},
+										pos:  position{line: 970, col: 10, offset: 23405},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 970, col: 20, offset: 23437},
+									pos:        position{line: 970, col: 20, offset: 23415},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 970, col: 24, offset: 23441},
+									pos:   position{line: 970, col: 24, offset: 23419},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 970, col: 27, offset: 23444},
+										pos:  position{line: 970, col: 27, offset: 23422},
 										name: "DerefKey",
 									},
 								},
@@ -6524,11 +6524,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 979, col: 5, offset: 23632},
+						pos:  position{line: 979, col: 5, offset: 23610},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 980, col: 5, offset: 23645},
+						pos:  position{line: 980, col: 5, offset: 23623},
 						name: "Primary",
 					},
 				},
@@ -6538,34 +6538,34 @@ var g = &grammar{
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 982, col: 1, offset: 23654},
+			pos:  position{line: 982, col: 1, offset: 23632},
 			expr: &choiceExpr{
-				pos: position{line: 983, col: 5, offset: 23667},
+				pos: position{line: 983, col: 5, offset: 23645},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 5, offset: 23667},
+						pos:  position{line: 983, col: 5, offset: 23645},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 984, col: 5, offset: 23683},
+						pos: position{line: 984, col: 5, offset: 23660},
 						run: (*parser).callonDerefKey3,
 						expr: &labeledExpr{
-							pos:   position{line: 984, col: 5, offset: 23683},
+							pos:   position{line: 984, col: 5, offset: 23660},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 984, col: 7, offset: 23685},
+								pos:  position{line: 984, col: 7, offset: 23662},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 985, col: 5, offset: 23777},
+						pos: position{line: 985, col: 5, offset: 23754},
 						run: (*parser).callonDerefKey6,
 						expr: &labeledExpr{
-							pos:   position{line: 985, col: 5, offset: 23777},
+							pos:   position{line: 985, col: 5, offset: 23754},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 985, col: 7, offset: 23779},
+								pos:  position{line: 985, col: 7, offset: 23756},
 								name: "BacktickString",
 							},
 						},
@@ -6577,16 +6577,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 987, col: 1, offset: 23868},
+			pos:  position{line: 987, col: 1, offset: 23845},
 			expr: &choiceExpr{
-				pos: position{line: 988, col: 5, offset: 23881},
+				pos: position{line: 988, col: 5, offset: 23858},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 988, col: 5, offset: 23881},
+						pos:  position{line: 988, col: 5, offset: 23858},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 989, col: 5, offset: 23890},
+						pos:  position{line: 989, col: 5, offset: 23867},
 						name: "Function",
 					},
 				},
@@ -6596,20 +6596,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 991, col: 1, offset: 23900},
+			pos:  position{line: 991, col: 1, offset: 23877},
 			expr: &seqExpr{
-				pos: position{line: 991, col: 13, offset: 23912},
+				pos: position{line: 991, col: 13, offset: 23889},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 991, col: 13, offset: 23912},
+						pos:  position{line: 991, col: 13, offset: 23889},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 991, col: 22, offset: 23921},
+						pos:  position{line: 991, col: 22, offset: 23898},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 991, col: 25, offset: 23924},
+						pos:        position{line: 991, col: 25, offset: 23901},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -6621,16 +6621,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 993, col: 1, offset: 23929},
+			pos:  position{line: 993, col: 1, offset: 23906},
 			expr: &choiceExpr{
-				pos: position{line: 994, col: 5, offset: 23942},
+				pos: position{line: 994, col: 5, offset: 23919},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 994, col: 5, offset: 23942},
+						pos:  position{line: 994, col: 5, offset: 23919},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 995, col: 5, offset: 23950},
+						pos:  position{line: 995, col: 5, offset: 23927},
 						name: "SELECT",
 					},
 				},
@@ -6640,58 +6640,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 997, col: 1, offset: 23958},
+			pos:  position{line: 997, col: 1, offset: 23935},
 			expr: &actionExpr{
-				pos: position{line: 998, col: 5, offset: 23967},
+				pos: position{line: 998, col: 5, offset: 23944},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 998, col: 5, offset: 23967},
+					pos: position{line: 998, col: 5, offset: 23944},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 998, col: 5, offset: 23967},
+							pos:   position{line: 998, col: 5, offset: 23944},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 998, col: 9, offset: 23971},
+								pos:  position{line: 998, col: 9, offset: 23948},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 998, col: 21, offset: 23983},
+							pos:  position{line: 998, col: 21, offset: 23960},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 998, col: 24, offset: 23986},
+							pos:        position{line: 998, col: 24, offset: 23963},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 998, col: 28, offset: 23990},
+							pos:  position{line: 998, col: 28, offset: 23967},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 998, col: 31, offset: 23993},
+							pos:   position{line: 998, col: 31, offset: 23970},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 998, col: 37, offset: 23999},
+								pos: position{line: 998, col: 37, offset: 23976},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 998, col: 37, offset: 23999},
+										pos:  position{line: 998, col: 37, offset: 23976},
 										name: "UnnestExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 998, col: 50, offset: 24012},
+										pos:  position{line: 998, col: 50, offset: 23989},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 998, col: 56, offset: 24018},
+							pos:  position{line: 998, col: 56, offset: 23995},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 998, col: 59, offset: 24021},
+							pos:        position{line: 998, col: 59, offset: 23998},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -6704,85 +6704,85 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1002, col: 1, offset: 24134},
+			pos:  position{line: 1002, col: 1, offset: 24111},
 			expr: &choiceExpr{
-				pos: position{line: 1003, col: 5, offset: 24147},
+				pos: position{line: 1003, col: 5, offset: 24124},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1003, col: 5, offset: 24147},
+						pos:  position{line: 1003, col: 5, offset: 24124},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1005, col: 5, offset: 24234},
+						pos: position{line: 1005, col: 5, offset: 24211},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1005, col: 5, offset: 24234},
+							pos: position{line: 1005, col: 5, offset: 24211},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1005, col: 5, offset: 24234},
+									pos:  position{line: 1005, col: 5, offset: 24211},
 									name: "REGEXP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1005, col: 12, offset: 24241},
+									pos:  position{line: 1005, col: 12, offset: 24218},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1005, col: 15, offset: 24244},
+									pos:        position{line: 1005, col: 15, offset: 24221},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1005, col: 19, offset: 24248},
+									pos:  position{line: 1005, col: 19, offset: 24225},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1005, col: 22, offset: 24251},
+									pos:   position{line: 1005, col: 22, offset: 24228},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1005, col: 27, offset: 24256},
+										pos:  position{line: 1005, col: 27, offset: 24233},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1005, col: 43, offset: 24272},
+									pos:  position{line: 1005, col: 43, offset: 24249},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1005, col: 46, offset: 24275},
+									pos:        position{line: 1005, col: 46, offset: 24252},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1005, col: 50, offset: 24279},
+									pos:  position{line: 1005, col: 50, offset: 24256},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1005, col: 53, offset: 24282},
+									pos:   position{line: 1005, col: 53, offset: 24259},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1005, col: 58, offset: 24287},
+										pos:  position{line: 1005, col: 58, offset: 24264},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1005, col: 63, offset: 24292},
+									pos:  position{line: 1005, col: 63, offset: 24269},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1005, col: 66, offset: 24295},
+									pos:        position{line: 1005, col: 66, offset: 24272},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1005, col: 70, offset: 24299},
+									pos:   position{line: 1005, col: 70, offset: 24276},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1005, col: 76, offset: 24305},
+										pos: position{line: 1005, col: 76, offset: 24282},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1005, col: 76, offset: 24305},
+											pos:  position{line: 1005, col: 76, offset: 24282},
 											name: "WhereClause",
 										},
 									},
@@ -6791,98 +6791,98 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1009, col: 5, offset: 24484},
+						pos: position{line: 1009, col: 5, offset: 24461},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1009, col: 5, offset: 24484},
+							pos: position{line: 1009, col: 5, offset: 24461},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1009, col: 5, offset: 24484},
+									pos:  position{line: 1009, col: 5, offset: 24461},
 									name: "REGEXP_REPLACE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1009, col: 20, offset: 24499},
+									pos:  position{line: 1009, col: 20, offset: 24476},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1009, col: 23, offset: 24502},
+									pos:        position{line: 1009, col: 23, offset: 24479},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1009, col: 27, offset: 24506},
+									pos:  position{line: 1009, col: 27, offset: 24483},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1009, col: 30, offset: 24509},
+									pos:   position{line: 1009, col: 30, offset: 24486},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1009, col: 35, offset: 24514},
+										pos:  position{line: 1009, col: 35, offset: 24491},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1009, col: 40, offset: 24519},
+									pos:  position{line: 1009, col: 40, offset: 24496},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1009, col: 43, offset: 24522},
+									pos:        position{line: 1009, col: 43, offset: 24499},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1009, col: 47, offset: 24526},
+									pos:  position{line: 1009, col: 47, offset: 24503},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1009, col: 50, offset: 24529},
+									pos:   position{line: 1009, col: 50, offset: 24506},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1009, col: 55, offset: 24534},
+										pos:  position{line: 1009, col: 55, offset: 24511},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1009, col: 71, offset: 24550},
+									pos:  position{line: 1009, col: 71, offset: 24527},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1009, col: 74, offset: 24553},
+									pos:        position{line: 1009, col: 74, offset: 24530},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1009, col: 78, offset: 24557},
+									pos:  position{line: 1009, col: 78, offset: 24534},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1009, col: 81, offset: 24560},
+									pos:   position{line: 1009, col: 81, offset: 24537},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1009, col: 86, offset: 24565},
+										pos:  position{line: 1009, col: 86, offset: 24542},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1009, col: 91, offset: 24570},
+									pos:  position{line: 1009, col: 91, offset: 24547},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1009, col: 94, offset: 24573},
+									pos:        position{line: 1009, col: 94, offset: 24550},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1009, col: 98, offset: 24577},
+									pos:   position{line: 1009, col: 98, offset: 24554},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1009, col: 104, offset: 24583},
+										pos: position{line: 1009, col: 104, offset: 24560},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1009, col: 104, offset: 24583},
+											pos:  position{line: 1009, col: 104, offset: 24560},
 											name: "WhereClause",
 										},
 									},
@@ -6891,81 +6891,81 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1013, col: 5, offset: 24777},
+						pos: position{line: 1013, col: 5, offset: 24754},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1013, col: 5, offset: 24777},
+							pos: position{line: 1013, col: 5, offset: 24754},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1013, col: 5, offset: 24777},
+									pos: position{line: 1013, col: 5, offset: 24754},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 6, offset: 24778},
+										pos:  position{line: 1013, col: 6, offset: 24755},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 16, offset: 24788},
+									pos:  position{line: 1013, col: 16, offset: 24765},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 24, offset: 24796},
+									pos:  position{line: 1013, col: 24, offset: 24773},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1013, col: 27, offset: 24799},
+									pos:        position{line: 1013, col: 27, offset: 24776},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 31, offset: 24803},
+									pos:  position{line: 1013, col: 31, offset: 24780},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 34, offset: 24806},
+									pos:   position{line: 1013, col: 34, offset: 24783},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 39, offset: 24811},
+										pos:  position{line: 1013, col: 39, offset: 24788},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 44, offset: 24816},
+									pos:  position{line: 1013, col: 44, offset: 24793},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 46, offset: 24818},
+									pos:  position{line: 1013, col: 46, offset: 24795},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 51, offset: 24823},
+									pos:  position{line: 1013, col: 51, offset: 24800},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 53, offset: 24825},
+									pos:   position{line: 1013, col: 53, offset: 24802},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 55, offset: 24827},
+										pos:  position{line: 1013, col: 55, offset: 24804},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 60, offset: 24832},
+									pos:  position{line: 1013, col: 60, offset: 24809},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1013, col: 63, offset: 24835},
+									pos:        position{line: 1013, col: 63, offset: 24812},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 67, offset: 24839},
+									pos:   position{line: 1013, col: 67, offset: 24816},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1013, col: 73, offset: 24845},
+										pos: position{line: 1013, col: 73, offset: 24822},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1013, col: 73, offset: 24845},
+											pos:  position{line: 1013, col: 73, offset: 24822},
 											name: "WhereClause",
 										},
 									},
@@ -6974,70 +6974,70 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1021, col: 5, offset: 25024},
+						pos: position{line: 1021, col: 5, offset: 25000},
 						run: (*parser).callonFunction64,
 						expr: &seqExpr{
-							pos: position{line: 1021, col: 5, offset: 25024},
+							pos: position{line: 1021, col: 5, offset: 25000},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1021, col: 5, offset: 25024},
+									pos: position{line: 1021, col: 5, offset: 25000},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1021, col: 6, offset: 25025},
+										pos:  position{line: 1021, col: 6, offset: 25001},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 16, offset: 25035},
+									pos:  position{line: 1021, col: 16, offset: 25011},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 21, offset: 25040},
+									pos:  position{line: 1021, col: 21, offset: 25016},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1021, col: 24, offset: 25043},
+									pos:        position{line: 1021, col: 24, offset: 25019},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 28, offset: 25047},
+									pos:  position{line: 1021, col: 28, offset: 25023},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1021, col: 31, offset: 25050},
+									pos:   position{line: 1021, col: 31, offset: 25026},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1021, col: 33, offset: 25052},
+										pos:  position{line: 1021, col: 33, offset: 25028},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 38, offset: 25057},
+									pos:  position{line: 1021, col: 38, offset: 25033},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 40, offset: 25059},
+									pos:  position{line: 1021, col: 40, offset: 25035},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 43, offset: 25062},
+									pos:  position{line: 1021, col: 43, offset: 25038},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1021, col: 45, offset: 25064},
+									pos:   position{line: 1021, col: 45, offset: 25040},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1021, col: 49, offset: 25068},
+										pos:  position{line: 1021, col: 49, offset: 25044},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 60, offset: 25079},
+									pos:  position{line: 1021, col: 60, offset: 25055},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1021, col: 63, offset: 25082},
+									pos:        position{line: 1021, col: 63, offset: 25058},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7046,72 +7046,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1029, col: 5, offset: 25241},
+						pos: position{line: 1029, col: 5, offset: 25217},
 						run: (*parser).callonFunction81,
 						expr: &seqExpr{
-							pos: position{line: 1029, col: 5, offset: 25241},
+							pos: position{line: 1029, col: 5, offset: 25217},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1029, col: 5, offset: 25241},
+									pos: position{line: 1029, col: 5, offset: 25217},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1029, col: 6, offset: 25242},
+										pos:  position{line: 1029, col: 6, offset: 25218},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1029, col: 16, offset: 25252},
+									pos:  position{line: 1029, col: 16, offset: 25228},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1029, col: 26, offset: 25262},
+									pos:  position{line: 1029, col: 26, offset: 25238},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1029, col: 29, offset: 25265},
+									pos:        position{line: 1029, col: 29, offset: 25241},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1029, col: 33, offset: 25269},
+									pos:  position{line: 1029, col: 33, offset: 25245},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1029, col: 36, offset: 25272},
+									pos:   position{line: 1029, col: 36, offset: 25248},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1029, col: 41, offset: 25277},
+										pos:  position{line: 1029, col: 41, offset: 25253},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1029, col: 46, offset: 25282},
+									pos:   position{line: 1029, col: 46, offset: 25258},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1029, col: 51, offset: 25287},
+										pos: position{line: 1029, col: 51, offset: 25263},
 										expr: &actionExpr{
-											pos: position{line: 1029, col: 52, offset: 25288},
+											pos: position{line: 1029, col: 52, offset: 25264},
 											run: (*parser).callonFunction93,
 											expr: &seqExpr{
-												pos: position{line: 1029, col: 52, offset: 25288},
+												pos: position{line: 1029, col: 52, offset: 25264},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1029, col: 52, offset: 25288},
+														pos:  position{line: 1029, col: 52, offset: 25264},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1029, col: 54, offset: 25290},
+														pos:  position{line: 1029, col: 54, offset: 25266},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1029, col: 59, offset: 25295},
+														pos:  position{line: 1029, col: 59, offset: 25271},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1029, col: 61, offset: 25297},
+														pos:   position{line: 1029, col: 61, offset: 25273},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1029, col: 63, offset: 25299},
+															pos:  position{line: 1029, col: 63, offset: 25275},
 															name: "Expr",
 														},
 													},
@@ -7121,33 +7121,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1029, col: 88, offset: 25324},
+									pos:   position{line: 1029, col: 88, offset: 25300},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1029, col: 93, offset: 25329},
+										pos: position{line: 1029, col: 93, offset: 25305},
 										expr: &actionExpr{
-											pos: position{line: 1029, col: 94, offset: 25330},
+											pos: position{line: 1029, col: 94, offset: 25306},
 											run: (*parser).callonFunction102,
 											expr: &seqExpr{
-												pos: position{line: 1029, col: 94, offset: 25330},
+												pos: position{line: 1029, col: 94, offset: 25306},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1029, col: 94, offset: 25330},
+														pos:  position{line: 1029, col: 94, offset: 25306},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1029, col: 96, offset: 25332},
+														pos:  position{line: 1029, col: 96, offset: 25308},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1029, col: 100, offset: 25336},
+														pos:  position{line: 1029, col: 100, offset: 25312},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1029, col: 102, offset: 25338},
+														pos:   position{line: 1029, col: 102, offset: 25314},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1029, col: 104, offset: 25340},
+															pos:  position{line: 1029, col: 104, offset: 25316},
 															name: "Expr",
 														},
 													},
@@ -7157,7 +7157,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1029, col: 129, offset: 25365},
+									pos:        position{line: 1029, col: 129, offset: 25341},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7166,65 +7166,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 25648},
+						pos: position{line: 1043, col: 5, offset: 25624},
 						run: (*parser).callonFunction110,
 						expr: &seqExpr{
-							pos: position{line: 1043, col: 5, offset: 25648},
+							pos: position{line: 1043, col: 5, offset: 25624},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1043, col: 5, offset: 25648},
+									pos: position{line: 1043, col: 5, offset: 25624},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 6, offset: 25649},
+										pos:  position{line: 1043, col: 6, offset: 25625},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 16, offset: 25659},
+									pos:   position{line: 1043, col: 16, offset: 25635},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 19, offset: 25662},
+										pos:  position{line: 1043, col: 19, offset: 25638},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 30, offset: 25673},
+									pos:  position{line: 1043, col: 30, offset: 25649},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 33, offset: 25676},
+									pos:        position{line: 1043, col: 33, offset: 25652},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 37, offset: 25680},
+									pos:  position{line: 1043, col: 37, offset: 25656},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 40, offset: 25683},
+									pos:   position{line: 1043, col: 40, offset: 25659},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 45, offset: 25688},
+										pos:  position{line: 1043, col: 45, offset: 25664},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 58, offset: 25701},
+									pos:  position{line: 1043, col: 58, offset: 25677},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 61, offset: 25704},
+									pos:        position{line: 1043, col: 61, offset: 25680},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 65, offset: 25708},
+									pos:   position{line: 1043, col: 65, offset: 25684},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1043, col: 71, offset: 25714},
+										pos: position{line: 1043, col: 71, offset: 25690},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1043, col: 71, offset: 25714},
+											pos:  position{line: 1043, col: 71, offset: 25690},
 											name: "WhereClause",
 										},
 									},
@@ -7233,7 +7233,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1046, col: 5, offset: 25785},
+						pos:  position{line: 1046, col: 5, offset: 25761},
 						name: "CountStar",
 					},
 				},
@@ -7243,15 +7243,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1048, col: 1, offset: 25796},
+			pos:  position{line: 1048, col: 1, offset: 25772},
 			expr: &actionExpr{
-				pos: position{line: 1049, col: 5, offset: 25816},
+				pos: position{line: 1049, col: 5, offset: 25792},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1049, col: 5, offset: 25816},
+					pos:   position{line: 1049, col: 5, offset: 25792},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1049, col: 9, offset: 25820},
+						pos:  position{line: 1049, col: 9, offset: 25796},
 						name: "RegexpPattern",
 					},
 				},
@@ -7261,24 +7261,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1051, col: 1, offset: 25891},
+			pos:  position{line: 1051, col: 1, offset: 25867},
 			expr: &choiceExpr{
-				pos: position{line: 1052, col: 5, offset: 25908},
+				pos: position{line: 1052, col: 5, offset: 25884},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1052, col: 5, offset: 25908},
+						pos: position{line: 1052, col: 5, offset: 25884},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1052, col: 5, offset: 25908},
+							pos:   position{line: 1052, col: 5, offset: 25884},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1052, col: 10, offset: 25913},
+								pos:  position{line: 1052, col: 10, offset: 25889},
 								name: "UnnestExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1053, col: 5, offset: 25956},
+						pos:  position{line: 1053, col: 5, offset: 25932},
 						name: "OptionalExprs",
 					},
 				},
@@ -7288,96 +7288,96 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1055, col: 1, offset: 25971},
+			pos:  position{line: 1055, col: 1, offset: 25947},
 			expr: &actionExpr{
-				pos: position{line: 1056, col: 5, offset: 25980},
+				pos: position{line: 1056, col: 5, offset: 25956},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1056, col: 5, offset: 25980},
+					pos: position{line: 1056, col: 5, offset: 25956},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1056, col: 5, offset: 25980},
+							pos:  position{line: 1056, col: 5, offset: 25956},
 							name: "GREP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1056, col: 10, offset: 25985},
+							pos:  position{line: 1056, col: 10, offset: 25961},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1056, col: 13, offset: 25988},
+							pos:        position{line: 1056, col: 13, offset: 25964},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1056, col: 17, offset: 25992},
+							pos:  position{line: 1056, col: 17, offset: 25968},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1056, col: 20, offset: 25995},
+							pos:   position{line: 1056, col: 20, offset: 25971},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1056, col: 29, offset: 26004},
+								pos: position{line: 1056, col: 29, offset: 25980},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1056, col: 29, offset: 26004},
+										pos:  position{line: 1056, col: 29, offset: 25980},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1056, col: 38, offset: 26013},
+										pos:  position{line: 1056, col: 38, offset: 25989},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1056, col: 45, offset: 26020},
+										pos:  position{line: 1056, col: 45, offset: 25996},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1056, col: 51, offset: 26026},
+							pos:  position{line: 1056, col: 51, offset: 26002},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1056, col: 54, offset: 26029},
+							pos:   position{line: 1056, col: 54, offset: 26005},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1056, col: 58, offset: 26033},
+								pos: position{line: 1056, col: 58, offset: 26009},
 								expr: &actionExpr{
-									pos: position{line: 1056, col: 59, offset: 26034},
+									pos: position{line: 1056, col: 59, offset: 26010},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1056, col: 59, offset: 26034},
+										pos: position{line: 1056, col: 59, offset: 26010},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1056, col: 59, offset: 26034},
+												pos:        position{line: 1056, col: 59, offset: 26010},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1056, col: 63, offset: 26038},
+												pos:  position{line: 1056, col: 63, offset: 26014},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1056, col: 66, offset: 26041},
+												pos:   position{line: 1056, col: 66, offset: 26017},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1056, col: 69, offset: 26044},
+													pos: position{line: 1056, col: 69, offset: 26020},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1056, col: 69, offset: 26044},
+															pos:  position{line: 1056, col: 69, offset: 26020},
 															name: "UnnestExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1056, col: 82, offset: 26057},
+															pos:  position{line: 1056, col: 82, offset: 26033},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1056, col: 88, offset: 26063},
+												pos:  position{line: 1056, col: 88, offset: 26039},
 												name: "__",
 											},
 										},
@@ -7386,7 +7386,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1056, col: 111, offset: 26086},
+							pos:        position{line: 1056, col: 111, offset: 26062},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7399,19 +7399,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1068, col: 1, offset: 26299},
+			pos:  position{line: 1068, col: 1, offset: 26275},
 			expr: &choiceExpr{
-				pos: position{line: 1069, col: 5, offset: 26317},
+				pos: position{line: 1069, col: 5, offset: 26293},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1069, col: 5, offset: 26317},
+						pos:  position{line: 1069, col: 5, offset: 26293},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 26327},
+						pos: position{line: 1070, col: 5, offset: 26303},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1070, col: 5, offset: 26327},
+							pos:  position{line: 1070, col: 5, offset: 26303},
 							name: "__",
 						},
 					},
@@ -7422,51 +7422,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1072, col: 1, offset: 26355},
+			pos:  position{line: 1072, col: 1, offset: 26331},
 			expr: &actionExpr{
-				pos: position{line: 1073, col: 5, offset: 26365},
+				pos: position{line: 1073, col: 5, offset: 26341},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1073, col: 5, offset: 26365},
+					pos: position{line: 1073, col: 5, offset: 26341},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1073, col: 5, offset: 26365},
+							pos:   position{line: 1073, col: 5, offset: 26341},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1073, col: 11, offset: 26371},
+								pos:  position{line: 1073, col: 11, offset: 26347},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 16, offset: 26376},
+							pos:   position{line: 1073, col: 16, offset: 26352},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1073, col: 21, offset: 26381},
+								pos: position{line: 1073, col: 21, offset: 26357},
 								expr: &actionExpr{
-									pos: position{line: 1073, col: 22, offset: 26382},
+									pos: position{line: 1073, col: 22, offset: 26358},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1073, col: 22, offset: 26382},
+										pos: position{line: 1073, col: 22, offset: 26358},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1073, col: 22, offset: 26382},
+												pos:  position{line: 1073, col: 22, offset: 26358},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1073, col: 25, offset: 26385},
+												pos:        position{line: 1073, col: 25, offset: 26361},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1073, col: 29, offset: 26389},
+												pos:  position{line: 1073, col: 29, offset: 26365},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1073, col: 32, offset: 26392},
+												pos:   position{line: 1073, col: 32, offset: 26368},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1073, col: 34, offset: 26394},
+													pos:  position{line: 1073, col: 34, offset: 26370},
 													name: "Expr",
 												},
 											},
@@ -7483,76 +7483,76 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1077, col: 1, offset: 26467},
+			pos:  position{line: 1077, col: 1, offset: 26443},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 5, offset: 26479},
+				pos: position{line: 1078, col: 5, offset: 26455},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 5, offset: 26479},
+						pos:  position{line: 1078, col: 5, offset: 26455},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1079, col: 5, offset: 26492},
+						pos:  position{line: 1079, col: 5, offset: 26468},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1080, col: 5, offset: 26503},
+						pos:  position{line: 1080, col: 5, offset: 26479},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1081, col: 5, offset: 26513},
+						pos:  position{line: 1081, col: 5, offset: 26489},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1082, col: 5, offset: 26521},
+						pos:  position{line: 1082, col: 5, offset: 26497},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1083, col: 5, offset: 26529},
+						pos:  position{line: 1083, col: 5, offset: 26505},
 						name: "SQLTimeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1084, col: 5, offset: 26546},
+						pos:  position{line: 1084, col: 5, offset: 26522},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1085, col: 5, offset: 26558},
+						pos:  position{line: 1085, col: 5, offset: 26534},
 						name: "Identifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1086, col: 5, offset: 26573},
+						pos:  position{line: 1086, col: 5, offset: 26549},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1087, col: 5, offset: 26583},
+						pos: position{line: 1087, col: 5, offset: 26559},
 						run: (*parser).callonPrimary11,
 						expr: &seqExpr{
-							pos: position{line: 1087, col: 5, offset: 26583},
+							pos: position{line: 1087, col: 5, offset: 26559},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1087, col: 5, offset: 26583},
+									pos:        position{line: 1087, col: 5, offset: 26559},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1087, col: 9, offset: 26587},
+									pos:  position{line: 1087, col: 9, offset: 26563},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1087, col: 12, offset: 26590},
+									pos:   position{line: 1087, col: 12, offset: 26566},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1087, col: 17, offset: 26595},
+										pos:  position{line: 1087, col: 17, offset: 26571},
 										name: "UnnestExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1087, col: 28, offset: 26606},
+									pos:  position{line: 1087, col: 28, offset: 26582},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1087, col: 31, offset: 26609},
+									pos:        position{line: 1087, col: 31, offset: 26585},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7561,35 +7561,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1088, col: 5, offset: 26638},
+						pos: position{line: 1088, col: 5, offset: 26614},
 						run: (*parser).callonPrimary19,
 						expr: &seqExpr{
-							pos: position{line: 1088, col: 5, offset: 26638},
+							pos: position{line: 1088, col: 5, offset: 26614},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1088, col: 5, offset: 26638},
+									pos:        position{line: 1088, col: 5, offset: 26614},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1088, col: 9, offset: 26642},
+									pos:  position{line: 1088, col: 9, offset: 26618},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1088, col: 12, offset: 26645},
+									pos:   position{line: 1088, col: 12, offset: 26621},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1088, col: 17, offset: 26650},
+										pos:  position{line: 1088, col: 17, offset: 26626},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1088, col: 22, offset: 26655},
+									pos:  position{line: 1088, col: 22, offset: 26631},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1088, col: 25, offset: 26658},
+									pos:        position{line: 1088, col: 25, offset: 26634},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7598,35 +7598,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1089, col: 5, offset: 26687},
+						pos: position{line: 1089, col: 5, offset: 26663},
 						run: (*parser).callonPrimary27,
 						expr: &seqExpr{
-							pos: position{line: 1089, col: 5, offset: 26687},
+							pos: position{line: 1089, col: 5, offset: 26663},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1089, col: 5, offset: 26687},
+									pos:        position{line: 1089, col: 5, offset: 26663},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1089, col: 9, offset: 26691},
+									pos:  position{line: 1089, col: 9, offset: 26667},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1089, col: 12, offset: 26694},
+									pos:   position{line: 1089, col: 12, offset: 26670},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1089, col: 17, offset: 26699},
+										pos:  position{line: 1089, col: 17, offset: 26675},
 										name: "QueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1089, col: 27, offset: 26709},
+									pos:  position{line: 1089, col: 27, offset: 26685},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1089, col: 30, offset: 26712},
+									pos:        position{line: 1089, col: 30, offset: 26688},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7641,53 +7641,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1091, col: 1, offset: 26738},
+			pos:  position{line: 1091, col: 1, offset: 26714},
 			expr: &choiceExpr{
-				pos: position{line: 1092, col: 5, offset: 26751},
+				pos: position{line: 1092, col: 5, offset: 26727},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1092, col: 5, offset: 26751},
+						pos: position{line: 1092, col: 5, offset: 26727},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1092, col: 5, offset: 26751},
+							pos: position{line: 1092, col: 5, offset: 26727},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1092, col: 5, offset: 26751},
+									pos:  position{line: 1092, col: 5, offset: 26727},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1092, col: 10, offset: 26756},
+									pos:   position{line: 1092, col: 10, offset: 26732},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1092, col: 16, offset: 26762},
+										pos: position{line: 1092, col: 16, offset: 26738},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1092, col: 16, offset: 26762},
+											pos:  position{line: 1092, col: 16, offset: 26738},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1092, col: 22, offset: 26768},
+									pos:   position{line: 1092, col: 22, offset: 26744},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1092, col: 28, offset: 26774},
+										pos: position{line: 1092, col: 28, offset: 26750},
 										expr: &seqExpr{
-											pos: position{line: 1092, col: 29, offset: 26775},
+											pos: position{line: 1092, col: 29, offset: 26751},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1092, col: 29, offset: 26775},
+													pos:  position{line: 1092, col: 29, offset: 26751},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1092, col: 31, offset: 26777},
+													pos:  position{line: 1092, col: 31, offset: 26753},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1092, col: 36, offset: 26782},
+													pos:  position{line: 1092, col: 36, offset: 26758},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1092, col: 38, offset: 26784},
+													pos:  position{line: 1092, col: 38, offset: 26760},
 													name: "Expr",
 												},
 											},
@@ -7695,24 +7695,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1092, col: 45, offset: 26791},
+									pos:  position{line: 1092, col: 45, offset: 26767},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1092, col: 47, offset: 26793},
+									pos:  position{line: 1092, col: 47, offset: 26769},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1092, col: 51, offset: 26797},
+									pos: position{line: 1092, col: 51, offset: 26773},
 									expr: &seqExpr{
-										pos: position{line: 1092, col: 52, offset: 26798},
+										pos: position{line: 1092, col: 52, offset: 26774},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1092, col: 52, offset: 26798},
+												pos:  position{line: 1092, col: 52, offset: 26774},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1092, col: 54, offset: 26800},
+												pos:  position{line: 1092, col: 54, offset: 26776},
 												name: "CASE",
 											},
 										},
@@ -7722,60 +7722,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1116, col: 5, offset: 27449},
+						pos: position{line: 1116, col: 5, offset: 27425},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1116, col: 5, offset: 27449},
+							pos: position{line: 1116, col: 5, offset: 27425},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 5, offset: 27449},
+									pos:  position{line: 1116, col: 5, offset: 27425},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 10, offset: 27454},
+									pos:  position{line: 1116, col: 10, offset: 27430},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1116, col: 12, offset: 27456},
+									pos:   position{line: 1116, col: 12, offset: 27432},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1116, col: 17, offset: 27461},
+										pos:  position{line: 1116, col: 17, offset: 27437},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1116, col: 22, offset: 27466},
+									pos:   position{line: 1116, col: 22, offset: 27442},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1116, col: 28, offset: 27472},
+										pos: position{line: 1116, col: 28, offset: 27448},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1116, col: 28, offset: 27472},
+											pos:  position{line: 1116, col: 28, offset: 27448},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1116, col: 34, offset: 27478},
+									pos:   position{line: 1116, col: 34, offset: 27454},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1116, col: 40, offset: 27484},
+										pos: position{line: 1116, col: 40, offset: 27460},
 										expr: &seqExpr{
-											pos: position{line: 1116, col: 41, offset: 27485},
+											pos: position{line: 1116, col: 41, offset: 27461},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1116, col: 41, offset: 27485},
+													pos:  position{line: 1116, col: 41, offset: 27461},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1116, col: 43, offset: 27487},
+													pos:  position{line: 1116, col: 43, offset: 27463},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1116, col: 48, offset: 27492},
+													pos:  position{line: 1116, col: 48, offset: 27468},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1116, col: 50, offset: 27494},
+													pos:  position{line: 1116, col: 50, offset: 27470},
 													name: "Expr",
 												},
 											},
@@ -7783,24 +7783,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 57, offset: 27501},
+									pos:  position{line: 1116, col: 57, offset: 27477},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 59, offset: 27503},
+									pos:  position{line: 1116, col: 59, offset: 27479},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1116, col: 63, offset: 27507},
+									pos: position{line: 1116, col: 63, offset: 27483},
 									expr: &seqExpr{
-										pos: position{line: 1116, col: 64, offset: 27508},
+										pos: position{line: 1116, col: 64, offset: 27484},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1116, col: 64, offset: 27508},
+												pos:  position{line: 1116, col: 64, offset: 27484},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1116, col: 66, offset: 27510},
+												pos:  position{line: 1116, col: 66, offset: 27486},
 												name: "CASE",
 											},
 										},
@@ -7816,50 +7816,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1129, col: 1, offset: 27816},
+			pos:  position{line: 1129, col: 1, offset: 27792},
 			expr: &actionExpr{
-				pos: position{line: 1130, col: 5, offset: 27825},
+				pos: position{line: 1130, col: 5, offset: 27801},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1130, col: 5, offset: 27825},
+					pos: position{line: 1130, col: 5, offset: 27801},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1130, col: 5, offset: 27825},
+							pos:  position{line: 1130, col: 5, offset: 27801},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1130, col: 7, offset: 27827},
+							pos:  position{line: 1130, col: 7, offset: 27803},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1130, col: 12, offset: 27832},
+							pos:  position{line: 1130, col: 12, offset: 27808},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1130, col: 14, offset: 27834},
+							pos:   position{line: 1130, col: 14, offset: 27810},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1130, col: 19, offset: 27839},
+								pos:  position{line: 1130, col: 19, offset: 27815},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1130, col: 24, offset: 27844},
+							pos:  position{line: 1130, col: 24, offset: 27820},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1130, col: 26, offset: 27846},
+							pos:  position{line: 1130, col: 26, offset: 27822},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1130, col: 31, offset: 27851},
+							pos:  position{line: 1130, col: 31, offset: 27827},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1130, col: 33, offset: 27853},
+							pos:   position{line: 1130, col: 33, offset: 27829},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1130, col: 38, offset: 27858},
+								pos:  position{line: 1130, col: 38, offset: 27834},
 								name: "Expr",
 							},
 						},
@@ -7871,46 +7871,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnnestExpr",
-			pos:  position{line: 1139, col: 1, offset: 28017},
+			pos:  position{line: 1139, col: 1, offset: 27989},
 			expr: &actionExpr{
-				pos: position{line: 1140, col: 5, offset: 28032},
+				pos: position{line: 1140, col: 5, offset: 28004},
 				run: (*parser).callonUnnestExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1140, col: 5, offset: 28032},
+					pos: position{line: 1140, col: 5, offset: 28004},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1140, col: 5, offset: 28032},
+							pos:  position{line: 1140, col: 5, offset: 28004},
 							name: "UNNEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1140, col: 12, offset: 28039},
+							pos:  position{line: 1140, col: 12, offset: 28011},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1140, col: 14, offset: 28041},
+							pos:   position{line: 1140, col: 14, offset: 28013},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1140, col: 16, offset: 28043},
+								pos:  position{line: 1140, col: 16, offset: 28015},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1140, col: 21, offset: 28048},
+							pos:  position{line: 1140, col: 21, offset: 28020},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1140, col: 24, offset: 28051},
+							pos:  position{line: 1140, col: 24, offset: 28023},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1140, col: 29, offset: 28056},
+							pos:  position{line: 1140, col: 29, offset: 28028},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1140, col: 32, offset: 28059},
+							pos:   position{line: 1140, col: 32, offset: 28031},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1140, col: 37, offset: 28064},
+								pos:  position{line: 1140, col: 37, offset: 28036},
 								name: "Seq",
 							},
 						},
@@ -7922,15 +7922,15 @@ var g = &grammar{
 		},
 		{
 			name: "QueryExpr",
-			pos:  position{line: 1149, col: 1, offset: 28242},
+			pos:  position{line: 1149, col: 1, offset: 28214},
 			expr: &actionExpr{
-				pos: position{line: 1150, col: 5, offset: 28256},
+				pos: position{line: 1150, col: 5, offset: 28228},
 				run: (*parser).callonQueryExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 1150, col: 5, offset: 28256},
+					pos:   position{line: 1150, col: 5, offset: 28228},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1150, col: 10, offset: 28261},
+						pos:  position{line: 1150, col: 10, offset: 28233},
 						name: "Seq",
 					},
 				},
@@ -7940,37 +7940,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1158, col: 1, offset: 28399},
+			pos:  position{line: 1158, col: 1, offset: 28371},
 			expr: &actionExpr{
-				pos: position{line: 1159, col: 5, offset: 28410},
+				pos: position{line: 1159, col: 5, offset: 28382},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1159, col: 5, offset: 28410},
+					pos: position{line: 1159, col: 5, offset: 28382},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1159, col: 5, offset: 28410},
+							pos:        position{line: 1159, col: 5, offset: 28382},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 9, offset: 28414},
+							pos:  position{line: 1159, col: 9, offset: 28386},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1159, col: 12, offset: 28417},
+							pos:   position{line: 1159, col: 12, offset: 28389},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1159, col: 18, offset: 28423},
+								pos:  position{line: 1159, col: 18, offset: 28395},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 30, offset: 28435},
+							pos:  position{line: 1159, col: 30, offset: 28407},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1159, col: 33, offset: 28438},
+							pos:        position{line: 1159, col: 33, offset: 28410},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7983,31 +7983,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1167, col: 1, offset: 28596},
+			pos:  position{line: 1167, col: 1, offset: 28568},
 			expr: &choiceExpr{
-				pos: position{line: 1168, col: 5, offset: 28612},
+				pos: position{line: 1168, col: 5, offset: 28584},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1168, col: 5, offset: 28612},
+						pos: position{line: 1168, col: 5, offset: 28584},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1168, col: 5, offset: 28612},
+							pos: position{line: 1168, col: 5, offset: 28584},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1168, col: 5, offset: 28612},
+									pos:   position{line: 1168, col: 5, offset: 28584},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1168, col: 11, offset: 28618},
+										pos:  position{line: 1168, col: 11, offset: 28590},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1168, col: 22, offset: 28629},
+									pos:   position{line: 1168, col: 22, offset: 28601},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1168, col: 27, offset: 28634},
+										pos: position{line: 1168, col: 27, offset: 28606},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1168, col: 27, offset: 28634},
+											pos:  position{line: 1168, col: 27, offset: 28606},
 											name: "RecordElemTail",
 										},
 									},
@@ -8016,10 +8016,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1171, col: 5, offset: 28697},
+						pos: position{line: 1171, col: 5, offset: 28669},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1171, col: 5, offset: 28697},
+							pos:  position{line: 1171, col: 5, offset: 28669},
 							name: "__",
 						},
 					},
@@ -8030,32 +8030,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1173, col: 1, offset: 28721},
+			pos:  position{line: 1173, col: 1, offset: 28693},
 			expr: &actionExpr{
-				pos: position{line: 1173, col: 18, offset: 28738},
+				pos: position{line: 1173, col: 18, offset: 28710},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1173, col: 18, offset: 28738},
+					pos: position{line: 1173, col: 18, offset: 28710},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1173, col: 18, offset: 28738},
+							pos:  position{line: 1173, col: 18, offset: 28710},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1173, col: 21, offset: 28741},
+							pos:        position{line: 1173, col: 21, offset: 28713},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1173, col: 25, offset: 28745},
+							pos:  position{line: 1173, col: 25, offset: 28717},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1173, col: 28, offset: 28748},
+							pos:   position{line: 1173, col: 28, offset: 28720},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1173, col: 33, offset: 28753},
+								pos:  position{line: 1173, col: 33, offset: 28725},
 								name: "RecordElem",
 							},
 						},
@@ -8067,20 +8067,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1175, col: 1, offset: 28786},
+			pos:  position{line: 1175, col: 1, offset: 28758},
 			expr: &choiceExpr{
-				pos: position{line: 1176, col: 5, offset: 28801},
+				pos: position{line: 1176, col: 5, offset: 28773},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1176, col: 5, offset: 28801},
+						pos:  position{line: 1176, col: 5, offset: 28773},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1177, col: 5, offset: 28812},
+						pos:  position{line: 1177, col: 5, offset: 28784},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1178, col: 5, offset: 28826},
+						pos:  position{line: 1178, col: 5, offset: 28798},
 						name: "Identifier",
 					},
 				},
@@ -8090,28 +8090,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1180, col: 1, offset: 28838},
+			pos:  position{line: 1180, col: 1, offset: 28810},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 5, offset: 28849},
+				pos: position{line: 1181, col: 5, offset: 28821},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1181, col: 5, offset: 28849},
+					pos: position{line: 1181, col: 5, offset: 28821},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1181, col: 5, offset: 28849},
+							pos:        position{line: 1181, col: 5, offset: 28821},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 11, offset: 28855},
+							pos:  position{line: 1181, col: 11, offset: 28827},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 14, offset: 28858},
+							pos:   position{line: 1181, col: 14, offset: 28830},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 19, offset: 28863},
+								pos:  position{line: 1181, col: 19, offset: 28835},
 								name: "Expr",
 							},
 						},
@@ -8123,40 +8123,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1185, col: 1, offset: 28959},
+			pos:  position{line: 1185, col: 1, offset: 28931},
 			expr: &actionExpr{
-				pos: position{line: 1186, col: 5, offset: 28973},
+				pos: position{line: 1186, col: 5, offset: 28945},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1186, col: 5, offset: 28973},
+					pos: position{line: 1186, col: 5, offset: 28945},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1186, col: 5, offset: 28973},
+							pos:   position{line: 1186, col: 5, offset: 28945},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1186, col: 10, offset: 28978},
+								pos:  position{line: 1186, col: 10, offset: 28950},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1186, col: 15, offset: 28983},
+							pos:  position{line: 1186, col: 15, offset: 28955},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1186, col: 18, offset: 28986},
+							pos:        position{line: 1186, col: 18, offset: 28958},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1186, col: 22, offset: 28990},
+							pos:  position{line: 1186, col: 22, offset: 28962},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1186, col: 25, offset: 28993},
+							pos:   position{line: 1186, col: 25, offset: 28965},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1186, col: 31, offset: 28999},
+								pos:  position{line: 1186, col: 31, offset: 28971},
 								name: "Expr",
 							},
 						},
@@ -8168,37 +8168,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1195, col: 1, offset: 29168},
+			pos:  position{line: 1195, col: 1, offset: 29140},
 			expr: &actionExpr{
-				pos: position{line: 1196, col: 5, offset: 29178},
+				pos: position{line: 1196, col: 5, offset: 29150},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1196, col: 5, offset: 29178},
+					pos: position{line: 1196, col: 5, offset: 29150},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1196, col: 5, offset: 29178},
+							pos:        position{line: 1196, col: 5, offset: 29150},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1196, col: 9, offset: 29182},
+							pos:  position{line: 1196, col: 9, offset: 29154},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1196, col: 12, offset: 29185},
+							pos:   position{line: 1196, col: 12, offset: 29157},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1196, col: 18, offset: 29191},
+								pos:  position{line: 1196, col: 18, offset: 29163},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1196, col: 30, offset: 29203},
+							pos:  position{line: 1196, col: 30, offset: 29175},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1196, col: 33, offset: 29206},
+							pos:        position{line: 1196, col: 33, offset: 29178},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8211,37 +8211,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1204, col: 1, offset: 29362},
+			pos:  position{line: 1204, col: 1, offset: 29334},
 			expr: &actionExpr{
-				pos: position{line: 1205, col: 5, offset: 29370},
+				pos: position{line: 1205, col: 5, offset: 29342},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1205, col: 5, offset: 29370},
+					pos: position{line: 1205, col: 5, offset: 29342},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1205, col: 5, offset: 29370},
+							pos:        position{line: 1205, col: 5, offset: 29342},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1205, col: 10, offset: 29375},
+							pos:  position{line: 1205, col: 10, offset: 29347},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1205, col: 13, offset: 29378},
+							pos:   position{line: 1205, col: 13, offset: 29350},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1205, col: 19, offset: 29384},
+								pos:  position{line: 1205, col: 19, offset: 29356},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1205, col: 31, offset: 29396},
+							pos:  position{line: 1205, col: 31, offset: 29368},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1205, col: 34, offset: 29399},
+							pos:        position{line: 1205, col: 34, offset: 29371},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8254,54 +8254,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1213, col: 1, offset: 29552},
+			pos:  position{line: 1213, col: 1, offset: 29524},
 			expr: &choiceExpr{
-				pos: position{line: 1214, col: 5, offset: 29568},
+				pos: position{line: 1214, col: 5, offset: 29540},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1214, col: 5, offset: 29568},
+						pos: position{line: 1214, col: 5, offset: 29540},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1214, col: 5, offset: 29568},
+							pos: position{line: 1214, col: 5, offset: 29540},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1214, col: 5, offset: 29568},
+									pos:   position{line: 1214, col: 5, offset: 29540},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1214, col: 11, offset: 29574},
+										pos:  position{line: 1214, col: 11, offset: 29546},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1214, col: 22, offset: 29585},
+									pos:   position{line: 1214, col: 22, offset: 29557},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1214, col: 27, offset: 29590},
+										pos: position{line: 1214, col: 27, offset: 29562},
 										expr: &actionExpr{
-											pos: position{line: 1214, col: 28, offset: 29591},
+											pos: position{line: 1214, col: 28, offset: 29563},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1214, col: 28, offset: 29591},
+												pos: position{line: 1214, col: 28, offset: 29563},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1214, col: 28, offset: 29591},
+														pos:  position{line: 1214, col: 28, offset: 29563},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1214, col: 31, offset: 29594},
+														pos:        position{line: 1214, col: 31, offset: 29566},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1214, col: 35, offset: 29598},
+														pos:  position{line: 1214, col: 35, offset: 29570},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1214, col: 38, offset: 29601},
+														pos:   position{line: 1214, col: 38, offset: 29573},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1214, col: 40, offset: 29603},
+															pos:  position{line: 1214, col: 40, offset: 29575},
 															name: "VectorElem",
 														},
 													},
@@ -8314,10 +8314,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1217, col: 5, offset: 29685},
+						pos: position{line: 1217, col: 5, offset: 29657},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1217, col: 5, offset: 29685},
+							pos:  position{line: 1217, col: 5, offset: 29657},
 							name: "__",
 						},
 					},
@@ -8328,22 +8328,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1219, col: 1, offset: 29709},
+			pos:  position{line: 1219, col: 1, offset: 29681},
 			expr: &choiceExpr{
-				pos: position{line: 1220, col: 5, offset: 29724},
+				pos: position{line: 1220, col: 5, offset: 29696},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 5, offset: 29724},
+						pos:  position{line: 1220, col: 5, offset: 29696},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1221, col: 5, offset: 29735},
+						pos: position{line: 1221, col: 5, offset: 29707},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1221, col: 5, offset: 29735},
+							pos:   position{line: 1221, col: 5, offset: 29707},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1221, col: 7, offset: 29737},
+								pos:  position{line: 1221, col: 7, offset: 29709},
 								name: "Expr",
 							},
 						},
@@ -8355,37 +8355,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1223, col: 1, offset: 29828},
+			pos:  position{line: 1223, col: 1, offset: 29800},
 			expr: &actionExpr{
-				pos: position{line: 1224, col: 5, offset: 29836},
+				pos: position{line: 1224, col: 5, offset: 29808},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1224, col: 5, offset: 29836},
+					pos: position{line: 1224, col: 5, offset: 29808},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1224, col: 5, offset: 29836},
+							pos:        position{line: 1224, col: 5, offset: 29808},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1224, col: 10, offset: 29841},
+							pos:  position{line: 1224, col: 10, offset: 29813},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1224, col: 13, offset: 29844},
+							pos:   position{line: 1224, col: 13, offset: 29816},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1224, col: 19, offset: 29850},
+								pos:  position{line: 1224, col: 19, offset: 29822},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1224, col: 27, offset: 29858},
+							pos:  position{line: 1224, col: 27, offset: 29830},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1224, col: 30, offset: 29861},
+							pos:        position{line: 1224, col: 30, offset: 29833},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8398,31 +8398,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1232, col: 1, offset: 30015},
+			pos:  position{line: 1232, col: 1, offset: 29987},
 			expr: &choiceExpr{
-				pos: position{line: 1233, col: 5, offset: 30027},
+				pos: position{line: 1233, col: 5, offset: 29999},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1233, col: 5, offset: 30027},
+						pos: position{line: 1233, col: 5, offset: 29999},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1233, col: 5, offset: 30027},
+							pos: position{line: 1233, col: 5, offset: 29999},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1233, col: 5, offset: 30027},
+									pos:   position{line: 1233, col: 5, offset: 29999},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1233, col: 11, offset: 30033},
+										pos:  position{line: 1233, col: 11, offset: 30005},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1233, col: 17, offset: 30039},
+									pos:   position{line: 1233, col: 17, offset: 30011},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1233, col: 22, offset: 30044},
+										pos: position{line: 1233, col: 22, offset: 30016},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1233, col: 22, offset: 30044},
+											pos:  position{line: 1233, col: 22, offset: 30016},
 											name: "EntryTail",
 										},
 									},
@@ -8431,10 +8431,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1236, col: 5, offset: 30102},
+						pos: position{line: 1236, col: 5, offset: 30074},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1236, col: 5, offset: 30102},
+							pos:  position{line: 1236, col: 5, offset: 30074},
 							name: "__",
 						},
 					},
@@ -8445,32 +8445,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1239, col: 1, offset: 30127},
+			pos:  position{line: 1239, col: 1, offset: 30099},
 			expr: &actionExpr{
-				pos: position{line: 1239, col: 13, offset: 30139},
+				pos: position{line: 1239, col: 13, offset: 30111},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1239, col: 13, offset: 30139},
+					pos: position{line: 1239, col: 13, offset: 30111},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1239, col: 13, offset: 30139},
+							pos:  position{line: 1239, col: 13, offset: 30111},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1239, col: 16, offset: 30142},
+							pos:        position{line: 1239, col: 16, offset: 30114},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1239, col: 20, offset: 30146},
+							pos:  position{line: 1239, col: 20, offset: 30118},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1239, col: 23, offset: 30149},
+							pos:   position{line: 1239, col: 23, offset: 30121},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1239, col: 25, offset: 30151},
+								pos:  position{line: 1239, col: 25, offset: 30123},
 								name: "Entry",
 							},
 						},
@@ -8482,40 +8482,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1241, col: 1, offset: 30176},
+			pos:  position{line: 1241, col: 1, offset: 30148},
 			expr: &actionExpr{
-				pos: position{line: 1242, col: 5, offset: 30186},
+				pos: position{line: 1242, col: 5, offset: 30158},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1242, col: 5, offset: 30186},
+					pos: position{line: 1242, col: 5, offset: 30158},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1242, col: 5, offset: 30186},
+							pos:   position{line: 1242, col: 5, offset: 30158},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1242, col: 9, offset: 30190},
+								pos:  position{line: 1242, col: 9, offset: 30162},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1242, col: 14, offset: 30195},
+							pos:  position{line: 1242, col: 14, offset: 30167},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1242, col: 17, offset: 30198},
+							pos:        position{line: 1242, col: 17, offset: 30170},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1242, col: 21, offset: 30202},
+							pos:  position{line: 1242, col: 21, offset: 30174},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1242, col: 24, offset: 30205},
+							pos:   position{line: 1242, col: 24, offset: 30177},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1242, col: 30, offset: 30211},
+								pos:  position{line: 1242, col: 30, offset: 30183},
 								name: "Expr",
 							},
 						},
@@ -8527,61 +8527,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1246, col: 1, offset: 30314},
+			pos:  position{line: 1246, col: 1, offset: 30286},
 			expr: &actionExpr{
-				pos: position{line: 1247, col: 5, offset: 30324},
+				pos: position{line: 1247, col: 5, offset: 30296},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1247, col: 5, offset: 30324},
+					pos: position{line: 1247, col: 5, offset: 30296},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1247, col: 5, offset: 30324},
+							pos:        position{line: 1247, col: 5, offset: 30296},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 9, offset: 30328},
+							pos:  position{line: 1247, col: 9, offset: 30300},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1247, col: 12, offset: 30331},
+							pos:   position{line: 1247, col: 12, offset: 30303},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1247, col: 18, offset: 30337},
+								pos:  position{line: 1247, col: 18, offset: 30309},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1247, col: 23, offset: 30342},
+							pos:   position{line: 1247, col: 23, offset: 30314},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1247, col: 28, offset: 30347},
+								pos: position{line: 1247, col: 28, offset: 30319},
 								expr: &actionExpr{
-									pos: position{line: 1247, col: 29, offset: 30348},
+									pos: position{line: 1247, col: 29, offset: 30320},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1247, col: 29, offset: 30348},
+										pos: position{line: 1247, col: 29, offset: 30320},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1247, col: 29, offset: 30348},
+												pos:  position{line: 1247, col: 29, offset: 30320},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1247, col: 32, offset: 30351},
+												pos:        position{line: 1247, col: 32, offset: 30323},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1247, col: 36, offset: 30355},
+												pos:  position{line: 1247, col: 36, offset: 30327},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1247, col: 39, offset: 30358},
+												pos:   position{line: 1247, col: 39, offset: 30330},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1247, col: 41, offset: 30360},
+													pos:  position{line: 1247, col: 41, offset: 30332},
 													name: "Expr",
 												},
 											},
@@ -8591,11 +8591,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 66, offset: 30385},
+							pos:  position{line: 1247, col: 66, offset: 30357},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1247, col: 69, offset: 30388},
+							pos:        position{line: 1247, col: 69, offset: 30360},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8608,39 +8608,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1255, col: 1, offset: 30547},
+			pos:  position{line: 1255, col: 1, offset: 30519},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 5, offset: 30564},
+				pos: position{line: 1256, col: 5, offset: 30536},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1256, col: 5, offset: 30564},
+					pos: position{line: 1256, col: 5, offset: 30536},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1256, col: 5, offset: 30564},
+							pos:   position{line: 1256, col: 5, offset: 30536},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1256, col: 10, offset: 30569},
+								pos: position{line: 1256, col: 10, offset: 30541},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1256, col: 10, offset: 30569},
+										pos:  position{line: 1256, col: 10, offset: 30541},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1256, col: 17, offset: 30576},
+										pos:  position{line: 1256, col: 17, offset: 30548},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 28, offset: 30587},
+							pos:  position{line: 1256, col: 28, offset: 30559},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1256, col: 30, offset: 30589},
+							pos:   position{line: 1256, col: 30, offset: 30561},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1256, col: 32, offset: 30591},
+								pos:  position{line: 1256, col: 32, offset: 30563},
 								name: "StringLiteral",
 							},
 						},
@@ -8652,56 +8652,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1267, col: 1, offset: 30808},
+			pos:  position{line: 1267, col: 1, offset: 30780},
 			expr: &choiceExpr{
-				pos: position{line: 1268, col: 5, offset: 30820},
+				pos: position{line: 1268, col: 5, offset: 30792},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1268, col: 5, offset: 30820},
+						pos:  position{line: 1268, col: 5, offset: 30792},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1269, col: 5, offset: 30836},
+						pos:  position{line: 1269, col: 5, offset: 30808},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1270, col: 5, offset: 30854},
+						pos:  position{line: 1270, col: 5, offset: 30826},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1271, col: 5, offset: 30866},
+						pos:  position{line: 1271, col: 5, offset: 30838},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1272, col: 5, offset: 30884},
+						pos:  position{line: 1272, col: 5, offset: 30856},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 30903},
+						pos:  position{line: 1273, col: 5, offset: 30875},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1274, col: 5, offset: 30920},
+						pos:  position{line: 1274, col: 5, offset: 30892},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1275, col: 5, offset: 30933},
+						pos:  position{line: 1275, col: 5, offset: 30905},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1276, col: 5, offset: 30942},
+						pos:  position{line: 1276, col: 5, offset: 30914},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1277, col: 5, offset: 30959},
+						pos:  position{line: 1277, col: 5, offset: 30931},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 30978},
+						pos:  position{line: 1278, col: 5, offset: 30950},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 5, offset: 30997},
+						pos:  position{line: 1279, col: 5, offset: 30969},
 						name: "NullLiteral",
 					},
 				},
@@ -8711,28 +8711,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1281, col: 1, offset: 31010},
+			pos:  position{line: 1281, col: 1, offset: 30982},
 			expr: &choiceExpr{
-				pos: position{line: 1282, col: 5, offset: 31028},
+				pos: position{line: 1282, col: 5, offset: 31000},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1282, col: 5, offset: 31028},
+						pos: position{line: 1282, col: 5, offset: 31000},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1282, col: 5, offset: 31028},
+							pos: position{line: 1282, col: 5, offset: 31000},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1282, col: 5, offset: 31028},
+									pos:   position{line: 1282, col: 5, offset: 31000},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1282, col: 7, offset: 31030},
+										pos:  position{line: 1282, col: 7, offset: 31002},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1282, col: 14, offset: 31037},
+									pos: position{line: 1282, col: 14, offset: 31009},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1282, col: 15, offset: 31038},
+										pos:  position{line: 1282, col: 15, offset: 31010},
 										name: "IdentifierRest",
 									},
 								},
@@ -8740,13 +8740,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1285, col: 5, offset: 31118},
+						pos: position{line: 1285, col: 5, offset: 31090},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1285, col: 5, offset: 31118},
+							pos:   position{line: 1285, col: 5, offset: 31090},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1285, col: 7, offset: 31120},
+								pos:  position{line: 1285, col: 7, offset: 31092},
 								name: "IP4Net",
 							},
 						},
@@ -8758,35 +8758,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1289, col: 1, offset: 31189},
+			pos:  position{line: 1289, col: 1, offset: 31161},
 			expr: &choiceExpr{
-				pos: position{line: 1290, col: 5, offset: 31208},
+				pos: position{line: 1290, col: 5, offset: 31180},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 31208},
+						pos: position{line: 1290, col: 5, offset: 31180},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1290, col: 5, offset: 31208},
+							pos: position{line: 1290, col: 5, offset: 31180},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1290, col: 5, offset: 31208},
+									pos:   position{line: 1290, col: 5, offset: 31180},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1290, col: 7, offset: 31210},
+										pos:  position{line: 1290, col: 7, offset: 31182},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1290, col: 11, offset: 31214},
+									pos: position{line: 1290, col: 11, offset: 31186},
 									expr: &choiceExpr{
-										pos: position{line: 1290, col: 13, offset: 31216},
+										pos: position{line: 1290, col: 13, offset: 31188},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1290, col: 13, offset: 31216},
+												pos:  position{line: 1290, col: 13, offset: 31188},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1290, col: 30, offset: 31233},
+												pos:  position{line: 1290, col: 30, offset: 31205},
 												name: "TypeLiteral",
 											},
 										},
@@ -8796,13 +8796,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1293, col: 5, offset: 31310},
+						pos: position{line: 1293, col: 5, offset: 31282},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1293, col: 5, offset: 31310},
+							pos:   position{line: 1293, col: 5, offset: 31282},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1293, col: 7, offset: 31312},
+								pos:  position{line: 1293, col: 7, offset: 31284},
 								name: "IP",
 							},
 						},
@@ -8814,15 +8814,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1297, col: 1, offset: 31376},
+			pos:  position{line: 1297, col: 1, offset: 31348},
 			expr: &actionExpr{
-				pos: position{line: 1298, col: 5, offset: 31393},
+				pos: position{line: 1298, col: 5, offset: 31365},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1298, col: 5, offset: 31393},
+					pos:   position{line: 1298, col: 5, offset: 31365},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1298, col: 7, offset: 31395},
+						pos:  position{line: 1298, col: 7, offset: 31367},
 						name: "FloatString",
 					},
 				},
@@ -8832,15 +8832,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1302, col: 1, offset: 31473},
+			pos:  position{line: 1302, col: 1, offset: 31445},
 			expr: &actionExpr{
-				pos: position{line: 1303, col: 5, offset: 31492},
+				pos: position{line: 1303, col: 5, offset: 31464},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1303, col: 5, offset: 31492},
+					pos:   position{line: 1303, col: 5, offset: 31464},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1303, col: 7, offset: 31494},
+						pos:  position{line: 1303, col: 7, offset: 31466},
 						name: "IntString",
 					},
 				},
@@ -8850,23 +8850,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1307, col: 1, offset: 31568},
+			pos:  position{line: 1307, col: 1, offset: 31540},
 			expr: &choiceExpr{
-				pos: position{line: 1308, col: 5, offset: 31587},
+				pos: position{line: 1308, col: 5, offset: 31559},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1308, col: 5, offset: 31587},
+						pos: position{line: 1308, col: 5, offset: 31559},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1308, col: 5, offset: 31587},
+							pos:  position{line: 1308, col: 5, offset: 31559},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 31645},
+						pos: position{line: 1309, col: 5, offset: 31617},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1309, col: 5, offset: 31645},
+							pos:  position{line: 1309, col: 5, offset: 31617},
 							name: "FALSE",
 						},
 					},
@@ -8877,12 +8877,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1311, col: 1, offset: 31701},
+			pos:  position{line: 1311, col: 1, offset: 31673},
 			expr: &actionExpr{
-				pos: position{line: 1312, col: 5, offset: 31717},
+				pos: position{line: 1312, col: 5, offset: 31689},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1312, col: 5, offset: 31717},
+					pos:  position{line: 1312, col: 5, offset: 31689},
 					name: "NULL",
 				},
 			},
@@ -8891,23 +8891,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1314, col: 1, offset: 31767},
+			pos:  position{line: 1314, col: 1, offset: 31739},
 			expr: &actionExpr{
-				pos: position{line: 1315, col: 5, offset: 31784},
+				pos: position{line: 1315, col: 5, offset: 31756},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1315, col: 5, offset: 31784},
+					pos: position{line: 1315, col: 5, offset: 31756},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1315, col: 5, offset: 31784},
+							pos:        position{line: 1315, col: 5, offset: 31756},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1315, col: 10, offset: 31789},
+							pos: position{line: 1315, col: 10, offset: 31761},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1315, col: 10, offset: 31789},
+								pos:  position{line: 1315, col: 10, offset: 31761},
 								name: "HexDigit",
 							},
 						},
@@ -8919,29 +8919,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1319, col: 1, offset: 31863},
+			pos:  position{line: 1319, col: 1, offset: 31835},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 5, offset: 31879},
+				pos: position{line: 1320, col: 5, offset: 31851},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1320, col: 5, offset: 31879},
+					pos: position{line: 1320, col: 5, offset: 31851},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1320, col: 5, offset: 31879},
+							pos:        position{line: 1320, col: 5, offset: 31851},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1320, col: 9, offset: 31883},
+							pos:   position{line: 1320, col: 9, offset: 31855},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1320, col: 13, offset: 31887},
+								pos:  position{line: 1320, col: 13, offset: 31859},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1320, col: 18, offset: 31892},
+							pos:        position{line: 1320, col: 18, offset: 31864},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8954,27 +8954,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1328, col: 1, offset: 32025},
+			pos:  position{line: 1328, col: 1, offset: 31997},
 			expr: &choiceExpr{
-				pos: position{line: 1329, col: 5, offset: 32041},
+				pos: position{line: 1329, col: 5, offset: 32013},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 32041},
+						pos: position{line: 1329, col: 5, offset: 32013},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1329, col: 5, offset: 32041},
+							pos: position{line: 1329, col: 5, offset: 32013},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1329, col: 5, offset: 32041},
+									pos:        position{line: 1329, col: 5, offset: 32013},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1329, col: 9, offset: 32045},
+									pos:   position{line: 1329, col: 9, offset: 32017},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1329, col: 14, offset: 32050},
+										pos:  position{line: 1329, col: 14, offset: 32022},
 										name: "Name",
 									},
 								},
@@ -8982,13 +8982,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1330, col: 5, offset: 32124},
+						pos: position{line: 1330, col: 5, offset: 32096},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1330, col: 5, offset: 32124},
+							pos:   position{line: 1330, col: 5, offset: 32096},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1330, col: 7, offset: 32126},
+								pos:  position{line: 1330, col: 7, offset: 32098},
 								name: "EasyType",
 							},
 						},
@@ -9000,16 +9000,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1338, col: 1, offset: 32262},
+			pos:  position{line: 1338, col: 1, offset: 32234},
 			expr: &choiceExpr{
-				pos: position{line: 1339, col: 5, offset: 32271},
+				pos: position{line: 1339, col: 5, offset: 32243},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1339, col: 5, offset: 32271},
+						pos:  position{line: 1339, col: 5, offset: 32243},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1340, col: 5, offset: 32285},
+						pos:  position{line: 1340, col: 5, offset: 32257},
 						name: "ComponentType",
 					},
 				},
@@ -9019,52 +9019,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1342, col: 1, offset: 32300},
+			pos:  position{line: 1342, col: 1, offset: 32272},
 			expr: &choiceExpr{
-				pos: position{line: 1343, col: 5, offset: 32318},
+				pos: position{line: 1343, col: 5, offset: 32290},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1343, col: 5, offset: 32318},
+						pos:  position{line: 1343, col: 5, offset: 32290},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1344, col: 5, offset: 32331},
+						pos: position{line: 1344, col: 5, offset: 32303},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1344, col: 5, offset: 32331},
+							pos: position{line: 1344, col: 5, offset: 32303},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1344, col: 5, offset: 32331},
+									pos:   position{line: 1344, col: 5, offset: 32303},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1344, col: 10, offset: 32336},
+										pos:  position{line: 1344, col: 10, offset: 32308},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1344, col: 15, offset: 32341},
+									pos:   position{line: 1344, col: 15, offset: 32313},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1344, col: 19, offset: 32345},
+										pos: position{line: 1344, col: 19, offset: 32317},
 										expr: &seqExpr{
-											pos: position{line: 1344, col: 20, offset: 32346},
+											pos: position{line: 1344, col: 20, offset: 32318},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1344, col: 20, offset: 32346},
+													pos:  position{line: 1344, col: 20, offset: 32318},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1344, col: 23, offset: 32349},
+													pos:        position{line: 1344, col: 23, offset: 32321},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1344, col: 27, offset: 32353},
+													pos:  position{line: 1344, col: 27, offset: 32325},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1344, col: 30, offset: 32356},
+													pos:  position{line: 1344, col: 30, offset: 32328},
 													name: "Type",
 												},
 											},
@@ -9081,40 +9081,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1356, col: 1, offset: 32678},
+			pos:  position{line: 1356, col: 1, offset: 32650},
 			expr: &choiceExpr{
-				pos: position{line: 1357, col: 5, offset: 32691},
+				pos: position{line: 1357, col: 5, offset: 32663},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1357, col: 5, offset: 32691},
+						pos: position{line: 1357, col: 5, offset: 32663},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1357, col: 5, offset: 32691},
+							pos: position{line: 1357, col: 5, offset: 32663},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1357, col: 5, offset: 32691},
+									pos:        position{line: 1357, col: 5, offset: 32663},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1357, col: 9, offset: 32695},
+									pos:  position{line: 1357, col: 9, offset: 32667},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1357, col: 12, offset: 32698},
+									pos:   position{line: 1357, col: 12, offset: 32670},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1357, col: 16, offset: 32702},
+										pos:  position{line: 1357, col: 16, offset: 32674},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1357, col: 21, offset: 32707},
+									pos:  position{line: 1357, col: 21, offset: 32679},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1357, col: 24, offset: 32710},
+									pos:        position{line: 1357, col: 24, offset: 32682},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9123,23 +9123,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1358, col: 5, offset: 32737},
+						pos: position{line: 1358, col: 5, offset: 32709},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1358, col: 5, offset: 32737},
+							pos: position{line: 1358, col: 5, offset: 32709},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1358, col: 5, offset: 32737},
+									pos:   position{line: 1358, col: 5, offset: 32709},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1358, col: 10, offset: 32742},
+										pos:  position{line: 1358, col: 10, offset: 32714},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1358, col: 24, offset: 32756},
+									pos: position{line: 1358, col: 24, offset: 32728},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1358, col: 25, offset: 32757},
+										pos:  position{line: 1358, col: 25, offset: 32729},
 										name: "IdentifierRest",
 									},
 								},
@@ -9147,43 +9147,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1359, col: 5, offset: 32797},
+						pos: position{line: 1359, col: 5, offset: 32769},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1359, col: 5, offset: 32797},
+							pos: position{line: 1359, col: 5, offset: 32769},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1359, col: 5, offset: 32797},
+									pos:  position{line: 1359, col: 5, offset: 32769},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1359, col: 11, offset: 32803},
+									pos:  position{line: 1359, col: 11, offset: 32775},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1359, col: 14, offset: 32806},
+									pos:        position{line: 1359, col: 14, offset: 32778},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1359, col: 18, offset: 32810},
+									pos:  position{line: 1359, col: 18, offset: 32782},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1359, col: 21, offset: 32813},
+									pos:   position{line: 1359, col: 21, offset: 32785},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1359, col: 23, offset: 32815},
+										pos:  position{line: 1359, col: 23, offset: 32787},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1359, col: 28, offset: 32820},
+									pos:  position{line: 1359, col: 28, offset: 32792},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1359, col: 31, offset: 32823},
+									pos:        position{line: 1359, col: 31, offset: 32795},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9192,43 +9192,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1366, col: 5, offset: 32963},
+						pos: position{line: 1366, col: 5, offset: 32935},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1366, col: 5, offset: 32963},
+							pos: position{line: 1366, col: 5, offset: 32935},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1366, col: 5, offset: 32963},
+									pos:  position{line: 1366, col: 5, offset: 32935},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1366, col: 10, offset: 32968},
+									pos:  position{line: 1366, col: 10, offset: 32940},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1366, col: 13, offset: 32971},
+									pos:        position{line: 1366, col: 13, offset: 32943},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1366, col: 17, offset: 32975},
+									pos:  position{line: 1366, col: 17, offset: 32947},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1366, col: 20, offset: 32978},
+									pos:   position{line: 1366, col: 20, offset: 32950},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 26, offset: 32984},
+										pos:  position{line: 1366, col: 26, offset: 32956},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1366, col: 32, offset: 32990},
+									pos:  position{line: 1366, col: 32, offset: 32962},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1366, col: 35, offset: 32993},
+									pos:        position{line: 1366, col: 35, offset: 32965},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9237,35 +9237,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1373, col: 5, offset: 33147},
+						pos: position{line: 1373, col: 5, offset: 33119},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1373, col: 5, offset: 33147},
+							pos: position{line: 1373, col: 5, offset: 33119},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1373, col: 5, offset: 33147},
+									pos:        position{line: 1373, col: 5, offset: 33119},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1373, col: 9, offset: 33151},
+									pos:  position{line: 1373, col: 9, offset: 33123},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1373, col: 12, offset: 33154},
+									pos:   position{line: 1373, col: 12, offset: 33126},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1373, col: 19, offset: 33161},
+										pos:  position{line: 1373, col: 19, offset: 33133},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1373, col: 33, offset: 33175},
+									pos:  position{line: 1373, col: 33, offset: 33147},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1373, col: 36, offset: 33178},
+									pos:        position{line: 1373, col: 36, offset: 33150},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9274,35 +9274,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1380, col: 5, offset: 33340},
+						pos: position{line: 1380, col: 5, offset: 33312},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1380, col: 5, offset: 33340},
+							pos: position{line: 1380, col: 5, offset: 33312},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1380, col: 5, offset: 33340},
+									pos:        position{line: 1380, col: 5, offset: 33312},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1380, col: 9, offset: 33344},
+									pos:  position{line: 1380, col: 9, offset: 33316},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1380, col: 12, offset: 33347},
+									pos:   position{line: 1380, col: 12, offset: 33319},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1380, col: 16, offset: 33351},
+										pos:  position{line: 1380, col: 16, offset: 33323},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1380, col: 21, offset: 33356},
+									pos:  position{line: 1380, col: 21, offset: 33328},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1380, col: 24, offset: 33359},
+									pos:        position{line: 1380, col: 24, offset: 33331},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9311,35 +9311,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1387, col: 5, offset: 33501},
+						pos: position{line: 1387, col: 5, offset: 33473},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1387, col: 5, offset: 33501},
+							pos: position{line: 1387, col: 5, offset: 33473},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1387, col: 5, offset: 33501},
+									pos:        position{line: 1387, col: 5, offset: 33473},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1387, col: 10, offset: 33506},
+									pos:  position{line: 1387, col: 10, offset: 33478},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1387, col: 13, offset: 33509},
+									pos:   position{line: 1387, col: 13, offset: 33481},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1387, col: 17, offset: 33513},
+										pos:  position{line: 1387, col: 17, offset: 33485},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1387, col: 22, offset: 33518},
+									pos:  position{line: 1387, col: 22, offset: 33490},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1387, col: 25, offset: 33521},
+									pos:        position{line: 1387, col: 25, offset: 33493},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9348,57 +9348,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1394, col: 5, offset: 33660},
+						pos: position{line: 1394, col: 5, offset: 33632},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1394, col: 5, offset: 33660},
+							pos: position{line: 1394, col: 5, offset: 33632},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1394, col: 5, offset: 33660},
+									pos:        position{line: 1394, col: 5, offset: 33632},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1394, col: 10, offset: 33665},
+									pos:  position{line: 1394, col: 10, offset: 33637},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1394, col: 13, offset: 33668},
+									pos:   position{line: 1394, col: 13, offset: 33640},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1394, col: 21, offset: 33676},
+										pos:  position{line: 1394, col: 21, offset: 33648},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1394, col: 26, offset: 33681},
+									pos:  position{line: 1394, col: 26, offset: 33653},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1394, col: 29, offset: 33684},
+									pos:        position{line: 1394, col: 29, offset: 33656},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1394, col: 33, offset: 33688},
+									pos:  position{line: 1394, col: 33, offset: 33660},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1394, col: 36, offset: 33691},
+									pos:   position{line: 1394, col: 36, offset: 33663},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1394, col: 44, offset: 33699},
+										pos:  position{line: 1394, col: 44, offset: 33671},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1394, col: 49, offset: 33704},
+									pos:  position{line: 1394, col: 49, offset: 33676},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1394, col: 52, offset: 33707},
+									pos:        position{line: 1394, col: 52, offset: 33679},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9413,15 +9413,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1403, col: 1, offset: 33881},
+			pos:  position{line: 1403, col: 1, offset: 33853},
 			expr: &actionExpr{
-				pos: position{line: 1404, col: 5, offset: 33895},
+				pos: position{line: 1404, col: 5, offset: 33867},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1404, col: 5, offset: 33895},
+					pos:   position{line: 1404, col: 5, offset: 33867},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1404, col: 11, offset: 33901},
+						pos:  position{line: 1404, col: 11, offset: 33873},
 						name: "TypeList",
 					},
 				},
@@ -9431,28 +9431,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1412, col: 1, offset: 34038},
+			pos:  position{line: 1412, col: 1, offset: 34010},
 			expr: &actionExpr{
-				pos: position{line: 1413, col: 5, offset: 34051},
+				pos: position{line: 1413, col: 5, offset: 34023},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1413, col: 5, offset: 34051},
+					pos: position{line: 1413, col: 5, offset: 34023},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1413, col: 5, offset: 34051},
+							pos:   position{line: 1413, col: 5, offset: 34023},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1413, col: 11, offset: 34057},
+								pos:  position{line: 1413, col: 11, offset: 34029},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1413, col: 25, offset: 34071},
+							pos:   position{line: 1413, col: 25, offset: 34043},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1413, col: 30, offset: 34076},
+								pos: position{line: 1413, col: 30, offset: 34048},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1413, col: 30, offset: 34076},
+									pos:  position{line: 1413, col: 30, offset: 34048},
 									name: "TypeListTail",
 								},
 							},
@@ -9465,32 +9465,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1417, col: 1, offset: 34134},
+			pos:  position{line: 1417, col: 1, offset: 34106},
 			expr: &actionExpr{
-				pos: position{line: 1417, col: 16, offset: 34149},
+				pos: position{line: 1417, col: 16, offset: 34121},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1417, col: 16, offset: 34149},
+					pos: position{line: 1417, col: 16, offset: 34121},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1417, col: 16, offset: 34149},
+							pos:  position{line: 1417, col: 16, offset: 34121},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1417, col: 19, offset: 34152},
+							pos:        position{line: 1417, col: 19, offset: 34124},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1417, col: 23, offset: 34156},
+							pos:  position{line: 1417, col: 23, offset: 34128},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1417, col: 26, offset: 34159},
+							pos:   position{line: 1417, col: 26, offset: 34131},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1417, col: 30, offset: 34163},
+								pos:  position{line: 1417, col: 30, offset: 34135},
 								name: "ComponentType",
 							},
 						},
@@ -9502,30 +9502,30 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1419, col: 1, offset: 34198},
+			pos:  position{line: 1419, col: 1, offset: 34170},
 			expr: &choiceExpr{
-				pos: position{line: 1420, col: 5, offset: 34216},
+				pos: position{line: 1420, col: 5, offset: 34188},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1420, col: 5, offset: 34216},
+						pos: position{line: 1420, col: 5, offset: 34188},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1420, col: 5, offset: 34216},
+							pos:   position{line: 1420, col: 5, offset: 34188},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1420, col: 7, offset: 34218},
+								pos:  position{line: 1420, col: 7, offset: 34190},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1421, col: 5, offset: 34325},
+						pos: position{line: 1421, col: 5, offset: 34297},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1421, col: 5, offset: 34325},
+							pos:   position{line: 1421, col: 5, offset: 34297},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1421, col: 7, offset: 34327},
+								pos:  position{line: 1421, col: 7, offset: 34299},
 								name: "SingleQuotedString",
 							},
 						},
@@ -9537,35 +9537,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1423, col: 1, offset: 34401},
+			pos:  position{line: 1423, col: 1, offset: 34373},
 			expr: &choiceExpr{
-				pos: position{line: 1424, col: 5, offset: 34413},
+				pos: position{line: 1424, col: 5, offset: 34385},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1424, col: 5, offset: 34413},
+						pos: position{line: 1424, col: 5, offset: 34385},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1424, col: 5, offset: 34413},
+							pos: position{line: 1424, col: 5, offset: 34385},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1424, col: 5, offset: 34413},
+									pos:        position{line: 1424, col: 5, offset: 34385},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1424, col: 11, offset: 34419},
+									pos:   position{line: 1424, col: 11, offset: 34391},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1424, col: 13, offset: 34421},
+										pos: position{line: 1424, col: 13, offset: 34393},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1424, col: 13, offset: 34421},
+											pos:  position{line: 1424, col: 13, offset: 34393},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1424, col: 38, offset: 34446},
+									pos:        position{line: 1424, col: 38, offset: 34418},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9574,30 +9574,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1431, col: 5, offset: 34592},
+						pos: position{line: 1431, col: 5, offset: 34564},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1431, col: 5, offset: 34592},
+							pos: position{line: 1431, col: 5, offset: 34564},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1431, col: 5, offset: 34592},
+									pos:        position{line: 1431, col: 5, offset: 34564},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1431, col: 10, offset: 34597},
+									pos:   position{line: 1431, col: 10, offset: 34569},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1431, col: 12, offset: 34599},
+										pos: position{line: 1431, col: 12, offset: 34571},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1431, col: 12, offset: 34599},
+											pos:  position{line: 1431, col: 12, offset: 34571},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1431, col: 37, offset: 34624},
+									pos:        position{line: 1431, col: 37, offset: 34596},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9612,24 +9612,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1439, col: 1, offset: 34767},
+			pos:  position{line: 1439, col: 1, offset: 34739},
 			expr: &choiceExpr{
-				pos: position{line: 1440, col: 5, offset: 34795},
+				pos: position{line: 1440, col: 5, offset: 34767},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1440, col: 5, offset: 34795},
+						pos:  position{line: 1440, col: 5, offset: 34767},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1441, col: 5, offset: 34811},
+						pos: position{line: 1441, col: 5, offset: 34783},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1441, col: 5, offset: 34811},
+							pos:   position{line: 1441, col: 5, offset: 34783},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1441, col: 7, offset: 34813},
+								pos: position{line: 1441, col: 7, offset: 34785},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1441, col: 7, offset: 34813},
+									pos:  position{line: 1441, col: 7, offset: 34785},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9642,27 +9642,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1445, col: 1, offset: 34936},
+			pos:  position{line: 1445, col: 1, offset: 34908},
 			expr: &choiceExpr{
-				pos: position{line: 1446, col: 5, offset: 34964},
+				pos: position{line: 1446, col: 5, offset: 34936},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1446, col: 5, offset: 34964},
+						pos: position{line: 1446, col: 5, offset: 34936},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1446, col: 5, offset: 34964},
+							pos: position{line: 1446, col: 5, offset: 34936},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1446, col: 5, offset: 34964},
+									pos:        position{line: 1446, col: 5, offset: 34936},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1446, col: 10, offset: 34969},
+									pos:   position{line: 1446, col: 10, offset: 34941},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1446, col: 12, offset: 34971},
+										pos:        position{line: 1446, col: 12, offset: 34943},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9672,25 +9672,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1447, col: 5, offset: 34997},
+						pos: position{line: 1447, col: 5, offset: 34969},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1447, col: 5, offset: 34997},
+							pos: position{line: 1447, col: 5, offset: 34969},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1447, col: 5, offset: 34997},
+									pos: position{line: 1447, col: 5, offset: 34969},
 									expr: &litMatcher{
-										pos:        position{line: 1447, col: 7, offset: 34999},
+										pos:        position{line: 1447, col: 7, offset: 34971},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1447, col: 12, offset: 35004},
+									pos:   position{line: 1447, col: 12, offset: 34976},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1447, col: 14, offset: 35006},
+										pos:  position{line: 1447, col: 14, offset: 34978},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9704,24 +9704,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1449, col: 1, offset: 35042},
+			pos:  position{line: 1449, col: 1, offset: 35014},
 			expr: &choiceExpr{
-				pos: position{line: 1450, col: 5, offset: 35070},
+				pos: position{line: 1450, col: 5, offset: 35042},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1450, col: 5, offset: 35070},
+						pos:  position{line: 1450, col: 5, offset: 35042},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1451, col: 5, offset: 35086},
+						pos: position{line: 1451, col: 5, offset: 35058},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1451, col: 5, offset: 35086},
+							pos:   position{line: 1451, col: 5, offset: 35058},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1451, col: 7, offset: 35088},
+								pos: position{line: 1451, col: 7, offset: 35060},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1451, col: 7, offset: 35088},
+									pos:  position{line: 1451, col: 7, offset: 35060},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9734,27 +9734,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1455, col: 1, offset: 35211},
+			pos:  position{line: 1455, col: 1, offset: 35183},
 			expr: &choiceExpr{
-				pos: position{line: 1456, col: 5, offset: 35239},
+				pos: position{line: 1456, col: 5, offset: 35211},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1456, col: 5, offset: 35239},
+						pos: position{line: 1456, col: 5, offset: 35211},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1456, col: 5, offset: 35239},
+							pos: position{line: 1456, col: 5, offset: 35211},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1456, col: 5, offset: 35239},
+									pos:        position{line: 1456, col: 5, offset: 35211},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1456, col: 10, offset: 35244},
+									pos:   position{line: 1456, col: 10, offset: 35216},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1456, col: 12, offset: 35246},
+										pos:        position{line: 1456, col: 12, offset: 35218},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9764,25 +9764,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1457, col: 5, offset: 35272},
+						pos: position{line: 1457, col: 5, offset: 35244},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1457, col: 5, offset: 35272},
+							pos: position{line: 1457, col: 5, offset: 35244},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1457, col: 5, offset: 35272},
+									pos: position{line: 1457, col: 5, offset: 35244},
 									expr: &litMatcher{
-										pos:        position{line: 1457, col: 7, offset: 35274},
+										pos:        position{line: 1457, col: 7, offset: 35246},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1457, col: 12, offset: 35279},
+									pos:   position{line: 1457, col: 12, offset: 35251},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1457, col: 14, offset: 35281},
+										pos:  position{line: 1457, col: 14, offset: 35253},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9796,37 +9796,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1459, col: 1, offset: 35317},
+			pos:  position{line: 1459, col: 1, offset: 35289},
 			expr: &actionExpr{
-				pos: position{line: 1460, col: 5, offset: 35333},
+				pos: position{line: 1460, col: 5, offset: 35305},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1460, col: 5, offset: 35333},
+					pos: position{line: 1460, col: 5, offset: 35305},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1460, col: 5, offset: 35333},
+							pos:        position{line: 1460, col: 5, offset: 35305},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1460, col: 9, offset: 35337},
+							pos:  position{line: 1460, col: 9, offset: 35309},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1460, col: 12, offset: 35340},
+							pos:   position{line: 1460, col: 12, offset: 35312},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1460, col: 14, offset: 35342},
+								pos:  position{line: 1460, col: 14, offset: 35314},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1460, col: 19, offset: 35347},
+							pos:  position{line: 1460, col: 19, offset: 35319},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1460, col: 22, offset: 35350},
+							pos:        position{line: 1460, col: 22, offset: 35322},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9839,129 +9839,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1468, col: 1, offset: 35485},
+			pos:  position{line: 1468, col: 1, offset: 35457},
 			expr: &actionExpr{
-				pos: position{line: 1469, col: 5, offset: 35503},
+				pos: position{line: 1469, col: 5, offset: 35475},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1469, col: 9, offset: 35507},
+					pos: position{line: 1469, col: 9, offset: 35479},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1469, col: 9, offset: 35507},
+							pos:        position{line: 1469, col: 9, offset: 35479},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1469, col: 19, offset: 35517},
+							pos:        position{line: 1469, col: 19, offset: 35489},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1469, col: 30, offset: 35528},
+							pos:        position{line: 1469, col: 30, offset: 35500},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1469, col: 41, offset: 35539},
+							pos:        position{line: 1469, col: 41, offset: 35511},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1470, col: 9, offset: 35556},
+							pos:        position{line: 1470, col: 9, offset: 35528},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1470, col: 18, offset: 35565},
+							pos:        position{line: 1470, col: 18, offset: 35537},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1470, col: 28, offset: 35575},
+							pos:        position{line: 1470, col: 28, offset: 35547},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1470, col: 38, offset: 35585},
+							pos:        position{line: 1470, col: 38, offset: 35557},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1471, col: 9, offset: 35601},
+							pos:        position{line: 1471, col: 9, offset: 35573},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1471, col: 21, offset: 35613},
+							pos:        position{line: 1471, col: 21, offset: 35585},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1471, col: 33, offset: 35625},
+							pos:        position{line: 1471, col: 33, offset: 35597},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1472, col: 9, offset: 35643},
+							pos:        position{line: 1472, col: 9, offset: 35615},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1472, col: 18, offset: 35652},
+							pos:        position{line: 1472, col: 18, offset: 35624},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1473, col: 9, offset: 35669},
+							pos:        position{line: 1473, col: 9, offset: 35641},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1473, col: 22, offset: 35682},
+							pos:        position{line: 1473, col: 22, offset: 35654},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1474, col: 9, offset: 35697},
+							pos:        position{line: 1474, col: 9, offset: 35669},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1475, col: 9, offset: 35713},
+							pos:        position{line: 1475, col: 9, offset: 35685},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1475, col: 16, offset: 35720},
+							pos:        position{line: 1475, col: 16, offset: 35692},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1476, col: 9, offset: 35734},
+							pos:        position{line: 1476, col: 9, offset: 35706},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1476, col: 18, offset: 35743},
+							pos:        position{line: 1476, col: 18, offset: 35715},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9974,31 +9974,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1484, col: 1, offset: 35928},
+			pos:  position{line: 1484, col: 1, offset: 35900},
 			expr: &choiceExpr{
-				pos: position{line: 1485, col: 5, offset: 35946},
+				pos: position{line: 1485, col: 5, offset: 35918},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1485, col: 5, offset: 35946},
+						pos: position{line: 1485, col: 5, offset: 35918},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1485, col: 5, offset: 35946},
+							pos: position{line: 1485, col: 5, offset: 35918},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1485, col: 5, offset: 35946},
+									pos:   position{line: 1485, col: 5, offset: 35918},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1485, col: 11, offset: 35952},
+										pos:  position{line: 1485, col: 11, offset: 35924},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1485, col: 21, offset: 35962},
+									pos:   position{line: 1485, col: 21, offset: 35934},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1485, col: 26, offset: 35967},
+										pos: position{line: 1485, col: 26, offset: 35939},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1485, col: 26, offset: 35967},
+											pos:  position{line: 1485, col: 26, offset: 35939},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10007,10 +10007,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1488, col: 5, offset: 36033},
+						pos: position{line: 1488, col: 5, offset: 36005},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1488, col: 5, offset: 36033},
+							pos:        position{line: 1488, col: 5, offset: 36005},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10023,32 +10023,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1490, col: 1, offset: 36057},
+			pos:  position{line: 1490, col: 1, offset: 36029},
 			expr: &actionExpr{
-				pos: position{line: 1490, col: 21, offset: 36077},
+				pos: position{line: 1490, col: 21, offset: 36049},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1490, col: 21, offset: 36077},
+					pos: position{line: 1490, col: 21, offset: 36049},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1490, col: 21, offset: 36077},
+							pos:  position{line: 1490, col: 21, offset: 36049},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1490, col: 24, offset: 36080},
+							pos:        position{line: 1490, col: 24, offset: 36052},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1490, col: 28, offset: 36084},
+							pos:  position{line: 1490, col: 28, offset: 36056},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1490, col: 31, offset: 36087},
+							pos:   position{line: 1490, col: 31, offset: 36059},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1490, col: 35, offset: 36091},
+								pos:  position{line: 1490, col: 35, offset: 36063},
 								name: "TypeField",
 							},
 						},
@@ -10060,40 +10060,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1492, col: 1, offset: 36122},
+			pos:  position{line: 1492, col: 1, offset: 36094},
 			expr: &actionExpr{
-				pos: position{line: 1493, col: 5, offset: 36136},
+				pos: position{line: 1493, col: 5, offset: 36108},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1493, col: 5, offset: 36136},
+					pos: position{line: 1493, col: 5, offset: 36108},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1493, col: 5, offset: 36136},
+							pos:   position{line: 1493, col: 5, offset: 36108},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1493, col: 10, offset: 36141},
+								pos:  position{line: 1493, col: 10, offset: 36113},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1493, col: 15, offset: 36146},
+							pos:  position{line: 1493, col: 15, offset: 36118},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1493, col: 18, offset: 36149},
+							pos:        position{line: 1493, col: 18, offset: 36121},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1493, col: 22, offset: 36153},
+							pos:  position{line: 1493, col: 22, offset: 36125},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1493, col: 25, offset: 36156},
+							pos:   position{line: 1493, col: 25, offset: 36128},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1493, col: 29, offset: 36160},
+								pos:  position{line: 1493, col: 29, offset: 36132},
 								name: "Type",
 							},
 						},
@@ -10105,26 +10105,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1501, col: 1, offset: 36309},
+			pos:  position{line: 1501, col: 1, offset: 36281},
 			expr: &actionExpr{
-				pos: position{line: 1502, col: 4, offset: 36317},
+				pos: position{line: 1502, col: 4, offset: 36289},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1502, col: 4, offset: 36317},
+					pos:   position{line: 1502, col: 4, offset: 36289},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1502, col: 7, offset: 36320},
+						pos: position{line: 1502, col: 7, offset: 36292},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1502, col: 7, offset: 36320},
+								pos:  position{line: 1502, col: 7, offset: 36292},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1502, col: 24, offset: 36337},
+								pos:  position{line: 1502, col: 24, offset: 36309},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1502, col: 45, offset: 36358},
+								pos:  position{line: 1502, col: 45, offset: 36330},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10136,51 +10136,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1506, col: 1, offset: 36458},
+			pos:  position{line: 1506, col: 1, offset: 36430},
 			expr: &actionExpr{
-				pos: position{line: 1507, col: 5, offset: 36468},
+				pos: position{line: 1507, col: 5, offset: 36440},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1507, col: 5, offset: 36468},
+					pos: position{line: 1507, col: 5, offset: 36440},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1507, col: 5, offset: 36468},
+							pos:   position{line: 1507, col: 5, offset: 36440},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1507, col: 11, offset: 36474},
+								pos:  position{line: 1507, col: 11, offset: 36446},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1507, col: 16, offset: 36479},
+							pos:   position{line: 1507, col: 16, offset: 36451},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1507, col: 21, offset: 36484},
+								pos: position{line: 1507, col: 21, offset: 36456},
 								expr: &actionExpr{
-									pos: position{line: 1507, col: 22, offset: 36485},
+									pos: position{line: 1507, col: 22, offset: 36457},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1507, col: 22, offset: 36485},
+										pos: position{line: 1507, col: 22, offset: 36457},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1507, col: 22, offset: 36485},
+												pos:  position{line: 1507, col: 22, offset: 36457},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1507, col: 25, offset: 36488},
+												pos:        position{line: 1507, col: 25, offset: 36460},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1507, col: 29, offset: 36492},
+												pos:  position{line: 1507, col: 29, offset: 36464},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1507, col: 32, offset: 36495},
+												pos:   position{line: 1507, col: 32, offset: 36467},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1507, col: 37, offset: 36500},
+													pos:  position{line: 1507, col: 37, offset: 36472},
 													name: "Name",
 												},
 											},
@@ -10197,15 +10197,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1511, col: 1, offset: 36574},
+			pos:  position{line: 1511, col: 1, offset: 36544},
 			expr: &actionExpr{
-				pos: position{line: 1512, col: 5, offset: 36589},
+				pos: position{line: 1512, col: 5, offset: 36559},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1512, col: 5, offset: 36589},
+					pos:   position{line: 1512, col: 5, offset: 36559},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1512, col: 8, offset: 36592},
+						pos:  position{line: 1512, col: 8, offset: 36562},
 						name: "IdentifierName",
 					},
 				},
@@ -10215,51 +10215,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1520, col: 1, offset: 36725},
+			pos:  position{line: 1520, col: 1, offset: 36695},
 			expr: &actionExpr{
-				pos: position{line: 1521, col: 5, offset: 36741},
+				pos: position{line: 1521, col: 5, offset: 36711},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1521, col: 5, offset: 36741},
+					pos: position{line: 1521, col: 5, offset: 36711},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1521, col: 5, offset: 36741},
+							pos:   position{line: 1521, col: 5, offset: 36711},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1521, col: 11, offset: 36747},
+								pos:  position{line: 1521, col: 11, offset: 36717},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1521, col: 22, offset: 36758},
+							pos:   position{line: 1521, col: 22, offset: 36728},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1521, col: 27, offset: 36763},
+								pos: position{line: 1521, col: 27, offset: 36733},
 								expr: &actionExpr{
-									pos: position{line: 1521, col: 28, offset: 36764},
+									pos: position{line: 1521, col: 28, offset: 36734},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1521, col: 28, offset: 36764},
+										pos: position{line: 1521, col: 28, offset: 36734},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1521, col: 28, offset: 36764},
+												pos:  position{line: 1521, col: 28, offset: 36734},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1521, col: 31, offset: 36767},
+												pos:        position{line: 1521, col: 31, offset: 36737},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1521, col: 35, offset: 36771},
+												pos:  position{line: 1521, col: 35, offset: 36741},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1521, col: 38, offset: 36774},
+												pos:   position{line: 1521, col: 38, offset: 36744},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1521, col: 43, offset: 36779},
+													pos:  position{line: 1521, col: 43, offset: 36749},
 													name: "Identifier",
 												},
 											},
@@ -10276,22 +10276,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1525, col: 1, offset: 36857},
+			pos:  position{line: 1525, col: 1, offset: 36827},
 			expr: &choiceExpr{
-				pos: position{line: 1526, col: 5, offset: 36875},
+				pos: position{line: 1526, col: 5, offset: 36845},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1526, col: 5, offset: 36875},
+						pos:  position{line: 1526, col: 5, offset: 36845},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1527, col: 5, offset: 36890},
+						pos: position{line: 1527, col: 5, offset: 36860},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1527, col: 5, offset: 36890},
+							pos:   position{line: 1527, col: 5, offset: 36860},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1527, col: 7, offset: 36892},
+								pos:  position{line: 1527, col: 7, offset: 36862},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10303,29 +10303,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1529, col: 1, offset: 36977},
+			pos:  position{line: 1529, col: 1, offset: 36947},
 			expr: &choiceExpr{
-				pos: position{line: 1530, col: 5, offset: 36996},
+				pos: position{line: 1530, col: 5, offset: 36966},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1530, col: 5, offset: 36996},
+						pos: position{line: 1530, col: 5, offset: 36966},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1530, col: 5, offset: 36996},
+							pos: position{line: 1530, col: 5, offset: 36966},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1530, col: 5, offset: 36996},
+									pos: position{line: 1530, col: 5, offset: 36966},
 									expr: &seqExpr{
-										pos: position{line: 1530, col: 7, offset: 36998},
+										pos: position{line: 1530, col: 7, offset: 36968},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1530, col: 7, offset: 36998},
+												pos:  position{line: 1530, col: 7, offset: 36968},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1530, col: 15, offset: 37006},
+												pos: position{line: 1530, col: 15, offset: 36976},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1530, col: 16, offset: 37007},
+													pos:  position{line: 1530, col: 16, offset: 36977},
 													name: "IdentifierRest",
 												},
 											},
@@ -10333,13 +10333,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1530, col: 32, offset: 37023},
+									pos:  position{line: 1530, col: 32, offset: 36993},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1530, col: 48, offset: 37039},
+									pos: position{line: 1530, col: 48, offset: 37009},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1530, col: 48, offset: 37039},
+										pos:  position{line: 1530, col: 48, offset: 37009},
 										name: "IdentifierRest",
 									},
 								},
@@ -10347,7 +10347,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1531, col: 5, offset: 37090},
+						pos:  position{line: 1531, col: 5, offset: 37060},
 						name: "BacktickString",
 					},
 				},
@@ -10357,22 +10357,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1533, col: 1, offset: 37107},
+			pos:  position{line: 1533, col: 1, offset: 37076},
 			expr: &choiceExpr{
-				pos: position{line: 1534, col: 5, offset: 37127},
+				pos: position{line: 1534, col: 5, offset: 37096},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 5, offset: 37127},
+						pos:  position{line: 1534, col: 5, offset: 37096},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1535, col: 5, offset: 37145},
+						pos:        position{line: 1535, col: 5, offset: 37114},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1536, col: 5, offset: 37153},
+						pos:        position{line: 1536, col: 5, offset: 37122},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10384,24 +10384,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1538, col: 1, offset: 37158},
+			pos:  position{line: 1538, col: 1, offset: 37127},
 			expr: &choiceExpr{
-				pos: position{line: 1539, col: 5, offset: 37177},
+				pos: position{line: 1539, col: 5, offset: 37146},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1539, col: 5, offset: 37177},
+						pos:  position{line: 1539, col: 5, offset: 37146},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1540, col: 5, offset: 37197},
+						pos:  position{line: 1540, col: 5, offset: 37166},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 5, offset: 37222},
+						pos:  position{line: 1541, col: 5, offset: 37191},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1542, col: 5, offset: 37239},
+						pos:  position{line: 1542, col: 5, offset: 37208},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10411,24 +10411,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1544, col: 1, offset: 37268},
+			pos:  position{line: 1544, col: 1, offset: 37237},
 			expr: &choiceExpr{
-				pos: position{line: 1545, col: 5, offset: 37280},
+				pos: position{line: 1545, col: 5, offset: 37249},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1545, col: 5, offset: 37280},
+						pos:  position{line: 1545, col: 5, offset: 37249},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1546, col: 5, offset: 37299},
+						pos:  position{line: 1546, col: 5, offset: 37268},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1547, col: 5, offset: 37315},
+						pos:  position{line: 1547, col: 5, offset: 37284},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1548, col: 5, offset: 37323},
+						pos:  position{line: 1548, col: 5, offset: 37292},
 						name: "Infinity",
 					},
 				},
@@ -10438,25 +10438,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1550, col: 1, offset: 37333},
+			pos:  position{line: 1550, col: 1, offset: 37302},
 			expr: &actionExpr{
-				pos: position{line: 1551, col: 5, offset: 37342},
+				pos: position{line: 1551, col: 5, offset: 37311},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1551, col: 5, offset: 37342},
+					pos: position{line: 1551, col: 5, offset: 37311},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1551, col: 5, offset: 37342},
+							pos:  position{line: 1551, col: 5, offset: 37311},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1551, col: 14, offset: 37351},
+							pos:        position{line: 1551, col: 14, offset: 37320},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1551, col: 18, offset: 37355},
+							pos:  position{line: 1551, col: 18, offset: 37324},
 							name: "FullTime",
 						},
 					},
@@ -10467,32 +10467,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1555, col: 1, offset: 37431},
+			pos:  position{line: 1555, col: 1, offset: 37400},
 			expr: &seqExpr{
-				pos: position{line: 1555, col: 12, offset: 37442},
+				pos: position{line: 1555, col: 12, offset: 37411},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1555, col: 12, offset: 37442},
+						pos:  position{line: 1555, col: 12, offset: 37411},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1555, col: 15, offset: 37445},
+						pos:        position{line: 1555, col: 15, offset: 37414},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1555, col: 19, offset: 37449},
+						pos:  position{line: 1555, col: 19, offset: 37418},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1555, col: 22, offset: 37452},
+						pos:        position{line: 1555, col: 22, offset: 37421},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1555, col: 26, offset: 37456},
+						pos:  position{line: 1555, col: 26, offset: 37425},
 						name: "D2",
 					},
 				},
@@ -10502,33 +10502,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1557, col: 1, offset: 37460},
+			pos:  position{line: 1557, col: 1, offset: 37429},
 			expr: &seqExpr{
-				pos: position{line: 1557, col: 6, offset: 37465},
+				pos: position{line: 1557, col: 6, offset: 37434},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1557, col: 6, offset: 37465},
+						pos:        position{line: 1557, col: 6, offset: 37434},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1557, col: 11, offset: 37470},
+						pos:        position{line: 1557, col: 11, offset: 37439},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1557, col: 16, offset: 37475},
+						pos:        position{line: 1557, col: 16, offset: 37444},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1557, col: 21, offset: 37480},
+						pos:        position{line: 1557, col: 21, offset: 37449},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10541,19 +10541,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1558, col: 1, offset: 37486},
+			pos:  position{line: 1558, col: 1, offset: 37455},
 			expr: &seqExpr{
-				pos: position{line: 1558, col: 6, offset: 37491},
+				pos: position{line: 1558, col: 6, offset: 37460},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1558, col: 6, offset: 37491},
+						pos:        position{line: 1558, col: 6, offset: 37460},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1558, col: 11, offset: 37496},
+						pos:        position{line: 1558, col: 11, offset: 37465},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10566,16 +10566,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1560, col: 1, offset: 37503},
+			pos:  position{line: 1560, col: 1, offset: 37472},
 			expr: &seqExpr{
-				pos: position{line: 1560, col: 12, offset: 37514},
+				pos: position{line: 1560, col: 12, offset: 37483},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1560, col: 12, offset: 37514},
+						pos:  position{line: 1560, col: 12, offset: 37483},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1560, col: 24, offset: 37526},
+						pos:  position{line: 1560, col: 24, offset: 37495},
 						name: "TimeOffset",
 					},
 				},
@@ -10585,49 +10585,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1562, col: 1, offset: 37538},
+			pos:  position{line: 1562, col: 1, offset: 37507},
 			expr: &seqExpr{
-				pos: position{line: 1562, col: 15, offset: 37552},
+				pos: position{line: 1562, col: 15, offset: 37521},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1562, col: 15, offset: 37552},
+						pos:  position{line: 1562, col: 15, offset: 37521},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1562, col: 18, offset: 37555},
+						pos:        position{line: 1562, col: 18, offset: 37524},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1562, col: 22, offset: 37559},
+						pos:  position{line: 1562, col: 22, offset: 37528},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1562, col: 25, offset: 37562},
+						pos:        position{line: 1562, col: 25, offset: 37531},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1562, col: 29, offset: 37566},
+						pos:  position{line: 1562, col: 29, offset: 37535},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1562, col: 32, offset: 37569},
+						pos: position{line: 1562, col: 32, offset: 37538},
 						expr: &seqExpr{
-							pos: position{line: 1562, col: 33, offset: 37570},
+							pos: position{line: 1562, col: 33, offset: 37539},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1562, col: 33, offset: 37570},
+									pos:        position{line: 1562, col: 33, offset: 37539},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1562, col: 37, offset: 37574},
+									pos: position{line: 1562, col: 37, offset: 37543},
 									expr: &charClassMatcher{
-										pos:        position{line: 1562, col: 37, offset: 37574},
+										pos:        position{line: 1562, col: 37, offset: 37543},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10644,30 +10644,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1564, col: 1, offset: 37584},
+			pos:  position{line: 1564, col: 1, offset: 37553},
 			expr: &choiceExpr{
-				pos: position{line: 1565, col: 5, offset: 37599},
+				pos: position{line: 1565, col: 5, offset: 37568},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1565, col: 5, offset: 37599},
+						pos:        position{line: 1565, col: 5, offset: 37568},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1566, col: 5, offset: 37607},
+						pos: position{line: 1566, col: 5, offset: 37576},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1566, col: 6, offset: 37608},
+								pos: position{line: 1566, col: 6, offset: 37577},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1566, col: 6, offset: 37608},
+										pos:        position{line: 1566, col: 6, offset: 37577},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1566, col: 12, offset: 37614},
+										pos:        position{line: 1566, col: 12, offset: 37583},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10675,34 +10675,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1566, col: 17, offset: 37619},
+								pos:  position{line: 1566, col: 17, offset: 37588},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1566, col: 20, offset: 37622},
+								pos:        position{line: 1566, col: 20, offset: 37591},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1566, col: 24, offset: 37626},
+								pos:  position{line: 1566, col: 24, offset: 37595},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1566, col: 27, offset: 37629},
+								pos: position{line: 1566, col: 27, offset: 37598},
 								expr: &seqExpr{
-									pos: position{line: 1566, col: 28, offset: 37630},
+									pos: position{line: 1566, col: 28, offset: 37599},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1566, col: 28, offset: 37630},
+											pos:        position{line: 1566, col: 28, offset: 37599},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1566, col: 32, offset: 37634},
+											pos: position{line: 1566, col: 32, offset: 37603},
 											expr: &charClassMatcher{
-												pos:        position{line: 1566, col: 32, offset: 37634},
+												pos:        position{line: 1566, col: 32, offset: 37603},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10721,33 +10721,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1568, col: 1, offset: 37644},
+			pos:  position{line: 1568, col: 1, offset: 37613},
 			expr: &actionExpr{
-				pos: position{line: 1569, col: 5, offset: 37657},
+				pos: position{line: 1569, col: 5, offset: 37626},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1569, col: 5, offset: 37657},
+					pos: position{line: 1569, col: 5, offset: 37626},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1569, col: 5, offset: 37657},
+							pos: position{line: 1569, col: 5, offset: 37626},
 							expr: &litMatcher{
-								pos:        position{line: 1569, col: 5, offset: 37657},
+								pos:        position{line: 1569, col: 5, offset: 37626},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1569, col: 10, offset: 37662},
+							pos: position{line: 1569, col: 10, offset: 37631},
 							expr: &seqExpr{
-								pos: position{line: 1569, col: 11, offset: 37663},
+								pos: position{line: 1569, col: 11, offset: 37632},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1569, col: 11, offset: 37663},
+										pos:  position{line: 1569, col: 11, offset: 37632},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1569, col: 19, offset: 37671},
+										pos:  position{line: 1569, col: 19, offset: 37640},
 										name: "TimeUnit",
 									},
 								},
@@ -10761,27 +10761,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1573, col: 1, offset: 37753},
+			pos:  position{line: 1573, col: 1, offset: 37722},
 			expr: &seqExpr{
-				pos: position{line: 1573, col: 11, offset: 37763},
+				pos: position{line: 1573, col: 11, offset: 37732},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1573, col: 11, offset: 37763},
+						pos:  position{line: 1573, col: 11, offset: 37732},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1573, col: 16, offset: 37768},
+						pos: position{line: 1573, col: 16, offset: 37737},
 						expr: &seqExpr{
-							pos: position{line: 1573, col: 17, offset: 37769},
+							pos: position{line: 1573, col: 17, offset: 37738},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1573, col: 17, offset: 37769},
+									pos:        position{line: 1573, col: 17, offset: 37738},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1573, col: 21, offset: 37773},
+									pos:  position{line: 1573, col: 21, offset: 37742},
 									name: "UInt",
 								},
 							},
@@ -10794,60 +10794,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1575, col: 1, offset: 37781},
+			pos:  position{line: 1575, col: 1, offset: 37750},
 			expr: &choiceExpr{
-				pos: position{line: 1576, col: 5, offset: 37794},
+				pos: position{line: 1576, col: 5, offset: 37763},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1576, col: 5, offset: 37794},
+						pos:        position{line: 1576, col: 5, offset: 37763},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1577, col: 5, offset: 37803},
+						pos:        position{line: 1577, col: 5, offset: 37772},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1578, col: 5, offset: 37812},
+						pos:        position{line: 1578, col: 5, offset: 37781},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1579, col: 5, offset: 37821},
+						pos:        position{line: 1579, col: 5, offset: 37790},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1580, col: 5, offset: 37829},
+						pos:        position{line: 1580, col: 5, offset: 37798},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1581, col: 5, offset: 37837},
+						pos:        position{line: 1581, col: 5, offset: 37806},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1582, col: 5, offset: 37845},
+						pos:        position{line: 1582, col: 5, offset: 37814},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1583, col: 5, offset: 37853},
+						pos:        position{line: 1583, col: 5, offset: 37822},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1584, col: 5, offset: 37861},
+						pos:        position{line: 1584, col: 5, offset: 37830},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10859,45 +10859,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1586, col: 1, offset: 37866},
+			pos:  position{line: 1586, col: 1, offset: 37835},
 			expr: &actionExpr{
-				pos: position{line: 1587, col: 5, offset: 37873},
+				pos: position{line: 1587, col: 5, offset: 37842},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1587, col: 5, offset: 37873},
+					pos: position{line: 1587, col: 5, offset: 37842},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1587, col: 5, offset: 37873},
+							pos:  position{line: 1587, col: 5, offset: 37842},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1587, col: 10, offset: 37878},
+							pos:        position{line: 1587, col: 10, offset: 37847},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1587, col: 14, offset: 37882},
+							pos:  position{line: 1587, col: 14, offset: 37851},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1587, col: 19, offset: 37887},
+							pos:        position{line: 1587, col: 19, offset: 37856},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1587, col: 23, offset: 37891},
+							pos:  position{line: 1587, col: 23, offset: 37860},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1587, col: 28, offset: 37896},
+							pos:        position{line: 1587, col: 28, offset: 37865},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1587, col: 32, offset: 37900},
+							pos:  position{line: 1587, col: 32, offset: 37869},
 							name: "UInt",
 						},
 					},
@@ -10908,43 +10908,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1589, col: 1, offset: 37937},
+			pos:  position{line: 1589, col: 1, offset: 37906},
 			expr: &actionExpr{
-				pos: position{line: 1590, col: 5, offset: 37945},
+				pos: position{line: 1590, col: 5, offset: 37914},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1590, col: 5, offset: 37945},
+					pos: position{line: 1590, col: 5, offset: 37914},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1590, col: 5, offset: 37945},
+							pos: position{line: 1590, col: 5, offset: 37914},
 							expr: &seqExpr{
-								pos: position{line: 1590, col: 7, offset: 37947},
+								pos: position{line: 1590, col: 7, offset: 37916},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1590, col: 7, offset: 37947},
+										pos:  position{line: 1590, col: 7, offset: 37916},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1590, col: 11, offset: 37951},
+										pos:        position{line: 1590, col: 11, offset: 37920},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1590, col: 15, offset: 37955},
+										pos:  position{line: 1590, col: 15, offset: 37924},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1590, col: 19, offset: 37959},
+										pos: position{line: 1590, col: 19, offset: 37928},
 										expr: &choiceExpr{
-											pos: position{line: 1590, col: 21, offset: 37961},
+											pos: position{line: 1590, col: 21, offset: 37930},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1590, col: 21, offset: 37961},
+													pos:  position{line: 1590, col: 21, offset: 37930},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1590, col: 32, offset: 37972},
+													pos:        position{line: 1590, col: 32, offset: 37941},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10956,10 +10956,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1590, col: 38, offset: 37978},
+							pos:   position{line: 1590, col: 38, offset: 37947},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1590, col: 40, offset: 37980},
+								pos:  position{line: 1590, col: 40, offset: 37949},
 								name: "IP6Variations",
 							},
 						},
@@ -10971,32 +10971,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1594, col: 1, offset: 38144},
+			pos:  position{line: 1594, col: 1, offset: 38113},
 			expr: &choiceExpr{
-				pos: position{line: 1595, col: 5, offset: 38162},
+				pos: position{line: 1595, col: 5, offset: 38131},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1595, col: 5, offset: 38162},
+						pos: position{line: 1595, col: 5, offset: 38131},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1595, col: 5, offset: 38162},
+							pos: position{line: 1595, col: 5, offset: 38131},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1595, col: 5, offset: 38162},
+									pos:   position{line: 1595, col: 5, offset: 38131},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1595, col: 7, offset: 38164},
+										pos: position{line: 1595, col: 7, offset: 38133},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1595, col: 7, offset: 38164},
+											pos:  position{line: 1595, col: 7, offset: 38133},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1595, col: 17, offset: 38174},
+									pos:   position{line: 1595, col: 17, offset: 38143},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1595, col: 19, offset: 38176},
+										pos:  position{line: 1595, col: 19, offset: 38145},
 										name: "IP6Tail",
 									},
 								},
@@ -11004,52 +11004,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1598, col: 5, offset: 38240},
+						pos: position{line: 1598, col: 5, offset: 38209},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1598, col: 5, offset: 38240},
+							pos: position{line: 1598, col: 5, offset: 38209},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1598, col: 5, offset: 38240},
+									pos:   position{line: 1598, col: 5, offset: 38209},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1598, col: 7, offset: 38242},
+										pos:  position{line: 1598, col: 7, offset: 38211},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1598, col: 11, offset: 38246},
+									pos:   position{line: 1598, col: 11, offset: 38215},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1598, col: 13, offset: 38248},
+										pos: position{line: 1598, col: 13, offset: 38217},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1598, col: 13, offset: 38248},
+											pos:  position{line: 1598, col: 13, offset: 38217},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1598, col: 23, offset: 38258},
+									pos:        position{line: 1598, col: 23, offset: 38227},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1598, col: 28, offset: 38263},
+									pos:   position{line: 1598, col: 28, offset: 38232},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1598, col: 30, offset: 38265},
+										pos: position{line: 1598, col: 30, offset: 38234},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1598, col: 30, offset: 38265},
+											pos:  position{line: 1598, col: 30, offset: 38234},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1598, col: 40, offset: 38275},
+									pos:   position{line: 1598, col: 40, offset: 38244},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1598, col: 42, offset: 38277},
+										pos:  position{line: 1598, col: 42, offset: 38246},
 										name: "IP6Tail",
 									},
 								},
@@ -11057,33 +11057,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1601, col: 5, offset: 38376},
+						pos: position{line: 1601, col: 5, offset: 38345},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1601, col: 5, offset: 38376},
+							pos: position{line: 1601, col: 5, offset: 38345},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1601, col: 5, offset: 38376},
+									pos:        position{line: 1601, col: 5, offset: 38345},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1601, col: 10, offset: 38381},
+									pos:   position{line: 1601, col: 10, offset: 38350},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1601, col: 12, offset: 38383},
+										pos: position{line: 1601, col: 12, offset: 38352},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1601, col: 12, offset: 38383},
+											pos:  position{line: 1601, col: 12, offset: 38352},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1601, col: 22, offset: 38393},
+									pos:   position{line: 1601, col: 22, offset: 38362},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1601, col: 24, offset: 38395},
+										pos:  position{line: 1601, col: 24, offset: 38364},
 										name: "IP6Tail",
 									},
 								},
@@ -11091,40 +11091,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1604, col: 5, offset: 38466},
+						pos: position{line: 1604, col: 5, offset: 38435},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1604, col: 5, offset: 38466},
+							pos: position{line: 1604, col: 5, offset: 38435},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1604, col: 5, offset: 38466},
+									pos:   position{line: 1604, col: 5, offset: 38435},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1604, col: 7, offset: 38468},
+										pos:  position{line: 1604, col: 7, offset: 38437},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1604, col: 11, offset: 38472},
+									pos:   position{line: 1604, col: 11, offset: 38441},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1604, col: 13, offset: 38474},
+										pos: position{line: 1604, col: 13, offset: 38443},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1604, col: 13, offset: 38474},
+											pos:  position{line: 1604, col: 13, offset: 38443},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1604, col: 23, offset: 38484},
+									pos:        position{line: 1604, col: 23, offset: 38453},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1604, col: 28, offset: 38489},
+									pos: position{line: 1604, col: 28, offset: 38458},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1604, col: 29, offset: 38490},
+										pos:  position{line: 1604, col: 29, offset: 38459},
 										name: "TypeAsValue",
 									},
 								},
@@ -11132,10 +11132,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1607, col: 5, offset: 38565},
+						pos: position{line: 1607, col: 5, offset: 38534},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1607, col: 5, offset: 38565},
+							pos:        position{line: 1607, col: 5, offset: 38534},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11148,16 +11148,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1611, col: 1, offset: 38602},
+			pos:  position{line: 1611, col: 1, offset: 38571},
 			expr: &choiceExpr{
-				pos: position{line: 1612, col: 5, offset: 38614},
+				pos: position{line: 1612, col: 5, offset: 38583},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1612, col: 5, offset: 38614},
+						pos:  position{line: 1612, col: 5, offset: 38583},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1613, col: 5, offset: 38621},
+						pos:  position{line: 1613, col: 5, offset: 38590},
 						name: "Hex",
 					},
 				},
@@ -11167,24 +11167,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1615, col: 1, offset: 38626},
+			pos:  position{line: 1615, col: 1, offset: 38595},
 			expr: &actionExpr{
-				pos: position{line: 1615, col: 12, offset: 38637},
+				pos: position{line: 1615, col: 12, offset: 38606},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1615, col: 12, offset: 38637},
+					pos: position{line: 1615, col: 12, offset: 38606},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1615, col: 12, offset: 38637},
+							pos:        position{line: 1615, col: 12, offset: 38606},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1615, col: 16, offset: 38641},
+							pos:   position{line: 1615, col: 16, offset: 38610},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1615, col: 18, offset: 38643},
+								pos:  position{line: 1615, col: 18, offset: 38612},
 								name: "Hex",
 							},
 						},
@@ -11196,23 +11196,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1617, col: 1, offset: 38681},
+			pos:  position{line: 1617, col: 1, offset: 38650},
 			expr: &actionExpr{
-				pos: position{line: 1617, col: 12, offset: 38692},
+				pos: position{line: 1617, col: 12, offset: 38661},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1617, col: 12, offset: 38692},
+					pos: position{line: 1617, col: 12, offset: 38661},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1617, col: 12, offset: 38692},
+							pos:   position{line: 1617, col: 12, offset: 38661},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1617, col: 14, offset: 38694},
+								pos:  position{line: 1617, col: 14, offset: 38663},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1617, col: 18, offset: 38698},
+							pos:        position{line: 1617, col: 18, offset: 38667},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11225,32 +11225,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1619, col: 1, offset: 38736},
+			pos:  position{line: 1619, col: 1, offset: 38705},
 			expr: &actionExpr{
-				pos: position{line: 1620, col: 5, offset: 38747},
+				pos: position{line: 1620, col: 5, offset: 38716},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1620, col: 5, offset: 38747},
+					pos: position{line: 1620, col: 5, offset: 38716},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1620, col: 5, offset: 38747},
+							pos:   position{line: 1620, col: 5, offset: 38716},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1620, col: 7, offset: 38749},
+								pos:  position{line: 1620, col: 7, offset: 38718},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1620, col: 10, offset: 38752},
+							pos:        position{line: 1620, col: 10, offset: 38721},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1620, col: 14, offset: 38756},
+							pos:   position{line: 1620, col: 14, offset: 38725},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1620, col: 16, offset: 38758},
+								pos:  position{line: 1620, col: 16, offset: 38727},
 								name: "UIntString",
 							},
 						},
@@ -11262,32 +11262,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1624, col: 1, offset: 38826},
+			pos:  position{line: 1624, col: 1, offset: 38795},
 			expr: &actionExpr{
-				pos: position{line: 1625, col: 5, offset: 38837},
+				pos: position{line: 1625, col: 5, offset: 38806},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1625, col: 5, offset: 38837},
+					pos: position{line: 1625, col: 5, offset: 38806},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1625, col: 5, offset: 38837},
+							pos:   position{line: 1625, col: 5, offset: 38806},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1625, col: 7, offset: 38839},
+								pos:  position{line: 1625, col: 7, offset: 38808},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1625, col: 11, offset: 38843},
+							pos:        position{line: 1625, col: 11, offset: 38812},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1625, col: 15, offset: 38847},
+							pos:   position{line: 1625, col: 15, offset: 38816},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1625, col: 17, offset: 38849},
+								pos:  position{line: 1625, col: 17, offset: 38818},
 								name: "UIntString",
 							},
 						},
@@ -11299,15 +11299,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1629, col: 1, offset: 38917},
+			pos:  position{line: 1629, col: 1, offset: 38886},
 			expr: &actionExpr{
-				pos: position{line: 1630, col: 4, offset: 38925},
+				pos: position{line: 1630, col: 4, offset: 38894},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1630, col: 4, offset: 38925},
+					pos:   position{line: 1630, col: 4, offset: 38894},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1630, col: 6, offset: 38927},
+						pos:  position{line: 1630, col: 6, offset: 38896},
 						name: "UIntString",
 					},
 				},
@@ -11317,16 +11317,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1632, col: 1, offset: 38967},
+			pos:  position{line: 1632, col: 1, offset: 38936},
 			expr: &choiceExpr{
-				pos: position{line: 1633, col: 5, offset: 38981},
+				pos: position{line: 1633, col: 5, offset: 38950},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1633, col: 5, offset: 38981},
+						pos:  position{line: 1633, col: 5, offset: 38950},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1634, col: 5, offset: 38996},
+						pos:  position{line: 1634, col: 5, offset: 38965},
 						name: "MinusIntString",
 					},
 				},
@@ -11336,14 +11336,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1636, col: 1, offset: 39012},
+			pos:  position{line: 1636, col: 1, offset: 38981},
 			expr: &actionExpr{
-				pos: position{line: 1636, col: 14, offset: 39025},
+				pos: position{line: 1636, col: 14, offset: 38994},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1636, col: 14, offset: 39025},
+					pos: position{line: 1636, col: 14, offset: 38994},
 					expr: &charClassMatcher{
-						pos:        position{line: 1636, col: 14, offset: 39025},
+						pos:        position{line: 1636, col: 14, offset: 38994},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11356,21 +11356,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1638, col: 1, offset: 39064},
+			pos:  position{line: 1638, col: 1, offset: 39033},
 			expr: &actionExpr{
-				pos: position{line: 1639, col: 5, offset: 39083},
+				pos: position{line: 1639, col: 5, offset: 39052},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1639, col: 5, offset: 39083},
+					pos: position{line: 1639, col: 5, offset: 39052},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1639, col: 5, offset: 39083},
+							pos:        position{line: 1639, col: 5, offset: 39052},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1639, col: 9, offset: 39087},
+							pos:  position{line: 1639, col: 9, offset: 39056},
 							name: "UIntString",
 						},
 					},
@@ -11381,29 +11381,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1641, col: 1, offset: 39130},
+			pos:  position{line: 1641, col: 1, offset: 39099},
 			expr: &choiceExpr{
-				pos: position{line: 1642, col: 5, offset: 39146},
+				pos: position{line: 1642, col: 5, offset: 39115},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1642, col: 5, offset: 39146},
+						pos: position{line: 1642, col: 5, offset: 39115},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1642, col: 5, offset: 39146},
+							pos: position{line: 1642, col: 5, offset: 39115},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1642, col: 5, offset: 39146},
+									pos: position{line: 1642, col: 5, offset: 39115},
 									expr: &litMatcher{
-										pos:        position{line: 1642, col: 5, offset: 39146},
+										pos:        position{line: 1642, col: 5, offset: 39115},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1642, col: 10, offset: 39151},
+									pos: position{line: 1642, col: 10, offset: 39120},
 									expr: &charClassMatcher{
-										pos:        position{line: 1642, col: 10, offset: 39151},
+										pos:        position{line: 1642, col: 10, offset: 39120},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11411,15 +11411,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1642, col: 17, offset: 39158},
+									pos:        position{line: 1642, col: 17, offset: 39127},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1642, col: 21, offset: 39162},
+									pos: position{line: 1642, col: 21, offset: 39131},
 									expr: &charClassMatcher{
-										pos:        position{line: 1642, col: 21, offset: 39162},
+										pos:        position{line: 1642, col: 21, offset: 39131},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11427,9 +11427,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1642, col: 28, offset: 39169},
+									pos: position{line: 1642, col: 28, offset: 39138},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1642, col: 28, offset: 39169},
+										pos:  position{line: 1642, col: 28, offset: 39138},
 										name: "ExponentPart",
 									},
 								},
@@ -11437,30 +11437,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1643, col: 5, offset: 39218},
+						pos: position{line: 1643, col: 5, offset: 39187},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1643, col: 5, offset: 39218},
+							pos: position{line: 1643, col: 5, offset: 39187},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1643, col: 5, offset: 39218},
+									pos: position{line: 1643, col: 5, offset: 39187},
 									expr: &litMatcher{
-										pos:        position{line: 1643, col: 5, offset: 39218},
+										pos:        position{line: 1643, col: 5, offset: 39187},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1643, col: 10, offset: 39223},
+									pos:        position{line: 1643, col: 10, offset: 39192},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1643, col: 14, offset: 39227},
+									pos: position{line: 1643, col: 14, offset: 39196},
 									expr: &charClassMatcher{
-										pos:        position{line: 1643, col: 14, offset: 39227},
+										pos:        position{line: 1643, col: 14, offset: 39196},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11468,9 +11468,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1643, col: 21, offset: 39234},
+									pos: position{line: 1643, col: 21, offset: 39203},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1643, col: 21, offset: 39234},
+										pos:  position{line: 1643, col: 21, offset: 39203},
 										name: "ExponentPart",
 									},
 								},
@@ -11478,17 +11478,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1644, col: 5, offset: 39283},
+						pos: position{line: 1644, col: 5, offset: 39252},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1644, col: 6, offset: 39284},
+							pos: position{line: 1644, col: 6, offset: 39253},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1644, col: 6, offset: 39284},
+									pos:  position{line: 1644, col: 6, offset: 39253},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1644, col: 12, offset: 39290},
+									pos:  position{line: 1644, col: 12, offset: 39259},
 									name: "Infinity",
 								},
 							},
@@ -11501,20 +11501,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1647, col: 1, offset: 39333},
+			pos:  position{line: 1647, col: 1, offset: 39302},
 			expr: &seqExpr{
-				pos: position{line: 1647, col: 16, offset: 39348},
+				pos: position{line: 1647, col: 16, offset: 39317},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1647, col: 16, offset: 39348},
+						pos:        position{line: 1647, col: 16, offset: 39317},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1647, col: 21, offset: 39353},
+						pos: position{line: 1647, col: 21, offset: 39322},
 						expr: &charClassMatcher{
-							pos:        position{line: 1647, col: 21, offset: 39353},
+							pos:        position{line: 1647, col: 21, offset: 39322},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11522,7 +11522,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1647, col: 27, offset: 39359},
+						pos:  position{line: 1647, col: 27, offset: 39328},
 						name: "UIntString",
 					},
 				},
@@ -11532,9 +11532,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1649, col: 1, offset: 39371},
+			pos:  position{line: 1649, col: 1, offset: 39340},
 			expr: &litMatcher{
-				pos:        position{line: 1649, col: 7, offset: 39377},
+				pos:        position{line: 1649, col: 7, offset: 39346},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11544,23 +11544,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1651, col: 1, offset: 39384},
+			pos:  position{line: 1651, col: 1, offset: 39353},
 			expr: &seqExpr{
-				pos: position{line: 1651, col: 12, offset: 39395},
+				pos: position{line: 1651, col: 12, offset: 39364},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1651, col: 12, offset: 39395},
+						pos: position{line: 1651, col: 12, offset: 39364},
 						expr: &choiceExpr{
-							pos: position{line: 1651, col: 13, offset: 39396},
+							pos: position{line: 1651, col: 13, offset: 39365},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1651, col: 13, offset: 39396},
+									pos:        position{line: 1651, col: 13, offset: 39365},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1651, col: 19, offset: 39402},
+									pos:        position{line: 1651, col: 19, offset: 39371},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11569,7 +11569,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1651, col: 25, offset: 39408},
+						pos:        position{line: 1651, col: 25, offset: 39377},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11581,14 +11581,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1653, col: 1, offset: 39415},
+			pos:  position{line: 1653, col: 1, offset: 39384},
 			expr: &actionExpr{
-				pos: position{line: 1653, col: 7, offset: 39421},
+				pos: position{line: 1653, col: 7, offset: 39390},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1653, col: 7, offset: 39421},
+					pos: position{line: 1653, col: 7, offset: 39390},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1653, col: 7, offset: 39421},
+						pos:  position{line: 1653, col: 7, offset: 39390},
 						name: "HexDigit",
 					},
 				},
@@ -11598,9 +11598,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1655, col: 1, offset: 39463},
+			pos:  position{line: 1655, col: 1, offset: 39432},
 			expr: &charClassMatcher{
-				pos:        position{line: 1655, col: 12, offset: 39474},
+				pos:        position{line: 1655, col: 12, offset: 39443},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11611,32 +11611,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1657, col: 1, offset: 39487},
+			pos:  position{line: 1657, col: 1, offset: 39456},
 			expr: &actionExpr{
-				pos: position{line: 1658, col: 5, offset: 39510},
+				pos: position{line: 1658, col: 5, offset: 39479},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1658, col: 5, offset: 39510},
+					pos: position{line: 1658, col: 5, offset: 39479},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1658, col: 5, offset: 39510},
+							pos:        position{line: 1658, col: 5, offset: 39479},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1658, col: 9, offset: 39514},
+							pos:   position{line: 1658, col: 9, offset: 39483},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1658, col: 11, offset: 39516},
+								pos: position{line: 1658, col: 11, offset: 39485},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1658, col: 11, offset: 39516},
+									pos:  position{line: 1658, col: 11, offset: 39485},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1658, col: 29, offset: 39534},
+							pos:        position{line: 1658, col: 29, offset: 39503},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11649,32 +11649,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1660, col: 1, offset: 39568},
+			pos:  position{line: 1660, col: 1, offset: 39537},
 			expr: &actionExpr{
-				pos: position{line: 1661, col: 5, offset: 39591},
+				pos: position{line: 1661, col: 5, offset: 39560},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1661, col: 5, offset: 39591},
+					pos: position{line: 1661, col: 5, offset: 39560},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1661, col: 5, offset: 39591},
+							pos:        position{line: 1661, col: 5, offset: 39560},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1661, col: 9, offset: 39595},
+							pos:   position{line: 1661, col: 9, offset: 39564},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1661, col: 11, offset: 39597},
+								pos: position{line: 1661, col: 11, offset: 39566},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1661, col: 11, offset: 39597},
+									pos:  position{line: 1661, col: 11, offset: 39566},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1661, col: 29, offset: 39615},
+							pos:        position{line: 1661, col: 29, offset: 39584},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11687,57 +11687,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1663, col: 1, offset: 39649},
+			pos:  position{line: 1663, col: 1, offset: 39618},
 			expr: &choiceExpr{
-				pos: position{line: 1664, col: 5, offset: 39670},
+				pos: position{line: 1664, col: 5, offset: 39639},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1664, col: 5, offset: 39670},
+						pos: position{line: 1664, col: 5, offset: 39639},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1664, col: 5, offset: 39670},
+							pos: position{line: 1664, col: 5, offset: 39639},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1664, col: 5, offset: 39670},
+									pos: position{line: 1664, col: 5, offset: 39639},
 									expr: &choiceExpr{
-										pos: position{line: 1664, col: 7, offset: 39672},
+										pos: position{line: 1664, col: 7, offset: 39641},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1664, col: 7, offset: 39672},
+												pos:        position{line: 1664, col: 7, offset: 39641},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1664, col: 13, offset: 39678},
+												pos:  position{line: 1664, col: 13, offset: 39647},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1664, col: 26, offset: 39691,
+									line: 1664, col: 26, offset: 39660,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1665, col: 5, offset: 39728},
+						pos: position{line: 1665, col: 5, offset: 39697},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1665, col: 5, offset: 39728},
+							pos: position{line: 1665, col: 5, offset: 39697},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1665, col: 5, offset: 39728},
+									pos:        position{line: 1665, col: 5, offset: 39697},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1665, col: 10, offset: 39733},
+									pos:   position{line: 1665, col: 10, offset: 39702},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1665, col: 12, offset: 39735},
+										pos:  position{line: 1665, col: 12, offset: 39704},
 										name: "EscapeSequence",
 									},
 								},
@@ -11751,32 +11751,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1667, col: 1, offset: 39769},
+			pos:  position{line: 1667, col: 1, offset: 39738},
 			expr: &actionExpr{
-				pos: position{line: 1668, col: 5, offset: 39788},
+				pos: position{line: 1668, col: 5, offset: 39757},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1668, col: 5, offset: 39788},
+					pos: position{line: 1668, col: 5, offset: 39757},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1668, col: 5, offset: 39788},
+							pos:        position{line: 1668, col: 5, offset: 39757},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1668, col: 9, offset: 39792},
+							pos:   position{line: 1668, col: 9, offset: 39761},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1668, col: 11, offset: 39794},
+								pos: position{line: 1668, col: 11, offset: 39763},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1668, col: 11, offset: 39794},
+									pos:  position{line: 1668, col: 11, offset: 39763},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1668, col: 25, offset: 39808},
+							pos:        position{line: 1668, col: 25, offset: 39777},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11789,57 +11789,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1670, col: 1, offset: 39842},
+			pos:  position{line: 1670, col: 1, offset: 39811},
 			expr: &choiceExpr{
-				pos: position{line: 1671, col: 5, offset: 39859},
+				pos: position{line: 1671, col: 5, offset: 39828},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1671, col: 5, offset: 39859},
+						pos: position{line: 1671, col: 5, offset: 39828},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1671, col: 5, offset: 39859},
+							pos: position{line: 1671, col: 5, offset: 39828},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1671, col: 5, offset: 39859},
+									pos: position{line: 1671, col: 5, offset: 39828},
 									expr: &choiceExpr{
-										pos: position{line: 1671, col: 7, offset: 39861},
+										pos: position{line: 1671, col: 7, offset: 39830},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1671, col: 7, offset: 39861},
+												pos:        position{line: 1671, col: 7, offset: 39830},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1671, col: 13, offset: 39867},
+												pos:  position{line: 1671, col: 13, offset: 39836},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1671, col: 26, offset: 39880,
+									line: 1671, col: 26, offset: 39849,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1672, col: 5, offset: 39917},
+						pos: position{line: 1672, col: 5, offset: 39886},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1672, col: 5, offset: 39917},
+							pos: position{line: 1672, col: 5, offset: 39886},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1672, col: 5, offset: 39917},
+									pos:        position{line: 1672, col: 5, offset: 39886},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1672, col: 10, offset: 39922},
+									pos:   position{line: 1672, col: 10, offset: 39891},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1672, col: 12, offset: 39924},
+										pos:  position{line: 1672, col: 12, offset: 39893},
 										name: "EscapeSequence",
 									},
 								},
@@ -11853,28 +11853,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1674, col: 1, offset: 39958},
+			pos:  position{line: 1674, col: 1, offset: 39927},
 			expr: &actionExpr{
-				pos: position{line: 1675, col: 5, offset: 39970},
+				pos: position{line: 1675, col: 5, offset: 39939},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1675, col: 5, offset: 39970},
+					pos: position{line: 1675, col: 5, offset: 39939},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1675, col: 5, offset: 39970},
+							pos:   position{line: 1675, col: 5, offset: 39939},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1675, col: 10, offset: 39975},
+								pos:  position{line: 1675, col: 10, offset: 39944},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1675, col: 23, offset: 39988},
+							pos:   position{line: 1675, col: 23, offset: 39957},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1675, col: 28, offset: 39993},
+								pos: position{line: 1675, col: 28, offset: 39962},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1675, col: 28, offset: 39993},
+									pos:  position{line: 1675, col: 28, offset: 39962},
 									name: "KeyWordRest",
 								},
 							},
@@ -11887,16 +11887,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1677, col: 1, offset: 40055},
+			pos:  position{line: 1677, col: 1, offset: 40024},
 			expr: &choiceExpr{
-				pos: position{line: 1678, col: 5, offset: 40072},
+				pos: position{line: 1678, col: 5, offset: 40041},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1678, col: 5, offset: 40072},
+						pos:  position{line: 1678, col: 5, offset: 40041},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1679, col: 5, offset: 40089},
+						pos:  position{line: 1679, col: 5, offset: 40058},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11906,16 +11906,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1681, col: 1, offset: 40101},
+			pos:  position{line: 1681, col: 1, offset: 40070},
 			expr: &choiceExpr{
-				pos: position{line: 1682, col: 5, offset: 40117},
+				pos: position{line: 1682, col: 5, offset: 40086},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1682, col: 5, offset: 40117},
+						pos:  position{line: 1682, col: 5, offset: 40086},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1683, col: 5, offset: 40134},
+						pos:        position{line: 1683, col: 5, offset: 40103},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11928,19 +11928,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1685, col: 1, offset: 40141},
+			pos:  position{line: 1685, col: 1, offset: 40110},
 			expr: &actionExpr{
-				pos: position{line: 1685, col: 16, offset: 40156},
+				pos: position{line: 1685, col: 16, offset: 40125},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1685, col: 17, offset: 40157},
+					pos: position{line: 1685, col: 17, offset: 40126},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1685, col: 17, offset: 40157},
+							pos:  position{line: 1685, col: 17, offset: 40126},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1685, col: 33, offset: 40173},
+							pos:        position{line: 1685, col: 33, offset: 40142},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11954,31 +11954,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1687, col: 1, offset: 40217},
+			pos:  position{line: 1687, col: 1, offset: 40186},
 			expr: &actionExpr{
-				pos: position{line: 1687, col: 14, offset: 40230},
+				pos: position{line: 1687, col: 14, offset: 40199},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1687, col: 14, offset: 40230},
+					pos: position{line: 1687, col: 14, offset: 40199},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1687, col: 14, offset: 40230},
+							pos:        position{line: 1687, col: 14, offset: 40199},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1687, col: 19, offset: 40235},
+							pos:   position{line: 1687, col: 19, offset: 40204},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1687, col: 22, offset: 40238},
+								pos: position{line: 1687, col: 22, offset: 40207},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1687, col: 22, offset: 40238},
+										pos:  position{line: 1687, col: 22, offset: 40207},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1687, col: 38, offset: 40254},
+										pos:  position{line: 1687, col: 38, offset: 40223},
 										name: "EscapeSequence",
 									},
 								},
@@ -11992,42 +11992,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1689, col: 1, offset: 40289},
+			pos:  position{line: 1689, col: 1, offset: 40258},
 			expr: &actionExpr{
-				pos: position{line: 1690, col: 5, offset: 40305},
+				pos: position{line: 1690, col: 5, offset: 40274},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1690, col: 5, offset: 40305},
+					pos: position{line: 1690, col: 5, offset: 40274},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1690, col: 5, offset: 40305},
+							pos: position{line: 1690, col: 5, offset: 40274},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1690, col: 6, offset: 40306},
+								pos:  position{line: 1690, col: 6, offset: 40275},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1690, col: 22, offset: 40322},
+							pos: position{line: 1690, col: 22, offset: 40291},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1690, col: 23, offset: 40323},
+								pos:  position{line: 1690, col: 23, offset: 40292},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1690, col: 35, offset: 40335},
+							pos:   position{line: 1690, col: 35, offset: 40304},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1690, col: 40, offset: 40340},
+								pos:  position{line: 1690, col: 40, offset: 40309},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1690, col: 50, offset: 40350},
+							pos:   position{line: 1690, col: 50, offset: 40319},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1690, col: 55, offset: 40355},
+								pos: position{line: 1690, col: 55, offset: 40324},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1690, col: 55, offset: 40355},
+									pos:  position{line: 1690, col: 55, offset: 40324},
 									name: "GlobRest",
 								},
 							},
@@ -12040,28 +12040,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1694, col: 1, offset: 40424},
+			pos:  position{line: 1694, col: 1, offset: 40393},
 			expr: &choiceExpr{
-				pos: position{line: 1694, col: 19, offset: 40442},
+				pos: position{line: 1694, col: 19, offset: 40411},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1694, col: 19, offset: 40442},
+						pos:  position{line: 1694, col: 19, offset: 40411},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1694, col: 34, offset: 40457},
+						pos: position{line: 1694, col: 34, offset: 40426},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1694, col: 34, offset: 40457},
+								pos: position{line: 1694, col: 34, offset: 40426},
 								expr: &litMatcher{
-									pos:        position{line: 1694, col: 34, offset: 40457},
+									pos:        position{line: 1694, col: 34, offset: 40426},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1694, col: 39, offset: 40462},
+								pos:  position{line: 1694, col: 39, offset: 40431},
 								name: "KeyWordRest",
 							},
 						},
@@ -12073,19 +12073,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1695, col: 1, offset: 40474},
+			pos:  position{line: 1695, col: 1, offset: 40443},
 			expr: &seqExpr{
-				pos: position{line: 1695, col: 15, offset: 40488},
+				pos: position{line: 1695, col: 15, offset: 40457},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1695, col: 15, offset: 40488},
+						pos: position{line: 1695, col: 15, offset: 40457},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1695, col: 15, offset: 40488},
+							pos:  position{line: 1695, col: 15, offset: 40457},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1695, col: 28, offset: 40501},
+						pos:        position{line: 1695, col: 28, offset: 40470},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12097,23 +12097,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1697, col: 1, offset: 40506},
+			pos:  position{line: 1697, col: 1, offset: 40475},
 			expr: &choiceExpr{
-				pos: position{line: 1698, col: 5, offset: 40520},
+				pos: position{line: 1698, col: 5, offset: 40489},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1698, col: 5, offset: 40520},
+						pos:  position{line: 1698, col: 5, offset: 40489},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1699, col: 5, offset: 40537},
+						pos:  position{line: 1699, col: 5, offset: 40506},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1700, col: 5, offset: 40549},
+						pos: position{line: 1700, col: 5, offset: 40518},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1700, col: 5, offset: 40549},
+							pos:        position{line: 1700, col: 5, offset: 40518},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12126,16 +12126,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1702, col: 1, offset: 40574},
+			pos:  position{line: 1702, col: 1, offset: 40543},
 			expr: &choiceExpr{
-				pos: position{line: 1703, col: 5, offset: 40587},
+				pos: position{line: 1703, col: 5, offset: 40556},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1703, col: 5, offset: 40587},
+						pos:  position{line: 1703, col: 5, offset: 40556},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1704, col: 5, offset: 40601},
+						pos:        position{line: 1704, col: 5, offset: 40570},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12148,31 +12148,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1706, col: 1, offset: 40608},
+			pos:  position{line: 1706, col: 1, offset: 40577},
 			expr: &actionExpr{
-				pos: position{line: 1706, col: 11, offset: 40618},
+				pos: position{line: 1706, col: 11, offset: 40587},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1706, col: 11, offset: 40618},
+					pos: position{line: 1706, col: 11, offset: 40587},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1706, col: 11, offset: 40618},
+							pos:        position{line: 1706, col: 11, offset: 40587},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1706, col: 16, offset: 40623},
+							pos:   position{line: 1706, col: 16, offset: 40592},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1706, col: 19, offset: 40626},
+								pos: position{line: 1706, col: 19, offset: 40595},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1706, col: 19, offset: 40626},
+										pos:  position{line: 1706, col: 19, offset: 40595},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1706, col: 32, offset: 40639},
+										pos:  position{line: 1706, col: 32, offset: 40608},
 										name: "EscapeSequence",
 									},
 								},
@@ -12186,32 +12186,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1708, col: 1, offset: 40674},
+			pos:  position{line: 1708, col: 1, offset: 40643},
 			expr: &choiceExpr{
-				pos: position{line: 1709, col: 5, offset: 40689},
+				pos: position{line: 1709, col: 5, offset: 40658},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1709, col: 5, offset: 40689},
+						pos: position{line: 1709, col: 5, offset: 40658},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1709, col: 5, offset: 40689},
+							pos:        position{line: 1709, col: 5, offset: 40658},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1710, col: 5, offset: 40717},
+						pos: position{line: 1710, col: 5, offset: 40686},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1710, col: 5, offset: 40717},
+							pos:        position{line: 1710, col: 5, offset: 40686},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1711, col: 5, offset: 40747},
+						pos:        position{line: 1711, col: 5, offset: 40716},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12224,57 +12224,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1713, col: 1, offset: 40753},
+			pos:  position{line: 1713, col: 1, offset: 40722},
 			expr: &choiceExpr{
-				pos: position{line: 1714, col: 5, offset: 40774},
+				pos: position{line: 1714, col: 5, offset: 40743},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1714, col: 5, offset: 40774},
+						pos: position{line: 1714, col: 5, offset: 40743},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1714, col: 5, offset: 40774},
+							pos: position{line: 1714, col: 5, offset: 40743},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1714, col: 5, offset: 40774},
+									pos: position{line: 1714, col: 5, offset: 40743},
 									expr: &choiceExpr{
-										pos: position{line: 1714, col: 7, offset: 40776},
+										pos: position{line: 1714, col: 7, offset: 40745},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1714, col: 7, offset: 40776},
+												pos:        position{line: 1714, col: 7, offset: 40745},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1714, col: 13, offset: 40782},
+												pos:  position{line: 1714, col: 13, offset: 40751},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1714, col: 26, offset: 40795,
+									line: 1714, col: 26, offset: 40764,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1715, col: 5, offset: 40832},
+						pos: position{line: 1715, col: 5, offset: 40801},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1715, col: 5, offset: 40832},
+							pos: position{line: 1715, col: 5, offset: 40801},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1715, col: 5, offset: 40832},
+									pos:        position{line: 1715, col: 5, offset: 40801},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1715, col: 10, offset: 40837},
+									pos:   position{line: 1715, col: 10, offset: 40806},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1715, col: 12, offset: 40839},
+										pos:  position{line: 1715, col: 12, offset: 40808},
 										name: "EscapeSequence",
 									},
 								},
@@ -12288,16 +12288,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1717, col: 1, offset: 40873},
+			pos:  position{line: 1717, col: 1, offset: 40842},
 			expr: &choiceExpr{
-				pos: position{line: 1718, col: 5, offset: 40892},
+				pos: position{line: 1718, col: 5, offset: 40861},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1718, col: 5, offset: 40892},
+						pos:  position{line: 1718, col: 5, offset: 40861},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1719, col: 5, offset: 40913},
+						pos:  position{line: 1719, col: 5, offset: 40882},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12307,87 +12307,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1721, col: 1, offset: 40928},
+			pos:  position{line: 1721, col: 1, offset: 40897},
 			expr: &choiceExpr{
-				pos: position{line: 1722, col: 5, offset: 40949},
+				pos: position{line: 1722, col: 5, offset: 40918},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1722, col: 5, offset: 40949},
+						pos:        position{line: 1722, col: 5, offset: 40918},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1723, col: 5, offset: 40957},
+						pos: position{line: 1723, col: 5, offset: 40926},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1723, col: 5, offset: 40957},
+							pos:        position{line: 1723, col: 5, offset: 40926},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1724, col: 5, offset: 40997},
+						pos:        position{line: 1724, col: 5, offset: 40966},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1725, col: 5, offset: 41006},
+						pos: position{line: 1725, col: 5, offset: 40975},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1725, col: 5, offset: 41006},
+							pos:        position{line: 1725, col: 5, offset: 40975},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1726, col: 5, offset: 41035},
+						pos: position{line: 1726, col: 5, offset: 41004},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1726, col: 5, offset: 41035},
+							pos:        position{line: 1726, col: 5, offset: 41004},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1727, col: 5, offset: 41064},
+						pos: position{line: 1727, col: 5, offset: 41033},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1727, col: 5, offset: 41064},
+							pos:        position{line: 1727, col: 5, offset: 41033},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1728, col: 5, offset: 41093},
+						pos: position{line: 1728, col: 5, offset: 41062},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1728, col: 5, offset: 41093},
+							pos:        position{line: 1728, col: 5, offset: 41062},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1729, col: 5, offset: 41122},
+						pos: position{line: 1729, col: 5, offset: 41091},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1729, col: 5, offset: 41122},
+							pos:        position{line: 1729, col: 5, offset: 41091},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1730, col: 5, offset: 41151},
+						pos: position{line: 1730, col: 5, offset: 41120},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1730, col: 5, offset: 41151},
+							pos:        position{line: 1730, col: 5, offset: 41120},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12400,32 +12400,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1732, col: 1, offset: 41177},
+			pos:  position{line: 1732, col: 1, offset: 41146},
 			expr: &choiceExpr{
-				pos: position{line: 1733, col: 5, offset: 41195},
+				pos: position{line: 1733, col: 5, offset: 41164},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1733, col: 5, offset: 41195},
+						pos: position{line: 1733, col: 5, offset: 41164},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1733, col: 5, offset: 41195},
+							pos:        position{line: 1733, col: 5, offset: 41164},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1734, col: 5, offset: 41223},
+						pos: position{line: 1734, col: 5, offset: 41192},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1734, col: 5, offset: 41223},
+							pos:        position{line: 1734, col: 5, offset: 41192},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1735, col: 5, offset: 41251},
+						pos:        position{line: 1735, col: 5, offset: 41220},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12438,42 +12438,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1737, col: 1, offset: 41257},
+			pos:  position{line: 1737, col: 1, offset: 41226},
 			expr: &choiceExpr{
-				pos: position{line: 1738, col: 5, offset: 41275},
+				pos: position{line: 1738, col: 5, offset: 41244},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1738, col: 5, offset: 41275},
+						pos: position{line: 1738, col: 5, offset: 41244},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1738, col: 5, offset: 41275},
+							pos: position{line: 1738, col: 5, offset: 41244},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1738, col: 5, offset: 41275},
+									pos:        position{line: 1738, col: 5, offset: 41244},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1738, col: 9, offset: 41279},
+									pos:   position{line: 1738, col: 9, offset: 41248},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1738, col: 16, offset: 41286},
+										pos: position{line: 1738, col: 16, offset: 41255},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1738, col: 16, offset: 41286},
+												pos:  position{line: 1738, col: 16, offset: 41255},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1738, col: 25, offset: 41295},
+												pos:  position{line: 1738, col: 25, offset: 41264},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1738, col: 34, offset: 41304},
+												pos:  position{line: 1738, col: 34, offset: 41273},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1738, col: 43, offset: 41313},
+												pos:  position{line: 1738, col: 43, offset: 41282},
 												name: "HexDigit",
 											},
 										},
@@ -12483,65 +12483,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1741, col: 5, offset: 41376},
+						pos: position{line: 1741, col: 5, offset: 41345},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1741, col: 5, offset: 41376},
+							pos: position{line: 1741, col: 5, offset: 41345},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1741, col: 5, offset: 41376},
+									pos:        position{line: 1741, col: 5, offset: 41345},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1741, col: 9, offset: 41380},
+									pos:        position{line: 1741, col: 9, offset: 41349},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1741, col: 13, offset: 41384},
+									pos:   position{line: 1741, col: 13, offset: 41353},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1741, col: 20, offset: 41391},
+										pos: position{line: 1741, col: 20, offset: 41360},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1741, col: 20, offset: 41391},
+												pos:  position{line: 1741, col: 20, offset: 41360},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1741, col: 29, offset: 41400},
+												pos: position{line: 1741, col: 29, offset: 41369},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1741, col: 29, offset: 41400},
+													pos:  position{line: 1741, col: 29, offset: 41369},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1741, col: 39, offset: 41410},
+												pos: position{line: 1741, col: 39, offset: 41379},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1741, col: 39, offset: 41410},
+													pos:  position{line: 1741, col: 39, offset: 41379},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1741, col: 49, offset: 41420},
+												pos: position{line: 1741, col: 49, offset: 41389},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1741, col: 49, offset: 41420},
+													pos:  position{line: 1741, col: 49, offset: 41389},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1741, col: 59, offset: 41430},
+												pos: position{line: 1741, col: 59, offset: 41399},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1741, col: 59, offset: 41430},
+													pos:  position{line: 1741, col: 59, offset: 41399},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1741, col: 69, offset: 41440},
+												pos: position{line: 1741, col: 69, offset: 41409},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1741, col: 69, offset: 41440},
+													pos:  position{line: 1741, col: 69, offset: 41409},
 													name: "HexDigit",
 												},
 											},
@@ -12549,7 +12549,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1741, col: 80, offset: 41451},
+									pos:        position{line: 1741, col: 80, offset: 41420},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12564,37 +12564,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1745, col: 1, offset: 41505},
+			pos:  position{line: 1745, col: 1, offset: 41474},
 			expr: &actionExpr{
-				pos: position{line: 1746, col: 5, offset: 41523},
+				pos: position{line: 1746, col: 5, offset: 41492},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1746, col: 5, offset: 41523},
+					pos: position{line: 1746, col: 5, offset: 41492},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1746, col: 5, offset: 41523},
+							pos:        position{line: 1746, col: 5, offset: 41492},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1746, col: 9, offset: 41527},
+							pos:   position{line: 1746, col: 9, offset: 41496},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1746, col: 14, offset: 41532},
+								pos:  position{line: 1746, col: 14, offset: 41501},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1746, col: 25, offset: 41543},
+							pos:        position{line: 1746, col: 25, offset: 41512},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1746, col: 29, offset: 41547},
+							pos: position{line: 1746, col: 29, offset: 41516},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1746, col: 30, offset: 41548},
+								pos:  position{line: 1746, col: 30, offset: 41517},
 								name: "KeyWordStart",
 							},
 						},
@@ -12606,33 +12606,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1748, col: 1, offset: 41583},
+			pos:  position{line: 1748, col: 1, offset: 41552},
 			expr: &actionExpr{
-				pos: position{line: 1749, col: 5, offset: 41598},
+				pos: position{line: 1749, col: 5, offset: 41567},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1749, col: 5, offset: 41598},
+					pos: position{line: 1749, col: 5, offset: 41567},
 					expr: &choiceExpr{
-						pos: position{line: 1749, col: 6, offset: 41599},
+						pos: position{line: 1749, col: 6, offset: 41568},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1749, col: 6, offset: 41599},
+								pos:        position{line: 1749, col: 6, offset: 41568},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1749, col: 15, offset: 41608},
+								pos: position{line: 1749, col: 15, offset: 41577},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1749, col: 15, offset: 41608},
+										pos:        position{line: 1749, col: 15, offset: 41577},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1749, col: 20, offset: 41613,
+										line: 1749, col: 20, offset: 41582,
 									},
 								},
 							},
@@ -12645,9 +12645,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1751, col: 1, offset: 41649},
+			pos:  position{line: 1751, col: 1, offset: 41618},
 			expr: &charClassMatcher{
-				pos:        position{line: 1752, col: 5, offset: 41665},
+				pos:        position{line: 1752, col: 5, offset: 41634},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12659,11 +12659,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1754, col: 1, offset: 41680},
+			pos:  position{line: 1754, col: 1, offset: 41649},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1754, col: 5, offset: 41684},
+				pos: position{line: 1754, col: 5, offset: 41653},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1754, col: 5, offset: 41684},
+					pos:  position{line: 1754, col: 5, offset: 41653},
 					name: "AnySpace",
 				},
 			},
@@ -12672,11 +12672,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1756, col: 1, offset: 41695},
+			pos:  position{line: 1756, col: 1, offset: 41664},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1756, col: 6, offset: 41700},
+				pos: position{line: 1756, col: 6, offset: 41669},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1756, col: 6, offset: 41700},
+					pos:  position{line: 1756, col: 6, offset: 41669},
 					name: "AnySpace",
 				},
 			},
@@ -12685,20 +12685,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1758, col: 1, offset: 41711},
+			pos:  position{line: 1758, col: 1, offset: 41680},
 			expr: &choiceExpr{
-				pos: position{line: 1759, col: 5, offset: 41724},
+				pos: position{line: 1759, col: 5, offset: 41693},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1759, col: 5, offset: 41724},
+						pos:  position{line: 1759, col: 5, offset: 41693},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1760, col: 5, offset: 41739},
+						pos:  position{line: 1760, col: 5, offset: 41708},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1761, col: 5, offset: 41758},
+						pos:  position{line: 1761, col: 5, offset: 41727},
 						name: "Comment",
 					},
 				},
@@ -12708,32 +12708,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1763, col: 1, offset: 41767},
+			pos:  position{line: 1763, col: 1, offset: 41736},
 			expr: &choiceExpr{
-				pos: position{line: 1764, col: 5, offset: 41785},
+				pos: position{line: 1764, col: 5, offset: 41754},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1764, col: 5, offset: 41785},
+						pos:  position{line: 1764, col: 5, offset: 41754},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1765, col: 5, offset: 41792},
+						pos:  position{line: 1765, col: 5, offset: 41761},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1766, col: 5, offset: 41799},
+						pos:  position{line: 1766, col: 5, offset: 41768},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1767, col: 5, offset: 41806},
+						pos:  position{line: 1767, col: 5, offset: 41775},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1768, col: 5, offset: 41813},
+						pos:  position{line: 1768, col: 5, offset: 41782},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1769, col: 5, offset: 41820},
+						pos:  position{line: 1769, col: 5, offset: 41789},
 						name: "Nl",
 					},
 				},
@@ -12743,16 +12743,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1771, col: 1, offset: 41824},
+			pos:  position{line: 1771, col: 1, offset: 41793},
 			expr: &choiceExpr{
-				pos: position{line: 1772, col: 5, offset: 41849},
+				pos: position{line: 1772, col: 5, offset: 41818},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1772, col: 5, offset: 41849},
+						pos:  position{line: 1772, col: 5, offset: 41818},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1773, col: 5, offset: 41856},
+						pos:  position{line: 1773, col: 5, offset: 41825},
 						name: "Mc",
 					},
 				},
@@ -12762,9 +12762,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1775, col: 1, offset: 41860},
+			pos:  position{line: 1775, col: 1, offset: 41829},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1776, col: 5, offset: 41877},
+				pos:  position{line: 1776, col: 5, offset: 41846},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12772,9 +12772,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1778, col: 1, offset: 41881},
+			pos:  position{line: 1778, col: 1, offset: 41850},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1779, col: 5, offset: 41913},
+				pos:  position{line: 1779, col: 5, offset: 41882},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12782,9 +12782,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1785, col: 1, offset: 42094},
+			pos:  position{line: 1785, col: 1, offset: 42063},
 			expr: &charClassMatcher{
-				pos:        position{line: 1785, col: 6, offset: 42099},
+				pos:        position{line: 1785, col: 6, offset: 42068},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12796,9 +12796,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1788, col: 1, offset: 46251},
+			pos:  position{line: 1788, col: 1, offset: 46220},
 			expr: &charClassMatcher{
-				pos:        position{line: 1788, col: 6, offset: 46256},
+				pos:        position{line: 1788, col: 6, offset: 46225},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12810,9 +12810,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1791, col: 1, offset: 46741},
+			pos:  position{line: 1791, col: 1, offset: 46710},
 			expr: &charClassMatcher{
-				pos:        position{line: 1791, col: 6, offset: 46746},
+				pos:        position{line: 1791, col: 6, offset: 46715},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12824,9 +12824,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1794, col: 1, offset: 50193},
+			pos:  position{line: 1794, col: 1, offset: 50162},
 			expr: &charClassMatcher{
-				pos:        position{line: 1794, col: 6, offset: 50198},
+				pos:        position{line: 1794, col: 6, offset: 50167},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12838,9 +12838,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1797, col: 1, offset: 50304},
+			pos:  position{line: 1797, col: 1, offset: 50273},
 			expr: &charClassMatcher{
-				pos:        position{line: 1797, col: 6, offset: 50309},
+				pos:        position{line: 1797, col: 6, offset: 50278},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12852,9 +12852,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1800, col: 1, offset: 54310},
+			pos:  position{line: 1800, col: 1, offset: 54279},
 			expr: &charClassMatcher{
-				pos:        position{line: 1800, col: 6, offset: 54315},
+				pos:        position{line: 1800, col: 6, offset: 54284},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12866,9 +12866,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1803, col: 1, offset: 55503},
+			pos:  position{line: 1803, col: 1, offset: 55472},
 			expr: &charClassMatcher{
-				pos:        position{line: 1803, col: 6, offset: 55508},
+				pos:        position{line: 1803, col: 6, offset: 55477},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12880,9 +12880,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1806, col: 1, offset: 57688},
+			pos:  position{line: 1806, col: 1, offset: 57657},
 			expr: &charClassMatcher{
-				pos:        position{line: 1806, col: 6, offset: 57693},
+				pos:        position{line: 1806, col: 6, offset: 57662},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12893,9 +12893,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1809, col: 1, offset: 58196},
+			pos:  position{line: 1809, col: 1, offset: 58165},
 			expr: &charClassMatcher{
-				pos:        position{line: 1809, col: 6, offset: 58201},
+				pos:        position{line: 1809, col: 6, offset: 58170},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12907,9 +12907,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1812, col: 1, offset: 58315},
+			pos:  position{line: 1812, col: 1, offset: 58284},
 			expr: &charClassMatcher{
-				pos:        position{line: 1812, col: 6, offset: 58320},
+				pos:        position{line: 1812, col: 6, offset: 58289},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12921,9 +12921,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1815, col: 1, offset: 58401},
+			pos:  position{line: 1815, col: 1, offset: 58370},
 			expr: &charClassMatcher{
-				pos:        position{line: 1815, col: 6, offset: 58406},
+				pos:        position{line: 1815, col: 6, offset: 58375},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12935,9 +12935,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1817, col: 1, offset: 58459},
+			pos:  position{line: 1817, col: 1, offset: 58428},
 			expr: &anyMatcher{
-				line: 1818, col: 5, offset: 58479,
+				line: 1818, col: 5, offset: 58448,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12945,48 +12945,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1820, col: 1, offset: 58482},
+			pos:         position{line: 1820, col: 1, offset: 58451},
 			expr: &choiceExpr{
-				pos: position{line: 1821, col: 5, offset: 58510},
+				pos: position{line: 1821, col: 5, offset: 58479},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1821, col: 5, offset: 58510},
+						pos:        position{line: 1821, col: 5, offset: 58479},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1822, col: 5, offset: 58519},
+						pos:        position{line: 1822, col: 5, offset: 58488},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1823, col: 5, offset: 58528},
+						pos:        position{line: 1823, col: 5, offset: 58497},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1824, col: 5, offset: 58537},
+						pos:        position{line: 1824, col: 5, offset: 58506},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1825, col: 5, offset: 58545},
+						pos:        position{line: 1825, col: 5, offset: 58514},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1826, col: 5, offset: 58558},
+						pos:        position{line: 1826, col: 5, offset: 58527},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1827, col: 5, offset: 58571},
+						pos:  position{line: 1827, col: 5, offset: 58540},
 						name: "Zs",
 					},
 				},
@@ -12996,9 +12996,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1829, col: 1, offset: 58575},
+			pos:  position{line: 1829, col: 1, offset: 58544},
 			expr: &charClassMatcher{
-				pos:        position{line: 1830, col: 5, offset: 58594},
+				pos:        position{line: 1830, col: 5, offset: 58563},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13010,16 +13010,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1832, col: 1, offset: 58614},
+			pos:         position{line: 1832, col: 1, offset: 58583},
 			expr: &choiceExpr{
-				pos: position{line: 1833, col: 5, offset: 58636},
+				pos: position{line: 1833, col: 5, offset: 58605},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1833, col: 5, offset: 58636},
+						pos:  position{line: 1833, col: 5, offset: 58605},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1834, col: 5, offset: 58657},
+						pos:  position{line: 1834, col: 5, offset: 58626},
 						name: "SingleLineComment",
 					},
 				},
@@ -13029,39 +13029,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1836, col: 1, offset: 58676},
+			pos:  position{line: 1836, col: 1, offset: 58645},
 			expr: &seqExpr{
-				pos: position{line: 1837, col: 5, offset: 58697},
+				pos: position{line: 1837, col: 5, offset: 58666},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1837, col: 5, offset: 58697},
+						pos:        position{line: 1837, col: 5, offset: 58666},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1837, col: 10, offset: 58702},
+						pos: position{line: 1837, col: 10, offset: 58671},
 						expr: &seqExpr{
-							pos: position{line: 1837, col: 11, offset: 58703},
+							pos: position{line: 1837, col: 11, offset: 58672},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1837, col: 11, offset: 58703},
+									pos: position{line: 1837, col: 11, offset: 58672},
 									expr: &litMatcher{
-										pos:        position{line: 1837, col: 12, offset: 58704},
+										pos:        position{line: 1837, col: 12, offset: 58673},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1837, col: 17, offset: 58709},
+									pos:  position{line: 1837, col: 17, offset: 58678},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1837, col: 35, offset: 58727},
+						pos:        position{line: 1837, col: 35, offset: 58696},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13073,30 +13073,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1839, col: 1, offset: 58733},
+			pos:  position{line: 1839, col: 1, offset: 58702},
 			expr: &seqExpr{
-				pos: position{line: 1840, col: 5, offset: 58755},
+				pos: position{line: 1840, col: 5, offset: 58724},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1840, col: 5, offset: 58755},
+						pos:        position{line: 1840, col: 5, offset: 58724},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1840, col: 10, offset: 58760},
+						pos: position{line: 1840, col: 10, offset: 58729},
 						expr: &seqExpr{
-							pos: position{line: 1840, col: 11, offset: 58761},
+							pos: position{line: 1840, col: 11, offset: 58730},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1840, col: 11, offset: 58761},
+									pos: position{line: 1840, col: 11, offset: 58730},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1840, col: 12, offset: 58762},
+										pos:  position{line: 1840, col: 12, offset: 58731},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1840, col: 27, offset: 58777},
+									pos:  position{line: 1840, col: 27, offset: 58746},
 									name: "SourceCharacter",
 								},
 							},
@@ -13109,19 +13109,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1842, col: 1, offset: 58796},
+			pos:  position{line: 1842, col: 1, offset: 58765},
 			expr: &seqExpr{
-				pos: position{line: 1842, col: 7, offset: 58802},
+				pos: position{line: 1842, col: 7, offset: 58771},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1842, col: 7, offset: 58802},
+						pos: position{line: 1842, col: 7, offset: 58771},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1842, col: 7, offset: 58802},
+							pos:  position{line: 1842, col: 7, offset: 58771},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1842, col: 19, offset: 58814},
+						pos:  position{line: 1842, col: 19, offset: 58783},
 						name: "LineTerminator",
 					},
 				},
@@ -13131,16 +13131,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1844, col: 1, offset: 58830},
+			pos:  position{line: 1844, col: 1, offset: 58799},
 			expr: &choiceExpr{
-				pos: position{line: 1844, col: 7, offset: 58836},
+				pos: position{line: 1844, col: 7, offset: 58805},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1844, col: 7, offset: 58836},
+						pos:  position{line: 1844, col: 7, offset: 58805},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1844, col: 11, offset: 58840},
+						pos:  position{line: 1844, col: 11, offset: 58809},
 						name: "EOF",
 					},
 				},
@@ -13150,11 +13150,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1846, col: 1, offset: 58845},
+			pos:  position{line: 1846, col: 1, offset: 58814},
 			expr: &notExpr{
-				pos: position{line: 1846, col: 7, offset: 58851},
+				pos: position{line: 1846, col: 7, offset: 58820},
 				expr: &anyMatcher{
-					line: 1846, col: 8, offset: 58852,
+					line: 1846, col: 8, offset: 58821,
 				},
 			},
 			leader:        false,
@@ -13162,11 +13162,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1848, col: 1, offset: 58855},
+			pos:  position{line: 1848, col: 1, offset: 58824},
 			expr: &notExpr{
-				pos: position{line: 1848, col: 8, offset: 58862},
+				pos: position{line: 1848, col: 8, offset: 58831},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1848, col: 9, offset: 58863},
+					pos:  position{line: 1848, col: 9, offset: 58832},
 					name: "KeyWordChars",
 				},
 			},
@@ -13175,15 +13175,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1852, col: 1, offset: 58899},
+			pos:  position{line: 1852, col: 1, offset: 58868},
 			expr: &actionExpr{
-				pos: position{line: 1853, col: 5, offset: 58912},
+				pos: position{line: 1853, col: 5, offset: 58880},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1853, col: 5, offset: 58912},
+					pos:   position{line: 1853, col: 5, offset: 58880},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1853, col: 7, offset: 58914},
+						pos:  position{line: 1853, col: 7, offset: 58882},
 						name: "Seq",
 					},
 				},
@@ -13193,9 +13193,9 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1861, col: 1, offset: 59060},
+			pos:  position{line: 1861, col: 1, offset: 59028},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1861, col: 12, offset: 59071},
+				pos:  position{line: 1861, col: 12, offset: 59039},
 				name: "SelectExpr",
 			},
 			leader:        false,
@@ -13203,73 +13203,73 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1863, col: 1, offset: 59083},
+			pos:  position{line: 1863, col: 1, offset: 59051},
 			expr: &actionExpr{
-				pos: position{line: 1864, col: 5, offset: 59099},
+				pos: position{line: 1864, col: 5, offset: 59066},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1864, col: 5, offset: 59099},
+					pos: position{line: 1864, col: 5, offset: 59066},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1864, col: 5, offset: 59099},
+							pos:   position{line: 1864, col: 5, offset: 59066},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1864, col: 10, offset: 59104},
+								pos:  position{line: 1864, col: 10, offset: 59071},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1865, col: 5, offset: 59122},
+							pos:   position{line: 1865, col: 5, offset: 59089},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1866, col: 9, offset: 59137},
+								pos: position{line: 1866, col: 9, offset: 59104},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1866, col: 9, offset: 59137},
+										pos:  position{line: 1866, col: 9, offset: 59104},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1867, col: 9, offset: 59158},
+										pos:  position{line: 1867, col: 9, offset: 59125},
 										name: "Select",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1868, col: 9, offset: 59173},
+										pos:  position{line: 1868, col: 9, offset: 59140},
 										name: "FromSelect",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1869, col: 9, offset: 59192},
+										pos:  position{line: 1869, col: 9, offset: 59159},
 										name: "SQLValues",
 									},
 									&actionExpr{
-										pos: position{line: 1870, col: 9, offset: 59210},
+										pos: position{line: 1870, col: 9, offset: 59177},
 										run: (*parser).callonSelectExpr11,
 										expr: &seqExpr{
-											pos: position{line: 1870, col: 9, offset: 59210},
+											pos: position{line: 1870, col: 9, offset: 59177},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1870, col: 9, offset: 59210},
+													pos:        position{line: 1870, col: 9, offset: 59177},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1870, col: 13, offset: 59214},
+													pos:  position{line: 1870, col: 13, offset: 59181},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1870, col: 16, offset: 59217},
+													pos:   position{line: 1870, col: 16, offset: 59184},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1870, col: 18, offset: 59219},
+														pos:  position{line: 1870, col: 18, offset: 59186},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1870, col: 26, offset: 59227},
+													pos:  position{line: 1870, col: 26, offset: 59194},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1870, col: 28, offset: 59229},
+													pos:        position{line: 1870, col: 28, offset: 59196},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13281,97 +13281,97 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1872, col: 5, offset: 59266},
+							pos:   position{line: 1872, col: 5, offset: 59233},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1872, col: 13, offset: 59274},
+								pos:  position{line: 1872, col: 13, offset: 59241},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1873, col: 5, offset: 59295},
+							pos:   position{line: 1873, col: 5, offset: 59262},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1873, col: 10, offset: 59300},
+								pos:  position{line: 1873, col: 10, offset: 59267},
 								name: "OptSQLLimitOffset",
 							},
 						},
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1893, col: 1, offset: 59702},
+			pos:  position{line: 1893, col: 1, offset: 59668},
 			expr: &actionExpr{
-				pos: position{line: 1894, col: 5, offset: 59714},
+				pos: position{line: 1894, col: 5, offset: 59679},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1894, col: 5, offset: 59714},
+					pos: position{line: 1894, col: 5, offset: 59679},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1894, col: 5, offset: 59714},
+							pos:  position{line: 1894, col: 5, offset: 59679},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1895, col: 5, offset: 59726},
+							pos:   position{line: 1895, col: 5, offset: 59690},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1895, col: 14, offset: 59735},
+								pos:  position{line: 1895, col: 14, offset: 59699},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1896, col: 5, offset: 59751},
+							pos:   position{line: 1896, col: 5, offset: 59715},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1896, col: 11, offset: 59757},
+								pos:  position{line: 1896, col: 11, offset: 59721},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1899, col: 5, offset: 59897},
+							pos:  position{line: 1899, col: 5, offset: 59860},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1899, col: 7, offset: 59899},
+							pos:   position{line: 1899, col: 7, offset: 59862},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1899, col: 17, offset: 59909},
+								pos:  position{line: 1899, col: 17, offset: 59872},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1900, col: 5, offset: 59923},
+							pos:   position{line: 1900, col: 5, offset: 59886},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1900, col: 10, offset: 59928},
+								pos:  position{line: 1900, col: 10, offset: 59891},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1901, col: 5, offset: 59946},
+							pos:   position{line: 1901, col: 5, offset: 59909},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1901, col: 11, offset: 59952},
+								pos:  position{line: 1901, col: 11, offset: 59915},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1902, col: 5, offset: 59971},
+							pos:   position{line: 1902, col: 5, offset: 59934},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1902, col: 11, offset: 59977},
+								pos:  position{line: 1902, col: 11, offset: 59940},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1903, col: 5, offset: 59996},
+							pos:   position{line: 1903, col: 5, offset: 59959},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1903, col: 12, offset: 60003},
+								pos:  position{line: 1903, col: 12, offset: 59966},
 								name: "OptHavingClause",
 							},
 						},
@@ -13383,78 +13383,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1929, col: 1, offset: 60618},
+			pos:  position{line: 1929, col: 1, offset: 60581},
 			expr: &actionExpr{
-				pos: position{line: 1930, col: 5, offset: 60633},
+				pos: position{line: 1930, col: 5, offset: 60596},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1930, col: 5, offset: 60633},
+					pos: position{line: 1930, col: 5, offset: 60596},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1930, col: 5, offset: 60633},
+							pos:   position{line: 1930, col: 5, offset: 60596},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1930, col: 10, offset: 60638},
+								pos:  position{line: 1930, col: 10, offset: 60601},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1930, col: 17, offset: 60645},
+							pos:  position{line: 1930, col: 17, offset: 60608},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1930, col: 19, offset: 60647},
+							pos:  position{line: 1930, col: 19, offset: 60610},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1931, col: 5, offset: 60659},
+							pos:   position{line: 1931, col: 5, offset: 60621},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1931, col: 14, offset: 60668},
+								pos:  position{line: 1931, col: 14, offset: 60630},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1932, col: 5, offset: 60684},
+							pos:   position{line: 1932, col: 5, offset: 60646},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1932, col: 11, offset: 60690},
+								pos:  position{line: 1932, col: 11, offset: 60652},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1935, col: 5, offset: 60830},
+							pos:  position{line: 1935, col: 5, offset: 60791},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1935, col: 7, offset: 60832},
+							pos:   position{line: 1935, col: 7, offset: 60793},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1935, col: 17, offset: 60842},
+								pos:  position{line: 1935, col: 17, offset: 60803},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1936, col: 5, offset: 60856},
+							pos:   position{line: 1936, col: 5, offset: 60817},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1936, col: 11, offset: 60862},
+								pos:  position{line: 1936, col: 11, offset: 60823},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1937, col: 5, offset: 60881},
+							pos:   position{line: 1937, col: 5, offset: 60842},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1937, col: 11, offset: 60887},
+								pos:  position{line: 1937, col: 11, offset: 60848},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1938, col: 5, offset: 60906},
+							pos:   position{line: 1938, col: 5, offset: 60867},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1938, col: 12, offset: 60913},
+								pos:  position{line: 1938, col: 12, offset: 60874},
 								name: "OptHavingClause",
 							},
 						},
@@ -13466,26 +13466,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 1962, col: 1, offset: 61495},
+			pos:  position{line: 1962, col: 1, offset: 61456},
 			expr: &actionExpr{
-				pos: position{line: 1963, col: 5, offset: 61509},
+				pos: position{line: 1963, col: 5, offset: 61470},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 1963, col: 5, offset: 61509},
+					pos: position{line: 1963, col: 5, offset: 61470},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1963, col: 5, offset: 61509},
+							pos:  position{line: 1963, col: 5, offset: 61470},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1963, col: 12, offset: 61516},
+							pos:  position{line: 1963, col: 12, offset: 61477},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1963, col: 14, offset: 61518},
+							pos:   position{line: 1963, col: 14, offset: 61479},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1963, col: 21, offset: 61525},
+								pos:  position{line: 1963, col: 21, offset: 61486},
 								name: "SQLTuples",
 							},
 						},
@@ -13497,26 +13497,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 1971, col: 1, offset: 61682},
+			pos:  position{line: 1971, col: 1, offset: 61643},
 			expr: &actionExpr{
-				pos: position{line: 1972, col: 5, offset: 61695},
+				pos: position{line: 1972, col: 5, offset: 61656},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 1972, col: 5, offset: 61695},
+					pos: position{line: 1972, col: 5, offset: 61656},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1972, col: 5, offset: 61695},
+							pos:  position{line: 1972, col: 5, offset: 61656},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1972, col: 12, offset: 61702},
+							pos:  position{line: 1972, col: 12, offset: 61663},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1972, col: 14, offset: 61704},
+							pos:   position{line: 1972, col: 14, offset: 61665},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1972, col: 20, offset: 61710},
+								pos:  position{line: 1972, col: 20, offset: 61671},
 								name: "Exprs",
 							},
 						},
@@ -13528,51 +13528,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 1981, col: 1, offset: 61857},
+			pos:  position{line: 1981, col: 1, offset: 61818},
 			expr: &actionExpr{
-				pos: position{line: 1982, col: 5, offset: 61871},
+				pos: position{line: 1982, col: 5, offset: 61832},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 1982, col: 5, offset: 61871},
+					pos: position{line: 1982, col: 5, offset: 61832},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1982, col: 5, offset: 61871},
+							pos:   position{line: 1982, col: 5, offset: 61832},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 11, offset: 61877},
+								pos:  position{line: 1982, col: 11, offset: 61838},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 20, offset: 61886},
+							pos:   position{line: 1982, col: 20, offset: 61847},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1982, col: 25, offset: 61891},
+								pos: position{line: 1982, col: 25, offset: 61852},
 								expr: &actionExpr{
-									pos: position{line: 1982, col: 26, offset: 61892},
+									pos: position{line: 1982, col: 26, offset: 61853},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 1982, col: 26, offset: 61892},
+										pos: position{line: 1982, col: 26, offset: 61853},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1982, col: 26, offset: 61892},
+												pos:  position{line: 1982, col: 26, offset: 61853},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1982, col: 29, offset: 61895},
+												pos:        position{line: 1982, col: 29, offset: 61856},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1982, col: 33, offset: 61899},
+												pos:  position{line: 1982, col: 33, offset: 61860},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1982, col: 36, offset: 61902},
+												pos:   position{line: 1982, col: 36, offset: 61863},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1982, col: 38, offset: 61904},
+													pos:  position{line: 1982, col: 38, offset: 61865},
 													name: "SQLTuple",
 												},
 											},
@@ -13589,37 +13589,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 1986, col: 1, offset: 61981},
+			pos:  position{line: 1986, col: 1, offset: 61942},
 			expr: &actionExpr{
-				pos: position{line: 1987, col: 5, offset: 61995},
+				pos: position{line: 1987, col: 5, offset: 61955},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1987, col: 5, offset: 61995},
+					pos: position{line: 1987, col: 5, offset: 61955},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1987, col: 5, offset: 61995},
+							pos:        position{line: 1987, col: 5, offset: 61955},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1987, col: 9, offset: 61999},
+							pos:  position{line: 1987, col: 9, offset: 61959},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1987, col: 12, offset: 62002},
+							pos:   position{line: 1987, col: 12, offset: 61962},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 18, offset: 62008},
+								pos:  position{line: 1987, col: 18, offset: 61968},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1987, col: 24, offset: 62014},
+							pos:  position{line: 1987, col: 24, offset: 61974},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1987, col: 27, offset: 62017},
+							pos:        position{line: 1987, col: 27, offset: 61977},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13632,49 +13632,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 1995, col: 1, offset: 62161},
+			pos:  position{line: 1995, col: 1, offset: 62121},
 			expr: &choiceExpr{
-				pos: position{line: 1996, col: 5, offset: 62177},
+				pos: position{line: 1996, col: 5, offset: 62137},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1996, col: 5, offset: 62177},
+						pos: position{line: 1996, col: 5, offset: 62137},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 1996, col: 5, offset: 62177},
+							pos: position{line: 1996, col: 5, offset: 62137},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1996, col: 5, offset: 62177},
+									pos:  position{line: 1996, col: 5, offset: 62137},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1996, col: 7, offset: 62179},
+									pos:  position{line: 1996, col: 7, offset: 62139},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1997, col: 5, offset: 62216},
+						pos: position{line: 1997, col: 5, offset: 62176},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 1997, col: 5, offset: 62216},
+							pos: position{line: 1997, col: 5, offset: 62176},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1997, col: 5, offset: 62216},
+									pos:  position{line: 1997, col: 5, offset: 62176},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1997, col: 7, offset: 62218},
+									pos:  position{line: 1997, col: 7, offset: 62178},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1998, col: 5, offset: 62254},
+						pos: position{line: 1998, col: 5, offset: 62214},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 1998, col: 5, offset: 62254},
+							pos:        position{line: 1998, col: 5, offset: 62214},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13687,57 +13687,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2000, col: 1, offset: 62293},
+			pos:  position{line: 2000, col: 1, offset: 62253},
 			expr: &choiceExpr{
-				pos: position{line: 2001, col: 5, offset: 62312},
+				pos: position{line: 2001, col: 5, offset: 62272},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2001, col: 5, offset: 62312},
+						pos: position{line: 2001, col: 5, offset: 62272},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2001, col: 5, offset: 62312},
+							pos: position{line: 2001, col: 5, offset: 62272},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2001, col: 5, offset: 62312},
+									pos:  position{line: 2001, col: 5, offset: 62272},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2001, col: 7, offset: 62314},
+									pos:  position{line: 2001, col: 7, offset: 62274},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2001, col: 10, offset: 62317},
+									pos:  position{line: 2001, col: 10, offset: 62277},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2001, col: 12, offset: 62319},
+									pos:  position{line: 2001, col: 12, offset: 62279},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2002, col: 5, offset: 62351},
+						pos: position{line: 2002, col: 5, offset: 62311},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2002, col: 5, offset: 62351},
+							pos: position{line: 2002, col: 5, offset: 62311},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2002, col: 5, offset: 62351},
+									pos:  position{line: 2002, col: 5, offset: 62311},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2002, col: 7, offset: 62353},
+									pos:  position{line: 2002, col: 7, offset: 62313},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2003, col: 5, offset: 62424},
+						pos: position{line: 2003, col: 5, offset: 62384},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2003, col: 5, offset: 62424},
+							pos:        position{line: 2003, col: 5, offset: 62384},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13750,19 +13750,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2005, col: 1, offset: 62467},
+			pos:  position{line: 2005, col: 1, offset: 62427},
 			expr: &choiceExpr{
-				pos: position{line: 2006, col: 5, offset: 62486},
+				pos: position{line: 2006, col: 5, offset: 62445},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2006, col: 5, offset: 62486},
+						pos:  position{line: 2006, col: 5, offset: 62445},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2007, col: 5, offset: 62501},
+						pos: position{line: 2007, col: 5, offset: 62460},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2007, col: 5, offset: 62501},
+							pos:        position{line: 2007, col: 5, offset: 62460},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13775,39 +13775,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2009, col: 1, offset: 62534},
+			pos:  position{line: 2009, col: 1, offset: 62493},
 			expr: &actionExpr{
-				pos: position{line: 2010, col: 5, offset: 62550},
+				pos: position{line: 2010, col: 5, offset: 62508},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2010, col: 5, offset: 62550},
+					pos: position{line: 2010, col: 5, offset: 62508},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2010, col: 5, offset: 62550},
+							pos:  position{line: 2010, col: 5, offset: 62508},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2010, col: 10, offset: 62555},
+							pos:   position{line: 2010, col: 10, offset: 62513},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2010, col: 12, offset: 62557},
+								pos:  position{line: 2010, col: 12, offset: 62515},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2010, col: 25, offset: 62570},
+							pos:  position{line: 2010, col: 25, offset: 62528},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2010, col: 27, offset: 62572},
+							pos:   position{line: 2010, col: 27, offset: 62530},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2010, col: 32, offset: 62577},
+								pos:  position{line: 2010, col: 32, offset: 62535},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2010, col: 40, offset: 62585},
+							pos:  position{line: 2010, col: 40, offset: 62543},
 							name: "__",
 						},
 					},
@@ -13818,32 +13818,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2019, col: 1, offset: 62774},
+			pos:  position{line: 2019, col: 1, offset: 62731},
 			expr: &choiceExpr{
-				pos: position{line: 2020, col: 5, offset: 62792},
+				pos: position{line: 2020, col: 5, offset: 62748},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2020, col: 5, offset: 62792},
+						pos: position{line: 2020, col: 5, offset: 62748},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2020, col: 5, offset: 62792},
+							pos: position{line: 2020, col: 5, offset: 62748},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2020, col: 5, offset: 62792},
+									pos:  position{line: 2020, col: 5, offset: 62748},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2020, col: 7, offset: 62794},
+									pos:  position{line: 2020, col: 7, offset: 62750},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2021, col: 5, offset: 62830},
+						pos: position{line: 2021, col: 5, offset: 62786},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2021, col: 5, offset: 62830},
+							pos:        position{line: 2021, col: 5, offset: 62786},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13856,51 +13856,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2023, col: 1, offset: 62869},
+			pos:  position{line: 2023, col: 1, offset: 62825},
 			expr: &actionExpr{
-				pos: position{line: 2023, col: 11, offset: 62879},
+				pos: position{line: 2023, col: 11, offset: 62835},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2023, col: 11, offset: 62879},
+					pos: position{line: 2023, col: 11, offset: 62835},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2023, col: 11, offset: 62879},
+							pos:   position{line: 2023, col: 11, offset: 62835},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2023, col: 17, offset: 62885},
+								pos:  position{line: 2023, col: 17, offset: 62841},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2023, col: 21, offset: 62889},
+							pos:   position{line: 2023, col: 21, offset: 62845},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2023, col: 26, offset: 62894},
+								pos: position{line: 2023, col: 26, offset: 62850},
 								expr: &actionExpr{
-									pos: position{line: 2023, col: 28, offset: 62896},
+									pos: position{line: 2023, col: 28, offset: 62852},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2023, col: 28, offset: 62896},
+										pos: position{line: 2023, col: 28, offset: 62852},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2023, col: 28, offset: 62896},
+												pos:  position{line: 2023, col: 28, offset: 62852},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2023, col: 31, offset: 62899},
+												pos:        position{line: 2023, col: 31, offset: 62855},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2023, col: 35, offset: 62903},
+												pos:  position{line: 2023, col: 35, offset: 62859},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2023, col: 38, offset: 62906},
+												pos:   position{line: 2023, col: 38, offset: 62862},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2023, col: 42, offset: 62910},
+													pos:  position{line: 2023, col: 42, offset: 62866},
 													name: "Cte",
 												},
 											},
@@ -13917,65 +13917,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2027, col: 1, offset: 62979},
+			pos:  position{line: 2027, col: 1, offset: 62934},
 			expr: &actionExpr{
-				pos: position{line: 2028, col: 5, offset: 62987},
+				pos: position{line: 2028, col: 5, offset: 62942},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2028, col: 5, offset: 62987},
+					pos: position{line: 2028, col: 5, offset: 62942},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2028, col: 5, offset: 62987},
+							pos:   position{line: 2028, col: 5, offset: 62942},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2028, col: 10, offset: 62992},
+								pos:  position{line: 2028, col: 10, offset: 62947},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 24, offset: 63006},
+							pos:  position{line: 2028, col: 24, offset: 62961},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 26, offset: 63008},
+							pos:  position{line: 2028, col: 26, offset: 62963},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2028, col: 29, offset: 63011},
+							pos:   position{line: 2028, col: 29, offset: 62966},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2028, col: 31, offset: 63013},
+								pos:  position{line: 2028, col: 31, offset: 62968},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 47, offset: 63029},
+							pos:  position{line: 2028, col: 47, offset: 62984},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2028, col: 50, offset: 63032},
+							pos:        position{line: 2028, col: 50, offset: 62987},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 54, offset: 63036},
+							pos:  position{line: 2028, col: 54, offset: 62991},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2028, col: 57, offset: 63039},
+							pos:   position{line: 2028, col: 57, offset: 62994},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2028, col: 59, offset: 63041},
+								pos:  position{line: 2028, col: 59, offset: 62996},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 67, offset: 63049},
+							pos:  position{line: 2028, col: 67, offset: 63004},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2028, col: 70, offset: 63052},
+							pos:        position{line: 2028, col: 70, offset: 63007},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13988,65 +13988,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2037, col: 1, offset: 63238},
+			pos:  position{line: 2037, col: 1, offset: 63193},
 			expr: &choiceExpr{
-				pos: position{line: 2038, col: 5, offset: 63259},
+				pos: position{line: 2038, col: 5, offset: 63213},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2038, col: 5, offset: 63259},
+						pos: position{line: 2038, col: 5, offset: 63213},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2038, col: 5, offset: 63259},
+							pos: position{line: 2038, col: 5, offset: 63213},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2038, col: 5, offset: 63259},
+									pos:  position{line: 2038, col: 5, offset: 63213},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2038, col: 7, offset: 63261},
+									pos:  position{line: 2038, col: 7, offset: 63215},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2038, col: 20, offset: 63274},
+									pos:  position{line: 2038, col: 20, offset: 63228},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2039, col: 5, offset: 63313},
+						pos: position{line: 2039, col: 5, offset: 63267},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2039, col: 5, offset: 63313},
+							pos: position{line: 2039, col: 5, offset: 63267},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2039, col: 5, offset: 63313},
+									pos:  position{line: 2039, col: 5, offset: 63267},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2039, col: 7, offset: 63315},
+									pos:  position{line: 2039, col: 7, offset: 63269},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2039, col: 11, offset: 63319},
+									pos:  position{line: 2039, col: 11, offset: 63273},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2039, col: 13, offset: 63321},
+									pos:  position{line: 2039, col: 13, offset: 63275},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2039, col: 26, offset: 63334},
+									pos:  position{line: 2039, col: 26, offset: 63288},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2040, col: 5, offset: 63365},
+						pos: position{line: 2040, col: 5, offset: 63319},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2040, col: 5, offset: 63365},
+							pos:        position{line: 2040, col: 5, offset: 63319},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14059,25 +14059,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2042, col: 1, offset: 63420},
+			pos:  position{line: 2042, col: 1, offset: 63374},
 			expr: &choiceExpr{
-				pos: position{line: 2043, col: 5, offset: 63437},
+				pos: position{line: 2043, col: 5, offset: 63391},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2043, col: 5, offset: 63437},
+						pos: position{line: 2043, col: 5, offset: 63391},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2043, col: 5, offset: 63437},
+								pos:  position{line: 2043, col: 5, offset: 63391},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2043, col: 7, offset: 63439},
+								pos:  position{line: 2043, col: 7, offset: 63393},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2044, col: 5, offset: 63448},
+						pos:        position{line: 2044, col: 5, offset: 63401},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14089,25 +14089,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2046, col: 1, offset: 63452},
+			pos:  position{line: 2046, col: 1, offset: 63405},
 			expr: &choiceExpr{
-				pos: position{line: 2047, col: 5, offset: 63470},
+				pos: position{line: 2047, col: 5, offset: 63423},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2047, col: 5, offset: 63470},
+						pos: position{line: 2047, col: 5, offset: 63423},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2047, col: 5, offset: 63470},
+							pos: position{line: 2047, col: 5, offset: 63423},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2047, col: 5, offset: 63470},
+									pos:  position{line: 2047, col: 5, offset: 63423},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2047, col: 7, offset: 63472},
+									pos:   position{line: 2047, col: 7, offset: 63425},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2047, col: 12, offset: 63477},
+										pos:  position{line: 2047, col: 12, offset: 63430},
 										name: "FromOp",
 									},
 								},
@@ -14115,10 +14115,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2050, col: 5, offset: 63519},
+						pos: position{line: 2050, col: 5, offset: 63472},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2050, col: 5, offset: 63519},
+							pos:        position{line: 2050, col: 5, offset: 63472},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14131,27 +14131,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2052, col: 1, offset: 63560},
+			pos:  position{line: 2052, col: 1, offset: 63513},
 			expr: &choiceExpr{
-				pos: position{line: 2053, col: 5, offset: 63579},
+				pos: position{line: 2053, col: 5, offset: 63532},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2053, col: 5, offset: 63579},
+						pos: position{line: 2053, col: 5, offset: 63532},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2053, col: 5, offset: 63579},
+							pos:   position{line: 2053, col: 5, offset: 63532},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2053, col: 11, offset: 63585},
+								pos:  position{line: 2053, col: 11, offset: 63538},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2054, col: 5, offset: 63627},
+						pos: position{line: 2054, col: 5, offset: 63580},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2054, col: 5, offset: 63627},
+							pos:        position{line: 2054, col: 5, offset: 63580},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14164,25 +14164,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2056, col: 1, offset: 63672},
+			pos:  position{line: 2056, col: 1, offset: 63625},
 			expr: &choiceExpr{
-				pos: position{line: 2057, col: 5, offset: 63691},
+				pos: position{line: 2057, col: 5, offset: 63644},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2057, col: 5, offset: 63691},
+						pos: position{line: 2057, col: 5, offset: 63644},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2057, col: 5, offset: 63691},
+							pos: position{line: 2057, col: 5, offset: 63644},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 5, offset: 63691},
+									pos:  position{line: 2057, col: 5, offset: 63644},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2057, col: 7, offset: 63693},
+									pos:   position{line: 2057, col: 7, offset: 63646},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2057, col: 13, offset: 63699},
+										pos:  position{line: 2057, col: 13, offset: 63652},
 										name: "GroupClause",
 									},
 								},
@@ -14190,10 +14190,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2058, col: 5, offset: 63737},
+						pos: position{line: 2058, col: 5, offset: 63690},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2058, col: 5, offset: 63737},
+							pos:        position{line: 2058, col: 5, offset: 63690},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14206,34 +14206,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2060, col: 1, offset: 63778},
+			pos:  position{line: 2060, col: 1, offset: 63731},
 			expr: &actionExpr{
-				pos: position{line: 2061, col: 5, offset: 63794},
+				pos: position{line: 2061, col: 5, offset: 63747},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2061, col: 5, offset: 63794},
+					pos: position{line: 2061, col: 5, offset: 63747},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2061, col: 5, offset: 63794},
+							pos:  position{line: 2061, col: 5, offset: 63747},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2061, col: 11, offset: 63800},
+							pos:  position{line: 2061, col: 11, offset: 63753},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2061, col: 13, offset: 63802},
+							pos:  position{line: 2061, col: 13, offset: 63755},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2061, col: 16, offset: 63805},
+							pos:  position{line: 2061, col: 16, offset: 63758},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2061, col: 18, offset: 63807},
+							pos:   position{line: 2061, col: 18, offset: 63760},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2061, col: 23, offset: 63812},
+								pos:  position{line: 2061, col: 23, offset: 63765},
 								name: "GroupByList",
 							},
 						},
@@ -14245,51 +14245,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2063, col: 1, offset: 63846},
+			pos:  position{line: 2063, col: 1, offset: 63799},
 			expr: &actionExpr{
-				pos: position{line: 2064, col: 5, offset: 63863},
+				pos: position{line: 2064, col: 5, offset: 63815},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2064, col: 5, offset: 63863},
+					pos: position{line: 2064, col: 5, offset: 63815},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2064, col: 5, offset: 63863},
+							pos:   position{line: 2064, col: 5, offset: 63815},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2064, col: 11, offset: 63869},
+								pos:  position{line: 2064, col: 11, offset: 63821},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2064, col: 23, offset: 63881},
+							pos:   position{line: 2064, col: 23, offset: 63833},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2064, col: 28, offset: 63886},
+								pos: position{line: 2064, col: 28, offset: 63838},
 								expr: &actionExpr{
-									pos: position{line: 2064, col: 30, offset: 63888},
+									pos: position{line: 2064, col: 30, offset: 63840},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2064, col: 30, offset: 63888},
+										pos: position{line: 2064, col: 30, offset: 63840},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2064, col: 30, offset: 63888},
+												pos:  position{line: 2064, col: 30, offset: 63840},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2064, col: 33, offset: 63891},
+												pos:        position{line: 2064, col: 33, offset: 63843},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2064, col: 37, offset: 63895},
+												pos:  position{line: 2064, col: 37, offset: 63847},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2064, col: 40, offset: 63898},
+												pos:   position{line: 2064, col: 40, offset: 63850},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2064, col: 42, offset: 63900},
+													pos:  position{line: 2064, col: 42, offset: 63852},
 													name: "GroupByItem",
 												},
 											},
@@ -14306,9 +14306,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2068, col: 1, offset: 63981},
+			pos:  position{line: 2068, col: 1, offset: 63933},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2068, col: 15, offset: 63995},
+				pos:  position{line: 2068, col: 15, offset: 63947},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14316,25 +14316,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2070, col: 1, offset: 64001},
+			pos:  position{line: 2070, col: 1, offset: 63953},
 			expr: &choiceExpr{
-				pos: position{line: 2071, col: 5, offset: 64021},
+				pos: position{line: 2071, col: 5, offset: 63973},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2071, col: 5, offset: 64021},
+						pos: position{line: 2071, col: 5, offset: 63973},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2071, col: 5, offset: 64021},
+							pos: position{line: 2071, col: 5, offset: 63973},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2071, col: 5, offset: 64021},
+									pos:  position{line: 2071, col: 5, offset: 63973},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2071, col: 7, offset: 64023},
+									pos:   position{line: 2071, col: 7, offset: 63975},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2071, col: 9, offset: 64025},
+										pos:  position{line: 2071, col: 9, offset: 63977},
 										name: "HavingClause",
 									},
 								},
@@ -14342,10 +14342,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2072, col: 5, offset: 64060},
+						pos: position{line: 2072, col: 5, offset: 64012},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2072, col: 5, offset: 64060},
+							pos:        position{line: 2072, col: 5, offset: 64012},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14358,26 +14358,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2074, col: 1, offset: 64084},
+			pos:  position{line: 2074, col: 1, offset: 64036},
 			expr: &actionExpr{
-				pos: position{line: 2075, col: 5, offset: 64101},
+				pos: position{line: 2075, col: 5, offset: 64053},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2075, col: 5, offset: 64101},
+					pos: position{line: 2075, col: 5, offset: 64053},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2075, col: 5, offset: 64101},
+							pos:  position{line: 2075, col: 5, offset: 64053},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2075, col: 12, offset: 64108},
+							pos:  position{line: 2075, col: 12, offset: 64060},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2075, col: 14, offset: 64110},
+							pos:   position{line: 2075, col: 14, offset: 64062},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2075, col: 16, offset: 64112},
+								pos:  position{line: 2075, col: 16, offset: 64064},
 								name: "Expr",
 							},
 						},
@@ -14389,16 +14389,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2077, col: 1, offset: 64136},
+			pos:  position{line: 2077, col: 1, offset: 64088},
 			expr: &choiceExpr{
-				pos: position{line: 2078, col: 5, offset: 64154},
+				pos: position{line: 2078, col: 5, offset: 64106},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2078, col: 5, offset: 64154},
+						pos:  position{line: 2078, col: 5, offset: 64106},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2079, col: 5, offset: 64168},
+						pos:  position{line: 2079, col: 5, offset: 64120},
 						name: "ConditionJoin",
 					},
 				},
@@ -14408,30 +14408,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2081, col: 1, offset: 64183},
+			pos:  position{line: 2081, col: 1, offset: 64135},
 			expr: &actionExpr{
-				pos: position{line: 2082, col: 5, offset: 64197},
+				pos: position{line: 2082, col: 5, offset: 64149},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2082, col: 5, offset: 64197},
+					pos: position{line: 2082, col: 5, offset: 64149},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2082, col: 5, offset: 64197},
+							pos:   position{line: 2082, col: 5, offset: 64149},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2082, col: 10, offset: 64202},
+								pos:  position{line: 2082, col: 10, offset: 64154},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2082, col: 19, offset: 64211},
+							pos:  position{line: 2082, col: 19, offset: 64163},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2082, col: 31, offset: 64223},
+							pos:   position{line: 2082, col: 31, offset: 64175},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2082, col: 37, offset: 64229},
+								pos:  position{line: 2082, col: 37, offset: 64181},
 								name: "FromElem",
 							},
 						},
@@ -14443,50 +14443,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2091, col: 1, offset: 64437},
+			pos:  position{line: 2091, col: 1, offset: 64389},
 			expr: &choiceExpr{
-				pos: position{line: 2092, col: 5, offset: 64454},
+				pos: position{line: 2092, col: 5, offset: 64405},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2092, col: 5, offset: 64454},
+						pos: position{line: 2092, col: 5, offset: 64405},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2092, col: 5, offset: 64454},
+								pos:  position{line: 2092, col: 5, offset: 64405},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2092, col: 8, offset: 64457},
+								pos:        position{line: 2092, col: 8, offset: 64408},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2092, col: 12, offset: 64461},
+								pos:  position{line: 2092, col: 12, offset: 64412},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2093, col: 5, offset: 64469},
+						pos: position{line: 2093, col: 5, offset: 64419},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2093, col: 5, offset: 64469},
+								pos:  position{line: 2093, col: 5, offset: 64419},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2093, col: 7, offset: 64471},
+								pos:  position{line: 2093, col: 7, offset: 64421},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2093, col: 13, offset: 64477},
+								pos:  position{line: 2093, col: 13, offset: 64427},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2093, col: 15, offset: 64479},
+								pos:  position{line: 2093, col: 15, offset: 64429},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2093, col: 20, offset: 64484},
+								pos:  position{line: 2093, col: 20, offset: 64434},
 								name: "_",
 							},
 						},
@@ -14498,51 +14498,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2095, col: 1, offset: 64488},
+			pos:  position{line: 2095, col: 1, offset: 64437},
 			expr: &actionExpr{
-				pos: position{line: 2096, col: 5, offset: 64506},
+				pos: position{line: 2096, col: 5, offset: 64455},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2096, col: 5, offset: 64506},
+					pos: position{line: 2096, col: 5, offset: 64455},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2096, col: 5, offset: 64506},
+							pos:   position{line: 2096, col: 5, offset: 64455},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2096, col: 10, offset: 64511},
+								pos:  position{line: 2096, col: 10, offset: 64460},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2096, col: 19, offset: 64520},
+							pos:   position{line: 2096, col: 19, offset: 64469},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2096, col: 25, offset: 64526},
+								pos:  position{line: 2096, col: 25, offset: 64475},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2096, col: 38, offset: 64539},
+							pos:  position{line: 2096, col: 38, offset: 64488},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2096, col: 40, offset: 64541},
+							pos:   position{line: 2096, col: 40, offset: 64490},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2096, col: 46, offset: 64547},
+								pos:  position{line: 2096, col: 46, offset: 64496},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2096, col: 55, offset: 64556},
+							pos:  position{line: 2096, col: 55, offset: 64505},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2096, col: 57, offset: 64558},
+							pos:   position{line: 2096, col: 57, offset: 64507},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2096, col: 59, offset: 64560},
-								name: "JoinExpr",
+								pos:  position{line: 2096, col: 59, offset: 64509},
+								name: "JoinCond",
 							},
 						},
 					},
@@ -14553,161 +14553,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2107, col: 1, offset: 64829},
+			pos:  position{line: 2107, col: 1, offset: 64778},
 			expr: &choiceExpr{
-				pos: position{line: 2108, col: 5, offset: 64847},
+				pos: position{line: 2108, col: 5, offset: 64795},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2108, col: 5, offset: 64847},
+						pos: position{line: 2108, col: 5, offset: 64795},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2108, col: 5, offset: 64847},
+							pos: position{line: 2108, col: 5, offset: 64795},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2108, col: 5, offset: 64847},
+									pos: position{line: 2108, col: 5, offset: 64795},
 									expr: &seqExpr{
-										pos: position{line: 2108, col: 6, offset: 64848},
+										pos: position{line: 2108, col: 6, offset: 64796},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2108, col: 6, offset: 64848},
+												pos:  position{line: 2108, col: 6, offset: 64796},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2108, col: 8, offset: 64850},
+												pos:  position{line: 2108, col: 8, offset: 64798},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2108, col: 16, offset: 64858},
+									pos:  position{line: 2108, col: 16, offset: 64806},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2108, col: 18, offset: 64860},
+									pos:  position{line: 2108, col: 18, offset: 64808},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2109, col: 5, offset: 64905},
+						pos: position{line: 2109, col: 5, offset: 64853},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2109, col: 5, offset: 64905},
+							pos: position{line: 2109, col: 5, offset: 64853},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2109, col: 5, offset: 64905},
+									pos:  position{line: 2109, col: 5, offset: 64853},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2109, col: 7, offset: 64907},
+									pos:  position{line: 2109, col: 7, offset: 64855},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2109, col: 12, offset: 64912},
+									pos: position{line: 2109, col: 12, offset: 64860},
 									expr: &seqExpr{
-										pos: position{line: 2109, col: 13, offset: 64913},
+										pos: position{line: 2109, col: 13, offset: 64861},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2109, col: 13, offset: 64913},
+												pos:  position{line: 2109, col: 13, offset: 64861},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2109, col: 15, offset: 64915},
+												pos:  position{line: 2109, col: 15, offset: 64863},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2109, col: 23, offset: 64923},
+									pos:  position{line: 2109, col: 23, offset: 64871},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2109, col: 25, offset: 64925},
+									pos:  position{line: 2109, col: 25, offset: 64873},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2110, col: 5, offset: 64959},
+						pos: position{line: 2110, col: 5, offset: 64907},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2110, col: 5, offset: 64959},
+							pos: position{line: 2110, col: 5, offset: 64907},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2110, col: 5, offset: 64959},
+									pos:  position{line: 2110, col: 5, offset: 64907},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2110, col: 7, offset: 64961},
+									pos:  position{line: 2110, col: 7, offset: 64909},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2110, col: 12, offset: 64966},
+									pos: position{line: 2110, col: 12, offset: 64914},
 									expr: &seqExpr{
-										pos: position{line: 2110, col: 13, offset: 64967},
+										pos: position{line: 2110, col: 13, offset: 64915},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2110, col: 13, offset: 64967},
+												pos:  position{line: 2110, col: 13, offset: 64915},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2110, col: 15, offset: 64969},
+												pos:  position{line: 2110, col: 15, offset: 64917},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2110, col: 23, offset: 64977},
+									pos:  position{line: 2110, col: 23, offset: 64925},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2110, col: 25, offset: 64979},
+									pos:  position{line: 2110, col: 25, offset: 64927},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2111, col: 5, offset: 65013},
+						pos: position{line: 2111, col: 5, offset: 64961},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2111, col: 5, offset: 65013},
+							pos: position{line: 2111, col: 5, offset: 64961},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2111, col: 5, offset: 65013},
+									pos:  position{line: 2111, col: 5, offset: 64961},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2111, col: 7, offset: 65015},
+									pos:  position{line: 2111, col: 7, offset: 64963},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2111, col: 13, offset: 65021},
+									pos: position{line: 2111, col: 13, offset: 64969},
 									expr: &seqExpr{
-										pos: position{line: 2111, col: 14, offset: 65022},
+										pos: position{line: 2111, col: 14, offset: 64970},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2111, col: 14, offset: 65022},
+												pos:  position{line: 2111, col: 14, offset: 64970},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2111, col: 16, offset: 65024},
+												pos:  position{line: 2111, col: 16, offset: 64972},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2111, col: 24, offset: 65032},
+									pos:  position{line: 2111, col: 24, offset: 64980},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2111, col: 26, offset: 65034},
+									pos:  position{line: 2111, col: 26, offset: 64982},
 									name: "JOIN",
 								},
 							},
@@ -14719,30 +14719,30 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "JoinExpr",
-			pos:  position{line: 2113, col: 1, offset: 65066},
+			name: "JoinCond",
+			pos:  position{line: 2113, col: 1, offset: 65014},
 			expr: &choiceExpr{
-				pos: position{line: 2114, col: 5, offset: 65080},
+				pos: position{line: 2114, col: 5, offset: 65027},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2114, col: 5, offset: 65080},
-						run: (*parser).callonJoinExpr2,
+						pos: position{line: 2114, col: 5, offset: 65027},
+						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2114, col: 5, offset: 65080},
+							pos: position{line: 2114, col: 5, offset: 65027},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 5, offset: 65080},
+									pos:  position{line: 2114, col: 5, offset: 65027},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 8, offset: 65083},
+									pos:  position{line: 2114, col: 8, offset: 65030},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2114, col: 10, offset: 65085},
+									pos:   position{line: 2114, col: 10, offset: 65032},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2114, col: 12, offset: 65087},
+										pos:  position{line: 2114, col: 12, offset: 65034},
 										name: "Expr",
 									},
 								},
@@ -14750,43 +14750,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2121, col: 5, offset: 65242},
-						run: (*parser).callonJoinExpr8,
+						pos: position{line: 2121, col: 5, offset: 65187},
+						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2121, col: 5, offset: 65242},
+							pos: position{line: 2121, col: 5, offset: 65187},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2121, col: 5, offset: 65242},
+									pos:  position{line: 2121, col: 5, offset: 65187},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2121, col: 11, offset: 65248},
+									pos:  position{line: 2121, col: 11, offset: 65193},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2121, col: 14, offset: 65251},
+									pos:        position{line: 2121, col: 14, offset: 65196},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2121, col: 18, offset: 65255},
+									pos:  position{line: 2121, col: 18, offset: 65200},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2121, col: 21, offset: 65258},
+									pos:   position{line: 2121, col: 21, offset: 65203},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2121, col: 28, offset: 65265},
+										pos:  position{line: 2121, col: 28, offset: 65210},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2121, col: 34, offset: 65271},
+									pos:  position{line: 2121, col: 34, offset: 65216},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2121, col: 37, offset: 65274},
+									pos:        position{line: 2121, col: 37, offset: 65219},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14801,40 +14801,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2129, col: 1, offset: 65444},
+			pos:  position{line: 2129, col: 1, offset: 65389},
 			expr: &choiceExpr{
-				pos: position{line: 2130, col: 5, offset: 65463},
+				pos: position{line: 2130, col: 5, offset: 65407},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2130, col: 5, offset: 65463},
+						pos: position{line: 2130, col: 5, offset: 65407},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2130, col: 5, offset: 65463},
+							pos: position{line: 2130, col: 5, offset: 65407},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 5, offset: 65463},
+									pos:  position{line: 2130, col: 5, offset: 65407},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 7, offset: 65465},
+									pos:  position{line: 2130, col: 7, offset: 65409},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 12, offset: 65470},
+									pos:  position{line: 2130, col: 12, offset: 65414},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 14, offset: 65472},
+									pos:  position{line: 2130, col: 14, offset: 65416},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2136, col: 5, offset: 65601},
+						pos: position{line: 2136, col: 5, offset: 65545},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2136, col: 5, offset: 65601},
+							pos:        position{line: 2136, col: 5, offset: 65545},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14847,25 +14847,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2138, col: 1, offset: 65650},
+			pos:  position{line: 2138, col: 1, offset: 65594},
 			expr: &choiceExpr{
-				pos: position{line: 2139, col: 5, offset: 65663},
+				pos: position{line: 2139, col: 5, offset: 65607},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2139, col: 5, offset: 65663},
+						pos: position{line: 2139, col: 5, offset: 65607},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2139, col: 5, offset: 65663},
+							pos: position{line: 2139, col: 5, offset: 65607},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2139, col: 5, offset: 65663},
+									pos:  position{line: 2139, col: 5, offset: 65607},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2139, col: 7, offset: 65665},
+									pos:   position{line: 2139, col: 7, offset: 65609},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2139, col: 9, offset: 65667},
+										pos:  position{line: 2139, col: 9, offset: 65611},
 										name: "AliasClause",
 									},
 								},
@@ -14873,10 +14873,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2140, col: 5, offset: 65701},
+						pos: position{line: 2140, col: 5, offset: 65645},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2140, col: 5, offset: 65701},
+							pos:        position{line: 2140, col: 5, offset: 65645},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14889,51 +14889,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2142, col: 1, offset: 65738},
+			pos:  position{line: 2142, col: 1, offset: 65682},
 			expr: &actionExpr{
-				pos: position{line: 2143, col: 4, offset: 65753},
+				pos: position{line: 2143, col: 4, offset: 65697},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2143, col: 4, offset: 65753},
+					pos: position{line: 2143, col: 4, offset: 65697},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2143, col: 4, offset: 65753},
+							pos: position{line: 2143, col: 4, offset: 65697},
 							expr: &seqExpr{
-								pos: position{line: 2143, col: 5, offset: 65754},
+								pos: position{line: 2143, col: 5, offset: 65698},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2143, col: 5, offset: 65754},
+										pos:  position{line: 2143, col: 5, offset: 65698},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2143, col: 8, offset: 65757},
+										pos:  position{line: 2143, col: 8, offset: 65701},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2143, col: 12, offset: 65761},
+							pos: position{line: 2143, col: 12, offset: 65705},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2143, col: 13, offset: 65762},
+								pos:  position{line: 2143, col: 13, offset: 65706},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2143, col: 22, offset: 65771},
+							pos:   position{line: 2143, col: 22, offset: 65715},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2143, col: 27, offset: 65776},
+								pos:  position{line: 2143, col: 27, offset: 65720},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2143, col: 42, offset: 65791},
+							pos:   position{line: 2143, col: 42, offset: 65735},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2143, col: 47, offset: 65796},
+								pos: position{line: 2143, col: 47, offset: 65740},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2143, col: 47, offset: 65796},
+									pos:  position{line: 2143, col: 47, offset: 65740},
 									name: "Columns",
 								},
 							},
@@ -14946,65 +14946,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2151, col: 1, offset: 65995},
+			pos:  position{line: 2151, col: 1, offset: 65939},
 			expr: &actionExpr{
-				pos: position{line: 2152, col: 5, offset: 66007},
+				pos: position{line: 2152, col: 5, offset: 65951},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2152, col: 5, offset: 66007},
+					pos: position{line: 2152, col: 5, offset: 65951},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2152, col: 5, offset: 66007},
+							pos:  position{line: 2152, col: 5, offset: 65951},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2152, col: 8, offset: 66010},
+							pos:        position{line: 2152, col: 8, offset: 65954},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2152, col: 12, offset: 66014},
+							pos:  position{line: 2152, col: 12, offset: 65958},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2152, col: 15, offset: 66017},
+							pos:   position{line: 2152, col: 15, offset: 65961},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2152, col: 21, offset: 66023},
+								pos:  position{line: 2152, col: 21, offset: 65967},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2152, col: 35, offset: 66037},
+							pos:   position{line: 2152, col: 35, offset: 65981},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2152, col: 40, offset: 66042},
+								pos: position{line: 2152, col: 40, offset: 65986},
 								expr: &actionExpr{
-									pos: position{line: 2152, col: 42, offset: 66044},
+									pos: position{line: 2152, col: 42, offset: 65988},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2152, col: 42, offset: 66044},
+										pos: position{line: 2152, col: 42, offset: 65988},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2152, col: 42, offset: 66044},
+												pos:  position{line: 2152, col: 42, offset: 65988},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2152, col: 45, offset: 66047},
+												pos:        position{line: 2152, col: 45, offset: 65991},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2152, col: 49, offset: 66051},
+												pos:  position{line: 2152, col: 49, offset: 65995},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2152, col: 52, offset: 66054},
+												pos:   position{line: 2152, col: 52, offset: 65998},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2152, col: 54, offset: 66056},
+													pos:  position{line: 2152, col: 54, offset: 66000},
 													name: "SQLIdentifier",
 												},
 											},
@@ -15014,11 +15014,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2152, col: 87, offset: 66089},
+							pos:  position{line: 2152, col: 87, offset: 66033},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2152, col: 90, offset: 66092},
+							pos:        position{line: 2152, col: 90, offset: 66036},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -15031,51 +15031,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2156, col: 1, offset: 66164},
+			pos:  position{line: 2156, col: 1, offset: 66107},
 			expr: &actionExpr{
-				pos: position{line: 2157, col: 5, offset: 66178},
+				pos: position{line: 2157, col: 5, offset: 66121},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2157, col: 5, offset: 66178},
+					pos: position{line: 2157, col: 5, offset: 66121},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2157, col: 5, offset: 66178},
+							pos:   position{line: 2157, col: 5, offset: 66121},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2157, col: 11, offset: 66184},
+								pos:  position{line: 2157, col: 11, offset: 66127},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2157, col: 22, offset: 66195},
+							pos:   position{line: 2157, col: 22, offset: 66138},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2157, col: 27, offset: 66200},
+								pos: position{line: 2157, col: 27, offset: 66143},
 								expr: &actionExpr{
-									pos: position{line: 2157, col: 29, offset: 66202},
+									pos: position{line: 2157, col: 29, offset: 66145},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2157, col: 29, offset: 66202},
+										pos: position{line: 2157, col: 29, offset: 66145},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2157, col: 29, offset: 66202},
+												pos:  position{line: 2157, col: 29, offset: 66145},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2157, col: 32, offset: 66205},
+												pos:        position{line: 2157, col: 32, offset: 66148},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2157, col: 36, offset: 66209},
+												pos:  position{line: 2157, col: 36, offset: 66152},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2157, col: 39, offset: 66212},
+												pos:   position{line: 2157, col: 39, offset: 66155},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2157, col: 41, offset: 66214},
+													pos:  position{line: 2157, col: 41, offset: 66157},
 													name: "SelectElem",
 												},
 											},
@@ -15092,38 +15092,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2166, col: 1, offset: 66449},
+			pos:  position{line: 2166, col: 1, offset: 66392},
 			expr: &choiceExpr{
-				pos: position{line: 2167, col: 5, offset: 66465},
+				pos: position{line: 2167, col: 5, offset: 66407},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2167, col: 5, offset: 66465},
+						pos: position{line: 2167, col: 5, offset: 66407},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2167, col: 5, offset: 66465},
+							pos: position{line: 2167, col: 5, offset: 66407},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2167, col: 5, offset: 66465},
+									pos:   position{line: 2167, col: 5, offset: 66407},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2167, col: 11, offset: 66471},
+										pos: position{line: 2167, col: 11, offset: 66413},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2167, col: 11, offset: 66471},
+												pos:  position{line: 2167, col: 11, offset: 66413},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2167, col: 25, offset: 66485},
+												pos:  position{line: 2167, col: 25, offset: 66427},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2167, col: 31, offset: 66491},
+									pos:   position{line: 2167, col: 31, offset: 66433},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2167, col: 34, offset: 66494},
+										pos:  position{line: 2167, col: 34, offset: 66436},
 										name: "OptAsClause",
 									},
 								},
@@ -15131,10 +15131,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2178, col: 5, offset: 66722},
+						pos: position{line: 2178, col: 5, offset: 66664},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2178, col: 5, offset: 66722},
+							pos:        position{line: 2178, col: 5, offset: 66664},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15147,33 +15147,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2183, col: 1, offset: 66827},
+			pos:  position{line: 2183, col: 1, offset: 66769},
 			expr: &choiceExpr{
-				pos: position{line: 2184, col: 5, offset: 66844},
+				pos: position{line: 2184, col: 5, offset: 66785},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2184, col: 5, offset: 66844},
+						pos: position{line: 2184, col: 5, offset: 66785},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2184, col: 5, offset: 66844},
+							pos: position{line: 2184, col: 5, offset: 66785},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2184, col: 5, offset: 66844},
+									pos:  position{line: 2184, col: 5, offset: 66785},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2184, col: 7, offset: 66846},
+									pos:  position{line: 2184, col: 7, offset: 66787},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2184, col: 10, offset: 66849},
+									pos:  position{line: 2184, col: 10, offset: 66790},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2184, col: 12, offset: 66851},
+									pos:   position{line: 2184, col: 12, offset: 66792},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2184, col: 15, offset: 66854},
+										pos:  position{line: 2184, col: 15, offset: 66795},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15181,27 +15181,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2185, col: 5, offset: 66891},
+						pos: position{line: 2185, col: 5, offset: 66832},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2185, col: 5, offset: 66891},
+							pos: position{line: 2185, col: 5, offset: 66832},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2185, col: 5, offset: 66891},
+									pos:  position{line: 2185, col: 5, offset: 66832},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2185, col: 7, offset: 66893},
+									pos: position{line: 2185, col: 7, offset: 66834},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2185, col: 8, offset: 66894},
+										pos:  position{line: 2185, col: 8, offset: 66835},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2185, col: 17, offset: 66903},
+									pos:   position{line: 2185, col: 17, offset: 66844},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2185, col: 20, offset: 66906},
+										pos:  position{line: 2185, col: 20, offset: 66847},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15209,10 +15209,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2186, col: 5, offset: 66943},
+						pos: position{line: 2186, col: 5, offset: 66884},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2186, col: 5, offset: 66943},
+							pos:        position{line: 2186, col: 5, offset: 66884},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15225,41 +15225,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2188, col: 1, offset: 66968},
+			pos:  position{line: 2188, col: 1, offset: 66909},
 			expr: &choiceExpr{
-				pos: position{line: 2189, col: 5, offset: 66990},
+				pos: position{line: 2189, col: 5, offset: 66930},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2189, col: 5, offset: 66990},
+						pos: position{line: 2189, col: 5, offset: 66930},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2189, col: 5, offset: 66990},
+							pos: position{line: 2189, col: 5, offset: 66930},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 5, offset: 66990},
+									pos:  position{line: 2189, col: 5, offset: 66930},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 7, offset: 66992},
+									pos:  position{line: 2189, col: 7, offset: 66932},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 13, offset: 66998},
+									pos:  position{line: 2189, col: 13, offset: 66938},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 15, offset: 67000},
+									pos:  position{line: 2189, col: 15, offset: 66940},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 18, offset: 67003},
+									pos:  position{line: 2189, col: 18, offset: 66943},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2189, col: 20, offset: 67005},
+									pos:   position{line: 2189, col: 20, offset: 66945},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2189, col: 25, offset: 67010},
+										pos:  position{line: 2189, col: 25, offset: 66950},
 										name: "OrderByList",
 									},
 								},
@@ -15267,10 +15267,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2196, col: 5, offset: 67175},
+						pos: position{line: 2196, col: 5, offset: 67114},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2196, col: 5, offset: 67175},
+							pos:        position{line: 2196, col: 5, offset: 67114},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15283,51 +15283,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2198, col: 1, offset: 67208},
+			pos:  position{line: 2198, col: 1, offset: 67147},
 			expr: &actionExpr{
-				pos: position{line: 2199, col: 5, offset: 67225},
+				pos: position{line: 2199, col: 5, offset: 67163},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2199, col: 5, offset: 67225},
+					pos: position{line: 2199, col: 5, offset: 67163},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2199, col: 5, offset: 67225},
+							pos:   position{line: 2199, col: 5, offset: 67163},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2199, col: 11, offset: 67231},
+								pos:  position{line: 2199, col: 11, offset: 67169},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2199, col: 23, offset: 67243},
+							pos:   position{line: 2199, col: 23, offset: 67181},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2199, col: 28, offset: 67248},
+								pos: position{line: 2199, col: 28, offset: 67186},
 								expr: &actionExpr{
-									pos: position{line: 2199, col: 30, offset: 67250},
+									pos: position{line: 2199, col: 30, offset: 67188},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2199, col: 30, offset: 67250},
+										pos: position{line: 2199, col: 30, offset: 67188},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2199, col: 30, offset: 67250},
+												pos:  position{line: 2199, col: 30, offset: 67188},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2199, col: 33, offset: 67253},
+												pos:        position{line: 2199, col: 33, offset: 67191},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2199, col: 37, offset: 67257},
+												pos:  position{line: 2199, col: 37, offset: 67195},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2199, col: 40, offset: 67260},
+												pos:   position{line: 2199, col: 40, offset: 67198},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2199, col: 42, offset: 67262},
+													pos:  position{line: 2199, col: 42, offset: 67200},
 													name: "OrderByItem",
 												},
 											},
@@ -15344,34 +15344,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2203, col: 1, offset: 67363},
+			pos:  position{line: 2203, col: 1, offset: 67301},
 			expr: &actionExpr{
-				pos: position{line: 2204, col: 5, offset: 67379},
+				pos: position{line: 2204, col: 5, offset: 67317},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2204, col: 5, offset: 67379},
+					pos: position{line: 2204, col: 5, offset: 67317},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2204, col: 5, offset: 67379},
+							pos:   position{line: 2204, col: 5, offset: 67317},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2204, col: 7, offset: 67381},
+								pos:  position{line: 2204, col: 7, offset: 67319},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2204, col: 12, offset: 67386},
+							pos:   position{line: 2204, col: 12, offset: 67324},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2204, col: 18, offset: 67392},
+								pos:  position{line: 2204, col: 18, offset: 67330},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2204, col: 29, offset: 67403},
+							pos:   position{line: 2204, col: 29, offset: 67341},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2204, col: 35, offset: 67409},
+								pos:  position{line: 2204, col: 35, offset: 67347},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15383,49 +15383,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2215, col: 1, offset: 67659},
+			pos:  position{line: 2215, col: 1, offset: 67597},
 			expr: &choiceExpr{
-				pos: position{line: 2216, col: 5, offset: 67674},
+				pos: position{line: 2216, col: 5, offset: 67612},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2216, col: 5, offset: 67674},
+						pos: position{line: 2216, col: 5, offset: 67612},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2216, col: 5, offset: 67674},
+							pos: position{line: 2216, col: 5, offset: 67612},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2216, col: 5, offset: 67674},
+									pos:  position{line: 2216, col: 5, offset: 67612},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2216, col: 7, offset: 67676},
+									pos:  position{line: 2216, col: 7, offset: 67614},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2217, col: 5, offset: 67748},
+						pos: position{line: 2217, col: 5, offset: 67686},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2217, col: 5, offset: 67748},
+							pos: position{line: 2217, col: 5, offset: 67686},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2217, col: 5, offset: 67748},
+									pos:  position{line: 2217, col: 5, offset: 67686},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2217, col: 7, offset: 67750},
+									pos:  position{line: 2217, col: 7, offset: 67688},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2218, col: 5, offset: 67822},
+						pos: position{line: 2218, col: 5, offset: 67760},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2218, col: 5, offset: 67822},
+							pos:        position{line: 2218, col: 5, offset: 67760},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15438,65 +15438,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2220, col: 1, offset: 67854},
+			pos:  position{line: 2220, col: 1, offset: 67792},
 			expr: &choiceExpr{
-				pos: position{line: 2221, col: 5, offset: 67872},
+				pos: position{line: 2221, col: 5, offset: 67810},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2221, col: 5, offset: 67872},
+						pos: position{line: 2221, col: 5, offset: 67810},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2221, col: 5, offset: 67872},
+							pos: position{line: 2221, col: 5, offset: 67810},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2221, col: 5, offset: 67872},
+									pos:  position{line: 2221, col: 5, offset: 67810},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2221, col: 7, offset: 67874},
+									pos:  position{line: 2221, col: 7, offset: 67812},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2221, col: 13, offset: 67880},
+									pos:  position{line: 2221, col: 13, offset: 67818},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2221, col: 15, offset: 67882},
+									pos:  position{line: 2221, col: 15, offset: 67820},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2222, col: 5, offset: 67958},
+						pos: position{line: 2222, col: 5, offset: 67896},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2222, col: 5, offset: 67958},
+							pos: position{line: 2222, col: 5, offset: 67896},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2222, col: 5, offset: 67958},
+									pos:  position{line: 2222, col: 5, offset: 67896},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2222, col: 7, offset: 67960},
+									pos:  position{line: 2222, col: 7, offset: 67898},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2222, col: 13, offset: 67966},
+									pos:  position{line: 2222, col: 13, offset: 67904},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2222, col: 15, offset: 67968},
+									pos:  position{line: 2222, col: 15, offset: 67906},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2223, col: 5, offset: 68043},
+						pos: position{line: 2223, col: 5, offset: 67981},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2223, col: 5, offset: 68043},
+							pos:        position{line: 2223, col: 5, offset: 67981},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15509,25 +15509,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2225, col: 1, offset: 68088},
+			pos:  position{line: 2225, col: 1, offset: 68026},
 			expr: &choiceExpr{
-				pos: position{line: 2226, col: 5, offset: 68110},
+				pos: position{line: 2226, col: 5, offset: 68048},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2226, col: 5, offset: 68110},
+						pos: position{line: 2226, col: 5, offset: 68048},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2226, col: 5, offset: 68110},
+							pos: position{line: 2226, col: 5, offset: 68048},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2226, col: 5, offset: 68110},
+									pos:  position{line: 2226, col: 5, offset: 68048},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2226, col: 7, offset: 68112},
+									pos:   position{line: 2226, col: 7, offset: 68050},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2226, col: 10, offset: 68115},
+										pos:  position{line: 2226, col: 10, offset: 68053},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15535,10 +15535,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2227, col: 5, offset: 68154},
+						pos: position{line: 2227, col: 5, offset: 68091},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2227, col: 5, offset: 68154},
+							pos:        position{line: 2227, col: 5, offset: 68091},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15551,29 +15551,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2229, col: 1, offset: 68195},
+			pos:  position{line: 2229, col: 1, offset: 68132},
 			expr: &choiceExpr{
-				pos: position{line: 2230, col: 5, offset: 68214},
+				pos: position{line: 2230, col: 5, offset: 68151},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2230, col: 5, offset: 68214},
+						pos: position{line: 2230, col: 5, offset: 68151},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2230, col: 5, offset: 68214},
+							pos: position{line: 2230, col: 5, offset: 68151},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2230, col: 5, offset: 68214},
+									pos:   position{line: 2230, col: 5, offset: 68151},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2230, col: 7, offset: 68216},
+										pos:  position{line: 2230, col: 7, offset: 68153},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2230, col: 19, offset: 68228},
+									pos:   position{line: 2230, col: 19, offset: 68165},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2230, col: 21, offset: 68230},
+										pos:  position{line: 2230, col: 21, offset: 68167},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15581,24 +15581,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2243, col: 5, offset: 68494},
+						pos: position{line: 2243, col: 5, offset: 68431},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2243, col: 5, offset: 68494},
+							pos: position{line: 2243, col: 5, offset: 68431},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2243, col: 5, offset: 68494},
+									pos:   position{line: 2243, col: 5, offset: 68431},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2243, col: 7, offset: 68496},
+										pos:  position{line: 2243, col: 7, offset: 68433},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2243, col: 20, offset: 68509},
+									pos:   position{line: 2243, col: 20, offset: 68446},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2243, col: 22, offset: 68511},
+										pos:  position{line: 2243, col: 22, offset: 68448},
 										name: "OptLimitClause",
 									},
 								},
@@ -15612,25 +15612,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2255, col: 1, offset: 68740},
+			pos:  position{line: 2255, col: 1, offset: 68677},
 			expr: &choiceExpr{
-				pos: position{line: 2256, col: 5, offset: 68760},
+				pos: position{line: 2256, col: 5, offset: 68696},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2256, col: 5, offset: 68760},
+						pos: position{line: 2256, col: 5, offset: 68696},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2256, col: 5, offset: 68760},
+							pos: position{line: 2256, col: 5, offset: 68696},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2256, col: 5, offset: 68760},
+									pos:  position{line: 2256, col: 5, offset: 68696},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2256, col: 7, offset: 68762},
+									pos:   position{line: 2256, col: 7, offset: 68698},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2256, col: 9, offset: 68764},
+										pos:  position{line: 2256, col: 9, offset: 68700},
 										name: "LimitClause",
 									},
 								},
@@ -15638,10 +15638,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2257, col: 5, offset: 68798},
+						pos: position{line: 2257, col: 5, offset: 68734},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2257, col: 5, offset: 68798},
+							pos:        position{line: 2257, col: 5, offset: 68734},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15654,50 +15654,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2259, col: 1, offset: 68835},
+			pos:  position{line: 2259, col: 1, offset: 68771},
 			expr: &choiceExpr{
-				pos: position{line: 2260, col: 5, offset: 68852},
+				pos: position{line: 2260, col: 5, offset: 68787},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2260, col: 5, offset: 68852},
+						pos: position{line: 2260, col: 5, offset: 68787},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2260, col: 5, offset: 68852},
+							pos: position{line: 2260, col: 5, offset: 68787},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2260, col: 5, offset: 68852},
+									pos:  position{line: 2260, col: 5, offset: 68787},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2260, col: 11, offset: 68858},
+									pos:  position{line: 2260, col: 11, offset: 68793},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2260, col: 13, offset: 68860},
+									pos:  position{line: 2260, col: 13, offset: 68795},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2261, col: 5, offset: 68888},
+						pos: position{line: 2261, col: 5, offset: 68823},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2261, col: 5, offset: 68888},
+							pos: position{line: 2261, col: 5, offset: 68823},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2261, col: 5, offset: 68888},
+									pos:  position{line: 2261, col: 5, offset: 68823},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2261, col: 11, offset: 68894},
+									pos:  position{line: 2261, col: 11, offset: 68829},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2261, col: 13, offset: 68896},
+									pos:   position{line: 2261, col: 13, offset: 68831},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2261, col: 15, offset: 68898},
+										pos:  position{line: 2261, col: 15, offset: 68833},
 										name: "Expr",
 									},
 								},
@@ -15711,25 +15711,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2263, col: 1, offset: 68922},
+			pos:  position{line: 2263, col: 1, offset: 68857},
 			expr: &choiceExpr{
-				pos: position{line: 2264, col: 5, offset: 68943},
+				pos: position{line: 2264, col: 5, offset: 68877},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2264, col: 5, offset: 68943},
+						pos: position{line: 2264, col: 5, offset: 68877},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2264, col: 5, offset: 68943},
+							pos: position{line: 2264, col: 5, offset: 68877},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2264, col: 5, offset: 68943},
+									pos:  position{line: 2264, col: 5, offset: 68877},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2264, col: 7, offset: 68945},
+									pos:   position{line: 2264, col: 7, offset: 68879},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2264, col: 9, offset: 68947},
+										pos:  position{line: 2264, col: 9, offset: 68881},
 										name: "OffsetClause",
 									},
 								},
@@ -15737,10 +15737,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2265, col: 5, offset: 68983},
+						pos: position{line: 2265, col: 5, offset: 68917},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2265, col: 5, offset: 68983},
+							pos:        position{line: 2265, col: 5, offset: 68917},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15753,26 +15753,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2267, col: 1, offset: 69008},
+			pos:  position{line: 2267, col: 1, offset: 68942},
 			expr: &actionExpr{
-				pos: position{line: 2268, col: 5, offset: 69026},
+				pos: position{line: 2268, col: 5, offset: 68959},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2268, col: 5, offset: 69026},
+					pos: position{line: 2268, col: 5, offset: 68959},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2268, col: 5, offset: 69026},
+							pos:  position{line: 2268, col: 5, offset: 68959},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2268, col: 12, offset: 69033},
+							pos:  position{line: 2268, col: 12, offset: 68966},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2268, col: 14, offset: 69035},
+							pos:   position{line: 2268, col: 14, offset: 68968},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2268, col: 16, offset: 69037},
+								pos:  position{line: 2268, col: 16, offset: 68970},
 								name: "Expr",
 							},
 						},
@@ -15784,103 +15784,103 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2270, col: 1, offset: 69062},
+			pos:  position{line: 2270, col: 1, offset: 68995},
 			expr: &actionExpr{
-				pos: position{line: 2271, col: 5, offset: 69079},
+				pos: position{line: 2271, col: 5, offset: 69012},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2271, col: 5, offset: 69079},
+					pos: position{line: 2271, col: 5, offset: 69012},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2271, col: 5, offset: 69079},
+							pos:   position{line: 2271, col: 5, offset: 69012},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2271, col: 10, offset: 69084},
+								pos:  position{line: 2271, col: 10, offset: 69017},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2271, col: 21, offset: 69095},
+							pos:   position{line: 2271, col: 21, offset: 69028},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2271, col: 30, offset: 69104},
+								pos:  position{line: 2271, col: 30, offset: 69037},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2271, col: 36, offset: 69110},
+							pos:  position{line: 2271, col: 36, offset: 69043},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2271, col: 38, offset: 69112},
+							pos:   position{line: 2271, col: 38, offset: 69045},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2271, col: 44, offset: 69118},
+								pos:  position{line: 2271, col: 44, offset: 69051},
 								name: "SelectExpr",
 							},
 						},
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2281, col: 1, offset: 69345},
+			pos:  position{line: 2281, col: 1, offset: 69278},
 			expr: &choiceExpr{
-				pos: position{line: 2282, col: 5, offset: 69356},
+				pos: position{line: 2282, col: 5, offset: 69288},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2282, col: 5, offset: 69356},
+						pos: position{line: 2282, col: 5, offset: 69288},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2282, col: 5, offset: 69356},
+							pos: position{line: 2282, col: 5, offset: 69288},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 5, offset: 69356},
+									pos:  position{line: 2282, col: 5, offset: 69288},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 7, offset: 69358},
+									pos:  position{line: 2282, col: 7, offset: 69290},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 13, offset: 69364},
+									pos:  position{line: 2282, col: 13, offset: 69296},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 15, offset: 69366},
+									pos:  position{line: 2282, col: 15, offset: 69298},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2283, col: 5, offset: 69402},
+						pos: position{line: 2283, col: 5, offset: 69334},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2283, col: 5, offset: 69402},
+							pos: position{line: 2283, col: 5, offset: 69334},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2283, col: 5, offset: 69402},
+									pos:  position{line: 2283, col: 5, offset: 69334},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2283, col: 7, offset: 69404},
+									pos:  position{line: 2283, col: 7, offset: 69336},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2283, col: 13, offset: 69410},
+									pos: position{line: 2283, col: 13, offset: 69342},
 									expr: &seqExpr{
-										pos: position{line: 2283, col: 14, offset: 69411},
+										pos: position{line: 2283, col: 14, offset: 69343},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2283, col: 14, offset: 69411},
+												pos:  position{line: 2283, col: 14, offset: 69343},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2283, col: 16, offset: 69413},
+												pos:  position{line: 2283, col: 16, offset: 69345},
 												name: "DISTINCT",
 											},
 										},
@@ -15896,84 +15896,84 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2286, col: 1, offset: 69465},
+			pos:  position{line: 2286, col: 1, offset: 69397},
 			expr: &choiceExpr{
-				pos: position{line: 2287, col: 5, offset: 69480},
+				pos: position{line: 2287, col: 5, offset: 69412},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2287, col: 5, offset: 69480},
+						pos:  position{line: 2287, col: 5, offset: 69412},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2287, col: 12, offset: 69487},
+						pos:  position{line: 2287, col: 12, offset: 69419},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2287, col: 20, offset: 69495},
+						pos:  position{line: 2287, col: 20, offset: 69427},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2287, col: 29, offset: 69504},
+						pos:  position{line: 2287, col: 29, offset: 69436},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2287, col: 38, offset: 69513},
+						pos:  position{line: 2287, col: 38, offset: 69445},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2288, col: 5, offset: 69527},
+						pos:  position{line: 2288, col: 5, offset: 69459},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2288, col: 13, offset: 69535},
+						pos:  position{line: 2288, col: 13, offset: 69467},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2288, col: 20, offset: 69542},
+						pos:  position{line: 2288, col: 20, offset: 69474},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2288, col: 28, offset: 69550},
+						pos:  position{line: 2288, col: 28, offset: 69482},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2288, col: 36, offset: 69558},
+						pos:  position{line: 2288, col: 36, offset: 69490},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2288, col: 44, offset: 69566},
+						pos:  position{line: 2288, col: 44, offset: 69498},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2289, col: 5, offset: 69575},
+						pos:  position{line: 2289, col: 5, offset: 69507},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2290, col: 5, offset: 69585},
+						pos:  position{line: 2290, col: 5, offset: 69517},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2291, col: 5, offset: 69595},
+						pos:  position{line: 2291, col: 5, offset: 69527},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2292, col: 5, offset: 69606},
+						pos:  position{line: 2292, col: 5, offset: 69538},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2293, col: 5, offset: 69616},
+						pos:  position{line: 2293, col: 5, offset: 69548},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2294, col: 5, offset: 69627},
+						pos:  position{line: 2294, col: 5, offset: 69558},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2295, col: 5, offset: 69636},
+						pos:  position{line: 2295, col: 5, offset: 69567},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2296, col: 5, offset: 69646},
+						pos:  position{line: 2296, col: 5, offset: 69577},
 						name: "ON",
 					},
 				},
@@ -15983,20 +15983,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2298, col: 1, offset: 69650},
+			pos:  position{line: 2298, col: 1, offset: 69581},
 			expr: &seqExpr{
-				pos: position{line: 2298, col: 14, offset: 69663},
+				pos: position{line: 2298, col: 14, offset: 69594},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2298, col: 14, offset: 69663},
+						pos:        position{line: 2298, col: 14, offset: 69594},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2298, col: 33, offset: 69682},
+						pos: position{line: 2298, col: 33, offset: 69613},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2298, col: 34, offset: 69683},
+							pos:  position{line: 2298, col: 34, offset: 69614},
 							name: "IdentifierRest",
 						},
 					},
@@ -16007,20 +16007,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2299, col: 1, offset: 69698},
+			pos:  position{line: 2299, col: 1, offset: 69629},
 			expr: &seqExpr{
-				pos: position{line: 2299, col: 14, offset: 69711},
+				pos: position{line: 2299, col: 14, offset: 69642},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2299, col: 14, offset: 69711},
+						pos:        position{line: 2299, col: 14, offset: 69642},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2299, col: 33, offset: 69730},
+						pos: position{line: 2299, col: 33, offset: 69661},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2299, col: 34, offset: 69731},
+							pos:  position{line: 2299, col: 34, offset: 69662},
 							name: "IdentifierRest",
 						},
 					},
@@ -16031,23 +16031,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2300, col: 1, offset: 69746},
+			pos:  position{line: 2300, col: 1, offset: 69677},
 			expr: &actionExpr{
-				pos: position{line: 2300, col: 14, offset: 69759},
+				pos: position{line: 2300, col: 14, offset: 69690},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2300, col: 14, offset: 69759},
+					pos: position{line: 2300, col: 14, offset: 69690},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2300, col: 14, offset: 69759},
+							pos:        position{line: 2300, col: 14, offset: 69690},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2300, col: 33, offset: 69778},
+							pos: position{line: 2300, col: 33, offset: 69709},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2300, col: 34, offset: 69779},
+								pos:  position{line: 2300, col: 34, offset: 69710},
 								name: "IdentifierRest",
 							},
 						},
@@ -16059,20 +16059,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2301, col: 1, offset: 69816},
+			pos:  position{line: 2301, col: 1, offset: 69747},
 			expr: &seqExpr{
-				pos: position{line: 2301, col: 14, offset: 69829},
+				pos: position{line: 2301, col: 14, offset: 69760},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2301, col: 14, offset: 69829},
+						pos:        position{line: 2301, col: 14, offset: 69760},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2301, col: 33, offset: 69848},
+						pos: position{line: 2301, col: 33, offset: 69779},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2301, col: 34, offset: 69849},
+							pos:  position{line: 2301, col: 34, offset: 69780},
 							name: "IdentifierRest",
 						},
 					},
@@ -16083,20 +16083,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2302, col: 1, offset: 69864},
+			pos:  position{line: 2302, col: 1, offset: 69795},
 			expr: &seqExpr{
-				pos: position{line: 2302, col: 14, offset: 69877},
+				pos: position{line: 2302, col: 14, offset: 69808},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2302, col: 14, offset: 69877},
+						pos:        position{line: 2302, col: 14, offset: 69808},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2302, col: 33, offset: 69896},
+						pos: position{line: 2302, col: 33, offset: 69827},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2302, col: 34, offset: 69897},
+							pos:  position{line: 2302, col: 34, offset: 69828},
 							name: "IdentifierRest",
 						},
 					},
@@ -16107,23 +16107,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2303, col: 1, offset: 69912},
+			pos:  position{line: 2303, col: 1, offset: 69843},
 			expr: &actionExpr{
-				pos: position{line: 2303, col: 14, offset: 69925},
+				pos: position{line: 2303, col: 14, offset: 69856},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2303, col: 14, offset: 69925},
+					pos: position{line: 2303, col: 14, offset: 69856},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2303, col: 14, offset: 69925},
+							pos:        position{line: 2303, col: 14, offset: 69856},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2303, col: 33, offset: 69944},
+							pos: position{line: 2303, col: 33, offset: 69875},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2303, col: 34, offset: 69945},
+								pos:  position{line: 2303, col: 34, offset: 69876},
 								name: "IdentifierRest",
 							},
 						},
@@ -16135,20 +16135,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2304, col: 1, offset: 69982},
+			pos:  position{line: 2304, col: 1, offset: 69913},
 			expr: &seqExpr{
-				pos: position{line: 2304, col: 14, offset: 69995},
+				pos: position{line: 2304, col: 14, offset: 69926},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2304, col: 14, offset: 69995},
+						pos:        position{line: 2304, col: 14, offset: 69926},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2304, col: 33, offset: 70014},
+						pos: position{line: 2304, col: 33, offset: 69945},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2304, col: 34, offset: 70015},
+							pos:  position{line: 2304, col: 34, offset: 69946},
 							name: "IdentifierRest",
 						},
 					},
@@ -16159,20 +16159,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2305, col: 1, offset: 70030},
+			pos:  position{line: 2305, col: 1, offset: 69961},
 			expr: &seqExpr{
-				pos: position{line: 2305, col: 14, offset: 70043},
+				pos: position{line: 2305, col: 14, offset: 69974},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2305, col: 14, offset: 70043},
+						pos:        position{line: 2305, col: 14, offset: 69974},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2305, col: 33, offset: 70062},
+						pos: position{line: 2305, col: 33, offset: 69993},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2305, col: 34, offset: 70063},
+							pos:  position{line: 2305, col: 34, offset: 69994},
 							name: "IdentifierRest",
 						},
 					},
@@ -16183,20 +16183,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2306, col: 1, offset: 70078},
+			pos:  position{line: 2306, col: 1, offset: 70009},
 			expr: &seqExpr{
-				pos: position{line: 2306, col: 14, offset: 70091},
+				pos: position{line: 2306, col: 14, offset: 70022},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2306, col: 14, offset: 70091},
+						pos:        position{line: 2306, col: 14, offset: 70022},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2306, col: 33, offset: 70110},
+						pos: position{line: 2306, col: 33, offset: 70041},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2306, col: 34, offset: 70111},
+							pos:  position{line: 2306, col: 34, offset: 70042},
 							name: "IdentifierRest",
 						},
 					},
@@ -16207,20 +16207,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2307, col: 1, offset: 70126},
+			pos:  position{line: 2307, col: 1, offset: 70057},
 			expr: &seqExpr{
-				pos: position{line: 2307, col: 14, offset: 70139},
+				pos: position{line: 2307, col: 14, offset: 70070},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2307, col: 14, offset: 70139},
+						pos:        position{line: 2307, col: 14, offset: 70070},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2307, col: 33, offset: 70158},
+						pos: position{line: 2307, col: 33, offset: 70089},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2307, col: 34, offset: 70159},
+							pos:  position{line: 2307, col: 34, offset: 70090},
 							name: "IdentifierRest",
 						},
 					},
@@ -16231,20 +16231,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2308, col: 1, offset: 70174},
+			pos:  position{line: 2308, col: 1, offset: 70105},
 			expr: &seqExpr{
-				pos: position{line: 2308, col: 14, offset: 70187},
+				pos: position{line: 2308, col: 14, offset: 70118},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2308, col: 14, offset: 70187},
+						pos:        position{line: 2308, col: 14, offset: 70118},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2308, col: 33, offset: 70206},
+						pos: position{line: 2308, col: 33, offset: 70137},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2308, col: 34, offset: 70207},
+							pos:  position{line: 2308, col: 34, offset: 70138},
 							name: "IdentifierRest",
 						},
 					},
@@ -16255,20 +16255,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2309, col: 1, offset: 70222},
+			pos:  position{line: 2309, col: 1, offset: 70153},
 			expr: &seqExpr{
-				pos: position{line: 2309, col: 14, offset: 70235},
+				pos: position{line: 2309, col: 14, offset: 70166},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2309, col: 14, offset: 70235},
+						pos:        position{line: 2309, col: 14, offset: 70166},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2309, col: 33, offset: 70254},
+						pos: position{line: 2309, col: 33, offset: 70185},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2309, col: 34, offset: 70255},
+							pos:  position{line: 2309, col: 34, offset: 70186},
 							name: "IdentifierRest",
 						},
 					},
@@ -16279,20 +16279,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2310, col: 1, offset: 70270},
+			pos:  position{line: 2310, col: 1, offset: 70201},
 			expr: &seqExpr{
-				pos: position{line: 2310, col: 14, offset: 70283},
+				pos: position{line: 2310, col: 14, offset: 70214},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2310, col: 14, offset: 70283},
+						pos:        position{line: 2310, col: 14, offset: 70214},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2310, col: 33, offset: 70302},
+						pos: position{line: 2310, col: 33, offset: 70233},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2310, col: 34, offset: 70303},
+							pos:  position{line: 2310, col: 34, offset: 70234},
 							name: "IdentifierRest",
 						},
 					},
@@ -16303,20 +16303,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2311, col: 1, offset: 70318},
+			pos:  position{line: 2311, col: 1, offset: 70249},
 			expr: &seqExpr{
-				pos: position{line: 2311, col: 14, offset: 70331},
+				pos: position{line: 2311, col: 14, offset: 70262},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2311, col: 14, offset: 70331},
+						pos:        position{line: 2311, col: 14, offset: 70262},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2311, col: 33, offset: 70350},
+						pos: position{line: 2311, col: 33, offset: 70281},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2311, col: 34, offset: 70351},
+							pos:  position{line: 2311, col: 34, offset: 70282},
 							name: "IdentifierRest",
 						},
 					},
@@ -16327,20 +16327,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2312, col: 1, offset: 70366},
+			pos:  position{line: 2312, col: 1, offset: 70297},
 			expr: &seqExpr{
-				pos: position{line: 2312, col: 14, offset: 70379},
+				pos: position{line: 2312, col: 14, offset: 70310},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2312, col: 14, offset: 70379},
+						pos:        position{line: 2312, col: 14, offset: 70310},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2312, col: 33, offset: 70398},
+						pos: position{line: 2312, col: 33, offset: 70329},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2312, col: 34, offset: 70399},
+							pos:  position{line: 2312, col: 34, offset: 70330},
 							name: "IdentifierRest",
 						},
 					},
@@ -16351,20 +16351,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2313, col: 1, offset: 70414},
+			pos:  position{line: 2313, col: 1, offset: 70345},
 			expr: &seqExpr{
-				pos: position{line: 2313, col: 14, offset: 70427},
+				pos: position{line: 2313, col: 14, offset: 70358},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2313, col: 14, offset: 70427},
+						pos:        position{line: 2313, col: 14, offset: 70358},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2313, col: 33, offset: 70446},
+						pos: position{line: 2313, col: 33, offset: 70377},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2313, col: 34, offset: 70447},
+							pos:  position{line: 2313, col: 34, offset: 70378},
 							name: "IdentifierRest",
 						},
 					},
@@ -16375,23 +16375,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2314, col: 1, offset: 70462},
+			pos:  position{line: 2314, col: 1, offset: 70393},
 			expr: &actionExpr{
-				pos: position{line: 2314, col: 14, offset: 70475},
+				pos: position{line: 2314, col: 14, offset: 70406},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2314, col: 14, offset: 70475},
+					pos: position{line: 2314, col: 14, offset: 70406},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2314, col: 14, offset: 70475},
+							pos:        position{line: 2314, col: 14, offset: 70406},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2314, col: 33, offset: 70494},
+							pos: position{line: 2314, col: 33, offset: 70425},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2314, col: 34, offset: 70495},
+								pos:  position{line: 2314, col: 34, offset: 70426},
 								name: "IdentifierRest",
 							},
 						},
@@ -16403,20 +16403,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2315, col: 1, offset: 70533},
+			pos:  position{line: 2315, col: 1, offset: 70464},
 			expr: &seqExpr{
-				pos: position{line: 2315, col: 14, offset: 70546},
+				pos: position{line: 2315, col: 14, offset: 70477},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2315, col: 14, offset: 70546},
+						pos:        position{line: 2315, col: 14, offset: 70477},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2315, col: 33, offset: 70565},
+						pos: position{line: 2315, col: 33, offset: 70496},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2315, col: 34, offset: 70566},
+							pos:  position{line: 2315, col: 34, offset: 70497},
 							name: "IdentifierRest",
 						},
 					},
@@ -16427,20 +16427,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2316, col: 1, offset: 70581},
+			pos:  position{line: 2316, col: 1, offset: 70512},
 			expr: &seqExpr{
-				pos: position{line: 2316, col: 14, offset: 70594},
+				pos: position{line: 2316, col: 14, offset: 70525},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2316, col: 14, offset: 70594},
+						pos:        position{line: 2316, col: 14, offset: 70525},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2316, col: 33, offset: 70613},
+						pos: position{line: 2316, col: 33, offset: 70544},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2316, col: 34, offset: 70614},
+							pos:  position{line: 2316, col: 34, offset: 70545},
 							name: "IdentifierRest",
 						},
 					},
@@ -16451,23 +16451,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2317, col: 1, offset: 70629},
+			pos:  position{line: 2317, col: 1, offset: 70560},
 			expr: &actionExpr{
-				pos: position{line: 2317, col: 14, offset: 70642},
+				pos: position{line: 2317, col: 14, offset: 70573},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2317, col: 14, offset: 70642},
+					pos: position{line: 2317, col: 14, offset: 70573},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2317, col: 14, offset: 70642},
+							pos:        position{line: 2317, col: 14, offset: 70573},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2317, col: 33, offset: 70661},
+							pos: position{line: 2317, col: 33, offset: 70592},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2317, col: 34, offset: 70662},
+								pos:  position{line: 2317, col: 34, offset: 70593},
 								name: "IdentifierRest",
 							},
 						},
@@ -16479,20 +16479,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2318, col: 1, offset: 70700},
+			pos:  position{line: 2318, col: 1, offset: 70631},
 			expr: &seqExpr{
-				pos: position{line: 2318, col: 14, offset: 70713},
+				pos: position{line: 2318, col: 14, offset: 70644},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2318, col: 14, offset: 70713},
+						pos:        position{line: 2318, col: 14, offset: 70644},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2318, col: 33, offset: 70732},
+						pos: position{line: 2318, col: 33, offset: 70663},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2318, col: 34, offset: 70733},
+							pos:  position{line: 2318, col: 34, offset: 70664},
 							name: "IdentifierRest",
 						},
 					},
@@ -16503,20 +16503,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2319, col: 1, offset: 70748},
+			pos:  position{line: 2319, col: 1, offset: 70679},
 			expr: &seqExpr{
-				pos: position{line: 2319, col: 14, offset: 70761},
+				pos: position{line: 2319, col: 14, offset: 70692},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2319, col: 14, offset: 70761},
+						pos:        position{line: 2319, col: 14, offset: 70692},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2319, col: 33, offset: 70780},
+						pos: position{line: 2319, col: 33, offset: 70711},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2319, col: 34, offset: 70781},
+							pos:  position{line: 2319, col: 34, offset: 70712},
 							name: "IdentifierRest",
 						},
 					},
@@ -16527,20 +16527,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2320, col: 1, offset: 70797},
+			pos:  position{line: 2320, col: 1, offset: 70727},
 			expr: &seqExpr{
-				pos: position{line: 2320, col: 14, offset: 70810},
+				pos: position{line: 2320, col: 14, offset: 70740},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2320, col: 14, offset: 70810},
+						pos:        position{line: 2320, col: 14, offset: 70740},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2320, col: 33, offset: 70829},
+						pos: position{line: 2320, col: 33, offset: 70759},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2320, col: 34, offset: 70830},
+							pos:  position{line: 2320, col: 34, offset: 70760},
 							name: "IdentifierRest",
 						},
 					},
@@ -16551,20 +16551,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2321, col: 1, offset: 70845},
+			pos:  position{line: 2321, col: 1, offset: 70775},
 			expr: &seqExpr{
-				pos: position{line: 2321, col: 14, offset: 70858},
+				pos: position{line: 2321, col: 14, offset: 70788},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2321, col: 14, offset: 70858},
+						pos:        position{line: 2321, col: 14, offset: 70788},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2321, col: 33, offset: 70877},
+						pos: position{line: 2321, col: 33, offset: 70807},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2321, col: 34, offset: 70878},
+							pos:  position{line: 2321, col: 34, offset: 70808},
 							name: "IdentifierRest",
 						},
 					},
@@ -16575,20 +16575,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2322, col: 1, offset: 70893},
+			pos:  position{line: 2322, col: 1, offset: 70823},
 			expr: &seqExpr{
-				pos: position{line: 2322, col: 14, offset: 70906},
+				pos: position{line: 2322, col: 14, offset: 70836},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2322, col: 14, offset: 70906},
+						pos:        position{line: 2322, col: 14, offset: 70836},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2322, col: 33, offset: 70925},
+						pos: position{line: 2322, col: 33, offset: 70855},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2322, col: 34, offset: 70926},
+							pos:  position{line: 2322, col: 34, offset: 70856},
 							name: "IdentifierRest",
 						},
 					},
@@ -16599,20 +16599,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2323, col: 1, offset: 70941},
+			pos:  position{line: 2323, col: 1, offset: 70871},
 			expr: &seqExpr{
-				pos: position{line: 2323, col: 14, offset: 70954},
+				pos: position{line: 2323, col: 14, offset: 70884},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2323, col: 14, offset: 70954},
+						pos:        position{line: 2323, col: 14, offset: 70884},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2323, col: 33, offset: 70973},
+						pos: position{line: 2323, col: 33, offset: 70903},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2323, col: 34, offset: 70974},
+							pos:  position{line: 2323, col: 34, offset: 70904},
 							name: "IdentifierRest",
 						},
 					},
@@ -16623,20 +16623,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2324, col: 1, offset: 70989},
+			pos:  position{line: 2324, col: 1, offset: 70919},
 			expr: &seqExpr{
-				pos: position{line: 2324, col: 14, offset: 71002},
+				pos: position{line: 2324, col: 14, offset: 70932},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2324, col: 14, offset: 71002},
+						pos:        position{line: 2324, col: 14, offset: 70932},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2324, col: 33, offset: 71021},
+						pos: position{line: 2324, col: 33, offset: 70951},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2324, col: 34, offset: 71022},
+							pos:  position{line: 2324, col: 34, offset: 70952},
 							name: "IdentifierRest",
 						},
 					},
@@ -16647,20 +16647,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2325, col: 1, offset: 71037},
+			pos:  position{line: 2325, col: 1, offset: 70967},
 			expr: &seqExpr{
-				pos: position{line: 2325, col: 14, offset: 71050},
+				pos: position{line: 2325, col: 14, offset: 70980},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2325, col: 14, offset: 71050},
+						pos:        position{line: 2325, col: 14, offset: 70980},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2325, col: 33, offset: 71069},
+						pos: position{line: 2325, col: 33, offset: 70999},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2325, col: 34, offset: 71070},
+							pos:  position{line: 2325, col: 34, offset: 71000},
 							name: "IdentifierRest",
 						},
 					},
@@ -16671,20 +16671,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2326, col: 1, offset: 71085},
+			pos:  position{line: 2326, col: 1, offset: 71015},
 			expr: &seqExpr{
-				pos: position{line: 2326, col: 14, offset: 71098},
+				pos: position{line: 2326, col: 14, offset: 71028},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2326, col: 14, offset: 71098},
+						pos:        position{line: 2326, col: 14, offset: 71028},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2326, col: 33, offset: 71117},
+						pos: position{line: 2326, col: 33, offset: 71047},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2326, col: 34, offset: 71118},
+							pos:  position{line: 2326, col: 34, offset: 71048},
 							name: "IdentifierRest",
 						},
 					},
@@ -16695,20 +16695,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2327, col: 1, offset: 71133},
+			pos:  position{line: 2327, col: 1, offset: 71063},
 			expr: &seqExpr{
-				pos: position{line: 2327, col: 14, offset: 71146},
+				pos: position{line: 2327, col: 14, offset: 71076},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2327, col: 14, offset: 71146},
+						pos:        position{line: 2327, col: 14, offset: 71076},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2327, col: 33, offset: 71165},
+						pos: position{line: 2327, col: 33, offset: 71095},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2327, col: 34, offset: 71166},
+							pos:  position{line: 2327, col: 34, offset: 71096},
 							name: "IdentifierRest",
 						},
 					},
@@ -16719,20 +16719,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2328, col: 1, offset: 71181},
+			pos:  position{line: 2328, col: 1, offset: 71111},
 			expr: &seqExpr{
-				pos: position{line: 2328, col: 14, offset: 71194},
+				pos: position{line: 2328, col: 14, offset: 71124},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2328, col: 14, offset: 71194},
+						pos:        position{line: 2328, col: 14, offset: 71124},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2328, col: 33, offset: 71213},
+						pos: position{line: 2328, col: 33, offset: 71143},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2328, col: 34, offset: 71214},
+							pos:  position{line: 2328, col: 34, offset: 71144},
 							name: "IdentifierRest",
 						},
 					},
@@ -16743,20 +16743,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2329, col: 1, offset: 71229},
+			pos:  position{line: 2329, col: 1, offset: 71159},
 			expr: &seqExpr{
-				pos: position{line: 2329, col: 14, offset: 71242},
+				pos: position{line: 2329, col: 14, offset: 71172},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2329, col: 14, offset: 71242},
+						pos:        position{line: 2329, col: 14, offset: 71172},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2329, col: 33, offset: 71261},
+						pos: position{line: 2329, col: 33, offset: 71191},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2329, col: 34, offset: 71262},
+							pos:  position{line: 2329, col: 34, offset: 71192},
 							name: "IdentifierRest",
 						},
 					},
@@ -16767,20 +16767,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2330, col: 1, offset: 71277},
+			pos:  position{line: 2330, col: 1, offset: 71207},
 			expr: &seqExpr{
-				pos: position{line: 2330, col: 14, offset: 71290},
+				pos: position{line: 2330, col: 14, offset: 71220},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2330, col: 14, offset: 71290},
+						pos:        position{line: 2330, col: 14, offset: 71220},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2330, col: 33, offset: 71309},
+						pos: position{line: 2330, col: 33, offset: 71239},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2330, col: 34, offset: 71310},
+							pos:  position{line: 2330, col: 34, offset: 71240},
 							name: "IdentifierRest",
 						},
 					},
@@ -16791,20 +16791,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2331, col: 1, offset: 71325},
+			pos:  position{line: 2331, col: 1, offset: 71255},
 			expr: &seqExpr{
-				pos: position{line: 2331, col: 14, offset: 71338},
+				pos: position{line: 2331, col: 14, offset: 71268},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2331, col: 14, offset: 71338},
+						pos:        position{line: 2331, col: 14, offset: 71268},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2331, col: 33, offset: 71357},
+						pos: position{line: 2331, col: 33, offset: 71287},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2331, col: 34, offset: 71358},
+							pos:  position{line: 2331, col: 34, offset: 71288},
 							name: "IdentifierRest",
 						},
 					},
@@ -16815,20 +16815,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2332, col: 1, offset: 71373},
+			pos:  position{line: 2332, col: 1, offset: 71303},
 			expr: &seqExpr{
-				pos: position{line: 2332, col: 14, offset: 71386},
+				pos: position{line: 2332, col: 14, offset: 71316},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2332, col: 14, offset: 71386},
+						pos:        position{line: 2332, col: 14, offset: 71316},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2332, col: 33, offset: 71405},
+						pos: position{line: 2332, col: 33, offset: 71335},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2332, col: 34, offset: 71406},
+							pos:  position{line: 2332, col: 34, offset: 71336},
 							name: "IdentifierRest",
 						},
 					},
@@ -16839,20 +16839,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2333, col: 1, offset: 71421},
+			pos:  position{line: 2333, col: 1, offset: 71351},
 			expr: &seqExpr{
-				pos: position{line: 2333, col: 14, offset: 71434},
+				pos: position{line: 2333, col: 14, offset: 71364},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2333, col: 14, offset: 71434},
+						pos:        position{line: 2333, col: 14, offset: 71364},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2333, col: 33, offset: 71453},
+						pos: position{line: 2333, col: 33, offset: 71383},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2333, col: 34, offset: 71454},
+							pos:  position{line: 2333, col: 34, offset: 71384},
 							name: "IdentifierRest",
 						},
 					},
@@ -16863,20 +16863,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2334, col: 1, offset: 71469},
+			pos:  position{line: 2334, col: 1, offset: 71399},
 			expr: &seqExpr{
-				pos: position{line: 2334, col: 14, offset: 71482},
+				pos: position{line: 2334, col: 14, offset: 71412},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2334, col: 14, offset: 71482},
+						pos:        position{line: 2334, col: 14, offset: 71412},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2334, col: 33, offset: 71501},
+						pos: position{line: 2334, col: 33, offset: 71431},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2334, col: 34, offset: 71502},
+							pos:  position{line: 2334, col: 34, offset: 71432},
 							name: "IdentifierRest",
 						},
 					},
@@ -16887,20 +16887,20 @@ var g = &grammar{
 		},
 		{
 			name: "GREP",
-			pos:  position{line: 2335, col: 1, offset: 71517},
+			pos:  position{line: 2335, col: 1, offset: 71447},
 			expr: &seqExpr{
-				pos: position{line: 2335, col: 14, offset: 71530},
+				pos: position{line: 2335, col: 14, offset: 71460},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2335, col: 14, offset: 71530},
+						pos:        position{line: 2335, col: 14, offset: 71460},
 						val:        "grep",
 						ignoreCase: true,
 						want:       "\"GREP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2335, col: 33, offset: 71549},
+						pos: position{line: 2335, col: 33, offset: 71479},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2335, col: 34, offset: 71550},
+							pos:  position{line: 2335, col: 34, offset: 71480},
 							name: "IdentifierRest",
 						},
 					},
@@ -16911,20 +16911,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2336, col: 1, offset: 71565},
+			pos:  position{line: 2336, col: 1, offset: 71495},
 			expr: &seqExpr{
-				pos: position{line: 2336, col: 14, offset: 71578},
+				pos: position{line: 2336, col: 14, offset: 71508},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2336, col: 14, offset: 71578},
+						pos:        position{line: 2336, col: 14, offset: 71508},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2336, col: 33, offset: 71597},
+						pos: position{line: 2336, col: 33, offset: 71527},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2336, col: 34, offset: 71598},
+							pos:  position{line: 2336, col: 34, offset: 71528},
 							name: "IdentifierRest",
 						},
 					},
@@ -16935,20 +16935,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2337, col: 1, offset: 71613},
+			pos:  position{line: 2337, col: 1, offset: 71543},
 			expr: &seqExpr{
-				pos: position{line: 2337, col: 14, offset: 71626},
+				pos: position{line: 2337, col: 14, offset: 71556},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2337, col: 14, offset: 71626},
+						pos:        position{line: 2337, col: 14, offset: 71556},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2337, col: 33, offset: 71645},
+						pos: position{line: 2337, col: 33, offset: 71575},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2337, col: 34, offset: 71646},
+							pos:  position{line: 2337, col: 34, offset: 71576},
 							name: "IdentifierRest",
 						},
 					},
@@ -16959,20 +16959,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2338, col: 1, offset: 71661},
+			pos:  position{line: 2338, col: 1, offset: 71591},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 71674},
+				pos: position{line: 2338, col: 14, offset: 71604},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 71674},
+						pos:        position{line: 2338, col: 14, offset: 71604},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 71693},
+						pos: position{line: 2338, col: 33, offset: 71623},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 71694},
+							pos:  position{line: 2338, col: 34, offset: 71624},
 							name: "IdentifierRest",
 						},
 					},
@@ -16983,20 +16983,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2339, col: 1, offset: 71710},
+			pos:  position{line: 2339, col: 1, offset: 71639},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 71723},
+				pos: position{line: 2339, col: 14, offset: 71652},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 71723},
+						pos:        position{line: 2339, col: 14, offset: 71652},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 71742},
+						pos: position{line: 2339, col: 33, offset: 71671},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 71743},
+							pos:  position{line: 2339, col: 34, offset: 71672},
 							name: "IdentifierRest",
 						},
 					},
@@ -17007,20 +17007,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2340, col: 1, offset: 71758},
+			pos:  position{line: 2340, col: 1, offset: 71687},
 			expr: &seqExpr{
-				pos: position{line: 2340, col: 14, offset: 71771},
+				pos: position{line: 2340, col: 14, offset: 71700},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2340, col: 14, offset: 71771},
+						pos:        position{line: 2340, col: 14, offset: 71700},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2340, col: 33, offset: 71790},
+						pos: position{line: 2340, col: 33, offset: 71719},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2340, col: 34, offset: 71791},
+							pos:  position{line: 2340, col: 34, offset: 71720},
 							name: "IdentifierRest",
 						},
 					},
@@ -17031,20 +17031,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2341, col: 1, offset: 71806},
+			pos:  position{line: 2341, col: 1, offset: 71735},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 71819},
+				pos: position{line: 2341, col: 14, offset: 71748},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 71819},
+						pos:        position{line: 2341, col: 14, offset: 71748},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 71838},
+						pos: position{line: 2341, col: 33, offset: 71767},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 71839},
+							pos:  position{line: 2341, col: 34, offset: 71768},
 							name: "IdentifierRest",
 						},
 					},
@@ -17055,20 +17055,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2342, col: 1, offset: 71854},
+			pos:  position{line: 2342, col: 1, offset: 71783},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 71867},
+				pos: position{line: 2342, col: 14, offset: 71796},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 71867},
+						pos:        position{line: 2342, col: 14, offset: 71796},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 71886},
+						pos: position{line: 2342, col: 33, offset: 71815},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 71887},
+							pos:  position{line: 2342, col: 34, offset: 71816},
 							name: "IdentifierRest",
 						},
 					},
@@ -17079,20 +17079,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2343, col: 1, offset: 71902},
+			pos:  position{line: 2343, col: 1, offset: 71831},
 			expr: &seqExpr{
-				pos: position{line: 2343, col: 14, offset: 71915},
+				pos: position{line: 2343, col: 14, offset: 71844},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2343, col: 14, offset: 71915},
+						pos:        position{line: 2343, col: 14, offset: 71844},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2343, col: 33, offset: 71934},
+						pos: position{line: 2343, col: 33, offset: 71863},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2343, col: 34, offset: 71935},
+							pos:  position{line: 2343, col: 34, offset: 71864},
 							name: "IdentifierRest",
 						},
 					},
@@ -17103,20 +17103,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2344, col: 1, offset: 71950},
+			pos:  position{line: 2344, col: 1, offset: 71879},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 71963},
+				pos: position{line: 2344, col: 14, offset: 71892},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 71963},
+						pos:        position{line: 2344, col: 14, offset: 71892},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 71982},
+						pos: position{line: 2344, col: 33, offset: 71911},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 71983},
+							pos:  position{line: 2344, col: 34, offset: 71912},
 							name: "IdentifierRest",
 						},
 					},
@@ -17127,20 +17127,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2345, col: 1, offset: 71998},
+			pos:  position{line: 2345, col: 1, offset: 71927},
 			expr: &seqExpr{
-				pos: position{line: 2345, col: 14, offset: 72011},
+				pos: position{line: 2345, col: 14, offset: 71940},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2345, col: 14, offset: 72011},
+						pos:        position{line: 2345, col: 14, offset: 71940},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2345, col: 33, offset: 72030},
+						pos: position{line: 2345, col: 33, offset: 71959},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2345, col: 34, offset: 72031},
+							pos:  position{line: 2345, col: 34, offset: 71960},
 							name: "IdentifierRest",
 						},
 					},
@@ -17151,20 +17151,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2346, col: 1, offset: 72046},
+			pos:  position{line: 2346, col: 1, offset: 71975},
 			expr: &seqExpr{
-				pos: position{line: 2346, col: 14, offset: 72059},
+				pos: position{line: 2346, col: 14, offset: 71988},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2346, col: 14, offset: 72059},
+						pos:        position{line: 2346, col: 14, offset: 71988},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2346, col: 33, offset: 72078},
+						pos: position{line: 2346, col: 33, offset: 72007},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2346, col: 34, offset: 72079},
+							pos:  position{line: 2346, col: 34, offset: 72008},
 							name: "IdentifierRest",
 						},
 					},
@@ -17175,20 +17175,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2347, col: 1, offset: 72094},
+			pos:  position{line: 2347, col: 1, offset: 72023},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 72107},
+				pos: position{line: 2347, col: 14, offset: 72036},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 72107},
+						pos:        position{line: 2347, col: 14, offset: 72036},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 72126},
+						pos: position{line: 2347, col: 33, offset: 72055},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 72127},
+							pos:  position{line: 2347, col: 34, offset: 72056},
 							name: "IdentifierRest",
 						},
 					},
@@ -17199,20 +17199,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2348, col: 1, offset: 72142},
+			pos:  position{line: 2348, col: 1, offset: 72071},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 16, offset: 72157},
+				pos: position{line: 2348, col: 16, offset: 72086},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 16, offset: 72157},
+						pos:        position{line: 2348, col: 16, offset: 72086},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 72174},
+						pos: position{line: 2348, col: 33, offset: 72103},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 72175},
+							pos:  position{line: 2348, col: 34, offset: 72104},
 							name: "IdentifierRest",
 						},
 					},
@@ -17223,20 +17223,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2349, col: 1, offset: 72190},
+			pos:  position{line: 2349, col: 1, offset: 72119},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 72203},
+				pos: position{line: 2349, col: 14, offset: 72132},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 72203},
+						pos:        position{line: 2349, col: 14, offset: 72132},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 72222},
+						pos: position{line: 2349, col: 33, offset: 72151},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 72223},
+							pos:  position{line: 2349, col: 34, offset: 72152},
 							name: "IdentifierRest",
 						},
 					},
@@ -17247,20 +17247,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2350, col: 1, offset: 72238},
+			pos:  position{line: 2350, col: 1, offset: 72167},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 72251},
+				pos: position{line: 2350, col: 14, offset: 72180},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 72251},
+						pos:        position{line: 2350, col: 14, offset: 72180},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 72270},
+						pos: position{line: 2350, col: 33, offset: 72199},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 72271},
+							pos:  position{line: 2350, col: 34, offset: 72200},
 							name: "IdentifierRest",
 						},
 					},
@@ -17271,20 +17271,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2351, col: 1, offset: 72286},
+			pos:  position{line: 2351, col: 1, offset: 72215},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 72299},
+				pos: position{line: 2351, col: 14, offset: 72228},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 72299},
+						pos:        position{line: 2351, col: 14, offset: 72228},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 72318},
+						pos: position{line: 2351, col: 33, offset: 72247},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 72319},
+							pos:  position{line: 2351, col: 34, offset: 72248},
 							name: "IdentifierRest",
 						},
 					},
@@ -17295,20 +17295,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2352, col: 1, offset: 72334},
+			pos:  position{line: 2352, col: 1, offset: 72263},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 72347},
+				pos: position{line: 2352, col: 14, offset: 72276},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 72347},
+						pos:        position{line: 2352, col: 14, offset: 72276},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 72366},
+						pos: position{line: 2352, col: 33, offset: 72295},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 72367},
+							pos:  position{line: 2352, col: 34, offset: 72296},
 							name: "IdentifierRest",
 						},
 					},
@@ -17319,20 +17319,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2353, col: 1, offset: 72382},
+			pos:  position{line: 2353, col: 1, offset: 72311},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 72395},
+				pos: position{line: 2353, col: 14, offset: 72324},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 72395},
+						pos:        position{line: 2353, col: 14, offset: 72324},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 72414},
+						pos: position{line: 2353, col: 33, offset: 72343},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 72415},
+							pos:  position{line: 2353, col: 34, offset: 72344},
 							name: "IdentifierRest",
 						},
 					},
@@ -17343,20 +17343,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2354, col: 1, offset: 72430},
+			pos:  position{line: 2354, col: 1, offset: 72359},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 72443},
+				pos: position{line: 2354, col: 14, offset: 72372},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 72443},
+						pos:        position{line: 2354, col: 14, offset: 72372},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 72462},
+						pos: position{line: 2354, col: 33, offset: 72391},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 72463},
+							pos:  position{line: 2354, col: 34, offset: 72392},
 							name: "IdentifierRest",
 						},
 					},
@@ -17367,20 +17367,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2355, col: 1, offset: 72478},
+			pos:  position{line: 2355, col: 1, offset: 72407},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 72491},
+				pos: position{line: 2355, col: 14, offset: 72420},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 72491},
+						pos:        position{line: 2355, col: 14, offset: 72420},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 72510},
+						pos: position{line: 2355, col: 33, offset: 72439},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 72511},
+							pos:  position{line: 2355, col: 34, offset: 72440},
 							name: "IdentifierRest",
 						},
 					},
@@ -17391,23 +17391,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2356, col: 1, offset: 72526},
+			pos:  position{line: 2356, col: 1, offset: 72455},
 			expr: &actionExpr{
-				pos: position{line: 2356, col: 14, offset: 72539},
+				pos: position{line: 2356, col: 14, offset: 72468},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2356, col: 14, offset: 72539},
+					pos: position{line: 2356, col: 14, offset: 72468},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2356, col: 14, offset: 72539},
+							pos:        position{line: 2356, col: 14, offset: 72468},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2356, col: 33, offset: 72558},
+							pos: position{line: 2356, col: 33, offset: 72487},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2356, col: 34, offset: 72559},
+								pos:  position{line: 2356, col: 34, offset: 72488},
 								name: "IdentifierRest",
 							},
 						},
@@ -17419,20 +17419,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2357, col: 1, offset: 72595},
+			pos:  position{line: 2357, col: 1, offset: 72524},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 72608},
+				pos: position{line: 2357, col: 14, offset: 72537},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 72608},
+						pos:        position{line: 2357, col: 14, offset: 72537},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 72627},
+						pos: position{line: 2357, col: 33, offset: 72556},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 72628},
+							pos:  position{line: 2357, col: 34, offset: 72557},
 							name: "IdentifierRest",
 						},
 					},
@@ -17443,20 +17443,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2358, col: 1, offset: 72643},
+			pos:  position{line: 2358, col: 1, offset: 72572},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 72656},
+				pos: position{line: 2358, col: 14, offset: 72585},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 72656},
+						pos:        position{line: 2358, col: 14, offset: 72585},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 72675},
+						pos: position{line: 2358, col: 33, offset: 72604},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 72676},
+							pos:  position{line: 2358, col: 34, offset: 72605},
 							name: "IdentifierRest",
 						},
 					},
@@ -17467,20 +17467,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2359, col: 1, offset: 72691},
+			pos:  position{line: 2359, col: 1, offset: 72620},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 72704},
+				pos: position{line: 2359, col: 14, offset: 72633},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 72704},
+						pos:        position{line: 2359, col: 14, offset: 72633},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 72723},
+						pos: position{line: 2359, col: 33, offset: 72652},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 72724},
+							pos:  position{line: 2359, col: 34, offset: 72653},
 							name: "IdentifierRest",
 						},
 					},
@@ -17491,20 +17491,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2360, col: 1, offset: 72739},
+			pos:  position{line: 2360, col: 1, offset: 72668},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 72752},
+				pos: position{line: 2360, col: 14, offset: 72681},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 72752},
+						pos:        position{line: 2360, col: 14, offset: 72681},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 72771},
+						pos: position{line: 2360, col: 33, offset: 72700},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 72772},
+							pos:  position{line: 2360, col: 34, offset: 72701},
 							name: "IdentifierRest",
 						},
 					},
@@ -17515,20 +17515,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2361, col: 1, offset: 72787},
+			pos:  position{line: 2361, col: 1, offset: 72716},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 72800},
+				pos: position{line: 2361, col: 14, offset: 72729},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 72800},
+						pos:        position{line: 2361, col: 14, offset: 72729},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 72819},
+						pos: position{line: 2361, col: 33, offset: 72748},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 72820},
+							pos:  position{line: 2361, col: 34, offset: 72749},
 							name: "IdentifierRest",
 						},
 					},
@@ -17539,20 +17539,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2362, col: 1, offset: 72835},
+			pos:  position{line: 2362, col: 1, offset: 72764},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 72848},
+				pos: position{line: 2362, col: 14, offset: 72777},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 72848},
+						pos:        position{line: 2362, col: 14, offset: 72777},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 72867},
+						pos: position{line: 2362, col: 33, offset: 72796},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 72868},
+							pos:  position{line: 2362, col: 34, offset: 72797},
 							name: "IdentifierRest",
 						},
 					},
@@ -17563,20 +17563,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2363, col: 1, offset: 72883},
+			pos:  position{line: 2363, col: 1, offset: 72812},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 72896},
+				pos: position{line: 2363, col: 14, offset: 72825},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 72896},
+						pos:        position{line: 2363, col: 14, offset: 72825},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 72915},
+						pos: position{line: 2363, col: 33, offset: 72844},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 72916},
+							pos:  position{line: 2363, col: 34, offset: 72845},
 							name: "IdentifierRest",
 						},
 					},
@@ -17587,20 +17587,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP",
-			pos:  position{line: 2364, col: 1, offset: 72931},
+			pos:  position{line: 2364, col: 1, offset: 72860},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 72944},
+				pos: position{line: 2364, col: 14, offset: 72873},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 72944},
+						pos:        position{line: 2364, col: 14, offset: 72873},
 						val:        "regexp",
 						ignoreCase: true,
 						want:       "\"REGEXP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 72963},
+						pos: position{line: 2364, col: 33, offset: 72892},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 72964},
+							pos:  position{line: 2364, col: 34, offset: 72893},
 							name: "IdentifierRest",
 						},
 					},
@@ -17611,20 +17611,20 @@ var g = &grammar{
 		},
 		{
 			name: "REGEXP_REPLACE",
-			pos:  position{line: 2365, col: 1, offset: 72979},
+			pos:  position{line: 2365, col: 1, offset: 72908},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 18, offset: 72996},
+				pos: position{line: 2365, col: 18, offset: 72925},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 18, offset: 72996},
+						pos:        position{line: 2365, col: 18, offset: 72925},
 						val:        "regexp_replace",
 						ignoreCase: true,
 						want:       "\"REGEXP_REPLACE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 36, offset: 73014},
+						pos: position{line: 2365, col: 36, offset: 72943},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 37, offset: 73015},
+							pos:  position{line: 2365, col: 37, offset: 72944},
 							name: "IdentifierRest",
 						},
 					},
@@ -17635,20 +17635,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2366, col: 1, offset: 73030},
+			pos:  position{line: 2366, col: 1, offset: 72959},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 73043},
+				pos: position{line: 2366, col: 14, offset: 72972},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 73043},
+						pos:        position{line: 2366, col: 14, offset: 72972},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 73062},
+						pos: position{line: 2366, col: 33, offset: 72991},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 73063},
+							pos:  position{line: 2366, col: 34, offset: 72992},
 							name: "IdentifierRest",
 						},
 					},
@@ -17659,20 +17659,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2367, col: 1, offset: 73078},
+			pos:  position{line: 2367, col: 1, offset: 73007},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 73091},
+				pos: position{line: 2367, col: 14, offset: 73020},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 73091},
+						pos:        position{line: 2367, col: 14, offset: 73020},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 73110},
+						pos: position{line: 2367, col: 33, offset: 73039},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 73111},
+							pos:  position{line: 2367, col: 34, offset: 73040},
 							name: "IdentifierRest",
 						},
 					},
@@ -17683,20 +17683,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2368, col: 1, offset: 73126},
+			pos:  position{line: 2368, col: 1, offset: 73055},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 73139},
+				pos: position{line: 2368, col: 14, offset: 73068},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 73139},
+						pos:        position{line: 2368, col: 14, offset: 73068},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 73158},
+						pos: position{line: 2368, col: 33, offset: 73087},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 73159},
+							pos:  position{line: 2368, col: 34, offset: 73088},
 							name: "IdentifierRest",
 						},
 					},
@@ -17707,20 +17707,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2369, col: 1, offset: 73174},
+			pos:  position{line: 2369, col: 1, offset: 73103},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 73187},
+				pos: position{line: 2369, col: 14, offset: 73116},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 73187},
+						pos:        position{line: 2369, col: 14, offset: 73116},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 73206},
+						pos: position{line: 2369, col: 33, offset: 73135},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 73207},
+							pos:  position{line: 2369, col: 34, offset: 73136},
 							name: "IdentifierRest",
 						},
 					},
@@ -17731,20 +17731,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2370, col: 1, offset: 73222},
+			pos:  position{line: 2370, col: 1, offset: 73151},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 73235},
+				pos: position{line: 2370, col: 14, offset: 73164},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 73235},
+						pos:        position{line: 2370, col: 14, offset: 73164},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 73254},
+						pos: position{line: 2370, col: 33, offset: 73183},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 73255},
+							pos:  position{line: 2370, col: 34, offset: 73184},
 							name: "IdentifierRest",
 						},
 					},
@@ -17755,20 +17755,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2371, col: 1, offset: 73270},
+			pos:  position{line: 2371, col: 1, offset: 73199},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 73283},
+				pos: position{line: 2371, col: 14, offset: 73212},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 73283},
+						pos:        position{line: 2371, col: 14, offset: 73212},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 73302},
+						pos: position{line: 2371, col: 33, offset: 73231},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 73303},
+							pos:  position{line: 2371, col: 34, offset: 73232},
 							name: "IdentifierRest",
 						},
 					},
@@ -17779,20 +17779,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2372, col: 1, offset: 73318},
+			pos:  position{line: 2372, col: 1, offset: 73247},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 73331},
+				pos: position{line: 2372, col: 14, offset: 73260},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 73331},
+						pos:        position{line: 2372, col: 14, offset: 73260},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 73350},
+						pos: position{line: 2372, col: 33, offset: 73279},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 73351},
+							pos:  position{line: 2372, col: 34, offset: 73280},
 							name: "IdentifierRest",
 						},
 					},
@@ -17803,20 +17803,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2373, col: 1, offset: 73366},
+			pos:  position{line: 2373, col: 1, offset: 73295},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 73379},
+				pos: position{line: 2373, col: 14, offset: 73308},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 73379},
+						pos:        position{line: 2373, col: 14, offset: 73308},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 73398},
+						pos: position{line: 2373, col: 33, offset: 73327},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 73399},
+							pos:  position{line: 2373, col: 34, offset: 73328},
 							name: "IdentifierRest",
 						},
 					},
@@ -17827,20 +17827,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2374, col: 1, offset: 73414},
+			pos:  position{line: 2374, col: 1, offset: 73343},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 73427},
+				pos: position{line: 2374, col: 14, offset: 73356},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 73427},
+						pos:        position{line: 2374, col: 14, offset: 73356},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 73446},
+						pos: position{line: 2374, col: 33, offset: 73375},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 73447},
+							pos:  position{line: 2374, col: 34, offset: 73376},
 							name: "IdentifierRest",
 						},
 					},
@@ -17851,20 +17851,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2375, col: 1, offset: 73462},
+			pos:  position{line: 2375, col: 1, offset: 73391},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 73475},
+				pos: position{line: 2375, col: 14, offset: 73404},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 73475},
+						pos:        position{line: 2375, col: 14, offset: 73404},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 73494},
+						pos: position{line: 2375, col: 33, offset: 73423},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 73495},
+							pos:  position{line: 2375, col: 34, offset: 73424},
 							name: "IdentifierRest",
 						},
 					},
@@ -17875,20 +17875,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2376, col: 1, offset: 73510},
+			pos:  position{line: 2376, col: 1, offset: 73439},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 73523},
+				pos: position{line: 2376, col: 14, offset: 73452},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 73523},
+						pos:        position{line: 2376, col: 14, offset: 73452},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 73542},
+						pos: position{line: 2376, col: 33, offset: 73471},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 73543},
+							pos:  position{line: 2376, col: 34, offset: 73472},
 							name: "IdentifierRest",
 						},
 					},
@@ -17899,20 +17899,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2377, col: 1, offset: 73558},
+			pos:  position{line: 2377, col: 1, offset: 73487},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 73571},
+				pos: position{line: 2377, col: 14, offset: 73500},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 73571},
+						pos:        position{line: 2377, col: 14, offset: 73500},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 73590},
+						pos: position{line: 2377, col: 33, offset: 73519},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 73591},
+							pos:  position{line: 2377, col: 34, offset: 73520},
 							name: "IdentifierRest",
 						},
 					},
@@ -17923,20 +17923,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2378, col: 1, offset: 73607},
+			pos:  position{line: 2378, col: 1, offset: 73535},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 73620},
+				pos: position{line: 2378, col: 14, offset: 73548},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 73620},
+						pos:        position{line: 2378, col: 14, offset: 73548},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 73639},
+						pos: position{line: 2378, col: 33, offset: 73567},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 73640},
+							pos:  position{line: 2378, col: 34, offset: 73568},
 							name: "IdentifierRest",
 						},
 					},
@@ -17947,23 +17947,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2379, col: 1, offset: 73655},
+			pos:  position{line: 2379, col: 1, offset: 73583},
 			expr: &actionExpr{
-				pos: position{line: 2379, col: 14, offset: 73668},
+				pos: position{line: 2379, col: 14, offset: 73596},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2379, col: 14, offset: 73668},
+					pos: position{line: 2379, col: 14, offset: 73596},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2379, col: 14, offset: 73668},
+							pos:        position{line: 2379, col: 14, offset: 73596},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2379, col: 33, offset: 73687},
+							pos: position{line: 2379, col: 33, offset: 73615},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2379, col: 34, offset: 73688},
+								pos:  position{line: 2379, col: 34, offset: 73616},
 								name: "IdentifierRest",
 							},
 						},
@@ -17975,20 +17975,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2380, col: 1, offset: 73731},
+			pos:  position{line: 2380, col: 1, offset: 73659},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 73744},
+				pos: position{line: 2380, col: 14, offset: 73672},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 73744},
+						pos:        position{line: 2380, col: 14, offset: 73672},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 73763},
+						pos: position{line: 2380, col: 33, offset: 73691},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 73764},
+							pos:  position{line: 2380, col: 34, offset: 73692},
 							name: "IdentifierRest",
 						},
 					},
@@ -17999,20 +17999,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2381, col: 1, offset: 73779},
+			pos:  position{line: 2381, col: 1, offset: 73707},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 73792},
+				pos: position{line: 2381, col: 14, offset: 73720},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 73792},
+						pos:        position{line: 2381, col: 14, offset: 73720},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 73811},
+						pos: position{line: 2381, col: 33, offset: 73739},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 73812},
+							pos:  position{line: 2381, col: 34, offset: 73740},
 							name: "IdentifierRest",
 						},
 					},
@@ -18023,20 +18023,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2382, col: 1, offset: 73827},
+			pos:  position{line: 2382, col: 1, offset: 73755},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 73840},
+				pos: position{line: 2382, col: 14, offset: 73768},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 73840},
+						pos:        position{line: 2382, col: 14, offset: 73768},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 73859},
+						pos: position{line: 2382, col: 33, offset: 73787},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 73860},
+							pos:  position{line: 2382, col: 34, offset: 73788},
 							name: "IdentifierRest",
 						},
 					},
@@ -18047,20 +18047,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2383, col: 1, offset: 73875},
+			pos:  position{line: 2383, col: 1, offset: 73803},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 73888},
+				pos: position{line: 2383, col: 14, offset: 73816},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 73888},
+						pos:        position{line: 2383, col: 14, offset: 73816},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 73907},
+						pos: position{line: 2383, col: 33, offset: 73835},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 73908},
+							pos:  position{line: 2383, col: 34, offset: 73836},
 							name: "IdentifierRest",
 						},
 					},
@@ -18071,20 +18071,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2384, col: 1, offset: 73923},
+			pos:  position{line: 2384, col: 1, offset: 73851},
 			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 73936},
+				pos: position{line: 2384, col: 14, offset: 73864},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 73936},
+						pos:        position{line: 2384, col: 14, offset: 73864},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 73955},
+						pos: position{line: 2384, col: 33, offset: 73883},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 73956},
+							pos:  position{line: 2384, col: 34, offset: 73884},
 							name: "IdentifierRest",
 						},
 					},
@@ -18095,20 +18095,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2385, col: 1, offset: 73972},
+			pos:  position{line: 2385, col: 1, offset: 73899},
 			expr: &seqExpr{
-				pos: position{line: 2385, col: 14, offset: 73985},
+				pos: position{line: 2385, col: 14, offset: 73912},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2385, col: 14, offset: 73985},
+						pos:        position{line: 2385, col: 14, offset: 73912},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2385, col: 33, offset: 74004},
+						pos: position{line: 2385, col: 33, offset: 73931},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 34, offset: 74005},
+							pos:  position{line: 2385, col: 34, offset: 73932},
 							name: "IdentifierRest",
 						},
 					},
@@ -18119,20 +18119,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2386, col: 1, offset: 74020},
+			pos:  position{line: 2386, col: 1, offset: 73947},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 74033},
+				pos: position{line: 2386, col: 14, offset: 73960},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 74033},
+						pos:        position{line: 2386, col: 14, offset: 73960},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 74052},
+						pos: position{line: 2386, col: 33, offset: 73979},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 74053},
+							pos:  position{line: 2386, col: 34, offset: 73980},
 							name: "IdentifierRest",
 						},
 					},
@@ -18143,20 +18143,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2387, col: 1, offset: 74068},
+			pos:  position{line: 2387, col: 1, offset: 73995},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 74081},
+				pos: position{line: 2387, col: 14, offset: 74008},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 74081},
+						pos:        position{line: 2387, col: 14, offset: 74008},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 74100},
+						pos: position{line: 2387, col: 33, offset: 74027},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 74101},
+							pos:  position{line: 2387, col: 34, offset: 74028},
 							name: "IdentifierRest",
 						},
 					},
@@ -18167,20 +18167,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2388, col: 1, offset: 74116},
+			pos:  position{line: 2388, col: 1, offset: 74043},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 74129},
+				pos: position{line: 2388, col: 14, offset: 74056},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 74129},
+						pos:        position{line: 2388, col: 14, offset: 74056},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 74148},
+						pos: position{line: 2388, col: 33, offset: 74075},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 74149},
+							pos:  position{line: 2388, col: 34, offset: 74076},
 							name: "IdentifierRest",
 						},
 					},
@@ -18191,20 +18191,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2389, col: 1, offset: 74164},
+			pos:  position{line: 2389, col: 1, offset: 74091},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 74177},
+				pos: position{line: 2389, col: 14, offset: 74104},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 74177},
+						pos:        position{line: 2389, col: 14, offset: 74104},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 74196},
+						pos: position{line: 2389, col: 33, offset: 74123},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 74197},
+							pos:  position{line: 2389, col: 34, offset: 74124},
 							name: "IdentifierRest",
 						},
 					},
@@ -18215,20 +18215,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2390, col: 1, offset: 74212},
+			pos:  position{line: 2390, col: 1, offset: 74139},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 14, offset: 74225},
+				pos: position{line: 2390, col: 14, offset: 74152},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 14, offset: 74225},
+						pos:        position{line: 2390, col: 14, offset: 74152},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 74244},
+						pos: position{line: 2390, col: 33, offset: 74171},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 74245},
+							pos:  position{line: 2390, col: 34, offset: 74172},
 							name: "IdentifierRest",
 						},
 					},
@@ -18239,20 +18239,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2391, col: 1, offset: 74260},
+			pos:  position{line: 2391, col: 1, offset: 74187},
 			expr: &seqExpr{
-				pos: position{line: 2391, col: 14, offset: 74273},
+				pos: position{line: 2391, col: 14, offset: 74200},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2391, col: 14, offset: 74273},
+						pos:        position{line: 2391, col: 14, offset: 74200},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2391, col: 33, offset: 74292},
+						pos: position{line: 2391, col: 33, offset: 74219},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2391, col: 34, offset: 74293},
+							pos:  position{line: 2391, col: 34, offset: 74220},
 							name: "IdentifierRest",
 						},
 					},
@@ -19312,7 +19312,7 @@ func (c *current) onJoinOp1(style, rightInput, alias, e any) (any, error) {
 	o := &ast.Join{
 		Kind:  "Join",
 		Style: style.(string),
-		Cond:  e.(ast.JoinExpr),
+		Cond:  e.(ast.JoinCond),
 		Loc:   loc(c),
 	}
 	if rightInput != nil {
@@ -19738,7 +19738,6 @@ func (p *parser) callonMetaCommitish2() (any, error) {
 }
 
 func (c *current) onMetaCommitish9(meta any) (any, error) {
-
 	return []any{&ast.ArgText{Kind: "ArgText", Key: "meta", Value: meta.(*ast.Text), Loc: loc(c)}}, nil
 
 }
@@ -22543,7 +22542,7 @@ func (c *current) onConditionJoin1(left, style, right, e any) (any, error) {
 		Style: style.(string),
 		Left:  left.(*ast.FromElem),
 		Right: right.(*ast.FromElem),
-		Cond:  e.(ast.JoinExpr),
+		Cond:  e.(ast.JoinCond),
 		Loc:   loc(c),
 	}, nil
 
@@ -22595,35 +22594,34 @@ func (p *parser) callonSQLJoinStyle30() (any, error) {
 	return p.cur.onSQLJoinStyle30()
 }
 
-func (c *current) onJoinExpr2(e any) (any, error) {
-
-	return &ast.JoinOnExpr{
-		Kind: "JoinOnExpr",
+func (c *current) onJoinCond2(e any) (any, error) {
+	return &ast.JoinOnCond{
+		Kind: "JoinOnCond",
 		Expr: e.(ast.Expr),
 		Loc:  loc(c),
 	}, nil
 
 }
 
-func (p *parser) callonJoinExpr2() (any, error) {
+func (p *parser) callonJoinCond2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinExpr2(stack["e"])
+	return p.cur.onJoinCond2(stack["e"])
 }
 
-func (c *current) onJoinExpr8(fields any) (any, error) {
-	return &ast.JoinUsingExpr{
-		Kind:   "JoinUsingExpr",
+func (c *current) onJoinCond8(fields any) (any, error) {
+	return &ast.JoinUsingCond{
+		Kind:   "JoinUsingCond",
 		Fields: sliceOf[ast.Expr](fields),
 		Loc:    loc(c),
 	}, nil
 
 }
 
-func (p *parser) callonJoinExpr8() (any, error) {
+func (p *parser) callonJoinCond8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinExpr8(stack["fields"])
+	return p.cur.onJoinCond8(stack["fields"])
 }
 
 func (c *current) onOptOrdinality2() (any, error) {
@@ -22793,7 +22791,6 @@ func (p *parser) callonOptAsClause16() (any, error) {
 }
 
 func (c *current) onOptOrderByClause2(list any) (any, error) {
-
 	return &ast.SQLOrderBy{
 		Kind:  "SQLOrderBy",
 		Exprs: list.([]ast.SortExpr),

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -78,8 +78,8 @@ TypeDecl
       }, nil
     }
 
-// A LeanOp is a pipeline operator along with various forms of 
-// "lean-forward" shortcuts: a scope with other LeanOps, a shortcut assignment 
+// A LeanOp is a pipeline operator along with various forms of
+// "lean-forward" shortcuts: a scope with other LeanOps, a shortcut assignment
 // for "put", a shortcut "aggregate", or an expression that is either
 // implied values op (non-boolean) or implied where (boolean).
 LeanOp
@@ -92,7 +92,7 @@ LeanOp
     }
 
 EndOfOp = __ (Pipe / ")" / ";" / EOF)
-Pipe = "|>" / "|" 
+Pipe = "|>" / "|"
 
 ExprGuard = __ (Comparator / AdditiveOperator / MultiplicativeOperator / ":" / "(" / "[" / "~")
 
@@ -282,7 +282,7 @@ CountStar = COUNT __ "(" __ "*" __ ")" {
 Operator
   = op:SelectOp &EndOfOp { return op, nil }
   / ForkOp
-  / SwitchOp 
+  / SwitchOp
   / SearchOp
   / AssertOp
   / SortOp
@@ -526,11 +526,11 @@ ShapeOp
     }
 
 JoinOp
-  = style:JoinStyle JOIN rightInput:JoinRightInput alias:OptJoinAlias _ e:JoinExpr {
+  = style:JoinStyle JOIN rightInput:JoinRightInput alias:OptJoinAlias _ e:JoinCond {
       o := &ast.Join{
         Kind: "Join",
         Style: style.(string),
-        Cond: e.(ast.JoinExpr),
+        Cond: e.(ast.JoinCond),
         Loc: loc(c),
       }
       if rightInput != nil {
@@ -633,7 +633,7 @@ FromElems
   = first:FromElem rest:( __ "," __ elem:FromElem { return elem, nil} )* {
       return prepend(first, rest), nil
     }
-    
+
 FromElem
   = entity:FromEntity args:CommitishOpArgs? o:OptOrdinality alias:OptAlias {
       elem := &ast.FromElem{
@@ -646,7 +646,7 @@ FromElem
       }
       if o != nil {
         elem.Ordinality = o.(*ast.Ordinality)
-      }      
+      }
       if alias != nil {
         elem.Alias = alias.(*ast.TableAlias)
       }
@@ -708,7 +708,7 @@ MetaCommitish
       }
       return out, nil
     }
-  / meta:ColonText { 
+  / meta:ColonText {
       return []any{&ast.ArgText{Kind:"ArgText", Key: "meta", Value: meta.(*ast.Text), Loc: loc(c)}}, nil
     }
 
@@ -860,7 +860,7 @@ NotExpr
       }, nil
     }
   / BetweenExpr
-  
+
 BetweenExpr
   = expr:ComparisonExpr _ not:(NOT _)? BETWEEN _ lower:BetweenExpr _ AND _ upper:BetweenExpr {
       return &ast.Between{
@@ -882,7 +882,7 @@ ComparisonExpr
         Not: not != nil,
         Loc: loc(c),
       }, nil
-    }   
+    }
   / lhs:AdditiveExpr opAndRHS:(__ Comparator __ AdditiveExpr / __ ("~" { return string(c.text), nil }) __ Regexp)? {
       if opAndRHS == nil {
         return lhs, nil
@@ -895,7 +895,7 @@ ComparisonExpr
         Loc: loc(c),
       }, nil
     }
- 
+
 AdditiveExpr
   = first:MultiplicativeExpr
     rest:(__ op:AdditiveOperator __ expr:MultiplicativeExpr { return []any{op, expr}, nil })* {
@@ -912,7 +912,7 @@ MultiplicativeExpr
 
 MultiplicativeOperator = ("*" / "/" / "%") { return string(c.text), nil }
 
-ConcatExpr 
+ConcatExpr
   = first:UnaryPlusOrMinus
     rest:(__ "||" __ expr:UnaryPlusOrMinus { return []any{"||", expr}, nil })* {
         return makeBinaryExprChain(first, rest, c), nil
@@ -980,7 +980,7 @@ DerefExpr
   / Primary
 
 DerefKey
-  = Identifier 
+  = Identifier
   / s:DoubleQuotedString    { return &ast.ID{Kind: "ID", Name:s.(string), Loc: loc(c)}, nil }
   / s:BacktickString        { return &ast.ID{Kind: "ID", Name:s.(string), Loc: loc(c)}, nil }
 
@@ -1014,7 +1014,7 @@ Function
       return &ast.CallExtract{
         Kind: "CallExtract",
         Part: part.(ast.Expr),
-        Expr: e.(ast.Expr), 
+        Expr: e.(ast.Expr),
         Loc: loc(c),
       }, nil
     }
@@ -1135,7 +1135,7 @@ When
         Loc: loc(c),
       }, nil
     }
-    
+
 UnnestExpr
   = UNNEST _ e:Expr __ Pipe __ body:Seq {
       return &ast.UnnestExpr{
@@ -1507,7 +1507,7 @@ Names
   = first:Name rest:(__ "," __ name:Name { return name, nil })* {
     return prepend(first, rest), nil
   }
-  
+
 Identifier
   = id:IdentifierName {
       return &ast.ID{
@@ -1528,7 +1528,7 @@ SQLIdentifier
 
 IdentifierName
   = !(IDGuard !IdentifierRest) IdentifierStart IdentifierRest* { return string(c.text), nil }
-  / BacktickString 
+  / BacktickString
 
 IdentifierStart
   = UnicodeLetter
@@ -1849,7 +1849,7 @@ EOKW = !KeyWordChars
 
 /// === SuperSQL ===
 
-SQLPipe 
+SQLPipe
   = s:Seq {
       return &ast.SQLPipe{
             Kind: "SQLPipe",
@@ -1860,7 +1860,7 @@ SQLPipe
 
 SelectOp = SelectExpr
 
-SelectExpr 
+SelectExpr
   = with:OptWithClause
     body:(
         SetOperation
@@ -1875,7 +1875,7 @@ SelectExpr
       if with != nil {
           w := with.(*ast.SQLWith)
           w.Body = op
-          op = w 
+          op = w
       }
       if orderby != nil {
           o := orderby.(*ast.SQLOrderBy)
@@ -1890,11 +1890,11 @@ SelectExpr
       return op, nil
     }
 
-Select 
-  = SELECT 
+Select
+  = SELECT
     distinct:OptDistinct
     value:OptSelectValue
-    //XXX for whitespace in front of target need it only if it begins with 
+    //XXX for whitespace in front of target need it only if it begins with
     // an identifier, e.g., select(1); is ok
     _ selection:Selection
     from:OptFromClause
@@ -1927,10 +1927,10 @@ Select
     }
 
 FromSelect
-  = from:FromOp _ SELECT 
+  = from:FromOp _ SELECT
     distinct:OptDistinct
     value:OptSelectValue
-    //XXX for whitespace in front of target need it only if it begins with 
+    //XXX for whitespace in front of target need it only if it begins with
     // an identifier, e.g., select(1); is ok
     _ selection:Selection
     where:OptWhereClause
@@ -1983,7 +1983,7 @@ SQLTuples
       return prepend(first, rest), nil
     }
 
-SQLTuple 
+SQLTuple
   = "(" __ exprs:Exprs __ ")" {
       return &ast.TupleExpr{
         Kind: "TupleExpr",
@@ -2002,26 +2002,26 @@ OptSelectValue
   / _ VALUE          { return true, nil } // SQL++ form XXX decide which
   / ""                  { return false, nil }
 
-OptWithClause 
+OptWithClause
   = WithClause
   / ""          { return nil, nil }
 
-WithClause 
+WithClause
   = WITH r:OptRecursive _ ctes:CteList __ {
         return &ast.SQLWith{
             Kind: "SQLWith",
-            Recursive: r.(bool), 
+            Recursive: r.(bool),
             CTEs: sliceOf[ast.SQLCTE](ctes),
             Loc: loc(c),
         }, nil
     }
 
-OptRecursive 
+OptRecursive
   = _ RECURSIVE  { return true, nil }
   / ""              { return false, nil }
 
 CteList = first:Cte rest:( __ "," __ cte:Cte { return cte, nil} )* {
-    return prepend(first, rest), nil 
+    return prepend(first, rest), nil
 }
 
 Cte
@@ -2034,13 +2034,13 @@ Cte
         }, nil
     }
 
-OptMaterialized 
+OptMaterialized
   = _ MATERIALIZED _             { return true, nil }
   / _ NOT _ MATERIALIZED _    { return false, nil }
   / ""                              { return false, nil }
 
 OptAllClause
-  = _ ALL 
+  = _ ALL
   / ""
 
 OptFromClause
@@ -2060,7 +2060,7 @@ OptGroupClause
 GroupClause
   = GROUP _ BY _ list:GroupByList { return list, nil }
 
-GroupByList 
+GroupByList
   = first:GroupByItem rest:( __ "," __ g:GroupByItem { return g, nil } )* {
       return prepend(first, rest), nil
     }
@@ -2088,45 +2088,45 @@ CrossJoin
         }, nil
     }
 
-CrossJoinOp 
-  = __ "," __ 
-  / _ CROSS _ JOIN _ 
+CrossJoinOp
+  = __ "," __
+  / _ CROSS _ JOIN _
 
 ConditionJoin
-  = left:FromElem style:SQLJoinStyle _ right:FromElem _ e:JoinExpr {
+  = left:FromElem style:SQLJoinStyle _ right:FromElem _ e:JoinCond {
         return &ast.SQLJoin{
             Kind: "SQLJoin",
             Style: style.(string),
             Left: left.(*ast.FromElem),
             Right: right.(*ast.FromElem),
-            Cond: e.(ast.JoinExpr),
+            Cond: e.(ast.JoinCond),
             Loc: loc(c),
         }, nil
     }
 
-SQLJoinStyle 
+SQLJoinStyle
   = (_ INNER)? _ JOIN             { return "inner", nil }
   / _ FULL (_ OUTER)? _ JOIN   { return "full", nil }
   / _ LEFT (_ OUTER)? _ JOIN   { return "left", nil }
   / _ RIGHT (_ OUTER)? _ JOIN   { return "right", nil }
 
-JoinExpr 
-  = ON _ e:Expr { 
-        return &ast.JoinOnExpr{
-            Kind: "JoinOnExpr", 
+JoinCond
+  = ON _ e:Expr {
+        return &ast.JoinOnCond{
+            Kind: "JoinOnCond",
             Expr: e.(ast.Expr),
             Loc: loc(c),
         }, nil
     }
   / USING __ "(" __ fields:Lvals __ ")" {
-        return &ast.JoinUsingExpr{
-            Kind: "JoinUsingExpr",
+        return &ast.JoinUsingCond{
+            Kind: "JoinUsingCond",
             Fields: sliceOf[ast.Expr](fields),
             Loc: loc(c),
         }, nil
     }
 
-OptOrdinality 
+OptOrdinality
   = _ WITH _ ORDINALITY   {
         return &ast.Ordinality{
             Kind: "Ordinality",
@@ -2150,7 +2150,7 @@ AliasClause
 
 Columns
   = __ "(" __ first:SQLIdentifier rest:( __ "," __ s:SQLIdentifier{ return s, nil })* __ ")" {
-        return sliceOf[*ast.ID](prepend(first,rest)), nil 
+        return sliceOf[*ast.ID](prepend(first,rest)), nil
     }
 
 Selection
@@ -2163,7 +2163,7 @@ Selection
   }
 
 //XXX need to add *, id.*, except, replace
-SelectElem 
+SelectElem
   = expr:(AggDistinct / Expr) as:OptAsClause {
       elem := ast.SQLAsExpr{
         Kind: "SQLAsExpr",
@@ -2180,13 +2180,13 @@ SelectElem
       return ast.SQLAsExpr{Kind: "AsExpr"}, nil
     }
 
-OptAsClause 
+OptAsClause
   = _ AS _ id:SQLIdentifier { return id, nil }
   / _ !SQLGuard id:SQLIdentifier { return id, nil }
   / ""  { return nil, nil }
 
-OptOrderByClause 
-  = _ ORDER _ BY _ list:OrderByList { 
+OptOrderByClause
+  = _ ORDER _ BY _ list:OrderByList {
         return &ast.SQLOrderBy{
           Kind: "SQLOrderBy",
           Exprs: list.([]ast.SortExpr),
@@ -2195,7 +2195,7 @@ OptOrderByClause
     }
   / ""          { return nil, nil }
 
-OrderByList 
+OrderByList
   = first:OrderByItem rest:( __ "," __ o:OrderByItem{ return o, nil})* {
       return sliceOf[ast.SortExpr](prepend(first, rest)), nil
     }
@@ -2223,7 +2223,7 @@ OptNullsOrder
   / ""                      { return nil, nil }
 
 OptSQLLimitOffset
-  = _ op:SQLLimitOffset { return op, nil } 
+  = _ op:SQLLimitOffset { return op, nil }
   / ""                  { return nil, nil }
 
 SQLLimitOffset
@@ -2252,19 +2252,19 @@ SQLLimitOffset
       return op, nil
     }
 
-OptLimitClause 
+OptLimitClause
   = _ l:LimitClause { return l, nil }
   / ""              { return nil, nil }
 
-LimitClause 
+LimitClause
   = LIMIT _ ALL { return nil, nil }
   / LIMIT _ e:Expr { return e, nil }
 
-OptOffsetClause 
+OptOffsetClause
   = _ o:OffsetClause  { return o, nil }
   / ""  { return nil, nil }
 
-OffsetClause 
+OffsetClause
   = OFFSET _ e:Expr  { return e, nil }
 
 SetOperation
@@ -2278,7 +2278,7 @@ SetOperation
         }, nil
     }
 
-SetOp 
+SetOp
   = _ UNION _ ALL       { return false, nil }
   / _ UNION (_ DISTINCT)?  { return true, nil }
 
@@ -2290,7 +2290,7 @@ SQLGuard =
   / ORDER
   / OFFSET
   / LIMIT
-  / WHERE 
+  / WHERE
   / WITH
   / USING
   / ON
@@ -2316,7 +2316,7 @@ DEBUG      = "DEBUG"i           !IdentifierRest
 DEFAULT    = "DEFAULT"i         !IdentifierRest
 DESC       = "DESC"i            !IdentifierRest { return "desc", nil }
 DISTINCT   = "DISTINCT"i        !IdentifierRest
-DROP       = "DROP"i            !IdentifierRest 
+DROP       = "DROP"i            !IdentifierRest
 ELSE       = "ELSE"i            !IdentifierRest
 END        = "END"i             !IdentifierRest
 ENUM       = "ENUM"i            !IdentifierRest
@@ -2335,7 +2335,7 @@ FUSE       = "FUSE"i            !IdentifierRest
 GREP       = "GREP"i            !IdentifierRest
 GROUP      = "GROUP"i           !IdentifierRest
 HAVING     = "HAVING"i          !IdentifierRest
-HEAD       = "HEAD"i            !IdentifierRest 
+HEAD       = "HEAD"i            !IdentifierRest
 IN         = "IN"i              !IdentifierRest
 INNER      = "INNER"i           !IdentifierRest
 IS         = "IS"i              !IdentifierRest
@@ -2374,14 +2374,14 @@ SORT       = "SORT"i            !IdentifierRest
 SUBSTRING  = "SUBSTRING"i       !IdentifierRest
 SUMMARIZE  = "SUMMARIZE"i       !IdentifierRest
 SWITCH     = "SWITCH"i          !IdentifierRest
-TAIL       = "TAIL"i            !IdentifierRest 
+TAIL       = "TAIL"i            !IdentifierRest
 THEN       = "THEN"i            !IdentifierRest
 TIMESTAMP  = "TIMESTAMP"i       !IdentifierRest { return "timestamp", nil }
 TOP        = "TOP"i             !IdentifierRest
 TRUE       = "TRUE"i            !IdentifierRest
 TYPE       = "TYPE"i            !IdentifierRest
 UNION      = "UNION"i           !IdentifierRest
-UNIQ       = "UNIQ"i            !IdentifierRest 
+UNIQ       = "UNIQ"i            !IdentifierRest
 UNNEST     = "UNNEST"i          !IdentifierRest
 USING      = "USING"i           !IdentifierRest
 VALUE      = "VALUE"i           !IdentifierRest

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -610,10 +610,10 @@ func (c *canon) op(p ast.Op) {
 			c.write("as {%s,%s} ", p.Alias.Left.Name, p.Alias.Right.Name)
 		}
 		switch cond := p.Cond.(type) {
-		case *ast.JoinOnExpr:
+		case *ast.JoinOnCond:
 			c.write("on ")
 			c.expr(cond.Expr, "")
-		case *ast.JoinUsingExpr:
+		case *ast.JoinUsingCond:
 			c.write("using (")
 			c.exprs(cond.Fields)
 			c.write(")")


### PR DESCRIPTION
The ast.JoinExpr type represents a join condition so JoinCond feels like a better name.