### PR TITLE
zfmt: split SQL cross join across multiple lines

### DIFF
--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -780,7 +780,8 @@ func (c *canon) fromEntity(e ast.FromEntity) {
 		c.write(sup.QuotedName(e.Text))
 	case *ast.SQLCrossJoin:
 		c.fromElem(e.Left)
-		c.write(" cross join ")
+		c.ret()
+		c.write("cross join ")
 		c.fromElem(e.Right)
 	case *ast.SQLJoin:
 		c.fromElem(e.Left)

--- a/zfmt/ztests/join.yaml
+++ b/zfmt/ztests/join.yaml
@@ -6,15 +6,6 @@ script: |
   super compile -C "right join (from test.sup) as {l,r} on r.x=l.x"
   echo ===
   super compile -C -dag "right join (from test.sup) as {l,r} on r.x=l.x"
-  echo === SQL cross join
-  super compile -C "from a cross join b"
-  echo ===
-  super compile -C -dag "from a cross join b"
-  echo === SQL comma cross join
-  super compile -C "from a, b"
-  echo ===
-  super compile -C -dag "from a, b"
-
 
 outputs:
   - name: stdout
@@ -47,28 +38,4 @@ outputs:
           file test.sup format sup
         )
       | right join as {l,r} on x=x
-      | output main
-      === SQL cross join
-      from a cross join b
-      ===
-      fork
-        (
-          file a
-        )
-        (
-          file b
-        )
-      | cross join as {left,right}
-      | output main
-      === SQL comma cross join
-      from a cross join b
-      ===
-      fork
-        (
-          file a
-        )
-        (
-          file b
-        )
-      | cross join as {left,right}
       | output main

--- a/zfmt/ztests/sql.yaml
+++ b/zfmt/ztests/sql.yaml
@@ -1,4 +1,6 @@
 script: |
+  echo === cross join
+  super compile -C 'from a cross join b, c'
   echo === join with on condition
   super compile -C 'from a join b on c'
   echo === join with using condition
@@ -23,6 +25,10 @@ script: |
 outputs:
   - name: stdout
     data: |
+      === cross join
+      from a
+      cross join b
+      cross join c
       === join with on condition
       from a
       inner join b on c


### PR DESCRIPTION
This matches the output for ast.SQLJoin.

The tests removed from zfmt/ztests/join.yaml provide no additional coverage beyond that of the test moved to zfmt/ztests/sql.yaml.