### PR TITLE
book: always rebuild src/super.wasm when making "all"

### DIFF
--- a/book/Makefile
+++ b/book/Makefile
@@ -1,7 +1,7 @@
 js_bundle := super-example.bundle.js
-wasm := src/super.wasm
 
-all: $(js_bundle) $(wasm)
+all: $(js_bundle)
+	GOOS=js GOARCH=wasm go build -o src/super.wasm super-example/main.go
 
 $(js_bundle): node_modules super-example/wasm_exec.js super-example/*.js
 	./node_modules/.bin/esbuild --bundle --outfile=$@ super-example/super-example.js
@@ -11,6 +11,3 @@ super-example/wasm_exec.js:
 
 node_modules:
 	npm install
-
-$(wasm): super-example/main.go
-	GOOS=js GOARCH=wasm go build -o $@ $<

--- a/book/README.md
+++ b/book/README.md
@@ -10,7 +10,7 @@ brew install mdbook
 ```
 
 The easiest way to work on docs is to run an mdbook service in this directory
-and point your browser at its embedded web server, e.g., 
+and point your browser at its embedded web server, e.g.,
 ```
 cd book
 make
@@ -20,17 +20,16 @@ Then connect to localhost:3000.
 
 To add or remove sections of the book edit `src/SUMMARY.md`.
 
-When editing `SUMMARY.md` it can be useful to kill the mdbook service 
+When editing `SUMMARY.md` it can be useful to kill the mdbook service
 and build the book manually like this:
 ```
 mdbook build
 ```
-This was the service doesn't do things like recreating a file that you have 
+This way the service doesn't do things like recreating a file that you have
 removed when you are trying to rearrange things.
 
-After editing JavaScript or Go files in `super-example` run `make`.
+After editing any JavaScript or Go files run `make` in this directory.
 
 ## mdtest
 
 TBD
-

--- a/book/README.md
+++ b/book/README.md
@@ -29,6 +29,8 @@ This way the service doesn't do things like recreating a file that you have
 removed when you are trying to rearrange things.
 
 After editing any JavaScript or Go files run `make` in this directory.
+This will update the Wasm file so playground examples use a version of
+SuperDB built from Go source files in the local repository.
 
 ## mdtest
 


### PR DESCRIPTION
It's fast since it's just "go build".