### PR TITLE
simplify regexp/grep syntax

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -166,13 +166,6 @@ type SliceExpr struct {
 	Loc  `json:"loc"`
 }
 
-type Grep struct {
-	Kind    string `json:"kind" unpack:""`
-	Pattern Expr   `json:"pattern"`
-	Expr    Expr   `json:"expr"`
-	Loc     `json:"loc"`
-}
-
 type Glob struct {
 	Kind    string `json:"kind" unpack:""`
 	Pattern string `json:"pattern"`
@@ -365,7 +358,6 @@ func (*SliceExpr) exprNode()   {}
 
 func (*Assignment) exprNode() {}
 func (*Agg) exprNode()        {}
-func (*Grep) exprNode()       {}
 func (*Glob) exprNode()       {}
 func (*Regexp) exprNode()     {}
 func (*Term) exprNode()       {}

--- a/compiler/ast/unpack.go
+++ b/compiler/ast/unpack.go
@@ -43,7 +43,6 @@ var unpacker = unpack.New(
 	FStringText{},
 	FuncDecl{},
 	Fuse{},
-	Grep{},
 	Head{},
 	ID{},
 	ImpliedValue{},

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -1475,14 +1475,14 @@ var g = &grammar{
 									pos: position{line: 159, col: 5, offset: 4046},
 									expr: &ruleRefExpr{
 										pos:  position{line: 159, col: 6, offset: 4047},
-										name: "RegexpPattern",
+										name: "Regexp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 159, col: 20, offset: 4061},
+									pos:   position{line: 159, col: 13, offset: 4054},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 159, col: 22, offset: 4063},
+										pos:  position{line: 159, col: 15, offset: 4056},
 										name: "KeyWord",
 									},
 								},
@@ -1496,15 +1496,15 @@ var g = &grammar{
 		},
 		{
 			name: "Glob",
-			pos:  position{line: 163, col: 1, offset: 4136},
+			pos:  position{line: 163, col: 1, offset: 4129},
 			expr: &actionExpr{
-				pos: position{line: 164, col: 5, offset: 4145},
+				pos: position{line: 164, col: 5, offset: 4138},
 				run: (*parser).callonGlob1,
 				expr: &labeledExpr{
-					pos:   position{line: 164, col: 5, offset: 4145},
+					pos:   position{line: 164, col: 5, offset: 4138},
 					label: "pattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 164, col: 13, offset: 4153},
+						pos:  position{line: 164, col: 13, offset: 4146},
 						name: "GlobPattern",
 					},
 				},
@@ -1514,16 +1514,79 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 168, col: 1, offset: 4256},
+			pos:  position{line: 168, col: 1, offset: 4249},
 			expr: &actionExpr{
-				pos: position{line: 169, col: 5, offset: 4267},
+				pos: position{line: 169, col: 5, offset: 4260},
 				run: (*parser).callonRegexp1,
-				expr: &labeledExpr{
-					pos:   position{line: 169, col: 5, offset: 4267},
-					label: "pattern",
-					expr: &ruleRefExpr{
-						pos:  position{line: 169, col: 13, offset: 4275},
-						name: "RegexpPattern",
+				expr: &seqExpr{
+					pos: position{line: 169, col: 5, offset: 4260},
+					exprs: []any{
+						&litMatcher{
+							pos:        position{line: 169, col: 5, offset: 4260},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&labeledExpr{
+							pos:   position{line: 169, col: 9, offset: 4264},
+							label: "pattern",
+							expr: &ruleRefExpr{
+								pos:  position{line: 169, col: 17, offset: 4272},
+								name: "RegexpBody",
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 169, col: 28, offset: 4283},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&notExpr{
+							pos: position{line: 169, col: 32, offset: 4287},
+							expr: &ruleRefExpr{
+								pos:  position{line: 169, col: 33, offset: 4288},
+								name: "KeyWordStart",
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "RegexpBody",
+			pos:  position{line: 173, col: 1, offset: 4394},
+			expr: &actionExpr{
+				pos: position{line: 174, col: 5, offset: 4409},
+				run: (*parser).callonRegexpBody1,
+				expr: &oneOrMoreExpr{
+					pos: position{line: 174, col: 5, offset: 4409},
+					expr: &choiceExpr{
+						pos: position{line: 174, col: 6, offset: 4410},
+						alternatives: []any{
+							&charClassMatcher{
+								pos:        position{line: 174, col: 6, offset: 4410},
+								val:        "[^/\\\\]",
+								chars:      []rune{'/', '\\'},
+								ignoreCase: false,
+								inverted:   true,
+							},
+							&seqExpr{
+								pos: position{line: 174, col: 15, offset: 4419},
+								exprs: []any{
+									&litMatcher{
+										pos:        position{line: 174, col: 15, offset: 4419},
+										val:        "\\",
+										ignoreCase: false,
+										want:       "\"\\\\\"",
+									},
+									&anyMatcher{
+										line: 174, col: 20, offset: 4424,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1532,36 +1595,36 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregation",
-			pos:  position{line: 175, col: 1, offset: 4408},
+			pos:  position{line: 178, col: 1, offset: 4486},
 			expr: &choiceExpr{
-				pos: position{line: 176, col: 5, offset: 4424},
+				pos: position{line: 179, col: 5, offset: 4502},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 176, col: 5, offset: 4424},
+						pos: position{line: 179, col: 5, offset: 4502},
 						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 176, col: 5, offset: 4424},
+							pos: position{line: 179, col: 5, offset: 4502},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 176, col: 5, offset: 4424},
+									pos: position{line: 179, col: 5, offset: 4502},
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 5, offset: 4424},
+										pos:  position{line: 179, col: 5, offset: 4502},
 										name: "Aggregate",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 176, col: 16, offset: 4435},
+									pos:   position{line: 179, col: 16, offset: 4513},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 21, offset: 4440},
+										pos:  position{line: 179, col: 21, offset: 4518},
 										name: "AggregateKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 176, col: 35, offset: 4454},
+									pos:   position{line: 179, col: 35, offset: 4532},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 176, col: 41, offset: 4460},
+										pos:  position{line: 179, col: 41, offset: 4538},
 										name: "LimitArg",
 									},
 								},
@@ -1569,40 +1632,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 184, col: 5, offset: 4644},
+						pos: position{line: 187, col: 5, offset: 4722},
 						run: (*parser).callonAggregation10,
 						expr: &seqExpr{
-							pos: position{line: 184, col: 5, offset: 4644},
+							pos: position{line: 187, col: 5, offset: 4722},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 184, col: 5, offset: 4644},
+									pos: position{line: 187, col: 5, offset: 4722},
 									expr: &ruleRefExpr{
-										pos:  position{line: 184, col: 5, offset: 4644},
+										pos:  position{line: 187, col: 5, offset: 4722},
 										name: "Aggregate",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 184, col: 16, offset: 4655},
+									pos:   position{line: 187, col: 16, offset: 4733},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 184, col: 21, offset: 4660},
+										pos:  position{line: 187, col: 21, offset: 4738},
 										name: "AggAssignments",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 184, col: 36, offset: 4675},
+									pos:   position{line: 187, col: 36, offset: 4753},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 184, col: 41, offset: 4680},
+										pos: position{line: 187, col: 41, offset: 4758},
 										expr: &seqExpr{
-											pos: position{line: 184, col: 42, offset: 4681},
+											pos: position{line: 187, col: 42, offset: 4759},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 184, col: 42, offset: 4681},
+													pos:  position{line: 187, col: 42, offset: 4759},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 184, col: 44, offset: 4683},
+													pos:  position{line: 187, col: 44, offset: 4761},
 													name: "AggregateKeys",
 												},
 											},
@@ -1610,10 +1673,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 184, col: 60, offset: 4699},
+									pos:   position{line: 187, col: 60, offset: 4777},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 184, col: 66, offset: 4705},
+										pos:  position{line: 187, col: 66, offset: 4783},
 										name: "LimitArg",
 									},
 								},
@@ -1627,25 +1690,25 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregate",
-			pos:  position{line: 197, col: 1, offset: 4989},
+			pos:  position{line: 200, col: 1, offset: 5067},
 			expr: &seqExpr{
-				pos: position{line: 197, col: 13, offset: 5001},
+				pos: position{line: 200, col: 13, offset: 5079},
 				exprs: []any{
 					&choiceExpr{
-						pos: position{line: 197, col: 14, offset: 5002},
+						pos: position{line: 200, col: 14, offset: 5080},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 197, col: 14, offset: 5002},
+								pos:  position{line: 200, col: 14, offset: 5080},
 								name: "AGGREGATE",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 197, col: 26, offset: 5014},
+								pos:  position{line: 200, col: 26, offset: 5092},
 								name: "SUMMARIZE",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 197, col: 37, offset: 5025},
+						pos:  position{line: 200, col: 37, offset: 5103},
 						name: "_",
 					},
 				},
@@ -1655,42 +1718,42 @@ var g = &grammar{
 		},
 		{
 			name: "AggregateKeys",
-			pos:  position{line: 199, col: 1, offset: 5028},
+			pos:  position{line: 202, col: 1, offset: 5106},
 			expr: &actionExpr{
-				pos: position{line: 200, col: 5, offset: 5046},
+				pos: position{line: 203, col: 5, offset: 5124},
 				run: (*parser).callonAggregateKeys1,
 				expr: &seqExpr{
-					pos: position{line: 200, col: 5, offset: 5046},
+					pos: position{line: 203, col: 5, offset: 5124},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 200, col: 5, offset: 5046},
+							pos: position{line: 203, col: 5, offset: 5124},
 							expr: &seqExpr{
-								pos: position{line: 200, col: 6, offset: 5047},
+								pos: position{line: 203, col: 6, offset: 5125},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 200, col: 6, offset: 5047},
+										pos:  position{line: 203, col: 6, offset: 5125},
 										name: "GROUP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 200, col: 12, offset: 5053},
+										pos:  position{line: 203, col: 12, offset: 5131},
 										name: "_",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 16, offset: 5057},
+							pos:  position{line: 203, col: 16, offset: 5135},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 19, offset: 5060},
+							pos:  position{line: 203, col: 19, offset: 5138},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 200, col: 21, offset: 5062},
+							pos:   position{line: 203, col: 21, offset: 5140},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 200, col: 29, offset: 5070},
+								pos:  position{line: 203, col: 29, offset: 5148},
 								name: "Assignments",
 							},
 						},
@@ -1702,43 +1765,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 202, col: 1, offset: 5107},
+			pos:  position{line: 205, col: 1, offset: 5185},
 			expr: &choiceExpr{
-				pos: position{line: 203, col: 5, offset: 5120},
+				pos: position{line: 206, col: 5, offset: 5198},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 203, col: 5, offset: 5120},
+						pos: position{line: 206, col: 5, offset: 5198},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 203, col: 5, offset: 5120},
+							pos: position{line: 206, col: 5, offset: 5198},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 203, col: 5, offset: 5120},
+									pos:  position{line: 206, col: 5, offset: 5198},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 203, col: 7, offset: 5122},
+									pos:  position{line: 206, col: 7, offset: 5200},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 203, col: 12, offset: 5127},
+									pos:  position{line: 206, col: 12, offset: 5205},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 203, col: 14, offset: 5129},
+									pos:        position{line: 206, col: 14, offset: 5207},
 									val:        "-limit",
 									ignoreCase: false,
 									want:       "\"-limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 203, col: 23, offset: 5138},
+									pos:  position{line: 206, col: 23, offset: 5216},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 203, col: 25, offset: 5140},
+									pos:   position{line: 206, col: 25, offset: 5218},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 203, col: 31, offset: 5146},
+										pos:  position{line: 206, col: 31, offset: 5224},
 										name: "UInt",
 									},
 								},
@@ -1746,10 +1809,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 204, col: 5, offset: 5177},
+						pos: position{line: 207, col: 5, offset: 5255},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 204, col: 5, offset: 5177},
+							pos:        position{line: 207, col: 5, offset: 5255},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -1762,43 +1825,43 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignment",
-			pos:  position{line: 206, col: 1, offset: 5199},
+			pos:  position{line: 209, col: 1, offset: 5277},
 			expr: &choiceExpr{
-				pos: position{line: 207, col: 5, offset: 5217},
+				pos: position{line: 210, col: 5, offset: 5295},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 207, col: 5, offset: 5217},
+						pos: position{line: 210, col: 5, offset: 5295},
 						run: (*parser).callonAggAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 207, col: 5, offset: 5217},
+							pos: position{line: 210, col: 5, offset: 5295},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 207, col: 5, offset: 5217},
+									pos:   position{line: 210, col: 5, offset: 5295},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 207, col: 10, offset: 5222},
+										pos:  position{line: 210, col: 10, offset: 5300},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 15, offset: 5227},
+									pos:  position{line: 210, col: 15, offset: 5305},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 207, col: 18, offset: 5230},
+									pos:        position{line: 210, col: 18, offset: 5308},
 									val:        ":=",
 									ignoreCase: false,
 									want:       "\":=\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 23, offset: 5235},
+									pos:  position{line: 210, col: 23, offset: 5313},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 207, col: 26, offset: 5238},
+									pos:   position{line: 210, col: 26, offset: 5316},
 									label: "agg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 207, col: 30, offset: 5242},
+										pos:  position{line: 210, col: 30, offset: 5320},
 										name: "Agg",
 									},
 								},
@@ -1806,13 +1869,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 210, col: 5, offset: 5360},
+						pos: position{line: 213, col: 5, offset: 5438},
 						run: (*parser).callonAggAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 210, col: 5, offset: 5360},
+							pos:   position{line: 213, col: 5, offset: 5438},
 							label: "agg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 210, col: 9, offset: 5364},
+								pos:  position{line: 213, col: 9, offset: 5442},
 								name: "Agg",
 							},
 						},
@@ -1824,42 +1887,42 @@ var g = &grammar{
 		},
 		{
 			name: "Agg",
-			pos:  position{line: 214, col: 1, offset: 5459},
+			pos:  position{line: 217, col: 1, offset: 5537},
 			expr: &choiceExpr{
-				pos: position{line: 215, col: 5, offset: 5467},
+				pos: position{line: 218, col: 5, offset: 5545},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 215, col: 5, offset: 5467},
+						pos: position{line: 218, col: 5, offset: 5545},
 						run: (*parser).callonAgg2,
 						expr: &seqExpr{
-							pos: position{line: 215, col: 5, offset: 5467},
+							pos: position{line: 218, col: 5, offset: 5545},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 215, col: 5, offset: 5467},
+									pos: position{line: 218, col: 5, offset: 5545},
 									expr: &ruleRefExpr{
-										pos:  position{line: 215, col: 6, offset: 5468},
+										pos:  position{line: 218, col: 6, offset: 5546},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 215, col: 16, offset: 5478},
+									pos:   position{line: 218, col: 16, offset: 5556},
 									label: "aggDistinct",
 									expr: &ruleRefExpr{
-										pos:  position{line: 215, col: 28, offset: 5490},
+										pos:  position{line: 218, col: 28, offset: 5568},
 										name: "AggDistinct",
 									},
 								},
 								&notExpr{
-									pos: position{line: 215, col: 40, offset: 5502},
+									pos: position{line: 218, col: 40, offset: 5580},
 									expr: &seqExpr{
-										pos: position{line: 215, col: 42, offset: 5504},
+										pos: position{line: 218, col: 42, offset: 5582},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 215, col: 42, offset: 5504},
+												pos:  position{line: 218, col: 42, offset: 5582},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 215, col: 45, offset: 5507},
+												pos:        position{line: 218, col: 45, offset: 5585},
 												val:        ".",
 												ignoreCase: false,
 												want:       "\".\"",
@@ -1868,12 +1931,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 215, col: 50, offset: 5512},
+									pos:   position{line: 218, col: 50, offset: 5590},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 215, col: 56, offset: 5518},
+										pos: position{line: 218, col: 56, offset: 5596},
 										expr: &ruleRefExpr{
-											pos:  position{line: 215, col: 56, offset: 5518},
+											pos:  position{line: 218, col: 56, offset: 5596},
 											name: "WhereClause",
 										},
 									},
@@ -1882,72 +1945,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 223, col: 5, offset: 5693},
+						pos: position{line: 226, col: 5, offset: 5771},
 						run: (*parser).callonAgg15,
 						expr: &seqExpr{
-							pos: position{line: 223, col: 5, offset: 5693},
+							pos: position{line: 226, col: 5, offset: 5771},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 223, col: 5, offset: 5693},
+									pos: position{line: 226, col: 5, offset: 5771},
 									expr: &ruleRefExpr{
-										pos:  position{line: 223, col: 6, offset: 5694},
+										pos:  position{line: 226, col: 6, offset: 5772},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 223, col: 16, offset: 5704},
+									pos:   position{line: 226, col: 16, offset: 5782},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 223, col: 21, offset: 5709},
+										pos:  position{line: 226, col: 21, offset: 5787},
 										name: "AggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 29, offset: 5717},
+									pos:  position{line: 226, col: 29, offset: 5795},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 223, col: 32, offset: 5720},
+									pos:        position{line: 226, col: 32, offset: 5798},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 36, offset: 5724},
+									pos:  position{line: 226, col: 36, offset: 5802},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 223, col: 39, offset: 5727},
+									pos:   position{line: 226, col: 39, offset: 5805},
 									label: "expr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 223, col: 44, offset: 5732},
+										pos: position{line: 226, col: 44, offset: 5810},
 										expr: &ruleRefExpr{
-											pos:  position{line: 223, col: 44, offset: 5732},
+											pos:  position{line: 226, col: 44, offset: 5810},
 											name: "Expr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 50, offset: 5738},
+									pos:  position{line: 226, col: 50, offset: 5816},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 223, col: 53, offset: 5741},
+									pos:        position{line: 226, col: 53, offset: 5819},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&notExpr{
-									pos: position{line: 223, col: 57, offset: 5745},
+									pos: position{line: 226, col: 57, offset: 5823},
 									expr: &seqExpr{
-										pos: position{line: 223, col: 59, offset: 5747},
+										pos: position{line: 226, col: 59, offset: 5825},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 223, col: 59, offset: 5747},
+												pos:  position{line: 226, col: 59, offset: 5825},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 223, col: 62, offset: 5750},
+												pos:        position{line: 226, col: 62, offset: 5828},
 												val:        ".",
 												ignoreCase: false,
 												want:       "\".\"",
@@ -1956,12 +2019,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 223, col: 67, offset: 5755},
+									pos:   position{line: 226, col: 67, offset: 5833},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 223, col: 73, offset: 5761},
+										pos: position{line: 226, col: 73, offset: 5839},
 										expr: &ruleRefExpr{
-											pos:  position{line: 223, col: 73, offset: 5761},
+											pos:  position{line: 226, col: 73, offset: 5839},
 											name: "WhereClause",
 										},
 									},
@@ -1970,13 +2033,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 237, col: 5, offset: 6051},
+						pos: position{line: 240, col: 5, offset: 6129},
 						run: (*parser).callonAgg36,
 						expr: &labeledExpr{
-							pos:   position{line: 237, col: 5, offset: 6051},
+							pos:   position{line: 240, col: 5, offset: 6129},
 							label: "cs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 237, col: 8, offset: 6054},
+								pos:  position{line: 240, col: 8, offset: 6132},
 								name: "CountStar",
 							},
 						},
@@ -1988,64 +2051,64 @@ var g = &grammar{
 		},
 		{
 			name: "AggDistinct",
-			pos:  position{line: 245, col: 1, offset: 6192},
+			pos:  position{line: 248, col: 1, offset: 6270},
 			expr: &actionExpr{
-				pos: position{line: 246, col: 5, offset: 6208},
+				pos: position{line: 249, col: 5, offset: 6286},
 				run: (*parser).callonAggDistinct1,
 				expr: &seqExpr{
-					pos: position{line: 246, col: 5, offset: 6208},
+					pos: position{line: 249, col: 5, offset: 6286},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 246, col: 5, offset: 6208},
+							pos: position{line: 249, col: 5, offset: 6286},
 							expr: &ruleRefExpr{
-								pos:  position{line: 246, col: 6, offset: 6209},
+								pos:  position{line: 249, col: 6, offset: 6287},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 246, col: 16, offset: 6219},
+							pos:   position{line: 249, col: 16, offset: 6297},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 246, col: 21, offset: 6224},
+								pos:  position{line: 249, col: 21, offset: 6302},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 29, offset: 6232},
+							pos:  position{line: 249, col: 29, offset: 6310},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 246, col: 32, offset: 6235},
+							pos:        position{line: 249, col: 32, offset: 6313},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 36, offset: 6239},
+							pos:  position{line: 249, col: 36, offset: 6317},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 39, offset: 6242},
+							pos:  position{line: 249, col: 39, offset: 6320},
 							name: "DISTINCT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 48, offset: 6251},
+							pos:  position{line: 249, col: 48, offset: 6329},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 246, col: 50, offset: 6253},
+							pos:   position{line: 249, col: 50, offset: 6331},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 246, col: 55, offset: 6258},
+								pos:  position{line: 249, col: 55, offset: 6336},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 246, col: 60, offset: 6263},
+							pos:  position{line: 249, col: 60, offset: 6341},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 246, col: 63, offset: 6266},
+							pos:        position{line: 249, col: 63, offset: 6344},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2058,20 +2121,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 256, col: 1, offset: 6451},
+			pos:  position{line: 259, col: 1, offset: 6529},
 			expr: &choiceExpr{
-				pos: position{line: 257, col: 5, offset: 6463},
+				pos: position{line: 260, col: 5, offset: 6541},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 5, offset: 6463},
+						pos:  position{line: 260, col: 5, offset: 6541},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 258, col: 5, offset: 6482},
+						pos:  position{line: 261, col: 5, offset: 6560},
 						name: "AND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 259, col: 5, offset: 6490},
+						pos:  position{line: 262, col: 5, offset: 6568},
 						name: "OR",
 					},
 				},
@@ -2081,30 +2144,30 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 261, col: 1, offset: 6494},
+			pos:  position{line: 264, col: 1, offset: 6572},
 			expr: &actionExpr{
-				pos: position{line: 261, col: 15, offset: 6508},
+				pos: position{line: 264, col: 15, offset: 6586},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 261, col: 15, offset: 6508},
+					pos: position{line: 264, col: 15, offset: 6586},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 261, col: 15, offset: 6508},
+							pos:  position{line: 264, col: 15, offset: 6586},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 261, col: 17, offset: 6510},
+							pos:  position{line: 264, col: 17, offset: 6588},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 261, col: 23, offset: 6516},
+							pos:  position{line: 264, col: 23, offset: 6594},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 261, col: 25, offset: 6518},
+							pos:   position{line: 264, col: 25, offset: 6596},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 261, col: 30, offset: 6523},
+								pos:  position{line: 264, col: 30, offset: 6601},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -2116,45 +2179,45 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 263, col: 1, offset: 6559},
+			pos:  position{line: 266, col: 1, offset: 6637},
 			expr: &actionExpr{
-				pos: position{line: 264, col: 5, offset: 6578},
+				pos: position{line: 267, col: 5, offset: 6656},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 264, col: 5, offset: 6578},
+					pos: position{line: 267, col: 5, offset: 6656},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 264, col: 5, offset: 6578},
+							pos:   position{line: 267, col: 5, offset: 6656},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 264, col: 11, offset: 6584},
+								pos:  position{line: 267, col: 11, offset: 6662},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 264, col: 25, offset: 6598},
+							pos:   position{line: 267, col: 25, offset: 6676},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 264, col: 30, offset: 6603},
+								pos: position{line: 267, col: 30, offset: 6681},
 								expr: &seqExpr{
-									pos: position{line: 264, col: 31, offset: 6604},
+									pos: position{line: 267, col: 31, offset: 6682},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 264, col: 31, offset: 6604},
+											pos:  position{line: 267, col: 31, offset: 6682},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 264, col: 34, offset: 6607},
+											pos:        position{line: 267, col: 34, offset: 6685},
 											val:        ",",
 											ignoreCase: false,
 											want:       "\",\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 264, col: 38, offset: 6611},
+											pos:  position{line: 267, col: 38, offset: 6689},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 264, col: 41, offset: 6614},
+											pos:  position{line: 267, col: 41, offset: 6692},
 											name: "AggAssignment",
 										},
 									},
@@ -2169,43 +2232,43 @@ var g = &grammar{
 		},
 		{
 			name: "CountStar",
-			pos:  position{line: 272, col: 1, offset: 6788},
+			pos:  position{line: 275, col: 1, offset: 6866},
 			expr: &actionExpr{
-				pos: position{line: 272, col: 13, offset: 6800},
+				pos: position{line: 275, col: 13, offset: 6878},
 				run: (*parser).callonCountStar1,
 				expr: &seqExpr{
-					pos: position{line: 272, col: 13, offset: 6800},
+					pos: position{line: 275, col: 13, offset: 6878},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 272, col: 13, offset: 6800},
+							pos:  position{line: 275, col: 13, offset: 6878},
 							name: "COUNT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 272, col: 19, offset: 6806},
+							pos:  position{line: 275, col: 19, offset: 6884},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 272, col: 22, offset: 6809},
+							pos:        position{line: 275, col: 22, offset: 6887},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 272, col: 26, offset: 6813},
+							pos:  position{line: 275, col: 26, offset: 6891},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 272, col: 29, offset: 6816},
+							pos:        position{line: 275, col: 29, offset: 6894},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 272, col: 33, offset: 6820},
+							pos:  position{line: 275, col: 33, offset: 6898},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 272, col: 36, offset: 6823},
+							pos:        position{line: 275, col: 36, offset: 6901},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2218,28 +2281,28 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 282, col: 1, offset: 7017},
+			pos:  position{line: 285, col: 1, offset: 7095},
 			expr: &choiceExpr{
-				pos: position{line: 283, col: 5, offset: 7030},
+				pos: position{line: 286, col: 5, offset: 7108},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 283, col: 5, offset: 7030},
+						pos: position{line: 286, col: 5, offset: 7108},
 						run: (*parser).callonOperator2,
 						expr: &seqExpr{
-							pos: position{line: 283, col: 5, offset: 7030},
+							pos: position{line: 286, col: 5, offset: 7108},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 283, col: 5, offset: 7030},
+									pos:   position{line: 286, col: 5, offset: 7108},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 283, col: 8, offset: 7033},
+										pos:  position{line: 286, col: 8, offset: 7111},
 										name: "SelectOp",
 									},
 								},
 								&andExpr{
-									pos: position{line: 283, col: 17, offset: 7042},
+									pos: position{line: 286, col: 17, offset: 7120},
 									expr: &ruleRefExpr{
-										pos:  position{line: 283, col: 18, offset: 7043},
+										pos:  position{line: 286, col: 18, offset: 7121},
 										name: "EndOfOp",
 									},
 								},
@@ -2247,119 +2310,119 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 284, col: 5, offset: 7074},
+						pos:  position{line: 287, col: 5, offset: 7152},
 						name: "ForkOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 285, col: 5, offset: 7085},
+						pos:  position{line: 288, col: 5, offset: 7163},
 						name: "SwitchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 286, col: 5, offset: 7098},
+						pos:  position{line: 289, col: 5, offset: 7176},
 						name: "SearchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 5, offset: 7111},
+						pos:  position{line: 290, col: 5, offset: 7189},
 						name: "AssertOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 288, col: 5, offset: 7124},
+						pos:  position{line: 291, col: 5, offset: 7202},
 						name: "SortOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 289, col: 5, offset: 7135},
+						pos:  position{line: 292, col: 5, offset: 7213},
 						name: "TopOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 290, col: 5, offset: 7145},
+						pos:  position{line: 293, col: 5, offset: 7223},
 						name: "CutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 5, offset: 7155},
+						pos:  position{line: 294, col: 5, offset: 7233},
 						name: "DistinctOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 292, col: 5, offset: 7170},
+						pos:  position{line: 295, col: 5, offset: 7248},
 						name: "DropOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 293, col: 5, offset: 7181},
+						pos:  position{line: 296, col: 5, offset: 7259},
 						name: "HeadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 294, col: 5, offset: 7192},
+						pos:  position{line: 297, col: 5, offset: 7270},
 						name: "TailOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 5, offset: 7203},
+						pos:  position{line: 298, col: 5, offset: 7281},
 						name: "SkipOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 296, col: 5, offset: 7214},
+						pos:  position{line: 299, col: 5, offset: 7292},
 						name: "WhereOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 297, col: 5, offset: 7226},
+						pos:  position{line: 300, col: 5, offset: 7304},
 						name: "UniqOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 298, col: 5, offset: 7237},
+						pos:  position{line: 301, col: 5, offset: 7315},
 						name: "PutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 299, col: 5, offset: 7247},
+						pos:  position{line: 302, col: 5, offset: 7325},
 						name: "RenameOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 300, col: 5, offset: 7260},
+						pos:  position{line: 303, col: 5, offset: 7338},
 						name: "FuseOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 301, col: 5, offset: 7271},
+						pos:  position{line: 304, col: 5, offset: 7349},
 						name: "ShapeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 302, col: 5, offset: 7283},
+						pos:  position{line: 305, col: 5, offset: 7361},
 						name: "JoinOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 5, offset: 7294},
+						pos:  position{line: 306, col: 5, offset: 7372},
 						name: "ShapesOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 304, col: 5, offset: 7307},
+						pos:  position{line: 307, col: 5, offset: 7385},
 						name: "FromOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 305, col: 5, offset: 7318},
+						pos:  position{line: 308, col: 5, offset: 7396},
 						name: "PassOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 306, col: 5, offset: 7329},
+						pos:  position{line: 309, col: 5, offset: 7407},
 						name: "ExplodeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 307, col: 5, offset: 7343},
+						pos:  position{line: 310, col: 5, offset: 7421},
 						name: "MergeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 308, col: 5, offset: 7355},
+						pos:  position{line: 311, col: 5, offset: 7433},
 						name: "UnnestOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 5, offset: 7368},
+						pos:  position{line: 312, col: 5, offset: 7446},
 						name: "ValuesOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 310, col: 5, offset: 7381},
+						pos:  position{line: 313, col: 5, offset: 7459},
 						name: "LoadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 5, offset: 7392},
+						pos:  position{line: 314, col: 5, offset: 7470},
 						name: "OutputOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 312, col: 5, offset: 7405},
+						pos:  position{line: 315, col: 5, offset: 7483},
 						name: "DebugOp",
 					},
 				},
@@ -2369,37 +2432,37 @@ var g = &grammar{
 		},
 		{
 			name: "ForkOp",
-			pos:  position{line: 314, col: 2, offset: 7415},
+			pos:  position{line: 317, col: 2, offset: 7493},
 			expr: &actionExpr{
-				pos: position{line: 315, col: 4, offset: 7427},
+				pos: position{line: 318, col: 4, offset: 7505},
 				run: (*parser).callonForkOp1,
 				expr: &seqExpr{
-					pos: position{line: 315, col: 4, offset: 7427},
+					pos: position{line: 318, col: 4, offset: 7505},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 315, col: 4, offset: 7427},
+							pos:  position{line: 318, col: 4, offset: 7505},
 							name: "FORK",
 						},
 						&labeledExpr{
-							pos:   position{line: 315, col: 9, offset: 7432},
+							pos:   position{line: 318, col: 9, offset: 7510},
 							label: "paths",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 315, col: 15, offset: 7438},
+								pos: position{line: 318, col: 15, offset: 7516},
 								expr: &actionExpr{
-									pos: position{line: 315, col: 17, offset: 7440},
+									pos: position{line: 318, col: 17, offset: 7518},
 									run: (*parser).callonForkOp6,
 									expr: &seqExpr{
-										pos: position{line: 315, col: 17, offset: 7440},
+										pos: position{line: 318, col: 17, offset: 7518},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 315, col: 17, offset: 7440},
+												pos:  position{line: 318, col: 17, offset: 7518},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 315, col: 20, offset: 7443},
+												pos:   position{line: 318, col: 20, offset: 7521},
 												label: "path",
 												expr: &ruleRefExpr{
-													pos:  position{line: 315, col: 25, offset: 7448},
+													pos:  position{line: 318, col: 25, offset: 7526},
 													name: "ScopeBody",
 												},
 											},
@@ -2416,31 +2479,31 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchOp",
-			pos:  position{line: 327, col: 1, offset: 7726},
+			pos:  position{line: 330, col: 1, offset: 7804},
 			expr: &choiceExpr{
-				pos: position{line: 328, col: 5, offset: 7739},
+				pos: position{line: 331, col: 5, offset: 7817},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 328, col: 5, offset: 7739},
+						pos: position{line: 331, col: 5, offset: 7817},
 						run: (*parser).callonSwitchOp2,
 						expr: &seqExpr{
-							pos: position{line: 328, col: 5, offset: 7739},
+							pos: position{line: 331, col: 5, offset: 7817},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 328, col: 5, offset: 7739},
+									pos:  position{line: 331, col: 5, offset: 7817},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 328, col: 12, offset: 7746},
+									pos:  position{line: 331, col: 12, offset: 7824},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 328, col: 14, offset: 7748},
+									pos:   position{line: 331, col: 14, offset: 7826},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 328, col: 20, offset: 7754},
+										pos: position{line: 331, col: 20, offset: 7832},
 										expr: &ruleRefExpr{
-											pos:  position{line: 328, col: 20, offset: 7754},
+											pos:  position{line: 331, col: 20, offset: 7832},
 											name: "SwitchPath",
 										},
 									},
@@ -2449,38 +2512,38 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 335, col: 5, offset: 7909},
+						pos: position{line: 338, col: 5, offset: 7987},
 						run: (*parser).callonSwitchOp9,
 						expr: &seqExpr{
-							pos: position{line: 335, col: 5, offset: 7909},
+							pos: position{line: 338, col: 5, offset: 7987},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 335, col: 5, offset: 7909},
+									pos:  position{line: 338, col: 5, offset: 7987},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 335, col: 12, offset: 7916},
+									pos:  position{line: 338, col: 12, offset: 7994},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 335, col: 14, offset: 7918},
+									pos:   position{line: 338, col: 14, offset: 7996},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 335, col: 19, offset: 7923},
+										pos:  position{line: 338, col: 19, offset: 8001},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 335, col: 24, offset: 7928},
+									pos:  position{line: 338, col: 24, offset: 8006},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 335, col: 26, offset: 7930},
+									pos:   position{line: 338, col: 26, offset: 8008},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 335, col: 32, offset: 7936},
+										pos: position{line: 338, col: 32, offset: 8014},
 										expr: &ruleRefExpr{
-											pos:  position{line: 335, col: 32, offset: 7936},
+											pos:  position{line: 338, col: 32, offset: 8014},
 											name: "SwitchPath",
 										},
 									},
@@ -2495,34 +2558,34 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchPath",
-			pos:  position{line: 344, col: 1, offset: 8121},
+			pos:  position{line: 347, col: 1, offset: 8199},
 			expr: &actionExpr{
-				pos: position{line: 345, col: 5, offset: 8136},
+				pos: position{line: 348, col: 5, offset: 8214},
 				run: (*parser).callonSwitchPath1,
 				expr: &seqExpr{
-					pos: position{line: 345, col: 5, offset: 8136},
+					pos: position{line: 348, col: 5, offset: 8214},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 345, col: 5, offset: 8136},
+							pos:  position{line: 348, col: 5, offset: 8214},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 345, col: 8, offset: 8139},
+							pos:   position{line: 348, col: 8, offset: 8217},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 345, col: 13, offset: 8144},
+								pos:  position{line: 348, col: 13, offset: 8222},
 								name: "Case",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 345, col: 18, offset: 8149},
+							pos:  position{line: 348, col: 18, offset: 8227},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 345, col: 21, offset: 8152},
+							pos:   position{line: 348, col: 21, offset: 8230},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 345, col: 26, offset: 8157},
+								pos:  position{line: 348, col: 26, offset: 8235},
 								name: "ScopeBody",
 							},
 						},
@@ -2534,29 +2597,29 @@ var g = &grammar{
 		},
 		{
 			name: "Case",
-			pos:  position{line: 353, col: 1, offset: 8309},
+			pos:  position{line: 356, col: 1, offset: 8387},
 			expr: &choiceExpr{
-				pos: position{line: 354, col: 5, offset: 8318},
+				pos: position{line: 357, col: 5, offset: 8396},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 354, col: 5, offset: 8318},
+						pos: position{line: 357, col: 5, offset: 8396},
 						run: (*parser).callonCase2,
 						expr: &seqExpr{
-							pos: position{line: 354, col: 5, offset: 8318},
+							pos: position{line: 357, col: 5, offset: 8396},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 354, col: 5, offset: 8318},
+									pos:  position{line: 357, col: 5, offset: 8396},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 354, col: 10, offset: 8323},
+									pos:  position{line: 357, col: 10, offset: 8401},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 354, col: 12, offset: 8325},
+									pos:   position{line: 357, col: 12, offset: 8403},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 354, col: 17, offset: 8330},
+										pos:  position{line: 357, col: 17, offset: 8408},
 										name: "Expr",
 									},
 								},
@@ -2564,10 +2627,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 355, col: 5, offset: 8360},
+						pos: position{line: 358, col: 5, offset: 8438},
 						run: (*parser).callonCase8,
 						expr: &ruleRefExpr{
-							pos:  position{line: 355, col: 5, offset: 8360},
+							pos:  position{line: 358, col: 5, offset: 8438},
 							name: "DEFAULT",
 						},
 					},
@@ -2578,40 +2641,40 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOp",
-			pos:  position{line: 357, col: 1, offset: 8389},
+			pos:  position{line: 360, col: 1, offset: 8467},
 			expr: &actionExpr{
-				pos: position{line: 358, col: 5, offset: 8402},
+				pos: position{line: 361, col: 5, offset: 8480},
 				run: (*parser).callonSearchOp1,
 				expr: &seqExpr{
-					pos: position{line: 358, col: 5, offset: 8402},
+					pos: position{line: 361, col: 5, offset: 8480},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 358, col: 6, offset: 8403},
+							pos: position{line: 361, col: 6, offset: 8481},
 							alternatives: []any{
 								&seqExpr{
-									pos: position{line: 358, col: 6, offset: 8403},
+									pos: position{line: 361, col: 6, offset: 8481},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 6, offset: 8403},
+											pos:  position{line: 361, col: 6, offset: 8481},
 											name: "SEARCH",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 13, offset: 8410},
+											pos:  position{line: 361, col: 13, offset: 8488},
 											name: "_",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 358, col: 17, offset: 8414},
+									pos: position{line: 361, col: 17, offset: 8492},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 358, col: 17, offset: 8414},
+											pos:        position{line: 361, col: 17, offset: 8492},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 21, offset: 8418},
+											pos:  position{line: 361, col: 21, offset: 8496},
 											name: "__",
 										},
 									},
@@ -2619,10 +2682,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 358, col: 25, offset: 8422},
+							pos:   position{line: 361, col: 25, offset: 8500},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 358, col: 30, offset: 8427},
+								pos:  position{line: 361, col: 30, offset: 8505},
 								name: "SearchBoolean",
 							},
 						},
@@ -2634,32 +2697,32 @@ var g = &grammar{
 		},
 		{
 			name: "AssertOp",
-			pos:  position{line: 362, col: 1, offset: 8527},
+			pos:  position{line: 365, col: 1, offset: 8605},
 			expr: &actionExpr{
-				pos: position{line: 363, col: 5, offset: 8540},
+				pos: position{line: 366, col: 5, offset: 8618},
 				run: (*parser).callonAssertOp1,
 				expr: &seqExpr{
-					pos: position{line: 363, col: 5, offset: 8540},
+					pos: position{line: 366, col: 5, offset: 8618},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 363, col: 5, offset: 8540},
+							pos:  position{line: 366, col: 5, offset: 8618},
 							name: "ASSERT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 363, col: 12, offset: 8547},
+							pos:  position{line: 366, col: 12, offset: 8625},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 363, col: 14, offset: 8549},
+							pos:   position{line: 366, col: 14, offset: 8627},
 							label: "expr",
 							expr: &actionExpr{
-								pos: position{line: 363, col: 20, offset: 8555},
+								pos: position{line: 366, col: 20, offset: 8633},
 								run: (*parser).callonAssertOp6,
 								expr: &labeledExpr{
-									pos:   position{line: 363, col: 20, offset: 8555},
+									pos:   position{line: 366, col: 20, offset: 8633},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 22, offset: 8557},
+										pos:  position{line: 366, col: 22, offset: 8635},
 										name: "Expr",
 									},
 								},
@@ -2673,33 +2736,33 @@ var g = &grammar{
 		},
 		{
 			name: "SortOp",
-			pos:  position{line: 372, col: 1, offset: 8787},
+			pos:  position{line: 375, col: 1, offset: 8865},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 8798},
+				pos: position{line: 376, col: 5, offset: 8876},
 				run: (*parser).callonSortOp1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 5, offset: 8798},
+					pos: position{line: 376, col: 5, offset: 8876},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 373, col: 6, offset: 8799},
+							pos: position{line: 376, col: 6, offset: 8877},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 373, col: 6, offset: 8799},
+									pos:  position{line: 376, col: 6, offset: 8877},
 									name: "SORT",
 								},
 								&seqExpr{
-									pos: position{line: 373, col: 13, offset: 8806},
+									pos: position{line: 376, col: 13, offset: 8884},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 373, col: 13, offset: 8806},
+											pos:  position{line: 376, col: 13, offset: 8884},
 											name: "ORDER",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 373, col: 19, offset: 8812},
+											pos:  position{line: 376, col: 19, offset: 8890},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 373, col: 21, offset: 8814},
+											pos:  position{line: 376, col: 21, offset: 8892},
 											name: "BY",
 										},
 									},
@@ -2707,40 +2770,40 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 373, col: 25, offset: 8818},
+							pos: position{line: 376, col: 25, offset: 8896},
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 26, offset: 8819},
+								pos:  position{line: 376, col: 26, offset: 8897},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 31, offset: 8824},
+							pos:   position{line: 376, col: 31, offset: 8902},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 36, offset: 8829},
+								pos:  position{line: 376, col: 36, offset: 8907},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 45, offset: 8838},
+							pos:   position{line: 376, col: 45, offset: 8916},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 373, col: 51, offset: 8844},
+								pos: position{line: 376, col: 51, offset: 8922},
 								expr: &actionExpr{
-									pos: position{line: 373, col: 52, offset: 8845},
+									pos: position{line: 376, col: 52, offset: 8923},
 									run: (*parser).callonSortOp15,
 									expr: &seqExpr{
-										pos: position{line: 373, col: 52, offset: 8845},
+										pos: position{line: 376, col: 52, offset: 8923},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 373, col: 52, offset: 8845},
+												pos:  position{line: 376, col: 52, offset: 8923},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 373, col: 55, offset: 8848},
+												pos:   position{line: 376, col: 55, offset: 8926},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 373, col: 57, offset: 8850},
+													pos:  position{line: 376, col: 57, offset: 8928},
 													name: "OrderByList",
 												},
 											},
@@ -2757,30 +2820,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 388, col: 1, offset: 9160},
+			pos:  position{line: 391, col: 1, offset: 9238},
 			expr: &actionExpr{
-				pos: position{line: 388, col: 12, offset: 9171},
+				pos: position{line: 391, col: 12, offset: 9249},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 388, col: 12, offset: 9171},
+					pos:   position{line: 391, col: 12, offset: 9249},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 388, col: 17, offset: 9176},
+						pos: position{line: 391, col: 17, offset: 9254},
 						expr: &actionExpr{
-							pos: position{line: 388, col: 18, offset: 9177},
+							pos: position{line: 391, col: 18, offset: 9255},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 388, col: 18, offset: 9177},
+								pos: position{line: 391, col: 18, offset: 9255},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 388, col: 18, offset: 9177},
+										pos:  position{line: 391, col: 18, offset: 9255},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 388, col: 20, offset: 9179},
+										pos:   position{line: 391, col: 20, offset: 9257},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 388, col: 22, offset: 9181},
+											pos:  position{line: 391, col: 22, offset: 9259},
 											name: "SortArg",
 										},
 									},
@@ -2795,12 +2858,12 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 390, col: 1, offset: 9238},
+			pos:  position{line: 393, col: 1, offset: 9316},
 			expr: &actionExpr{
-				pos: position{line: 391, col: 5, offset: 9250},
+				pos: position{line: 394, col: 5, offset: 9328},
 				run: (*parser).callonSortArg1,
 				expr: &litMatcher{
-					pos:        position{line: 391, col: 5, offset: 9250},
+					pos:        position{line: 394, col: 5, offset: 9328},
 					val:        "-r",
 					ignoreCase: false,
 					want:       "\"-r\"",
@@ -2811,52 +2874,52 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 393, col: 1, offset: 9314},
+			pos:  position{line: 396, col: 1, offset: 9392},
 			expr: &actionExpr{
-				pos: position{line: 394, col: 5, offset: 9324},
+				pos: position{line: 397, col: 5, offset: 9402},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 394, col: 5, offset: 9324},
+					pos: position{line: 397, col: 5, offset: 9402},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 5, offset: 9324},
+							pos:  position{line: 397, col: 5, offset: 9402},
 							name: "TOP",
 						},
 						&andExpr{
-							pos: position{line: 394, col: 9, offset: 9328},
+							pos: position{line: 397, col: 9, offset: 9406},
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 10, offset: 9329},
+								pos:  position{line: 397, col: 10, offset: 9407},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 15, offset: 9334},
+							pos:   position{line: 397, col: 15, offset: 9412},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 20, offset: 9339},
+								pos:  position{line: 397, col: 20, offset: 9417},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 29, offset: 9348},
+							pos:   position{line: 397, col: 29, offset: 9426},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 394, col: 35, offset: 9354},
+								pos: position{line: 397, col: 35, offset: 9432},
 								expr: &actionExpr{
-									pos: position{line: 394, col: 36, offset: 9355},
+									pos: position{line: 397, col: 36, offset: 9433},
 									run: (*parser).callonTopOp10,
 									expr: &seqExpr{
-										pos: position{line: 394, col: 36, offset: 9355},
+										pos: position{line: 397, col: 36, offset: 9433},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 394, col: 36, offset: 9355},
+												pos:  position{line: 397, col: 36, offset: 9433},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 394, col: 38, offset: 9357},
+												pos:   position{line: 397, col: 38, offset: 9435},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 394, col: 40, offset: 9359},
+													pos:  position{line: 397, col: 40, offset: 9437},
 													name: "Expr",
 												},
 											},
@@ -2866,25 +2929,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 65, offset: 9384},
+							pos:   position{line: 397, col: 65, offset: 9462},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 394, col: 71, offset: 9390},
+								pos: position{line: 397, col: 71, offset: 9468},
 								expr: &actionExpr{
-									pos: position{line: 394, col: 72, offset: 9391},
+									pos: position{line: 397, col: 72, offset: 9469},
 									run: (*parser).callonTopOp17,
 									expr: &seqExpr{
-										pos: position{line: 394, col: 72, offset: 9391},
+										pos: position{line: 397, col: 72, offset: 9469},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 394, col: 72, offset: 9391},
+												pos:  position{line: 397, col: 72, offset: 9469},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 394, col: 74, offset: 9393},
+												pos:   position{line: 397, col: 74, offset: 9471},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 394, col: 76, offset: 9395},
+													pos:  position{line: 397, col: 76, offset: 9473},
 													name: "OrderByList",
 												},
 											},
@@ -2901,26 +2964,26 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 412, col: 1, offset: 9775},
+			pos:  position{line: 415, col: 1, offset: 9853},
 			expr: &actionExpr{
-				pos: position{line: 413, col: 5, offset: 9785},
+				pos: position{line: 416, col: 5, offset: 9863},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 413, col: 5, offset: 9785},
+					pos: position{line: 416, col: 5, offset: 9863},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 5, offset: 9785},
+							pos:  position{line: 416, col: 5, offset: 9863},
 							name: "CUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 9, offset: 9789},
+							pos:  position{line: 416, col: 9, offset: 9867},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 11, offset: 9791},
+							pos:   position{line: 416, col: 11, offset: 9869},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 16, offset: 9796},
+								pos:  position{line: 416, col: 16, offset: 9874},
 								name: "Assignments",
 							},
 						},
@@ -2932,26 +2995,26 @@ var g = &grammar{
 		},
 		{
 			name: "DistinctOp",
-			pos:  position{line: 421, col: 1, offset: 9940},
+			pos:  position{line: 424, col: 1, offset: 10018},
 			expr: &actionExpr{
-				pos: position{line: 422, col: 5, offset: 9955},
+				pos: position{line: 425, col: 5, offset: 10033},
 				run: (*parser).callonDistinctOp1,
 				expr: &seqExpr{
-					pos: position{line: 422, col: 5, offset: 9955},
+					pos: position{line: 425, col: 5, offset: 10033},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 422, col: 5, offset: 9955},
+							pos:  position{line: 425, col: 5, offset: 10033},
 							name: "DISTINCT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 422, col: 14, offset: 9964},
+							pos:  position{line: 425, col: 14, offset: 10042},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 422, col: 16, offset: 9966},
+							pos:   position{line: 425, col: 16, offset: 10044},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 422, col: 18, offset: 9968},
+								pos:  position{line: 425, col: 18, offset: 10046},
 								name: "Expr",
 							},
 						},
@@ -2963,26 +3026,26 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 430, col: 1, offset: 10104},
+			pos:  position{line: 433, col: 1, offset: 10182},
 			expr: &actionExpr{
-				pos: position{line: 431, col: 5, offset: 10115},
+				pos: position{line: 434, col: 5, offset: 10193},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 431, col: 5, offset: 10115},
+					pos: position{line: 434, col: 5, offset: 10193},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 431, col: 5, offset: 10115},
+							pos:  position{line: 434, col: 5, offset: 10193},
 							name: "DROP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 431, col: 10, offset: 10120},
+							pos:  position{line: 434, col: 10, offset: 10198},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 431, col: 12, offset: 10122},
+							pos:   position{line: 434, col: 12, offset: 10200},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 431, col: 17, offset: 10127},
+								pos:  position{line: 434, col: 17, offset: 10205},
 								name: "Lvals",
 							},
 						},
@@ -2994,45 +3057,45 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 439, col: 1, offset: 10267},
+			pos:  position{line: 442, col: 1, offset: 10345},
 			expr: &choiceExpr{
-				pos: position{line: 440, col: 5, offset: 10278},
+				pos: position{line: 443, col: 5, offset: 10356},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 440, col: 5, offset: 10278},
+						pos: position{line: 443, col: 5, offset: 10356},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 440, col: 5, offset: 10278},
+							pos: position{line: 443, col: 5, offset: 10356},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 440, col: 6, offset: 10279},
+									pos: position{line: 443, col: 6, offset: 10357},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 6, offset: 10279},
+											pos:  position{line: 443, col: 6, offset: 10357},
 											name: "HEAD",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 13, offset: 10286},
+											pos:  position{line: 443, col: 13, offset: 10364},
 											name: "LIMIT",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 440, col: 20, offset: 10293},
+									pos:  position{line: 443, col: 20, offset: 10371},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 440, col: 22, offset: 10295},
+									pos: position{line: 443, col: 22, offset: 10373},
 									expr: &ruleRefExpr{
-										pos:  position{line: 440, col: 23, offset: 10296},
+										pos:  position{line: 443, col: 23, offset: 10374},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 440, col: 31, offset: 10304},
+									pos:   position{line: 443, col: 31, offset: 10382},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 440, col: 37, offset: 10310},
+										pos:  position{line: 443, col: 37, offset: 10388},
 										name: "Expr",
 									},
 								},
@@ -3040,26 +3103,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 447, col: 5, offset: 10440},
+						pos: position{line: 450, col: 5, offset: 10518},
 						run: (*parser).callonHeadOp12,
 						expr: &seqExpr{
-							pos: position{line: 447, col: 5, offset: 10440},
+							pos: position{line: 450, col: 5, offset: 10518},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 447, col: 5, offset: 10440},
+									pos:  position{line: 450, col: 5, offset: 10518},
 									name: "HEAD",
 								},
 								&notExpr{
-									pos: position{line: 447, col: 10, offset: 10445},
+									pos: position{line: 450, col: 10, offset: 10523},
 									expr: &seqExpr{
-										pos: position{line: 447, col: 12, offset: 10447},
+										pos: position{line: 450, col: 12, offset: 10525},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 447, col: 12, offset: 10447},
+												pos:  position{line: 450, col: 12, offset: 10525},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 447, col: 15, offset: 10450},
+												pos:        position{line: 450, col: 15, offset: 10528},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3068,9 +3131,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 447, col: 20, offset: 10455},
+									pos: position{line: 450, col: 20, offset: 10533},
 									expr: &ruleRefExpr{
-										pos:  position{line: 447, col: 21, offset: 10456},
+										pos:  position{line: 450, col: 21, offset: 10534},
 										name: "EOKW",
 									},
 								},
@@ -3084,36 +3147,36 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 454, col: 1, offset: 10550},
+			pos:  position{line: 457, col: 1, offset: 10628},
 			expr: &choiceExpr{
-				pos: position{line: 455, col: 5, offset: 10561},
+				pos: position{line: 458, col: 5, offset: 10639},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 455, col: 5, offset: 10561},
+						pos: position{line: 458, col: 5, offset: 10639},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 455, col: 5, offset: 10561},
+							pos: position{line: 458, col: 5, offset: 10639},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 455, col: 5, offset: 10561},
+									pos:  position{line: 458, col: 5, offset: 10639},
 									name: "TAIL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 455, col: 10, offset: 10566},
+									pos:  position{line: 458, col: 10, offset: 10644},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 455, col: 12, offset: 10568},
+									pos: position{line: 458, col: 12, offset: 10646},
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 13, offset: 10569},
+										pos:  position{line: 458, col: 13, offset: 10647},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 455, col: 21, offset: 10577},
+									pos:   position{line: 458, col: 21, offset: 10655},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 27, offset: 10583},
+										pos:  position{line: 458, col: 27, offset: 10661},
 										name: "Expr",
 									},
 								},
@@ -3121,26 +3184,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 462, col: 5, offset: 10713},
+						pos: position{line: 465, col: 5, offset: 10791},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 462, col: 5, offset: 10713},
+							pos: position{line: 465, col: 5, offset: 10791},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 462, col: 5, offset: 10713},
+									pos:  position{line: 465, col: 5, offset: 10791},
 									name: "TAIL",
 								},
 								&notExpr{
-									pos: position{line: 462, col: 10, offset: 10718},
+									pos: position{line: 465, col: 10, offset: 10796},
 									expr: &seqExpr{
-										pos: position{line: 462, col: 12, offset: 10720},
+										pos: position{line: 465, col: 12, offset: 10798},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 462, col: 12, offset: 10720},
+												pos:  position{line: 465, col: 12, offset: 10798},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 462, col: 15, offset: 10723},
+												pos:        position{line: 465, col: 15, offset: 10801},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3149,9 +3212,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 462, col: 20, offset: 10728},
+									pos: position{line: 465, col: 20, offset: 10806},
 									expr: &ruleRefExpr{
-										pos:  position{line: 462, col: 21, offset: 10729},
+										pos:  position{line: 465, col: 21, offset: 10807},
 										name: "EOKW",
 									},
 								},
@@ -3165,26 +3228,26 @@ var g = &grammar{
 		},
 		{
 			name: "SkipOp",
-			pos:  position{line: 469, col: 1, offset: 10823},
+			pos:  position{line: 472, col: 1, offset: 10901},
 			expr: &actionExpr{
-				pos: position{line: 470, col: 5, offset: 10834},
+				pos: position{line: 473, col: 5, offset: 10912},
 				run: (*parser).callonSkipOp1,
 				expr: &seqExpr{
-					pos: position{line: 470, col: 5, offset: 10834},
+					pos: position{line: 473, col: 5, offset: 10912},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 470, col: 5, offset: 10834},
+							pos:  position{line: 473, col: 5, offset: 10912},
 							name: "SKIP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 470, col: 10, offset: 10839},
+							pos:  position{line: 473, col: 10, offset: 10917},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 470, col: 12, offset: 10841},
+							pos:   position{line: 473, col: 12, offset: 10919},
 							label: "count",
 							expr: &ruleRefExpr{
-								pos:  position{line: 470, col: 18, offset: 10847},
+								pos:  position{line: 473, col: 18, offset: 10925},
 								name: "Expr",
 							},
 						},
@@ -3196,26 +3259,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 478, col: 1, offset: 10974},
+			pos:  position{line: 481, col: 1, offset: 11052},
 			expr: &actionExpr{
-				pos: position{line: 479, col: 5, offset: 10986},
+				pos: position{line: 482, col: 5, offset: 11064},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 479, col: 5, offset: 10986},
+					pos: position{line: 482, col: 5, offset: 11064},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 479, col: 5, offset: 10986},
+							pos:  position{line: 482, col: 5, offset: 11064},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 479, col: 11, offset: 10992},
+							pos:  position{line: 482, col: 11, offset: 11070},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 479, col: 13, offset: 10994},
+							pos:   position{line: 482, col: 13, offset: 11072},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 479, col: 18, offset: 10999},
+								pos:  position{line: 482, col: 18, offset: 11077},
 								name: "Expr",
 							},
 						},
@@ -3227,26 +3290,26 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 487, col: 1, offset: 11126},
+			pos:  position{line: 490, col: 1, offset: 11204},
 			expr: &choiceExpr{
-				pos: position{line: 488, col: 5, offset: 11137},
+				pos: position{line: 491, col: 5, offset: 11215},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 488, col: 5, offset: 11137},
+						pos: position{line: 491, col: 5, offset: 11215},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 488, col: 5, offset: 11137},
+							pos: position{line: 491, col: 5, offset: 11215},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 488, col: 5, offset: 11137},
+									pos:  position{line: 491, col: 5, offset: 11215},
 									name: "UNIQ",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 488, col: 10, offset: 11142},
+									pos:  position{line: 491, col: 10, offset: 11220},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 488, col: 12, offset: 11144},
+									pos:        position{line: 491, col: 12, offset: 11222},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3255,26 +3318,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 491, col: 5, offset: 11229},
+						pos: position{line: 494, col: 5, offset: 11307},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 491, col: 5, offset: 11229},
+							pos: position{line: 494, col: 5, offset: 11307},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 491, col: 5, offset: 11229},
+									pos:  position{line: 494, col: 5, offset: 11307},
 									name: "UNIQ",
 								},
 								&notExpr{
-									pos: position{line: 491, col: 10, offset: 11234},
+									pos: position{line: 494, col: 10, offset: 11312},
 									expr: &seqExpr{
-										pos: position{line: 491, col: 12, offset: 11236},
+										pos: position{line: 494, col: 12, offset: 11314},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 491, col: 12, offset: 11236},
+												pos:  position{line: 494, col: 12, offset: 11314},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 491, col: 15, offset: 11239},
+												pos:        position{line: 494, col: 15, offset: 11317},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3283,9 +3346,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 491, col: 20, offset: 11244},
+									pos: position{line: 494, col: 20, offset: 11322},
 									expr: &ruleRefExpr{
-										pos:  position{line: 491, col: 21, offset: 11245},
+										pos:  position{line: 494, col: 21, offset: 11323},
 										name: "EOKW",
 									},
 								},
@@ -3299,26 +3362,26 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 495, col: 1, offset: 11314},
+			pos:  position{line: 498, col: 1, offset: 11392},
 			expr: &actionExpr{
-				pos: position{line: 496, col: 5, offset: 11324},
+				pos: position{line: 499, col: 5, offset: 11402},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 496, col: 5, offset: 11324},
+					pos: position{line: 499, col: 5, offset: 11402},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 496, col: 5, offset: 11324},
+							pos:  position{line: 499, col: 5, offset: 11402},
 							name: "PUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 496, col: 9, offset: 11328},
+							pos:  position{line: 499, col: 9, offset: 11406},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 496, col: 11, offset: 11330},
+							pos:   position{line: 499, col: 11, offset: 11408},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 496, col: 16, offset: 11335},
+								pos:  position{line: 499, col: 16, offset: 11413},
 								name: "Assignments",
 							},
 						},
@@ -3330,59 +3393,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 504, col: 1, offset: 11485},
+			pos:  position{line: 507, col: 1, offset: 11563},
 			expr: &actionExpr{
-				pos: position{line: 505, col: 5, offset: 11498},
+				pos: position{line: 508, col: 5, offset: 11576},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 505, col: 5, offset: 11498},
+					pos: position{line: 508, col: 5, offset: 11576},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 505, col: 5, offset: 11498},
+							pos:  position{line: 508, col: 5, offset: 11576},
 							name: "RENAME",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 505, col: 12, offset: 11505},
+							pos:  position{line: 508, col: 12, offset: 11583},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 505, col: 14, offset: 11507},
+							pos:   position{line: 508, col: 14, offset: 11585},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 505, col: 20, offset: 11513},
+								pos:  position{line: 508, col: 20, offset: 11591},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 505, col: 31, offset: 11524},
+							pos:   position{line: 508, col: 31, offset: 11602},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 505, col: 36, offset: 11529},
+								pos: position{line: 508, col: 36, offset: 11607},
 								expr: &actionExpr{
-									pos: position{line: 505, col: 37, offset: 11530},
+									pos: position{line: 508, col: 37, offset: 11608},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 505, col: 37, offset: 11530},
+										pos: position{line: 508, col: 37, offset: 11608},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 505, col: 37, offset: 11530},
+												pos:  position{line: 508, col: 37, offset: 11608},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 505, col: 40, offset: 11533},
+												pos:        position{line: 508, col: 40, offset: 11611},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 505, col: 44, offset: 11537},
+												pos:  position{line: 508, col: 44, offset: 11615},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 505, col: 47, offset: 11540},
+												pos:   position{line: 508, col: 47, offset: 11618},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 505, col: 50, offset: 11543},
+													pos:  position{line: 508, col: 50, offset: 11621},
 													name: "Assignment",
 												},
 											},
@@ -3399,28 +3462,28 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 518, col: 1, offset: 12008},
+			pos:  position{line: 521, col: 1, offset: 12086},
 			expr: &actionExpr{
-				pos: position{line: 519, col: 5, offset: 12019},
+				pos: position{line: 522, col: 5, offset: 12097},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 519, col: 5, offset: 12019},
+					pos: position{line: 522, col: 5, offset: 12097},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 519, col: 5, offset: 12019},
+							pos:  position{line: 522, col: 5, offset: 12097},
 							name: "FUSE",
 						},
 						&notExpr{
-							pos: position{line: 519, col: 10, offset: 12024},
+							pos: position{line: 522, col: 10, offset: 12102},
 							expr: &seqExpr{
-								pos: position{line: 519, col: 12, offset: 12026},
+								pos: position{line: 522, col: 12, offset: 12104},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 519, col: 12, offset: 12026},
+										pos:  position{line: 522, col: 12, offset: 12104},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 519, col: 15, offset: 12029},
+										pos:        position{line: 522, col: 15, offset: 12107},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3429,9 +3492,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 519, col: 20, offset: 12034},
+							pos: position{line: 522, col: 20, offset: 12112},
 							expr: &ruleRefExpr{
-								pos:  position{line: 519, col: 21, offset: 12035},
+								pos:  position{line: 522, col: 21, offset: 12113},
 								name: "EOKW",
 							},
 						},
@@ -3443,28 +3506,28 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 523, col: 1, offset: 12104},
+			pos:  position{line: 526, col: 1, offset: 12182},
 			expr: &actionExpr{
-				pos: position{line: 524, col: 5, offset: 12116},
+				pos: position{line: 527, col: 5, offset: 12194},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 524, col: 5, offset: 12116},
+					pos: position{line: 527, col: 5, offset: 12194},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 524, col: 5, offset: 12116},
+							pos:  position{line: 527, col: 5, offset: 12194},
 							name: "SHAPE",
 						},
 						&notExpr{
-							pos: position{line: 524, col: 11, offset: 12122},
+							pos: position{line: 527, col: 11, offset: 12200},
 							expr: &seqExpr{
-								pos: position{line: 524, col: 13, offset: 12124},
+								pos: position{line: 527, col: 13, offset: 12202},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 524, col: 13, offset: 12124},
+										pos:  position{line: 527, col: 13, offset: 12202},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 524, col: 16, offset: 12127},
+										pos:        position{line: 527, col: 16, offset: 12205},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3473,9 +3536,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 524, col: 21, offset: 12132},
+							pos: position{line: 527, col: 21, offset: 12210},
 							expr: &ruleRefExpr{
-								pos:  position{line: 524, col: 22, offset: 12133},
+								pos:  position{line: 527, col: 22, offset: 12211},
 								name: "EOKW",
 							},
 						},
@@ -3487,41 +3550,41 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 528, col: 1, offset: 12204},
+			pos:  position{line: 531, col: 1, offset: 12282},
 			expr: &choiceExpr{
-				pos: position{line: 529, col: 5, offset: 12215},
+				pos: position{line: 532, col: 5, offset: 12293},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 529, col: 5, offset: 12215},
+						pos: position{line: 532, col: 5, offset: 12293},
 						run: (*parser).callonJoinOp2,
 						expr: &seqExpr{
-							pos: position{line: 529, col: 5, offset: 12215},
+							pos: position{line: 532, col: 5, offset: 12293},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 529, col: 5, offset: 12215},
+									pos:  position{line: 532, col: 5, offset: 12293},
 									name: "CROSS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 529, col: 11, offset: 12221},
+									pos:  position{line: 532, col: 11, offset: 12299},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 529, col: 13, offset: 12223},
+									pos:  position{line: 532, col: 13, offset: 12301},
 									name: "JOIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 529, col: 18, offset: 12228},
+									pos:   position{line: 532, col: 18, offset: 12306},
 									label: "rightInput",
 									expr: &ruleRefExpr{
-										pos:  position{line: 529, col: 29, offset: 12239},
+										pos:  position{line: 532, col: 29, offset: 12317},
 										name: "JoinRightInput",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 529, col: 44, offset: 12254},
+									pos:   position{line: 532, col: 44, offset: 12332},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 529, col: 50, offset: 12260},
+										pos:  position{line: 532, col: 50, offset: 12338},
 										name: "OptJoinAlias",
 									},
 								},
@@ -3529,48 +3592,48 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 543, col: 5, offset: 12563},
+						pos: position{line: 546, col: 5, offset: 12641},
 						run: (*parser).callonJoinOp11,
 						expr: &seqExpr{
-							pos: position{line: 543, col: 5, offset: 12563},
+							pos: position{line: 546, col: 5, offset: 12641},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 543, col: 5, offset: 12563},
+									pos:   position{line: 546, col: 5, offset: 12641},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 543, col: 11, offset: 12569},
+										pos:  position{line: 546, col: 11, offset: 12647},
 										name: "JoinStyle",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 543, col: 21, offset: 12579},
+									pos:  position{line: 546, col: 21, offset: 12657},
 									name: "JOIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 543, col: 26, offset: 12584},
+									pos:   position{line: 546, col: 26, offset: 12662},
 									label: "rightInput",
 									expr: &ruleRefExpr{
-										pos:  position{line: 543, col: 37, offset: 12595},
+										pos:  position{line: 546, col: 37, offset: 12673},
 										name: "JoinRightInput",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 543, col: 52, offset: 12610},
+									pos:   position{line: 546, col: 52, offset: 12688},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 543, col: 58, offset: 12616},
+										pos:  position{line: 546, col: 58, offset: 12694},
 										name: "OptJoinAlias",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 543, col: 71, offset: 12629},
+									pos:  position{line: 546, col: 71, offset: 12707},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 543, col: 73, offset: 12631},
+									pos:   position{line: 546, col: 73, offset: 12709},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 543, col: 75, offset: 12633},
+										pos:  position{line: 546, col: 75, offset: 12711},
 										name: "JoinCond",
 									},
 								},
@@ -3584,83 +3647,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 559, col: 1, offset: 12968},
+			pos:  position{line: 562, col: 1, offset: 13046},
 			expr: &choiceExpr{
-				pos: position{line: 560, col: 5, offset: 12982},
+				pos: position{line: 563, col: 5, offset: 13060},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 560, col: 5, offset: 12982},
+						pos: position{line: 563, col: 5, offset: 13060},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 560, col: 5, offset: 12982},
+							pos: position{line: 563, col: 5, offset: 13060},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 560, col: 5, offset: 12982},
+									pos:  position{line: 563, col: 5, offset: 13060},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 560, col: 10, offset: 12987},
+									pos:  position{line: 563, col: 10, offset: 13065},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 561, col: 5, offset: 13017},
+						pos: position{line: 564, col: 5, offset: 13095},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 561, col: 5, offset: 13017},
+							pos: position{line: 564, col: 5, offset: 13095},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 561, col: 5, offset: 13017},
+									pos:  position{line: 564, col: 5, offset: 13095},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 561, col: 11, offset: 13023},
+									pos:  position{line: 564, col: 11, offset: 13101},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 562, col: 5, offset: 13053},
+						pos: position{line: 565, col: 5, offset: 13131},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 562, col: 5, offset: 13053},
+							pos: position{line: 565, col: 5, offset: 13131},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 562, col: 5, offset: 13053},
+									pos:  position{line: 565, col: 5, offset: 13131},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 562, col: 11, offset: 13059},
+									pos:  position{line: 565, col: 11, offset: 13137},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 563, col: 5, offset: 13088},
+						pos: position{line: 566, col: 5, offset: 13166},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 563, col: 5, offset: 13088},
+							pos: position{line: 566, col: 5, offset: 13166},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 563, col: 5, offset: 13088},
+									pos:  position{line: 566, col: 5, offset: 13166},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 563, col: 11, offset: 13094},
+									pos:  position{line: 566, col: 11, offset: 13172},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 564, col: 5, offset: 13124},
+						pos: position{line: 567, col: 5, offset: 13202},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 564, col: 5, offset: 13124},
+							pos:        position{line: 567, col: 5, offset: 13202},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3673,33 +3736,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptJoinAlias",
-			pos:  position{line: 566, col: 1, offset: 13152},
+			pos:  position{line: 569, col: 1, offset: 13230},
 			expr: &choiceExpr{
-				pos: position{line: 567, col: 5, offset: 13169},
+				pos: position{line: 570, col: 5, offset: 13247},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 567, col: 5, offset: 13169},
+						pos: position{line: 570, col: 5, offset: 13247},
 						run: (*parser).callonOptJoinAlias2,
 						expr: &seqExpr{
-							pos: position{line: 567, col: 5, offset: 13169},
+							pos: position{line: 570, col: 5, offset: 13247},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 5, offset: 13169},
+									pos:  position{line: 570, col: 5, offset: 13247},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 7, offset: 13171},
+									pos:  position{line: 570, col: 7, offset: 13249},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 10, offset: 13174},
+									pos:  position{line: 570, col: 10, offset: 13252},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 567, col: 12, offset: 13176},
+									pos:   position{line: 570, col: 12, offset: 13254},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 567, col: 14, offset: 13178},
+										pos:  position{line: 570, col: 14, offset: 13256},
 										name: "JoinAlias",
 									},
 								},
@@ -3707,10 +3770,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 568, col: 5, offset: 13210},
+						pos: position{line: 571, col: 5, offset: 13288},
 						run: (*parser).callonOptJoinAlias9,
 						expr: &litMatcher{
-							pos:        position{line: 568, col: 5, offset: 13210},
+							pos:        position{line: 571, col: 5, offset: 13288},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3723,59 +3786,59 @@ var g = &grammar{
 		},
 		{
 			name: "JoinAlias",
-			pos:  position{line: 570, col: 1, offset: 13234},
+			pos:  position{line: 573, col: 1, offset: 13312},
 			expr: &actionExpr{
-				pos: position{line: 571, col: 5, offset: 13248},
+				pos: position{line: 574, col: 5, offset: 13326},
 				run: (*parser).callonJoinAlias1,
 				expr: &seqExpr{
-					pos: position{line: 571, col: 5, offset: 13248},
+					pos: position{line: 574, col: 5, offset: 13326},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 571, col: 5, offset: 13248},
+							pos:        position{line: 574, col: 5, offset: 13326},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 571, col: 9, offset: 13252},
+							pos:  position{line: 574, col: 9, offset: 13330},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 571, col: 12, offset: 13255},
+							pos:   position{line: 574, col: 12, offset: 13333},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 571, col: 17, offset: 13260},
+								pos:  position{line: 574, col: 17, offset: 13338},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 571, col: 28, offset: 13271},
+							pos:  position{line: 574, col: 28, offset: 13349},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 571, col: 31, offset: 13274},
+							pos:        position{line: 574, col: 31, offset: 13352},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 571, col: 35, offset: 13278},
+							pos:  position{line: 574, col: 35, offset: 13356},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 571, col: 38, offset: 13281},
+							pos:   position{line: 574, col: 38, offset: 13359},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 571, col: 44, offset: 13287},
+								pos:  position{line: 574, col: 44, offset: 13365},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 571, col: 55, offset: 13298},
+							pos:  position{line: 574, col: 55, offset: 13376},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 571, col: 58, offset: 13301},
+							pos:        position{line: 574, col: 58, offset: 13379},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -3788,44 +3851,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 579, col: 1, offset: 13439},
+			pos:  position{line: 582, col: 1, offset: 13517},
 			expr: &choiceExpr{
-				pos: position{line: 580, col: 5, offset: 13458},
+				pos: position{line: 583, col: 5, offset: 13536},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 580, col: 5, offset: 13458},
+						pos: position{line: 583, col: 5, offset: 13536},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 580, col: 5, offset: 13458},
+							pos: position{line: 583, col: 5, offset: 13536},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 580, col: 5, offset: 13458},
+									pos:  position{line: 583, col: 5, offset: 13536},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 580, col: 8, offset: 13461},
+									pos:        position{line: 583, col: 8, offset: 13539},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 580, col: 12, offset: 13465},
+									pos:  position{line: 583, col: 12, offset: 13543},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 580, col: 15, offset: 13468},
+									pos:   position{line: 583, col: 15, offset: 13546},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 580, col: 17, offset: 13470},
+										pos:  position{line: 583, col: 17, offset: 13548},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 580, col: 21, offset: 13474},
+									pos:  position{line: 583, col: 21, offset: 13552},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 580, col: 24, offset: 13477},
+									pos:        position{line: 583, col: 24, offset: 13555},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3834,10 +3897,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 581, col: 5, offset: 13503},
+						pos: position{line: 584, col: 5, offset: 13581},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 581, col: 5, offset: 13503},
+							pos:        position{line: 584, col: 5, offset: 13581},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3850,44 +3913,44 @@ var g = &grammar{
 		},
 		{
 			name: "ShapesOp",
-			pos:  position{line: 583, col: 1, offset: 13527},
+			pos:  position{line: 586, col: 1, offset: 13605},
 			expr: &actionExpr{
-				pos: position{line: 584, col: 5, offset: 13540},
+				pos: position{line: 587, col: 5, offset: 13618},
 				run: (*parser).callonShapesOp1,
 				expr: &seqExpr{
-					pos: position{line: 584, col: 5, offset: 13540},
+					pos: position{line: 587, col: 5, offset: 13618},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 584, col: 5, offset: 13540},
+							pos:  position{line: 587, col: 5, offset: 13618},
 							name: "SHAPES",
 						},
 						&andExpr{
-							pos: position{line: 584, col: 12, offset: 13547},
+							pos: position{line: 587, col: 12, offset: 13625},
 							expr: &ruleRefExpr{
-								pos:  position{line: 584, col: 13, offset: 13548},
+								pos:  position{line: 587, col: 13, offset: 13626},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 584, col: 18, offset: 13553},
+							pos:   position{line: 587, col: 18, offset: 13631},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 584, col: 23, offset: 13558},
+								pos: position{line: 587, col: 23, offset: 13636},
 								expr: &actionExpr{
-									pos: position{line: 584, col: 24, offset: 13559},
+									pos: position{line: 587, col: 24, offset: 13637},
 									run: (*parser).callonShapesOp8,
 									expr: &seqExpr{
-										pos: position{line: 584, col: 24, offset: 13559},
+										pos: position{line: 587, col: 24, offset: 13637},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 584, col: 24, offset: 13559},
+												pos:  position{line: 587, col: 24, offset: 13637},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 584, col: 26, offset: 13561},
+												pos:   position{line: 587, col: 26, offset: 13639},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 584, col: 28, offset: 13563},
+													pos:  position{line: 587, col: 28, offset: 13641},
 													name: "Lval",
 												},
 											},
@@ -3904,28 +3967,28 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 597, col: 1, offset: 14002},
+			pos:  position{line: 600, col: 1, offset: 14080},
 			expr: &actionExpr{
-				pos: position{line: 598, col: 5, offset: 14019},
+				pos: position{line: 601, col: 5, offset: 14097},
 				run: (*parser).callonOpAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 598, col: 5, offset: 14019},
+					pos: position{line: 601, col: 5, offset: 14097},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 598, col: 5, offset: 14019},
+							pos: position{line: 601, col: 5, offset: 14097},
 							expr: &seqExpr{
-								pos: position{line: 598, col: 7, offset: 14021},
+								pos: position{line: 601, col: 7, offset: 14099},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 598, col: 7, offset: 14021},
+										pos:  position{line: 601, col: 7, offset: 14099},
 										name: "Lval",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 598, col: 12, offset: 14026},
+										pos:  position{line: 601, col: 12, offset: 14104},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 598, col: 15, offset: 14029},
+										pos:        position{line: 601, col: 15, offset: 14107},
 										val:        ":=",
 										ignoreCase: false,
 										want:       "\":=\"",
@@ -3934,10 +3997,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 598, col: 21, offset: 14035},
+							pos:   position{line: 601, col: 21, offset: 14113},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 598, col: 23, offset: 14037},
+								pos:  position{line: 601, col: 23, offset: 14115},
 								name: "Assignments",
 							},
 						},
@@ -3949,36 +4012,36 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 606, col: 1, offset: 14209},
+			pos:  position{line: 609, col: 1, offset: 14287},
 			expr: &actionExpr{
-				pos: position{line: 607, col: 5, offset: 14220},
+				pos: position{line: 610, col: 5, offset: 14298},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 607, col: 5, offset: 14220},
+					pos: position{line: 610, col: 5, offset: 14298},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 607, col: 5, offset: 14220},
+							pos:  position{line: 610, col: 5, offset: 14298},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 607, col: 10, offset: 14225},
+							pos:  position{line: 610, col: 10, offset: 14303},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 607, col: 12, offset: 14227},
+							pos:   position{line: 610, col: 12, offset: 14305},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 607, col: 17, offset: 14232},
+								pos:  position{line: 610, col: 17, offset: 14310},
 								name: "Text",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 607, col: 22, offset: 14237},
+							pos:   position{line: 610, col: 22, offset: 14315},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 607, col: 27, offset: 14242},
+								pos: position{line: 610, col: 27, offset: 14320},
 								expr: &ruleRefExpr{
-									pos:  position{line: 607, col: 27, offset: 14242},
+									pos:  position{line: 610, col: 27, offset: 14320},
 									name: "CommitishOpArgs",
 								},
 							},
@@ -3991,26 +4054,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 616, col: 1, offset: 14420},
+			pos:  position{line: 619, col: 1, offset: 14498},
 			expr: &actionExpr{
-				pos: position{line: 617, col: 5, offset: 14433},
+				pos: position{line: 620, col: 5, offset: 14511},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 617, col: 5, offset: 14433},
+					pos: position{line: 620, col: 5, offset: 14511},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 5, offset: 14433},
+							pos:  position{line: 620, col: 5, offset: 14511},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 12, offset: 14440},
+							pos:  position{line: 620, col: 12, offset: 14518},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 617, col: 14, offset: 14442},
+							pos:   position{line: 620, col: 14, offset: 14520},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 617, col: 19, offset: 14447},
+								pos:  position{line: 620, col: 19, offset: 14525},
 								name: "Identifier",
 							},
 						},
@@ -4022,44 +4085,44 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 625, col: 1, offset: 14581},
+			pos:  position{line: 628, col: 1, offset: 14659},
 			expr: &actionExpr{
-				pos: position{line: 626, col: 5, offset: 14593},
+				pos: position{line: 629, col: 5, offset: 14671},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 626, col: 5, offset: 14593},
+					pos: position{line: 629, col: 5, offset: 14671},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 5, offset: 14593},
+							pos:  position{line: 629, col: 5, offset: 14671},
 							name: "DEBUG",
 						},
 						&andExpr{
-							pos: position{line: 626, col: 11, offset: 14599},
+							pos: position{line: 629, col: 11, offset: 14677},
 							expr: &ruleRefExpr{
-								pos:  position{line: 626, col: 12, offset: 14600},
+								pos:  position{line: 629, col: 12, offset: 14678},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 17, offset: 14605},
+							pos:   position{line: 629, col: 17, offset: 14683},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 626, col: 22, offset: 14610},
+								pos: position{line: 629, col: 22, offset: 14688},
 								expr: &actionExpr{
-									pos: position{line: 626, col: 23, offset: 14611},
+									pos: position{line: 629, col: 23, offset: 14689},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 626, col: 23, offset: 14611},
+										pos: position{line: 629, col: 23, offset: 14689},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 626, col: 23, offset: 14611},
+												pos:  position{line: 629, col: 23, offset: 14689},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 626, col: 25, offset: 14613},
+												pos:   position{line: 629, col: 25, offset: 14691},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 626, col: 27, offset: 14615},
+													pos:  position{line: 629, col: 27, offset: 14693},
 													name: "Expr",
 												},
 											},
@@ -4076,26 +4139,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 637, col: 1, offset: 14808},
+			pos:  position{line: 640, col: 1, offset: 14886},
 			expr: &actionExpr{
-				pos: position{line: 638, col: 5, offset: 14819},
+				pos: position{line: 641, col: 5, offset: 14897},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 638, col: 5, offset: 14819},
+					pos: position{line: 641, col: 5, offset: 14897},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 638, col: 5, offset: 14819},
+							pos:  position{line: 641, col: 5, offset: 14897},
 							name: "FROM",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 638, col: 10, offset: 14824},
+							pos:  position{line: 641, col: 10, offset: 14902},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 638, col: 12, offset: 14826},
+							pos:   position{line: 641, col: 12, offset: 14904},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 18, offset: 14832},
+								pos:  position{line: 641, col: 18, offset: 14910},
 								name: "FromElems",
 							},
 						},
@@ -4107,51 +4170,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 646, col: 1, offset: 14975},
+			pos:  position{line: 649, col: 1, offset: 15053},
 			expr: &actionExpr{
-				pos: position{line: 647, col: 5, offset: 14989},
+				pos: position{line: 650, col: 5, offset: 15067},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 647, col: 5, offset: 14989},
+					pos: position{line: 650, col: 5, offset: 15067},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 647, col: 5, offset: 14989},
+							pos:   position{line: 650, col: 5, offset: 15067},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 647, col: 11, offset: 14995},
+								pos:  position{line: 650, col: 11, offset: 15073},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 647, col: 20, offset: 15004},
+							pos:   position{line: 650, col: 20, offset: 15082},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 647, col: 25, offset: 15009},
+								pos: position{line: 650, col: 25, offset: 15087},
 								expr: &actionExpr{
-									pos: position{line: 647, col: 27, offset: 15011},
+									pos: position{line: 650, col: 27, offset: 15089},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 647, col: 27, offset: 15011},
+										pos: position{line: 650, col: 27, offset: 15089},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 647, col: 27, offset: 15011},
+												pos:  position{line: 650, col: 27, offset: 15089},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 647, col: 30, offset: 15014},
+												pos:        position{line: 650, col: 30, offset: 15092},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 647, col: 34, offset: 15018},
+												pos:  position{line: 650, col: 34, offset: 15096},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 647, col: 37, offset: 15021},
+												pos:   position{line: 650, col: 37, offset: 15099},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 647, col: 42, offset: 15026},
+													pos:  position{line: 650, col: 42, offset: 15104},
 													name: "FromElem",
 												},
 											},
@@ -4168,84 +4231,84 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 651, col: 1, offset: 15106},
+			pos:  position{line: 654, col: 1, offset: 15184},
 			expr: &actionExpr{
-				pos: position{line: 652, col: 5, offset: 15119},
+				pos: position{line: 655, col: 5, offset: 15197},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 652, col: 5, offset: 15119},
+					pos: position{line: 655, col: 5, offset: 15197},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 652, col: 5, offset: 15119},
+							pos:   position{line: 655, col: 5, offset: 15197},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 12, offset: 15126},
+								pos:  position{line: 655, col: 12, offset: 15204},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 23, offset: 15137},
+							pos:   position{line: 655, col: 23, offset: 15215},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 652, col: 28, offset: 15142},
+								pos: position{line: 655, col: 28, offset: 15220},
 								expr: &ruleRefExpr{
-									pos:  position{line: 652, col: 28, offset: 15142},
+									pos:  position{line: 655, col: 28, offset: 15220},
 									name: "CommitishOpArgs",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 45, offset: 15159},
+							pos:   position{line: 655, col: 45, offset: 15237},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 47, offset: 15161},
+								pos:  position{line: 655, col: 47, offset: 15239},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 61, offset: 15175},
+							pos:   position{line: 655, col: 61, offset: 15253},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 67, offset: 15181},
+								pos:  position{line: 655, col: 67, offset: 15259},
 								name: "OptAlias",
 							},
 						},
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 670, col: 1, offset: 15574},
+			pos:  position{line: 673, col: 1, offset: 15652},
 			expr: &choiceExpr{
-				pos: position{line: 671, col: 5, offset: 15589},
+				pos: position{line: 674, col: 5, offset: 15667},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 671, col: 5, offset: 15589},
+						pos:  position{line: 674, col: 5, offset: 15667},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 672, col: 5, offset: 15600},
+						pos:  position{line: 675, col: 5, offset: 15678},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 15609},
+						pos: position{line: 676, col: 5, offset: 15687},
 						run: (*parser).callonFromEntity4,
 						expr: &seqExpr{
-							pos: position{line: 673, col: 5, offset: 15609},
+							pos: position{line: 676, col: 5, offset: 15687},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 673, col: 5, offset: 15609},
+									pos:        position{line: 676, col: 5, offset: 15687},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 673, col: 9, offset: 15613},
+									pos: position{line: 676, col: 9, offset: 15691},
 									expr: &ruleRefExpr{
-										pos:  position{line: 673, col: 10, offset: 15614},
+										pos:  position{line: 676, col: 10, offset: 15692},
 										name: "ExprGuard",
 									},
 								},
@@ -4253,43 +4316,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 15695},
+						pos: position{line: 677, col: 5, offset: 15773},
 						run: (*parser).callonFromEntity9,
 						expr: &seqExpr{
-							pos: position{line: 674, col: 5, offset: 15695},
+							pos: position{line: 677, col: 5, offset: 15773},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 674, col: 5, offset: 15695},
+									pos:  position{line: 677, col: 5, offset: 15773},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 674, col: 10, offset: 15700},
+									pos:  position{line: 677, col: 10, offset: 15778},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 674, col: 13, offset: 15703},
+									pos:        position{line: 677, col: 13, offset: 15781},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 674, col: 17, offset: 15707},
+									pos:  position{line: 677, col: 17, offset: 15785},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 674, col: 20, offset: 15710},
+									pos:   position{line: 677, col: 20, offset: 15788},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 674, col: 22, offset: 15712},
+										pos:  position{line: 677, col: 22, offset: 15790},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 674, col: 27, offset: 15717},
+									pos:  position{line: 677, col: 27, offset: 15795},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 674, col: 30, offset: 15720},
+									pos:        position{line: 677, col: 30, offset: 15798},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4298,35 +4361,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 15856},
+						pos: position{line: 684, col: 5, offset: 15934},
 						run: (*parser).callonFromEntity19,
 						expr: &labeledExpr{
-							pos:   position{line: 681, col: 5, offset: 15856},
+							pos:   position{line: 684, col: 5, offset: 15934},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 681, col: 10, offset: 15861},
+								pos:  position{line: 684, col: 10, offset: 15939},
 								name: "ColonText",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 16003},
+						pos: position{line: 691, col: 5, offset: 16081},
 						run: (*parser).callonFromEntity22,
 						expr: &seqExpr{
-							pos: position{line: 688, col: 5, offset: 16003},
+							pos: position{line: 691, col: 5, offset: 16081},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 688, col: 5, offset: 16003},
+									pos:   position{line: 691, col: 5, offset: 16081},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 688, col: 10, offset: 16008},
+										pos:  position{line: 691, col: 10, offset: 16086},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 688, col: 24, offset: 16022},
+									pos: position{line: 691, col: 24, offset: 16100},
 									expr: &ruleRefExpr{
-										pos:  position{line: 688, col: 25, offset: 16023},
+										pos:  position{line: 691, col: 25, offset: 16101},
 										name: "AliasClause",
 									},
 								},
@@ -4334,35 +4397,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 689, col: 5, offset: 16058},
+						pos: position{line: 692, col: 5, offset: 16136},
 						run: (*parser).callonFromEntity28,
 						expr: &seqExpr{
-							pos: position{line: 689, col: 5, offset: 16058},
+							pos: position{line: 692, col: 5, offset: 16136},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 689, col: 5, offset: 16058},
+									pos:        position{line: 692, col: 5, offset: 16136},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 9, offset: 16062},
+									pos:  position{line: 692, col: 9, offset: 16140},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 689, col: 12, offset: 16065},
+									pos:   position{line: 692, col: 12, offset: 16143},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 689, col: 17, offset: 16070},
+										pos:  position{line: 692, col: 17, offset: 16148},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 31, offset: 16084},
+									pos:  position{line: 692, col: 31, offset: 16162},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 689, col: 34, offset: 16087},
+									pos:        position{line: 692, col: 34, offset: 16165},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4371,35 +4434,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 690, col: 5, offset: 16116},
+						pos: position{line: 693, col: 5, offset: 16194},
 						run: (*parser).callonFromEntity36,
 						expr: &seqExpr{
-							pos: position{line: 690, col: 5, offset: 16116},
+							pos: position{line: 693, col: 5, offset: 16194},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 690, col: 5, offset: 16116},
+									pos:        position{line: 693, col: 5, offset: 16194},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 690, col: 9, offset: 16120},
+									pos:  position{line: 693, col: 9, offset: 16198},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 690, col: 12, offset: 16123},
+									pos:   position{line: 693, col: 12, offset: 16201},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 690, col: 14, offset: 16125},
+										pos:  position{line: 693, col: 14, offset: 16203},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 690, col: 22, offset: 16133},
+									pos:  position{line: 693, col: 22, offset: 16211},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 690, col: 25, offset: 16136},
+									pos:        position{line: 693, col: 25, offset: 16214},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4408,7 +4471,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 693, col: 5, offset: 16172},
+						pos:  position{line: 696, col: 5, offset: 16250},
 						name: "Text",
 					},
 				},
@@ -4418,34 +4481,34 @@ var g = &grammar{
 		},
 		{
 			name: "Text",
-			pos:  position{line: 696, col: 1, offset: 16246},
+			pos:  position{line: 699, col: 1, offset: 16324},
 			expr: &actionExpr{
-				pos: position{line: 697, col: 4, offset: 16254},
+				pos: position{line: 700, col: 4, offset: 16332},
 				run: (*parser).callonText1,
 				expr: &labeledExpr{
-					pos:   position{line: 697, col: 4, offset: 16254},
+					pos:   position{line: 700, col: 4, offset: 16332},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 697, col: 7, offset: 16257},
+						pos: position{line: 700, col: 7, offset: 16335},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 697, col: 7, offset: 16257},
+								pos:  position{line: 700, col: 7, offset: 16335},
 								name: "UnquotedURL",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 697, col: 21, offset: 16271},
+								pos:  position{line: 700, col: 21, offset: 16349},
 								name: "TextChars",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 697, col: 33, offset: 16283},
+								pos:  position{line: 700, col: 33, offset: 16361},
 								name: "KSUID",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 697, col: 41, offset: 16291},
+								pos:  position{line: 700, col: 41, offset: 16369},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 697, col: 62, offset: 16312},
+								pos:  position{line: 700, col: 62, offset: 16390},
 								name: "SingleQuotedString",
 							},
 						},
@@ -4457,30 +4520,30 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 701, col: 1, offset: 16412},
+			pos:  position{line: 704, col: 1, offset: 16490},
 			expr: &actionExpr{
-				pos: position{line: 701, col: 15, offset: 16426},
+				pos: position{line: 704, col: 15, offset: 16504},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 701, col: 15, offset: 16426},
+					pos: position{line: 704, col: 15, offset: 16504},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 701, col: 16, offset: 16427},
+							pos: position{line: 704, col: 16, offset: 16505},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 701, col: 16, offset: 16427},
+									pos:        position{line: 704, col: 16, offset: 16505},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 701, col: 28, offset: 16439},
+									pos:        position{line: 704, col: 28, offset: 16517},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 701, col: 41, offset: 16452},
+									pos:        position{line: 704, col: 41, offset: 16530},
 									val:        "s3://",
 									ignoreCase: false,
 									want:       "\"s3://\"",
@@ -4488,9 +4551,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 701, col: 50, offset: 16461},
+							pos: position{line: 704, col: 50, offset: 16539},
 							expr: &ruleRefExpr{
-								pos:  position{line: 701, col: 50, offset: 16461},
+								pos:  position{line: 704, col: 50, offset: 16539},
 								name: "URLChar",
 							},
 						},
@@ -4502,9 +4565,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 703, col: 1, offset: 16502},
+			pos:  position{line: 706, col: 1, offset: 16580},
 			expr: &charClassMatcher{
-				pos:        position{line: 703, col: 11, offset: 16512},
+				pos:        position{line: 706, col: 11, offset: 16590},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -4516,27 +4579,27 @@ var g = &grammar{
 		},
 		{
 			name: "TextChars",
-			pos:  position{line: 705, col: 1, offset: 16559},
+			pos:  position{line: 708, col: 1, offset: 16637},
 			expr: &actionExpr{
-				pos: position{line: 706, col: 5, offset: 16573},
+				pos: position{line: 709, col: 5, offset: 16651},
 				run: (*parser).callonTextChars1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 706, col: 5, offset: 16573},
+					pos: position{line: 709, col: 5, offset: 16651},
 					expr: &choiceExpr{
-						pos: position{line: 706, col: 6, offset: 16574},
+						pos: position{line: 709, col: 6, offset: 16652},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 706, col: 6, offset: 16574},
+								pos:  position{line: 709, col: 6, offset: 16652},
 								name: "IdentifierRest",
 							},
 							&litMatcher{
-								pos:        position{line: 706, col: 23, offset: 16591},
+								pos:        position{line: 709, col: 23, offset: 16669},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 706, col: 29, offset: 16597},
+								pos:        position{line: 709, col: 29, offset: 16675},
 								val:        "/",
 								ignoreCase: false,
 								want:       "\"/\"",
@@ -4550,40 +4613,40 @@ var g = &grammar{
 		},
 		{
 			name: "CommitishOpArgs",
-			pos:  position{line: 708, col: 1, offset: 16635},
+			pos:  position{line: 711, col: 1, offset: 16713},
 			expr: &choiceExpr{
-				pos: position{line: 709, col: 5, offset: 16655},
+				pos: position{line: 712, col: 5, offset: 16733},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 709, col: 5, offset: 16655},
+						pos: position{line: 712, col: 5, offset: 16733},
 						run: (*parser).callonCommitishOpArgs2,
 						expr: &seqExpr{
-							pos: position{line: 709, col: 5, offset: 16655},
+							pos: position{line: 712, col: 5, offset: 16733},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 709, col: 5, offset: 16655},
+									pos:  position{line: 712, col: 5, offset: 16733},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 709, col: 8, offset: 16658},
+									pos:   position{line: 712, col: 8, offset: 16736},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 709, col: 15, offset: 16665},
+										pos: position{line: 712, col: 15, offset: 16743},
 										expr: &ruleRefExpr{
-											pos:  position{line: 709, col: 15, offset: 16665},
+											pos:  position{line: 712, col: 15, offset: 16743},
 											name: "MetaCommitish",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 709, col: 30, offset: 16680},
+									pos:  position{line: 712, col: 30, offset: 16758},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 709, col: 33, offset: 16683},
+									pos:   position{line: 712, col: 33, offset: 16761},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 709, col: 38, offset: 16688},
+										pos:  position{line: 712, col: 38, offset: 16766},
 										name: "OpArgs",
 									},
 								},
@@ -4591,20 +4654,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 715, col: 5, offset: 16818},
+						pos: position{line: 718, col: 5, offset: 16896},
 						run: (*parser).callonCommitishOpArgs11,
 						expr: &seqExpr{
-							pos: position{line: 715, col: 5, offset: 16818},
+							pos: position{line: 718, col: 5, offset: 16896},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 715, col: 5, offset: 16818},
+									pos:  position{line: 718, col: 5, offset: 16896},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 715, col: 8, offset: 16821},
+									pos:   position{line: 718, col: 8, offset: 16899},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 715, col: 15, offset: 16828},
+										pos:  position{line: 718, col: 15, offset: 16906},
 										name: "MetaCommitish",
 									},
 								},
@@ -4618,31 +4681,31 @@ var g = &grammar{
 		},
 		{
 			name: "MetaCommitish",
-			pos:  position{line: 717, col: 1, offset: 16866},
+			pos:  position{line: 720, col: 1, offset: 16944},
 			expr: &choiceExpr{
-				pos: position{line: 718, col: 5, offset: 16884},
+				pos: position{line: 721, col: 5, offset: 16962},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 718, col: 5, offset: 16884},
+						pos: position{line: 721, col: 5, offset: 16962},
 						run: (*parser).callonMetaCommitish2,
 						expr: &seqExpr{
-							pos: position{line: 718, col: 5, offset: 16884},
+							pos: position{line: 721, col: 5, offset: 16962},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 718, col: 5, offset: 16884},
+									pos:   position{line: 721, col: 5, offset: 16962},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 718, col: 12, offset: 16891},
+										pos:  position{line: 721, col: 12, offset: 16969},
 										name: "Commitish",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 718, col: 22, offset: 16901},
+									pos:   position{line: 721, col: 22, offset: 16979},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 718, col: 27, offset: 16906},
+										pos: position{line: 721, col: 27, offset: 16984},
 										expr: &ruleRefExpr{
-											pos:  position{line: 718, col: 27, offset: 16906},
+											pos:  position{line: 721, col: 27, offset: 16984},
 											name: "ColonText",
 										},
 									},
@@ -4651,13 +4714,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 725, col: 5, offset: 17130},
+						pos: position{line: 728, col: 5, offset: 17208},
 						run: (*parser).callonMetaCommitish9,
 						expr: &labeledExpr{
-							pos:   position{line: 725, col: 5, offset: 17130},
+							pos:   position{line: 728, col: 5, offset: 17208},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 725, col: 10, offset: 17135},
+								pos:  position{line: 728, col: 10, offset: 17213},
 								name: "ColonText",
 							},
 						},
@@ -4669,24 +4732,24 @@ var g = &grammar{
 		},
 		{
 			name: "Commitish",
-			pos:  position{line: 729, col: 1, offset: 17259},
+			pos:  position{line: 732, col: 1, offset: 17337},
 			expr: &actionExpr{
-				pos: position{line: 730, col: 5, offset: 17273},
+				pos: position{line: 733, col: 5, offset: 17351},
 				run: (*parser).callonCommitish1,
 				expr: &seqExpr{
-					pos: position{line: 730, col: 5, offset: 17273},
+					pos: position{line: 733, col: 5, offset: 17351},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 730, col: 5, offset: 17273},
+							pos:        position{line: 733, col: 5, offset: 17351},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 730, col: 9, offset: 17277},
+							pos:   position{line: 733, col: 9, offset: 17355},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 14, offset: 17282},
+								pos:  position{line: 733, col: 14, offset: 17360},
 								name: "CommitText",
 							},
 						},
@@ -4698,22 +4761,22 @@ var g = &grammar{
 		},
 		{
 			name: "CommitText",
-			pos:  position{line: 734, col: 1, offset: 17417},
+			pos:  position{line: 737, col: 1, offset: 17495},
 			expr: &choiceExpr{
-				pos: position{line: 735, col: 5, offset: 17432},
+				pos: position{line: 738, col: 5, offset: 17510},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 735, col: 5, offset: 17432},
+						pos:  position{line: 738, col: 5, offset: 17510},
 						name: "Name",
 					},
 					&actionExpr{
-						pos: position{line: 736, col: 5, offset: 17441},
+						pos: position{line: 739, col: 5, offset: 17519},
 						run: (*parser).callonCommitText3,
 						expr: &labeledExpr{
-							pos:   position{line: 736, col: 5, offset: 17441},
+							pos:   position{line: 739, col: 5, offset: 17519},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 736, col: 7, offset: 17443},
+								pos:  position{line: 739, col: 7, offset: 17521},
 								name: "KSUID",
 							},
 						},
@@ -4725,40 +4788,40 @@ var g = &grammar{
 		},
 		{
 			name: "OpArg",
-			pos:  position{line: 738, col: 1, offset: 17518},
+			pos:  position{line: 741, col: 1, offset: 17596},
 			expr: &choiceExpr{
-				pos: position{line: 739, col: 5, offset: 17528},
+				pos: position{line: 742, col: 5, offset: 17606},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 739, col: 5, offset: 17528},
+						pos: position{line: 742, col: 5, offset: 17606},
 						run: (*parser).callonOpArg2,
 						expr: &seqExpr{
-							pos: position{line: 739, col: 5, offset: 17528},
+							pos: position{line: 742, col: 5, offset: 17606},
 							exprs: []any{
 								&andExpr{
-									pos: position{line: 739, col: 5, offset: 17528},
+									pos: position{line: 742, col: 5, offset: 17606},
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 6, offset: 17529},
+										pos:  position{line: 742, col: 6, offset: 17607},
 										name: "ArgNameExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 739, col: 18, offset: 17541},
+									pos:   position{line: 742, col: 18, offset: 17619},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 22, offset: 17545},
+										pos:  position{line: 742, col: 22, offset: 17623},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 739, col: 30, offset: 17553},
+									pos:  position{line: 742, col: 30, offset: 17631},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 739, col: 32, offset: 17555},
+									pos:   position{line: 742, col: 32, offset: 17633},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 34, offset: 17557},
+										pos:  position{line: 742, col: 34, offset: 17635},
 										name: "Expr",
 									},
 								},
@@ -4766,28 +4829,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 740, col: 5, offset: 17664},
+						pos: position{line: 743, col: 5, offset: 17742},
 						run: (*parser).callonOpArg11,
 						expr: &seqExpr{
-							pos: position{line: 740, col: 5, offset: 17664},
+							pos: position{line: 743, col: 5, offset: 17742},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 740, col: 5, offset: 17664},
+									pos:   position{line: 743, col: 5, offset: 17742},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 740, col: 9, offset: 17668},
+										pos:  position{line: 743, col: 9, offset: 17746},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 740, col: 17, offset: 17676},
+									pos:  position{line: 743, col: 17, offset: 17754},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 740, col: 19, offset: 17678},
+									pos:   position{line: 743, col: 19, offset: 17756},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 740, col: 21, offset: 17680},
+										pos:  position{line: 743, col: 21, offset: 17758},
 										name: "Text",
 									},
 								},
@@ -4801,51 +4864,51 @@ var g = &grammar{
 		},
 		{
 			name: "OpArgs",
-			pos:  position{line: 742, col: 1, offset: 17785},
+			pos:  position{line: 745, col: 1, offset: 17863},
 			expr: &actionExpr{
-				pos: position{line: 743, col: 5, offset: 17796},
+				pos: position{line: 746, col: 5, offset: 17874},
 				run: (*parser).callonOpArgs1,
 				expr: &seqExpr{
-					pos: position{line: 743, col: 5, offset: 17796},
+					pos: position{line: 746, col: 5, offset: 17874},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 743, col: 5, offset: 17796},
+							pos:        position{line: 746, col: 5, offset: 17874},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 743, col: 9, offset: 17800},
+							pos:  position{line: 746, col: 9, offset: 17878},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 743, col: 12, offset: 17803},
+							pos:   position{line: 746, col: 12, offset: 17881},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 743, col: 18, offset: 17809},
+								pos:  position{line: 746, col: 18, offset: 17887},
 								name: "OpArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 743, col: 24, offset: 17815},
+							pos:   position{line: 746, col: 24, offset: 17893},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 743, col: 29, offset: 17820},
+								pos: position{line: 746, col: 29, offset: 17898},
 								expr: &actionExpr{
-									pos: position{line: 743, col: 30, offset: 17821},
+									pos: position{line: 746, col: 30, offset: 17899},
 									run: (*parser).callonOpArgs9,
 									expr: &seqExpr{
-										pos: position{line: 743, col: 30, offset: 17821},
+										pos: position{line: 746, col: 30, offset: 17899},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 743, col: 30, offset: 17821},
+												pos:  position{line: 746, col: 30, offset: 17899},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 743, col: 32, offset: 17823},
+												pos:   position{line: 746, col: 32, offset: 17901},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 743, col: 34, offset: 17825},
+													pos:  position{line: 746, col: 34, offset: 17903},
 													name: "OpArg",
 												},
 											},
@@ -4855,11 +4918,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 743, col: 60, offset: 17851},
+							pos:  position{line: 746, col: 60, offset: 17929},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 743, col: 63, offset: 17854},
+							pos:        position{line: 746, col: 63, offset: 17932},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -4872,14 +4935,14 @@ var g = &grammar{
 		},
 		{
 			name: "ArgName",
-			pos:  position{line: 747, col: 1, offset: 17906},
+			pos:  position{line: 750, col: 1, offset: 17984},
 			expr: &actionExpr{
-				pos: position{line: 747, col: 11, offset: 17916},
+				pos: position{line: 750, col: 11, offset: 17994},
 				run: (*parser).callonArgName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 747, col: 11, offset: 17916},
+					pos: position{line: 750, col: 11, offset: 17994},
 					expr: &ruleRefExpr{
-						pos:  position{line: 747, col: 11, offset: 17916},
+						pos:  position{line: 750, col: 11, offset: 17994},
 						name: "UnicodeLetter",
 					},
 				},
@@ -4889,20 +4952,20 @@ var g = &grammar{
 		},
 		{
 			name: "ArgNameExpr",
-			pos:  position{line: 749, col: 1, offset: 17963},
+			pos:  position{line: 752, col: 1, offset: 18041},
 			expr: &seqExpr{
-				pos: position{line: 750, col: 5, offset: 17979},
+				pos: position{line: 753, col: 5, offset: 18057},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 750, col: 5, offset: 17979},
+						pos:        position{line: 753, col: 5, offset: 18057},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"headers\"i",
 					},
 					&notExpr{
-						pos: position{line: 750, col: 16, offset: 17990},
+						pos: position{line: 753, col: 16, offset: 18068},
 						expr: &ruleRefExpr{
-							pos:  position{line: 750, col: 17, offset: 17991},
+							pos:  position{line: 753, col: 17, offset: 18069},
 							name: "UnicodeLetter",
 						},
 					},
@@ -4913,30 +4976,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 753, col: 1, offset: 18039},
+			pos:  position{line: 756, col: 1, offset: 18117},
 			expr: &actionExpr{
-				pos: position{line: 754, col: 5, offset: 18050},
+				pos: position{line: 757, col: 5, offset: 18128},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 754, col: 5, offset: 18050},
+					pos: position{line: 757, col: 5, offset: 18128},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 754, col: 5, offset: 18050},
+							pos:  position{line: 757, col: 5, offset: 18128},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 754, col: 7, offset: 18052},
+							pos:  position{line: 757, col: 7, offset: 18130},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 754, col: 10, offset: 18055},
+							pos:  position{line: 757, col: 10, offset: 18133},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 754, col: 12, offset: 18057},
+							pos:   position{line: 757, col: 12, offset: 18135},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 754, col: 15, offset: 18060},
+								pos:  position{line: 757, col: 15, offset: 18138},
 								name: "KSUID",
 							},
 						},
@@ -4948,14 +5011,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 757, col: 1, offset: 18126},
+			pos:  position{line: 760, col: 1, offset: 18204},
 			expr: &actionExpr{
-				pos: position{line: 757, col: 9, offset: 18134},
+				pos: position{line: 760, col: 9, offset: 18212},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 757, col: 9, offset: 18134},
+					pos: position{line: 760, col: 9, offset: 18212},
 					expr: &charClassMatcher{
-						pos:        position{line: 757, col: 10, offset: 18135},
+						pos:        position{line: 760, col: 10, offset: 18213},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -4968,24 +5031,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonText",
-			pos:  position{line: 759, col: 1, offset: 18181},
+			pos:  position{line: 762, col: 1, offset: 18259},
 			expr: &actionExpr{
-				pos: position{line: 760, col: 5, offset: 18195},
+				pos: position{line: 763, col: 5, offset: 18273},
 				run: (*parser).callonColonText1,
 				expr: &seqExpr{
-					pos: position{line: 760, col: 5, offset: 18195},
+					pos: position{line: 763, col: 5, offset: 18273},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 760, col: 5, offset: 18195},
+							pos:        position{line: 763, col: 5, offset: 18273},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 760, col: 9, offset: 18199},
+							pos:   position{line: 763, col: 9, offset: 18277},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 760, col: 11, offset: 18201},
+								pos:  position{line: 763, col: 11, offset: 18279},
 								name: "Text",
 							},
 						},
@@ -4997,28 +5060,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 762, col: 1, offset: 18225},
+			pos:  position{line: 765, col: 1, offset: 18303},
 			expr: &actionExpr{
-				pos: position{line: 763, col: 5, offset: 18236},
+				pos: position{line: 766, col: 5, offset: 18314},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 763, col: 5, offset: 18236},
+					pos: position{line: 766, col: 5, offset: 18314},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 763, col: 5, offset: 18236},
+							pos:  position{line: 766, col: 5, offset: 18314},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 763, col: 10, offset: 18241},
+							pos: position{line: 766, col: 10, offset: 18319},
 							expr: &seqExpr{
-								pos: position{line: 763, col: 12, offset: 18243},
+								pos: position{line: 766, col: 12, offset: 18321},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 763, col: 12, offset: 18243},
+										pos:  position{line: 766, col: 12, offset: 18321},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 763, col: 15, offset: 18246},
+										pos:        position{line: 766, col: 15, offset: 18324},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5027,9 +5090,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 763, col: 20, offset: 18251},
+							pos: position{line: 766, col: 20, offset: 18329},
 							expr: &ruleRefExpr{
-								pos:  position{line: 763, col: 21, offset: 18252},
+								pos:  position{line: 766, col: 21, offset: 18330},
 								name: "EOKW",
 							},
 						},
@@ -5041,44 +5104,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 769, col: 1, offset: 18443},
+			pos:  position{line: 772, col: 1, offset: 18521},
 			expr: &actionExpr{
-				pos: position{line: 770, col: 5, offset: 18457},
+				pos: position{line: 773, col: 5, offset: 18535},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 770, col: 5, offset: 18457},
+					pos: position{line: 773, col: 5, offset: 18535},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 770, col: 5, offset: 18457},
+							pos:  position{line: 773, col: 5, offset: 18535},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 770, col: 13, offset: 18465},
+							pos:  position{line: 773, col: 13, offset: 18543},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 770, col: 15, offset: 18467},
+							pos:   position{line: 773, col: 15, offset: 18545},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 770, col: 20, offset: 18472},
+								pos:  position{line: 773, col: 20, offset: 18550},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 770, col: 26, offset: 18478},
+							pos:   position{line: 773, col: 26, offset: 18556},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 770, col: 30, offset: 18482},
+								pos:  position{line: 773, col: 30, offset: 18560},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 770, col: 38, offset: 18490},
+							pos:   position{line: 773, col: 38, offset: 18568},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 770, col: 41, offset: 18493},
+								pos: position{line: 773, col: 41, offset: 18571},
 								expr: &ruleRefExpr{
-									pos:  position{line: 770, col: 41, offset: 18493},
+									pos:  position{line: 773, col: 41, offset: 18571},
 									name: "AsArg",
 								},
 							},
@@ -5091,26 +5154,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 783, col: 1, offset: 18735},
+			pos:  position{line: 786, col: 1, offset: 18813},
 			expr: &actionExpr{
-				pos: position{line: 784, col: 5, offset: 18747},
+				pos: position{line: 787, col: 5, offset: 18825},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 784, col: 5, offset: 18747},
+					pos: position{line: 787, col: 5, offset: 18825},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 784, col: 5, offset: 18747},
+							pos:  position{line: 787, col: 5, offset: 18825},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 784, col: 11, offset: 18753},
+							pos:  position{line: 787, col: 11, offset: 18831},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 784, col: 13, offset: 18755},
+							pos:   position{line: 787, col: 13, offset: 18833},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 784, col: 19, offset: 18761},
+								pos:  position{line: 787, col: 19, offset: 18839},
 								name: "OrderByList",
 							},
 						},
@@ -5122,59 +5185,59 @@ var g = &grammar{
 		},
 		{
 			name: "UnnestOp",
-			pos:  position{line: 792, col: 1, offset: 18903},
+			pos:  position{line: 795, col: 1, offset: 18981},
 			expr: &actionExpr{
-				pos: position{line: 793, col: 6, offset: 18917},
+				pos: position{line: 796, col: 6, offset: 18995},
 				run: (*parser).callonUnnestOp1,
 				expr: &seqExpr{
-					pos: position{line: 793, col: 6, offset: 18917},
+					pos: position{line: 796, col: 6, offset: 18995},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 793, col: 6, offset: 18917},
+							pos:  position{line: 796, col: 6, offset: 18995},
 							name: "UNNEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 793, col: 13, offset: 18924},
+							pos:  position{line: 796, col: 13, offset: 19002},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 793, col: 15, offset: 18926},
+							pos:   position{line: 796, col: 15, offset: 19004},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 793, col: 17, offset: 18928},
+								pos:  position{line: 796, col: 17, offset: 19006},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 793, col: 22, offset: 18933},
+							pos:   position{line: 796, col: 22, offset: 19011},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 793, col: 27, offset: 18938},
+								pos: position{line: 796, col: 27, offset: 19016},
 								expr: &actionExpr{
-									pos: position{line: 793, col: 28, offset: 18939},
+									pos: position{line: 796, col: 28, offset: 19017},
 									run: (*parser).callonUnnestOp9,
 									expr: &seqExpr{
-										pos: position{line: 793, col: 28, offset: 18939},
+										pos: position{line: 796, col: 28, offset: 19017},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 793, col: 28, offset: 18939},
+												pos:  position{line: 796, col: 28, offset: 19017},
 												name: "_",
 											},
 											&litMatcher{
-												pos:        position{line: 793, col: 30, offset: 18941},
+												pos:        position{line: 796, col: 30, offset: 19019},
 												val:        "into",
 												ignoreCase: true,
 												want:       "\"into\"i",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 793, col: 38, offset: 18949},
+												pos:  position{line: 796, col: 38, offset: 19027},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 793, col: 40, offset: 18951},
+												pos:   position{line: 796, col: 40, offset: 19029},
 												label: "body",
 												expr: &ruleRefExpr{
-													pos:  position{line: 793, col: 45, offset: 18956},
+													pos:  position{line: 796, col: 45, offset: 19034},
 													name: "ScopeBody",
 												},
 											},
@@ -5191,30 +5254,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 805, col: 1, offset: 19193},
+			pos:  position{line: 808, col: 1, offset: 19271},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 5, offset: 19205},
+				pos: position{line: 809, col: 5, offset: 19283},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 806, col: 5, offset: 19205},
+					pos: position{line: 809, col: 5, offset: 19283},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 5, offset: 19205},
+							pos:  position{line: 809, col: 5, offset: 19283},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 7, offset: 19207},
+							pos:  position{line: 809, col: 7, offset: 19285},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 10, offset: 19210},
+							pos:  position{line: 809, col: 10, offset: 19288},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 806, col: 12, offset: 19212},
+							pos:   position{line: 809, col: 12, offset: 19290},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 806, col: 16, offset: 19216},
+								pos:  position{line: 809, col: 16, offset: 19294},
 								name: "Type",
 							},
 						},
@@ -5226,30 +5289,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 808, col: 1, offset: 19242},
+			pos:  position{line: 811, col: 1, offset: 19320},
 			expr: &actionExpr{
-				pos: position{line: 809, col: 5, offset: 19252},
+				pos: position{line: 812, col: 5, offset: 19330},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 809, col: 5, offset: 19252},
+					pos: position{line: 812, col: 5, offset: 19330},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 5, offset: 19252},
+							pos:  position{line: 812, col: 5, offset: 19330},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 7, offset: 19254},
+							pos:  position{line: 812, col: 7, offset: 19332},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 10, offset: 19257},
+							pos:  position{line: 812, col: 10, offset: 19335},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 809, col: 12, offset: 19259},
+							pos:   position{line: 812, col: 12, offset: 19337},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 809, col: 16, offset: 19263},
+								pos:  position{line: 812, col: 16, offset: 19341},
 								name: "Lval",
 							},
 						},
@@ -5261,9 +5324,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 813, col: 1, offset: 19314},
+			pos:  position{line: 816, col: 1, offset: 19392},
 			expr: &ruleRefExpr{
-				pos:  position{line: 813, col: 8, offset: 19321},
+				pos:  position{line: 816, col: 8, offset: 19399},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5271,51 +5334,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 815, col: 1, offset: 19332},
+			pos:  position{line: 818, col: 1, offset: 19410},
 			expr: &actionExpr{
-				pos: position{line: 816, col: 5, offset: 19342},
+				pos: position{line: 819, col: 5, offset: 19420},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 816, col: 5, offset: 19342},
+					pos: position{line: 819, col: 5, offset: 19420},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 816, col: 5, offset: 19342},
+							pos:   position{line: 819, col: 5, offset: 19420},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 816, col: 11, offset: 19348},
+								pos:  position{line: 819, col: 11, offset: 19426},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 816, col: 16, offset: 19353},
+							pos:   position{line: 819, col: 16, offset: 19431},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 816, col: 21, offset: 19358},
+								pos: position{line: 819, col: 21, offset: 19436},
 								expr: &actionExpr{
-									pos: position{line: 816, col: 22, offset: 19359},
+									pos: position{line: 819, col: 22, offset: 19437},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 816, col: 22, offset: 19359},
+										pos: position{line: 819, col: 22, offset: 19437},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 816, col: 22, offset: 19359},
+												pos:  position{line: 819, col: 22, offset: 19437},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 816, col: 25, offset: 19362},
+												pos:        position{line: 819, col: 25, offset: 19440},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 816, col: 29, offset: 19366},
+												pos:  position{line: 819, col: 29, offset: 19444},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 816, col: 32, offset: 19369},
+												pos:   position{line: 819, col: 32, offset: 19447},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 816, col: 37, offset: 19374},
+													pos:  position{line: 819, col: 37, offset: 19452},
 													name: "Lval",
 												},
 											},
@@ -5332,51 +5395,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 820, col: 1, offset: 19450},
+			pos:  position{line: 823, col: 1, offset: 19528},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 5, offset: 19466},
+				pos: position{line: 824, col: 5, offset: 19544},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 821, col: 5, offset: 19466},
+					pos: position{line: 824, col: 5, offset: 19544},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 821, col: 5, offset: 19466},
+							pos:   position{line: 824, col: 5, offset: 19544},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 821, col: 11, offset: 19472},
+								pos:  position{line: 824, col: 11, offset: 19550},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 22, offset: 19483},
+							pos:   position{line: 824, col: 22, offset: 19561},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 821, col: 27, offset: 19488},
+								pos: position{line: 824, col: 27, offset: 19566},
 								expr: &actionExpr{
-									pos: position{line: 821, col: 28, offset: 19489},
+									pos: position{line: 824, col: 28, offset: 19567},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 821, col: 28, offset: 19489},
+										pos: position{line: 824, col: 28, offset: 19567},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 821, col: 28, offset: 19489},
+												pos:  position{line: 824, col: 28, offset: 19567},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 821, col: 31, offset: 19492},
+												pos:        position{line: 824, col: 31, offset: 19570},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 821, col: 35, offset: 19496},
+												pos:  position{line: 824, col: 35, offset: 19574},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 821, col: 38, offset: 19499},
+												pos:   position{line: 824, col: 38, offset: 19577},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 821, col: 40, offset: 19501},
+													pos:  position{line: 824, col: 40, offset: 19579},
 													name: "Assignment",
 												},
 											},
@@ -5393,38 +5456,38 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 825, col: 1, offset: 19576},
+			pos:  position{line: 828, col: 1, offset: 19654},
 			expr: &actionExpr{
-				pos: position{line: 826, col: 5, offset: 19591},
+				pos: position{line: 829, col: 5, offset: 19669},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 826, col: 5, offset: 19591},
+					pos: position{line: 829, col: 5, offset: 19669},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 826, col: 5, offset: 19591},
+							pos:   position{line: 829, col: 5, offset: 19669},
 							label: "lhs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 826, col: 9, offset: 19595},
+								pos: position{line: 829, col: 9, offset: 19673},
 								expr: &actionExpr{
-									pos: position{line: 826, col: 10, offset: 19596},
+									pos: position{line: 829, col: 10, offset: 19674},
 									run: (*parser).callonAssignment5,
 									expr: &seqExpr{
-										pos: position{line: 826, col: 10, offset: 19596},
+										pos: position{line: 829, col: 10, offset: 19674},
 										exprs: []any{
 											&labeledExpr{
-												pos:   position{line: 826, col: 10, offset: 19596},
+												pos:   position{line: 829, col: 10, offset: 19674},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 826, col: 15, offset: 19601},
+													pos:  position{line: 829, col: 15, offset: 19679},
 													name: "Lval",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 826, col: 20, offset: 19606},
+												pos:  position{line: 829, col: 20, offset: 19684},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 826, col: 23, offset: 19609},
+												pos:        position{line: 829, col: 23, offset: 19687},
 												val:        ":=",
 												ignoreCase: false,
 												want:       "\":=\"",
@@ -5435,14 +5498,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 826, col: 51, offset: 19637},
+							pos:  position{line: 829, col: 51, offset: 19715},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 826, col: 54, offset: 19640},
+							pos:   position{line: 829, col: 54, offset: 19718},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 826, col: 58, offset: 19644},
+								pos:  position{line: 829, col: 58, offset: 19722},
 								name: "Expr",
 							},
 						},
@@ -5454,9 +5517,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 838, col: 1, offset: 19858},
+			pos:  position{line: 841, col: 1, offset: 19936},
 			expr: &ruleRefExpr{
-				pos:  position{line: 838, col: 8, offset: 19865},
+				pos:  position{line: 841, col: 8, offset: 19943},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -5464,63 +5527,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 840, col: 1, offset: 19882},
+			pos:  position{line: 843, col: 1, offset: 19960},
 			expr: &actionExpr{
-				pos: position{line: 841, col: 5, offset: 19902},
+				pos: position{line: 844, col: 5, offset: 19980},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 841, col: 5, offset: 19902},
+					pos: position{line: 844, col: 5, offset: 19980},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 841, col: 5, offset: 19902},
+							pos:   position{line: 844, col: 5, offset: 19980},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 841, col: 10, offset: 19907},
+								pos:  position{line: 844, col: 10, offset: 19985},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 841, col: 24, offset: 19921},
+							pos:   position{line: 844, col: 24, offset: 19999},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 841, col: 28, offset: 19925},
+								pos: position{line: 844, col: 28, offset: 20003},
 								expr: &seqExpr{
-									pos: position{line: 841, col: 29, offset: 19926},
+									pos: position{line: 844, col: 29, offset: 20004},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 841, col: 29, offset: 19926},
+											pos:  position{line: 844, col: 29, offset: 20004},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 841, col: 32, offset: 19929},
+											pos:        position{line: 844, col: 32, offset: 20007},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 841, col: 36, offset: 19933},
+											pos:  position{line: 844, col: 36, offset: 20011},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 841, col: 39, offset: 19936},
+											pos:  position{line: 844, col: 39, offset: 20014},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 841, col: 44, offset: 19941},
+											pos:  position{line: 844, col: 44, offset: 20019},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 841, col: 47, offset: 19944},
+											pos:        position{line: 844, col: 47, offset: 20022},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 841, col: 51, offset: 19948},
+											pos:  position{line: 844, col: 51, offset: 20026},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 841, col: 54, offset: 19951},
+											pos:  position{line: 844, col: 54, offset: 20029},
 											name: "Expr",
 										},
 									},
@@ -5535,53 +5598,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 855, col: 1, offset: 20272},
+			pos:  position{line: 858, col: 1, offset: 20350},
 			expr: &actionExpr{
-				pos: position{line: 856, col: 5, offset: 20290},
+				pos: position{line: 859, col: 5, offset: 20368},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 856, col: 5, offset: 20290},
+					pos: position{line: 859, col: 5, offset: 20368},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 856, col: 5, offset: 20290},
+							pos:   position{line: 859, col: 5, offset: 20368},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 856, col: 11, offset: 20296},
+								pos:  position{line: 859, col: 11, offset: 20374},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 857, col: 5, offset: 20315},
+							pos:   position{line: 860, col: 5, offset: 20393},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 857, col: 10, offset: 20320},
+								pos: position{line: 860, col: 10, offset: 20398},
 								expr: &actionExpr{
-									pos: position{line: 857, col: 11, offset: 20321},
+									pos: position{line: 860, col: 11, offset: 20399},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 857, col: 11, offset: 20321},
+										pos: position{line: 860, col: 11, offset: 20399},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 857, col: 11, offset: 20321},
+												pos:  position{line: 860, col: 11, offset: 20399},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 857, col: 14, offset: 20324},
+												pos:   position{line: 860, col: 14, offset: 20402},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 857, col: 17, offset: 20327},
+													pos:  position{line: 860, col: 17, offset: 20405},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 857, col: 20, offset: 20330},
+												pos:  position{line: 860, col: 20, offset: 20408},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 857, col: 23, offset: 20333},
+												pos:   position{line: 860, col: 23, offset: 20411},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 857, col: 28, offset: 20338},
+													pos:  position{line: 860, col: 28, offset: 20416},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -5598,53 +5661,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 861, col: 1, offset: 20452},
+			pos:  position{line: 864, col: 1, offset: 20530},
 			expr: &actionExpr{
-				pos: position{line: 862, col: 5, offset: 20471},
+				pos: position{line: 865, col: 5, offset: 20549},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 862, col: 5, offset: 20471},
+					pos: position{line: 865, col: 5, offset: 20549},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 862, col: 5, offset: 20471},
+							pos:   position{line: 865, col: 5, offset: 20549},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 11, offset: 20477},
+								pos:  position{line: 865, col: 11, offset: 20555},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 863, col: 5, offset: 20489},
+							pos:   position{line: 866, col: 5, offset: 20567},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 863, col: 10, offset: 20494},
+								pos: position{line: 866, col: 10, offset: 20572},
 								expr: &actionExpr{
-									pos: position{line: 863, col: 11, offset: 20495},
+									pos: position{line: 866, col: 11, offset: 20573},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 863, col: 11, offset: 20495},
+										pos: position{line: 866, col: 11, offset: 20573},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 863, col: 11, offset: 20495},
+												pos:  position{line: 866, col: 11, offset: 20573},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 863, col: 14, offset: 20498},
+												pos:   position{line: 866, col: 14, offset: 20576},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 863, col: 17, offset: 20501},
+													pos:  position{line: 866, col: 17, offset: 20579},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 863, col: 21, offset: 20505},
+												pos:  position{line: 866, col: 21, offset: 20583},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 863, col: 24, offset: 20508},
+												pos:   position{line: 866, col: 24, offset: 20586},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 863, col: 29, offset: 20513},
+													pos:  position{line: 866, col: 29, offset: 20591},
 													name: "NotExpr",
 												},
 											},
@@ -5661,43 +5724,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 867, col: 1, offset: 20620},
+			pos:  position{line: 870, col: 1, offset: 20698},
 			expr: &choiceExpr{
-				pos: position{line: 868, col: 5, offset: 20632},
+				pos: position{line: 871, col: 5, offset: 20710},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 868, col: 5, offset: 20632},
+						pos: position{line: 871, col: 5, offset: 20710},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 868, col: 5, offset: 20632},
+							pos: position{line: 871, col: 5, offset: 20710},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 868, col: 6, offset: 20633},
+									pos: position{line: 871, col: 6, offset: 20711},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 868, col: 6, offset: 20633},
+											pos: position{line: 871, col: 6, offset: 20711},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 868, col: 6, offset: 20633},
+													pos:  position{line: 871, col: 6, offset: 20711},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 868, col: 10, offset: 20637},
+													pos:  position{line: 871, col: 10, offset: 20715},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 868, col: 14, offset: 20641},
+											pos: position{line: 871, col: 14, offset: 20719},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 868, col: 14, offset: 20641},
+													pos:        position{line: 871, col: 14, offset: 20719},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 868, col: 18, offset: 20645},
+													pos:  position{line: 871, col: 18, offset: 20723},
 													name: "__",
 												},
 											},
@@ -5705,10 +5768,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 868, col: 22, offset: 20649},
+									pos:   position{line: 871, col: 22, offset: 20727},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 868, col: 24, offset: 20651},
+										pos:  position{line: 871, col: 24, offset: 20729},
 										name: "NotExpr",
 									},
 								},
@@ -5716,7 +5779,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 876, col: 5, offset: 20817},
+						pos:  position{line: 879, col: 5, offset: 20895},
 						name: "BetweenExpr",
 					},
 				},
@@ -5726,42 +5789,42 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 878, col: 1, offset: 20830},
+			pos:  position{line: 881, col: 1, offset: 20908},
 			expr: &choiceExpr{
-				pos: position{line: 879, col: 5, offset: 20846},
+				pos: position{line: 882, col: 5, offset: 20924},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 879, col: 5, offset: 20846},
+						pos: position{line: 882, col: 5, offset: 20924},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 879, col: 5, offset: 20846},
+							pos: position{line: 882, col: 5, offset: 20924},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 879, col: 5, offset: 20846},
+									pos:   position{line: 882, col: 5, offset: 20924},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 879, col: 10, offset: 20851},
+										pos:  position{line: 882, col: 10, offset: 20929},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 25, offset: 20866},
+									pos:  position{line: 882, col: 25, offset: 20944},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 879, col: 27, offset: 20868},
+									pos:   position{line: 882, col: 27, offset: 20946},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 879, col: 31, offset: 20872},
+										pos: position{line: 882, col: 31, offset: 20950},
 										expr: &seqExpr{
-											pos: position{line: 879, col: 32, offset: 20873},
+											pos: position{line: 882, col: 32, offset: 20951},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 32, offset: 20873},
+													pos:  position{line: 882, col: 32, offset: 20951},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 36, offset: 20877},
+													pos:  position{line: 882, col: 36, offset: 20955},
 													name: "_",
 												},
 											},
@@ -5769,38 +5832,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 40, offset: 20881},
+									pos:  position{line: 882, col: 40, offset: 20959},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 48, offset: 20889},
+									pos:  position{line: 882, col: 48, offset: 20967},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 879, col: 50, offset: 20891},
+									pos:   position{line: 882, col: 50, offset: 20969},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 879, col: 56, offset: 20897},
+										pos:  position{line: 882, col: 56, offset: 20975},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 68, offset: 20909},
+									pos:  position{line: 882, col: 68, offset: 20987},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 70, offset: 20911},
+									pos:  position{line: 882, col: 70, offset: 20989},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 879, col: 74, offset: 20915},
+									pos:  position{line: 882, col: 74, offset: 20993},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 879, col: 76, offset: 20917},
+									pos:   position{line: 882, col: 76, offset: 20995},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 879, col: 82, offset: 20923},
+										pos:  position{line: 882, col: 82, offset: 21001},
 										name: "BetweenExpr",
 									},
 								},
@@ -5808,7 +5871,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 889, col: 5, offset: 21155},
+						pos:  position{line: 892, col: 5, offset: 21233},
 						name: "ComparisonExpr",
 					},
 				},
@@ -5818,46 +5881,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 891, col: 1, offset: 21171},
+			pos:  position{line: 894, col: 1, offset: 21249},
 			expr: &choiceExpr{
-				pos: position{line: 892, col: 5, offset: 21190},
+				pos: position{line: 895, col: 5, offset: 21268},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 892, col: 5, offset: 21190},
+						pos: position{line: 895, col: 5, offset: 21268},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 892, col: 5, offset: 21190},
+							pos: position{line: 895, col: 5, offset: 21268},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 892, col: 5, offset: 21190},
+									pos:   position{line: 895, col: 5, offset: 21268},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 892, col: 10, offset: 21195},
+										pos:  position{line: 895, col: 10, offset: 21273},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 892, col: 23, offset: 21208},
+									pos:  position{line: 895, col: 23, offset: 21286},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 892, col: 25, offset: 21210},
+									pos:  position{line: 895, col: 25, offset: 21288},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 892, col: 28, offset: 21213},
+									pos:   position{line: 895, col: 28, offset: 21291},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 892, col: 32, offset: 21217},
+										pos: position{line: 895, col: 32, offset: 21295},
 										expr: &seqExpr{
-											pos: position{line: 892, col: 33, offset: 21218},
+											pos: position{line: 895, col: 33, offset: 21296},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 892, col: 33, offset: 21218},
+													pos:  position{line: 895, col: 33, offset: 21296},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 892, col: 35, offset: 21220},
+													pos:  position{line: 895, col: 35, offset: 21298},
 													name: "NOT",
 												},
 											},
@@ -5865,83 +5928,83 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 892, col: 41, offset: 21226},
+									pos:  position{line: 895, col: 41, offset: 21304},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 892, col: 43, offset: 21228},
+									pos:  position{line: 895, col: 43, offset: 21306},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 900, col: 5, offset: 21393},
+						pos: position{line: 903, col: 5, offset: 21471},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 900, col: 5, offset: 21393},
+							pos: position{line: 903, col: 5, offset: 21471},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 900, col: 5, offset: 21393},
+									pos:   position{line: 903, col: 5, offset: 21471},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 900, col: 9, offset: 21397},
+										pos:  position{line: 903, col: 9, offset: 21475},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 900, col: 22, offset: 21410},
+									pos:   position{line: 903, col: 22, offset: 21488},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 900, col: 31, offset: 21419},
+										pos: position{line: 903, col: 31, offset: 21497},
 										expr: &choiceExpr{
-											pos: position{line: 900, col: 32, offset: 21420},
+											pos: position{line: 903, col: 32, offset: 21498},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 900, col: 32, offset: 21420},
+													pos: position{line: 903, col: 32, offset: 21498},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 900, col: 32, offset: 21420},
+															pos:  position{line: 903, col: 32, offset: 21498},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 900, col: 35, offset: 21423},
+															pos:  position{line: 903, col: 35, offset: 21501},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 900, col: 46, offset: 21434},
+															pos:  position{line: 903, col: 46, offset: 21512},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 900, col: 49, offset: 21437},
+															pos:  position{line: 903, col: 49, offset: 21515},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 900, col: 64, offset: 21452},
+													pos: position{line: 903, col: 64, offset: 21530},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 900, col: 64, offset: 21452},
+															pos:  position{line: 903, col: 64, offset: 21530},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 900, col: 68, offset: 21456},
+															pos: position{line: 903, col: 68, offset: 21534},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 900, col: 68, offset: 21456},
+																pos:        position{line: 903, col: 68, offset: 21534},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 900, col: 104, offset: 21492},
+															pos:  position{line: 903, col: 104, offset: 21570},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 900, col: 107, offset: 21495},
-															name: "Regexp",
+															pos:  position{line: 903, col: 107, offset: 21573},
+															name: "AdditiveExpr",
 														},
 													},
 												},
@@ -5959,53 +6022,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 913, col: 1, offset: 21780},
+			pos:  position{line: 916, col: 1, offset: 21864},
 			expr: &actionExpr{
-				pos: position{line: 914, col: 5, offset: 21797},
+				pos: position{line: 917, col: 5, offset: 21881},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 914, col: 5, offset: 21797},
+					pos: position{line: 917, col: 5, offset: 21881},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 914, col: 5, offset: 21797},
+							pos:   position{line: 917, col: 5, offset: 21881},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 914, col: 11, offset: 21803},
+								pos:  position{line: 917, col: 11, offset: 21887},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 915, col: 5, offset: 21826},
+							pos:   position{line: 918, col: 5, offset: 21910},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 915, col: 10, offset: 21831},
+								pos: position{line: 918, col: 10, offset: 21915},
 								expr: &actionExpr{
-									pos: position{line: 915, col: 11, offset: 21832},
+									pos: position{line: 918, col: 11, offset: 21916},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 915, col: 11, offset: 21832},
+										pos: position{line: 918, col: 11, offset: 21916},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 915, col: 11, offset: 21832},
+												pos:  position{line: 918, col: 11, offset: 21916},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 915, col: 14, offset: 21835},
+												pos:   position{line: 918, col: 14, offset: 21919},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 915, col: 17, offset: 21838},
+													pos:  position{line: 918, col: 17, offset: 21922},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 915, col: 34, offset: 21855},
+												pos:  position{line: 918, col: 34, offset: 21939},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 915, col: 37, offset: 21858},
+												pos:   position{line: 918, col: 37, offset: 21942},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 915, col: 42, offset: 21863},
+													pos:  position{line: 918, col: 42, offset: 21947},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6022,21 +6085,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 919, col: 1, offset: 21981},
+			pos:  position{line: 922, col: 1, offset: 22065},
 			expr: &actionExpr{
-				pos: position{line: 919, col: 20, offset: 22000},
+				pos: position{line: 922, col: 20, offset: 22084},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 919, col: 21, offset: 22001},
+					pos: position{line: 922, col: 21, offset: 22085},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 919, col: 21, offset: 22001},
+							pos:        position{line: 922, col: 21, offset: 22085},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 919, col: 27, offset: 22007},
+							pos:        position{line: 922, col: 27, offset: 22091},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6049,53 +6112,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 921, col: 1, offset: 22044},
+			pos:  position{line: 924, col: 1, offset: 22128},
 			expr: &actionExpr{
-				pos: position{line: 922, col: 5, offset: 22067},
+				pos: position{line: 925, col: 5, offset: 22151},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 922, col: 5, offset: 22067},
+					pos: position{line: 925, col: 5, offset: 22151},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 922, col: 5, offset: 22067},
+							pos:   position{line: 925, col: 5, offset: 22151},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 922, col: 11, offset: 22073},
+								pos:  position{line: 925, col: 11, offset: 22157},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 923, col: 5, offset: 22088},
+							pos:   position{line: 926, col: 5, offset: 22172},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 923, col: 10, offset: 22093},
+								pos: position{line: 926, col: 10, offset: 22177},
 								expr: &actionExpr{
-									pos: position{line: 923, col: 11, offset: 22094},
+									pos: position{line: 926, col: 11, offset: 22178},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 923, col: 11, offset: 22094},
+										pos: position{line: 926, col: 11, offset: 22178},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 923, col: 11, offset: 22094},
+												pos:  position{line: 926, col: 11, offset: 22178},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 923, col: 14, offset: 22097},
+												pos:   position{line: 926, col: 14, offset: 22181},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 923, col: 17, offset: 22100},
+													pos:  position{line: 926, col: 17, offset: 22184},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 923, col: 40, offset: 22123},
+												pos:  position{line: 926, col: 40, offset: 22207},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 923, col: 43, offset: 22126},
+												pos:   position{line: 926, col: 43, offset: 22210},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 923, col: 48, offset: 22131},
+													pos:  position{line: 926, col: 48, offset: 22215},
 													name: "ConcatExpr",
 												},
 											},
@@ -6112,27 +6175,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 927, col: 1, offset: 22241},
+			pos:  position{line: 930, col: 1, offset: 22325},
 			expr: &actionExpr{
-				pos: position{line: 927, col: 26, offset: 22266},
+				pos: position{line: 930, col: 26, offset: 22350},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 927, col: 27, offset: 22267},
+					pos: position{line: 930, col: 27, offset: 22351},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 927, col: 27, offset: 22267},
+							pos:        position{line: 930, col: 27, offset: 22351},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 927, col: 33, offset: 22273},
+							pos:        position{line: 930, col: 33, offset: 22357},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 927, col: 39, offset: 22279},
+							pos:        position{line: 930, col: 39, offset: 22363},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6145,51 +6208,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 929, col: 1, offset: 22316},
+			pos:  position{line: 932, col: 1, offset: 22400},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 5, offset: 22331},
+				pos: position{line: 933, col: 5, offset: 22415},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 930, col: 5, offset: 22331},
+					pos: position{line: 933, col: 5, offset: 22415},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 930, col: 5, offset: 22331},
+							pos:   position{line: 933, col: 5, offset: 22415},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 930, col: 11, offset: 22337},
+								pos:  position{line: 933, col: 11, offset: 22421},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 931, col: 5, offset: 22358},
+							pos:   position{line: 934, col: 5, offset: 22442},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 931, col: 10, offset: 22363},
+								pos: position{line: 934, col: 10, offset: 22447},
 								expr: &actionExpr{
-									pos: position{line: 931, col: 11, offset: 22364},
+									pos: position{line: 934, col: 11, offset: 22448},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 931, col: 11, offset: 22364},
+										pos: position{line: 934, col: 11, offset: 22448},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 931, col: 11, offset: 22364},
+												pos:  position{line: 934, col: 11, offset: 22448},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 931, col: 14, offset: 22367},
+												pos:        position{line: 934, col: 14, offset: 22451},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 931, col: 19, offset: 22372},
+												pos:  position{line: 934, col: 19, offset: 22456},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 931, col: 22, offset: 22375},
+												pos:   position{line: 934, col: 22, offset: 22459},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 931, col: 27, offset: 22380},
+													pos:  position{line: 934, col: 27, offset: 22464},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6206,40 +6269,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 935, col: 1, offset: 22498},
+			pos:  position{line: 938, col: 1, offset: 22582},
 			expr: &choiceExpr{
-				pos: position{line: 936, col: 5, offset: 22519},
+				pos: position{line: 939, col: 5, offset: 22603},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 936, col: 5, offset: 22519},
+						pos: position{line: 939, col: 5, offset: 22603},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 936, col: 5, offset: 22519},
+							pos: position{line: 939, col: 5, offset: 22603},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 936, col: 5, offset: 22519},
+									pos: position{line: 939, col: 5, offset: 22603},
 									expr: &ruleRefExpr{
-										pos:  position{line: 936, col: 6, offset: 22520},
+										pos:  position{line: 939, col: 6, offset: 22604},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 936, col: 14, offset: 22528},
+									pos:   position{line: 939, col: 14, offset: 22612},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 936, col: 17, offset: 22531},
+										pos:  position{line: 939, col: 17, offset: 22615},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 31, offset: 22545},
+									pos:  position{line: 939, col: 31, offset: 22629},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 936, col: 34, offset: 22548},
+									pos:   position{line: 939, col: 34, offset: 22632},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 936, col: 36, offset: 22550},
+										pos:  position{line: 939, col: 36, offset: 22634},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6247,7 +6310,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 945, col: 5, offset: 22734},
+						pos:  position{line: 948, col: 5, offset: 22818},
 						name: "ColonCast",
 					},
 				},
@@ -6257,21 +6320,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 947, col: 1, offset: 22745},
+			pos:  position{line: 950, col: 1, offset: 22829},
 			expr: &actionExpr{
-				pos: position{line: 947, col: 17, offset: 22761},
+				pos: position{line: 950, col: 17, offset: 22845},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 947, col: 18, offset: 22762},
+					pos: position{line: 950, col: 18, offset: 22846},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 947, col: 18, offset: 22762},
+							pos:        position{line: 950, col: 18, offset: 22846},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 947, col: 24, offset: 22768},
+							pos:        position{line: 950, col: 24, offset: 22852},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6284,58 +6347,58 @@ var g = &grammar{
 		},
 		{
 			name: "ColonCast",
-			pos:  position{line: 949, col: 1, offset: 22805},
+			pos:  position{line: 952, col: 1, offset: 22889},
 			expr: &actionExpr{
-				pos: position{line: 950, col: 5, offset: 22819},
+				pos: position{line: 953, col: 5, offset: 22903},
 				run: (*parser).callonColonCast1,
 				expr: &seqExpr{
-					pos: position{line: 950, col: 5, offset: 22819},
+					pos: position{line: 953, col: 5, offset: 22903},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 950, col: 5, offset: 22819},
+							pos:   position{line: 953, col: 5, offset: 22903},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 950, col: 11, offset: 22825},
+								pos:  position{line: 953, col: 11, offset: 22909},
 								name: "DerefExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 951, col: 5, offset: 22839},
+							pos:   position{line: 954, col: 5, offset: 22923},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 951, col: 10, offset: 22844},
+								pos: position{line: 954, col: 10, offset: 22928},
 								expr: &actionExpr{
-									pos: position{line: 951, col: 11, offset: 22845},
+									pos: position{line: 954, col: 11, offset: 22929},
 									run: (*parser).callonColonCast7,
 									expr: &seqExpr{
-										pos: position{line: 951, col: 11, offset: 22845},
+										pos: position{line: 954, col: 11, offset: 22929},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 951, col: 11, offset: 22845},
+												pos:  position{line: 954, col: 11, offset: 22929},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 951, col: 14, offset: 22848},
+												pos:        position{line: 954, col: 14, offset: 22932},
 												val:        "::",
 												ignoreCase: false,
 												want:       "\"::\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 951, col: 19, offset: 22853},
+												pos:  position{line: 954, col: 19, offset: 22937},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 951, col: 22, offset: 22856},
+												pos:   position{line: 954, col: 22, offset: 22940},
 												label: "expr",
 												expr: &choiceExpr{
-													pos: position{line: 951, col: 28, offset: 22862},
+													pos: position{line: 954, col: 28, offset: 22946},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 951, col: 28, offset: 22862},
+															pos:  position{line: 954, col: 28, offset: 22946},
 															name: "TypeAsValue",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 951, col: 42, offset: 22876},
+															pos:  position{line: 954, col: 42, offset: 22960},
 															name: "DerefExpr",
 														},
 													},
@@ -6354,73 +6417,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 955, col: 1, offset: 22986},
+			pos:  position{line: 958, col: 1, offset: 23070},
 			expr: &choiceExpr{
-				pos: position{line: 956, col: 5, offset: 23000},
+				pos: position{line: 959, col: 5, offset: 23084},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 956, col: 5, offset: 23000},
+						pos: position{line: 959, col: 5, offset: 23084},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 956, col: 5, offset: 23000},
+							pos: position{line: 959, col: 5, offset: 23084},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 956, col: 5, offset: 23000},
+									pos:   position{line: 959, col: 5, offset: 23084},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 956, col: 10, offset: 23005},
+										pos:  position{line: 959, col: 10, offset: 23089},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 956, col: 20, offset: 23015},
+									pos:        position{line: 959, col: 20, offset: 23099},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 956, col: 24, offset: 23019},
+									pos:  position{line: 959, col: 24, offset: 23103},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 956, col: 27, offset: 23022},
+									pos:   position{line: 959, col: 27, offset: 23106},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 956, col: 32, offset: 23027},
+										pos:  position{line: 959, col: 32, offset: 23111},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 956, col: 45, offset: 23040},
+									pos:  position{line: 959, col: 45, offset: 23124},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 956, col: 48, offset: 23043},
+									pos:        position{line: 959, col: 48, offset: 23127},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 956, col: 52, offset: 23047},
+									pos:  position{line: 959, col: 52, offset: 23131},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 956, col: 55, offset: 23050},
+									pos:   position{line: 959, col: 55, offset: 23134},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 956, col: 58, offset: 23053},
+										pos: position{line: 959, col: 58, offset: 23137},
 										expr: &ruleRefExpr{
-											pos:  position{line: 956, col: 58, offset: 23053},
+											pos:  position{line: 959, col: 58, offset: 23137},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 956, col: 72, offset: 23067},
+									pos:  position{line: 959, col: 72, offset: 23151},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 956, col: 75, offset: 23070},
+									pos:        position{line: 959, col: 75, offset: 23154},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6429,49 +6492,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 968, col: 5, offset: 23309},
+						pos: position{line: 971, col: 5, offset: 23393},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 968, col: 5, offset: 23309},
+							pos: position{line: 971, col: 5, offset: 23393},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 968, col: 5, offset: 23309},
+									pos:   position{line: 971, col: 5, offset: 23393},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 968, col: 10, offset: 23314},
+										pos:  position{line: 971, col: 10, offset: 23398},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 968, col: 20, offset: 23324},
+									pos:        position{line: 971, col: 20, offset: 23408},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 968, col: 24, offset: 23328},
+									pos:  position{line: 971, col: 24, offset: 23412},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 968, col: 27, offset: 23331},
+									pos:        position{line: 971, col: 27, offset: 23415},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 968, col: 31, offset: 23335},
+									pos:  position{line: 971, col: 31, offset: 23419},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 968, col: 34, offset: 23338},
+									pos:   position{line: 971, col: 34, offset: 23422},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 968, col: 37, offset: 23341},
+										pos:  position{line: 971, col: 37, offset: 23425},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 968, col: 50, offset: 23354},
+									pos:        position{line: 971, col: 50, offset: 23438},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6480,35 +6543,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 976, col: 5, offset: 23518},
+						pos: position{line: 979, col: 5, offset: 23602},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 976, col: 5, offset: 23518},
+							pos: position{line: 979, col: 5, offset: 23602},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 976, col: 5, offset: 23518},
+									pos:   position{line: 979, col: 5, offset: 23602},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 10, offset: 23523},
+										pos:  position{line: 979, col: 10, offset: 23607},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 976, col: 20, offset: 23533},
+									pos:        position{line: 979, col: 20, offset: 23617},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 24, offset: 23537},
+									pos:   position{line: 979, col: 24, offset: 23621},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 30, offset: 23543},
+										pos:  position{line: 979, col: 30, offset: 23627},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 976, col: 35, offset: 23548},
+									pos:        position{line: 979, col: 35, offset: 23632},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6517,30 +6580,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 984, col: 5, offset: 23718},
+						pos: position{line: 987, col: 5, offset: 23802},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 984, col: 5, offset: 23718},
+							pos: position{line: 987, col: 5, offset: 23802},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 984, col: 5, offset: 23718},
+									pos:   position{line: 987, col: 5, offset: 23802},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 984, col: 10, offset: 23723},
+										pos:  position{line: 987, col: 10, offset: 23807},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 984, col: 20, offset: 23733},
+									pos:        position{line: 987, col: 20, offset: 23817},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 984, col: 24, offset: 23737},
+									pos:   position{line: 987, col: 24, offset: 23821},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 984, col: 27, offset: 23740},
+										pos:  position{line: 987, col: 27, offset: 23824},
 										name: "DerefKey",
 									},
 								},
@@ -6548,11 +6611,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 5, offset: 23928},
+						pos:  position{line: 996, col: 5, offset: 24012},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 994, col: 5, offset: 23941},
+						pos:  position{line: 997, col: 5, offset: 24025},
 						name: "Primary",
 					},
 				},
@@ -6562,34 +6625,34 @@ var g = &grammar{
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 996, col: 1, offset: 23950},
+			pos:  position{line: 999, col: 1, offset: 24034},
 			expr: &choiceExpr{
-				pos: position{line: 997, col: 5, offset: 23963},
+				pos: position{line: 1000, col: 5, offset: 24047},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 997, col: 5, offset: 23963},
+						pos:  position{line: 1000, col: 5, offset: 24047},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 998, col: 5, offset: 23978},
+						pos: position{line: 1001, col: 5, offset: 24062},
 						run: (*parser).callonDerefKey3,
 						expr: &labeledExpr{
-							pos:   position{line: 998, col: 5, offset: 23978},
+							pos:   position{line: 1001, col: 5, offset: 24062},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 998, col: 7, offset: 23980},
+								pos:  position{line: 1001, col: 7, offset: 24064},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 999, col: 5, offset: 24072},
+						pos: position{line: 1002, col: 5, offset: 24156},
 						run: (*parser).callonDerefKey6,
 						expr: &labeledExpr{
-							pos:   position{line: 999, col: 5, offset: 24072},
+							pos:   position{line: 1002, col: 5, offset: 24156},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 999, col: 7, offset: 24074},
+								pos:  position{line: 1002, col: 7, offset: 24158},
 								name: "BacktickString",
 							},
 						},
@@ -6601,16 +6664,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 1001, col: 1, offset: 24163},
+			pos:  position{line: 1004, col: 1, offset: 24247},
 			expr: &choiceExpr{
-				pos: position{line: 1002, col: 5, offset: 24176},
+				pos: position{line: 1005, col: 5, offset: 24260},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 5, offset: 24176},
+						pos:  position{line: 1005, col: 5, offset: 24260},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1003, col: 5, offset: 24185},
+						pos:  position{line: 1006, col: 5, offset: 24269},
 						name: "Function",
 					},
 				},
@@ -6620,20 +6683,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1005, col: 1, offset: 24195},
+			pos:  position{line: 1008, col: 1, offset: 24279},
 			expr: &seqExpr{
-				pos: position{line: 1005, col: 13, offset: 24207},
+				pos: position{line: 1008, col: 13, offset: 24291},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 13, offset: 24207},
+						pos:  position{line: 1008, col: 13, offset: 24291},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 22, offset: 24216},
+						pos:  position{line: 1008, col: 22, offset: 24300},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1005, col: 25, offset: 24219},
+						pos:        position{line: 1008, col: 25, offset: 24303},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -6645,16 +6708,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1007, col: 1, offset: 24224},
+			pos:  position{line: 1010, col: 1, offset: 24308},
 			expr: &choiceExpr{
-				pos: position{line: 1008, col: 5, offset: 24237},
+				pos: position{line: 1011, col: 5, offset: 24321},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 24237},
+						pos:  position{line: 1011, col: 5, offset: 24321},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 24245},
+						pos:  position{line: 1012, col: 5, offset: 24329},
 						name: "SELECT",
 					},
 				},
@@ -6664,49 +6727,49 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1011, col: 1, offset: 24253},
+			pos:  position{line: 1014, col: 1, offset: 24337},
 			expr: &actionExpr{
-				pos: position{line: 1012, col: 5, offset: 24262},
+				pos: position{line: 1015, col: 5, offset: 24346},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1012, col: 5, offset: 24262},
+					pos: position{line: 1015, col: 5, offset: 24346},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1012, col: 5, offset: 24262},
+							pos:   position{line: 1015, col: 5, offset: 24346},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1012, col: 9, offset: 24266},
+								pos:  position{line: 1015, col: 9, offset: 24350},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1012, col: 21, offset: 24278},
+							pos:  position{line: 1015, col: 21, offset: 24362},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1012, col: 24, offset: 24281},
+							pos:        position{line: 1015, col: 24, offset: 24365},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1012, col: 28, offset: 24285},
+							pos:  position{line: 1015, col: 28, offset: 24369},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1012, col: 31, offset: 24288},
+							pos:   position{line: 1015, col: 31, offset: 24372},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1012, col: 36, offset: 24293},
+								pos:  position{line: 1015, col: 36, offset: 24377},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1012, col: 41, offset: 24298},
+							pos:  position{line: 1015, col: 41, offset: 24382},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1012, col: 44, offset: 24301},
+							pos:        position{line: 1015, col: 44, offset: 24385},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -6719,268 +6782,86 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1016, col: 1, offset: 24414},
+			pos:  position{line: 1019, col: 1, offset: 24498},
 			expr: &choiceExpr{
-				pos: position{line: 1017, col: 5, offset: 24427},
+				pos: position{line: 1020, col: 5, offset: 24511},
 				alternatives: []any{
-					&ruleRefExpr{
-						pos:  position{line: 1017, col: 5, offset: 24427},
-						name: "Grep",
-					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 24514},
-						run: (*parser).callonFunction3,
+						pos: position{line: 1020, col: 5, offset: 24511},
+						run: (*parser).callonFunction2,
 						expr: &seqExpr{
-							pos: position{line: 1019, col: 5, offset: 24514},
-							exprs: []any{
-								&ruleRefExpr{
-									pos:  position{line: 1019, col: 5, offset: 24514},
-									name: "REGEXP",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1019, col: 12, offset: 24521},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 1019, col: 15, offset: 24524},
-									val:        "(",
-									ignoreCase: false,
-									want:       "\"(\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1019, col: 19, offset: 24528},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 1019, col: 22, offset: 24531},
-									label: "arg0",
-									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 27, offset: 24536},
-										name: "RegexpPrimitive",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1019, col: 43, offset: 24552},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 1019, col: 46, offset: 24555},
-									val:        ",",
-									ignoreCase: false,
-									want:       "\",\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1019, col: 50, offset: 24559},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 1019, col: 53, offset: 24562},
-									label: "arg1",
-									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 58, offset: 24567},
-										name: "Expr",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1019, col: 63, offset: 24572},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 1019, col: 66, offset: 24575},
-									val:        ")",
-									ignoreCase: false,
-									want:       "\")\"",
-								},
-								&labeledExpr{
-									pos:   position{line: 1019, col: 70, offset: 24579},
-									label: "where",
-									expr: &zeroOrOneExpr{
-										pos: position{line: 1019, col: 76, offset: 24585},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1019, col: 76, offset: 24585},
-											name: "WhereClause",
-										},
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 24764},
-						run: (*parser).callonFunction21,
-						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 24764},
-							exprs: []any{
-								&ruleRefExpr{
-									pos:  position{line: 1023, col: 5, offset: 24764},
-									name: "REGEXP_REPLACE",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1023, col: 20, offset: 24779},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 1023, col: 23, offset: 24782},
-									val:        "(",
-									ignoreCase: false,
-									want:       "\"(\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1023, col: 27, offset: 24786},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 1023, col: 30, offset: 24789},
-									label: "arg0",
-									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 35, offset: 24794},
-										name: "Expr",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1023, col: 40, offset: 24799},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 1023, col: 43, offset: 24802},
-									val:        ",",
-									ignoreCase: false,
-									want:       "\",\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1023, col: 47, offset: 24806},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 1023, col: 50, offset: 24809},
-									label: "arg1",
-									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 55, offset: 24814},
-										name: "RegexpPrimitive",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1023, col: 71, offset: 24830},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 1023, col: 74, offset: 24833},
-									val:        ",",
-									ignoreCase: false,
-									want:       "\",\"",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1023, col: 78, offset: 24837},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 1023, col: 81, offset: 24840},
-									label: "arg2",
-									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 86, offset: 24845},
-										name: "Expr",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1023, col: 91, offset: 24850},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 1023, col: 94, offset: 24853},
-									val:        ")",
-									ignoreCase: false,
-									want:       "\")\"",
-								},
-								&labeledExpr{
-									pos:   position{line: 1023, col: 98, offset: 24857},
-									label: "where",
-									expr: &zeroOrOneExpr{
-										pos: position{line: 1023, col: 104, offset: 24863},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1023, col: 104, offset: 24863},
-											name: "WhereClause",
-										},
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 1027, col: 5, offset: 25057},
-						run: (*parser).callonFunction44,
-						expr: &seqExpr{
-							pos: position{line: 1027, col: 5, offset: 25057},
+							pos: position{line: 1020, col: 5, offset: 24511},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1027, col: 5, offset: 25057},
+									pos: position{line: 1020, col: 5, offset: 24511},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 6, offset: 25058},
+										pos:  position{line: 1020, col: 6, offset: 24512},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 16, offset: 25068},
+									pos:  position{line: 1020, col: 16, offset: 24522},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 24, offset: 25076},
+									pos:  position{line: 1020, col: 24, offset: 24530},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 27, offset: 25079},
+									pos:        position{line: 1020, col: 27, offset: 24533},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 31, offset: 25083},
+									pos:  position{line: 1020, col: 31, offset: 24537},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 34, offset: 25086},
+									pos:   position{line: 1020, col: 34, offset: 24540},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 39, offset: 25091},
+										pos:  position{line: 1020, col: 39, offset: 24545},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 44, offset: 25096},
+									pos:  position{line: 1020, col: 44, offset: 24550},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 46, offset: 25098},
+									pos:  position{line: 1020, col: 46, offset: 24552},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 51, offset: 25103},
+									pos:  position{line: 1020, col: 51, offset: 24557},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 53, offset: 25105},
+									pos:   position{line: 1020, col: 53, offset: 24559},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 55, offset: 25107},
+										pos:  position{line: 1020, col: 55, offset: 24561},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 60, offset: 25112},
+									pos:  position{line: 1020, col: 60, offset: 24566},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 63, offset: 25115},
+									pos:        position{line: 1020, col: 63, offset: 24569},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 67, offset: 25119},
+									pos:   position{line: 1020, col: 67, offset: 24573},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1027, col: 73, offset: 25125},
+										pos: position{line: 1020, col: 73, offset: 24579},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1027, col: 73, offset: 25125},
+											pos:  position{line: 1020, col: 73, offset: 24579},
 											name: "WhereClause",
 										},
 									},
@@ -6989,50 +6870,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1035, col: 5, offset: 25303},
-						run: (*parser).callonFunction64,
+						pos: position{line: 1028, col: 5, offset: 24757},
+						run: (*parser).callonFunction22,
 						expr: &seqExpr{
-							pos: position{line: 1035, col: 5, offset: 25303},
+							pos: position{line: 1028, col: 5, offset: 24757},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1035, col: 5, offset: 25303},
+									pos: position{line: 1028, col: 5, offset: 24757},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1035, col: 6, offset: 25304},
+										pos:  position{line: 1028, col: 6, offset: 24758},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1035, col: 16, offset: 25314},
+									pos:  position{line: 1028, col: 16, offset: 24768},
 									name: "EXISTS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1035, col: 23, offset: 25321},
+									pos:  position{line: 1028, col: 23, offset: 24775},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1035, col: 26, offset: 25324},
+									pos:        position{line: 1028, col: 26, offset: 24778},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1035, col: 30, offset: 25328},
+									pos:  position{line: 1028, col: 30, offset: 24782},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1035, col: 33, offset: 25331},
+									pos:   position{line: 1028, col: 33, offset: 24785},
 									label: "body",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1035, col: 38, offset: 25336},
+										pos:  position{line: 1028, col: 38, offset: 24790},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1035, col: 42, offset: 25340},
+									pos:  position{line: 1028, col: 42, offset: 24794},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1035, col: 45, offset: 25343},
+									pos:        position{line: 1028, col: 45, offset: 24797},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7041,70 +6922,70 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1042, col: 5, offset: 25480},
-						run: (*parser).callonFunction76,
+						pos: position{line: 1035, col: 5, offset: 24934},
+						run: (*parser).callonFunction34,
 						expr: &seqExpr{
-							pos: position{line: 1042, col: 5, offset: 25480},
+							pos: position{line: 1035, col: 5, offset: 24934},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1042, col: 5, offset: 25480},
+									pos: position{line: 1035, col: 5, offset: 24934},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1042, col: 6, offset: 25481},
+										pos:  position{line: 1035, col: 6, offset: 24935},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1042, col: 16, offset: 25491},
+									pos:  position{line: 1035, col: 16, offset: 24945},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1042, col: 21, offset: 25496},
+									pos:  position{line: 1035, col: 21, offset: 24950},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1042, col: 24, offset: 25499},
+									pos:        position{line: 1035, col: 24, offset: 24953},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1042, col: 28, offset: 25503},
+									pos:  position{line: 1035, col: 28, offset: 24957},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1042, col: 31, offset: 25506},
+									pos:   position{line: 1035, col: 31, offset: 24960},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1042, col: 33, offset: 25508},
+										pos:  position{line: 1035, col: 33, offset: 24962},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1042, col: 38, offset: 25513},
+									pos:  position{line: 1035, col: 38, offset: 24967},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1042, col: 40, offset: 25515},
+									pos:  position{line: 1035, col: 40, offset: 24969},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1042, col: 43, offset: 25518},
+									pos:  position{line: 1035, col: 43, offset: 24972},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1042, col: 45, offset: 25520},
+									pos:   position{line: 1035, col: 45, offset: 24974},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1042, col: 49, offset: 25524},
+										pos:  position{line: 1035, col: 49, offset: 24978},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1042, col: 60, offset: 25535},
+									pos:  position{line: 1035, col: 60, offset: 24989},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1042, col: 63, offset: 25538},
+									pos:        position{line: 1035, col: 63, offset: 24992},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7113,72 +6994,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1050, col: 5, offset: 25697},
-						run: (*parser).callonFunction93,
+						pos: position{line: 1043, col: 5, offset: 25151},
+						run: (*parser).callonFunction51,
 						expr: &seqExpr{
-							pos: position{line: 1050, col: 5, offset: 25697},
+							pos: position{line: 1043, col: 5, offset: 25151},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1050, col: 5, offset: 25697},
+									pos: position{line: 1043, col: 5, offset: 25151},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1050, col: 6, offset: 25698},
+										pos:  position{line: 1043, col: 6, offset: 25152},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 16, offset: 25708},
+									pos:  position{line: 1043, col: 16, offset: 25162},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 26, offset: 25718},
+									pos:  position{line: 1043, col: 26, offset: 25172},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1050, col: 29, offset: 25721},
+									pos:        position{line: 1043, col: 29, offset: 25175},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 33, offset: 25725},
+									pos:  position{line: 1043, col: 33, offset: 25179},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1050, col: 36, offset: 25728},
+									pos:   position{line: 1043, col: 36, offset: 25182},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1050, col: 41, offset: 25733},
+										pos:  position{line: 1043, col: 41, offset: 25187},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1050, col: 46, offset: 25738},
+									pos:   position{line: 1043, col: 46, offset: 25192},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1050, col: 51, offset: 25743},
+										pos: position{line: 1043, col: 51, offset: 25197},
 										expr: &actionExpr{
-											pos: position{line: 1050, col: 52, offset: 25744},
-											run: (*parser).callonFunction105,
+											pos: position{line: 1043, col: 52, offset: 25198},
+											run: (*parser).callonFunction63,
 											expr: &seqExpr{
-												pos: position{line: 1050, col: 52, offset: 25744},
+												pos: position{line: 1043, col: 52, offset: 25198},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1050, col: 52, offset: 25744},
+														pos:  position{line: 1043, col: 52, offset: 25198},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1050, col: 54, offset: 25746},
+														pos:  position{line: 1043, col: 54, offset: 25200},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1050, col: 59, offset: 25751},
+														pos:  position{line: 1043, col: 59, offset: 25205},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1050, col: 61, offset: 25753},
+														pos:   position{line: 1043, col: 61, offset: 25207},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1050, col: 63, offset: 25755},
+															pos:  position{line: 1043, col: 63, offset: 25209},
 															name: "Expr",
 														},
 													},
@@ -7188,33 +7069,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1050, col: 88, offset: 25780},
+									pos:   position{line: 1043, col: 88, offset: 25234},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1050, col: 93, offset: 25785},
+										pos: position{line: 1043, col: 93, offset: 25239},
 										expr: &actionExpr{
-											pos: position{line: 1050, col: 94, offset: 25786},
-											run: (*parser).callonFunction114,
+											pos: position{line: 1043, col: 94, offset: 25240},
+											run: (*parser).callonFunction72,
 											expr: &seqExpr{
-												pos: position{line: 1050, col: 94, offset: 25786},
+												pos: position{line: 1043, col: 94, offset: 25240},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1050, col: 94, offset: 25786},
+														pos:  position{line: 1043, col: 94, offset: 25240},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1050, col: 96, offset: 25788},
+														pos:  position{line: 1043, col: 96, offset: 25242},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1050, col: 100, offset: 25792},
+														pos:  position{line: 1043, col: 100, offset: 25246},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1050, col: 102, offset: 25794},
+														pos:   position{line: 1043, col: 102, offset: 25248},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1050, col: 104, offset: 25796},
+															pos:  position{line: 1043, col: 104, offset: 25250},
 															name: "Expr",
 														},
 													},
@@ -7224,7 +7105,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1050, col: 129, offset: 25821},
+									pos:        position{line: 1043, col: 129, offset: 25275},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7233,65 +7114,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1064, col: 5, offset: 26104},
-						run: (*parser).callonFunction122,
+						pos: position{line: 1057, col: 5, offset: 25558},
+						run: (*parser).callonFunction80,
 						expr: &seqExpr{
-							pos: position{line: 1064, col: 5, offset: 26104},
+							pos: position{line: 1057, col: 5, offset: 25558},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1064, col: 5, offset: 26104},
+									pos: position{line: 1057, col: 5, offset: 25558},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1064, col: 6, offset: 26105},
+										pos:  position{line: 1057, col: 6, offset: 25559},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1064, col: 16, offset: 26115},
+									pos:   position{line: 1057, col: 16, offset: 25569},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1064, col: 19, offset: 26118},
+										pos:  position{line: 1057, col: 19, offset: 25572},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 30, offset: 26129},
+									pos:  position{line: 1057, col: 30, offset: 25583},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1064, col: 33, offset: 26132},
+									pos:        position{line: 1057, col: 33, offset: 25586},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 37, offset: 26136},
+									pos:  position{line: 1057, col: 37, offset: 25590},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1064, col: 40, offset: 26139},
+									pos:   position{line: 1057, col: 40, offset: 25593},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1064, col: 45, offset: 26144},
+										pos:  position{line: 1057, col: 45, offset: 25598},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1064, col: 58, offset: 26157},
+									pos:  position{line: 1057, col: 58, offset: 25611},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1064, col: 61, offset: 26160},
+									pos:        position{line: 1057, col: 61, offset: 25614},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1064, col: 65, offset: 26164},
+									pos:   position{line: 1057, col: 65, offset: 25618},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1064, col: 71, offset: 26170},
+										pos: position{line: 1057, col: 71, offset: 25624},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1064, col: 71, offset: 26170},
+											pos:  position{line: 1057, col: 71, offset: 25624},
 											name: "WhereClause",
 										},
 									},
@@ -7300,7 +7181,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 5, offset: 26241},
+						pos:  position{line: 1060, col: 5, offset: 25695},
 						name: "CountStar",
 					},
 				},
@@ -7309,141 +7190,21 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "RegexpPrimitive",
-			pos:  position{line: 1069, col: 1, offset: 26252},
-			expr: &actionExpr{
-				pos: position{line: 1070, col: 5, offset: 26272},
-				run: (*parser).callonRegexpPrimitive1,
-				expr: &labeledExpr{
-					pos:   position{line: 1070, col: 5, offset: 26272},
-					label: "pat",
-					expr: &ruleRefExpr{
-						pos:  position{line: 1070, col: 9, offset: 26276},
-						name: "RegexpPattern",
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
 			name: "FunctionArgs",
-			pos:  position{line: 1072, col: 1, offset: 26347},
+			pos:  position{line: 1062, col: 1, offset: 25706},
 			expr: &choiceExpr{
-				pos: position{line: 1073, col: 5, offset: 26364},
+				pos: position{line: 1063, col: 5, offset: 25723},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1073, col: 5, offset: 26364},
+						pos:  position{line: 1063, col: 5, offset: 25723},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1074, col: 5, offset: 26374},
+						pos: position{line: 1064, col: 5, offset: 25733},
 						run: (*parser).callonFunctionArgs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1074, col: 5, offset: 26374},
+							pos:  position{line: 1064, col: 5, offset: 25733},
 							name: "__",
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
-			name: "Grep",
-			pos:  position{line: 1076, col: 1, offset: 26402},
-			expr: &actionExpr{
-				pos: position{line: 1077, col: 5, offset: 26411},
-				run: (*parser).callonGrep1,
-				expr: &seqExpr{
-					pos: position{line: 1077, col: 5, offset: 26411},
-					exprs: []any{
-						&ruleRefExpr{
-							pos:  position{line: 1077, col: 5, offset: 26411},
-							name: "GREP",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 1077, col: 10, offset: 26416},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 1077, col: 13, offset: 26419},
-							val:        "(",
-							ignoreCase: false,
-							want:       "\"(\"",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 1077, col: 17, offset: 26423},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 1077, col: 20, offset: 26426},
-							label: "pattern",
-							expr: &choiceExpr{
-								pos: position{line: 1077, col: 29, offset: 26435},
-								alternatives: []any{
-									&ruleRefExpr{
-										pos:  position{line: 1077, col: 29, offset: 26435},
-										name: "Regexp",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 1077, col: 38, offset: 26444},
-										name: "Glob",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 1077, col: 45, offset: 26451},
-										name: "Expr",
-									},
-								},
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 1077, col: 51, offset: 26457},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 1077, col: 54, offset: 26460},
-							label: "opt",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 1077, col: 58, offset: 26464},
-								expr: &actionExpr{
-									pos: position{line: 1077, col: 59, offset: 26465},
-									run: (*parser).callonGrep15,
-									expr: &seqExpr{
-										pos: position{line: 1077, col: 59, offset: 26465},
-										exprs: []any{
-											&litMatcher{
-												pos:        position{line: 1077, col: 59, offset: 26465},
-												val:        ",",
-												ignoreCase: false,
-												want:       "\",\"",
-											},
-											&ruleRefExpr{
-												pos:  position{line: 1077, col: 63, offset: 26469},
-												name: "__",
-											},
-											&labeledExpr{
-												pos:   position{line: 1077, col: 66, offset: 26472},
-												label: "e",
-												expr: &ruleRefExpr{
-													pos:  position{line: 1077, col: 68, offset: 26474},
-													name: "Expr",
-												},
-											},
-											&ruleRefExpr{
-												pos:  position{line: 1077, col: 73, offset: 26479},
-												name: "__",
-											},
-										},
-									},
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 1077, col: 96, offset: 26502},
-							val:        ")",
-							ignoreCase: false,
-							want:       "\")\"",
 						},
 					},
 				},
@@ -7453,51 +7214,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1089, col: 1, offset: 26715},
+			pos:  position{line: 1066, col: 1, offset: 25761},
 			expr: &actionExpr{
-				pos: position{line: 1090, col: 5, offset: 26725},
+				pos: position{line: 1067, col: 5, offset: 25771},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1090, col: 5, offset: 26725},
+					pos: position{line: 1067, col: 5, offset: 25771},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1090, col: 5, offset: 26725},
+							pos:   position{line: 1067, col: 5, offset: 25771},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 11, offset: 26731},
+								pos:  position{line: 1067, col: 11, offset: 25777},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1090, col: 16, offset: 26736},
+							pos:   position{line: 1067, col: 16, offset: 25782},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1090, col: 21, offset: 26741},
+								pos: position{line: 1067, col: 21, offset: 25787},
 								expr: &actionExpr{
-									pos: position{line: 1090, col: 22, offset: 26742},
+									pos: position{line: 1067, col: 22, offset: 25788},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1090, col: 22, offset: 26742},
+										pos: position{line: 1067, col: 22, offset: 25788},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1090, col: 22, offset: 26742},
+												pos:  position{line: 1067, col: 22, offset: 25788},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1090, col: 25, offset: 26745},
+												pos:        position{line: 1067, col: 25, offset: 25791},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1090, col: 29, offset: 26749},
+												pos:  position{line: 1067, col: 29, offset: 25795},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1090, col: 32, offset: 26752},
+												pos:   position{line: 1067, col: 32, offset: 25798},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1090, col: 34, offset: 26754},
+													pos:  position{line: 1067, col: 34, offset: 25800},
 													name: "Expr",
 												},
 											},
@@ -7514,83 +7275,83 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1094, col: 1, offset: 26827},
+			pos:  position{line: 1071, col: 1, offset: 25873},
 			expr: &choiceExpr{
-				pos: position{line: 1095, col: 5, offset: 26839},
+				pos: position{line: 1072, col: 5, offset: 25885},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1095, col: 5, offset: 26839},
+						pos:  position{line: 1072, col: 5, offset: 25885},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1096, col: 5, offset: 26852},
+						pos:  position{line: 1073, col: 5, offset: 25898},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1097, col: 5, offset: 26863},
+						pos:  position{line: 1074, col: 5, offset: 25909},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1098, col: 5, offset: 26873},
+						pos:  position{line: 1075, col: 5, offset: 25919},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1099, col: 5, offset: 26881},
+						pos:  position{line: 1076, col: 5, offset: 25927},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 26889},
+						pos:  position{line: 1077, col: 5, offset: 25935},
 						name: "SQLTimeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1101, col: 5, offset: 26906},
+						pos:  position{line: 1078, col: 5, offset: 25952},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1102, col: 5, offset: 26918},
+						pos:  position{line: 1079, col: 5, offset: 25964},
 						name: "Identifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1103, col: 5, offset: 26933},
+						pos:  position{line: 1080, col: 5, offset: 25979},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1104, col: 5, offset: 26943},
+						pos: position{line: 1081, col: 5, offset: 25989},
 						run: (*parser).callonPrimary11,
 						expr: &seqExpr{
-							pos: position{line: 1104, col: 5, offset: 26943},
+							pos: position{line: 1081, col: 5, offset: 25989},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1104, col: 5, offset: 26943},
+									pos:        position{line: 1081, col: 5, offset: 25989},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 9, offset: 26947},
+									pos:  position{line: 1081, col: 9, offset: 25993},
 									name: "__",
 								},
 								&andExpr{
-									pos: position{line: 1104, col: 12, offset: 26950},
+									pos: position{line: 1081, col: 12, offset: 25996},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1104, col: 13, offset: 26951},
+										pos:  position{line: 1081, col: 13, offset: 25997},
 										name: "SubqueryOps",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1104, col: 25, offset: 26963},
+									pos:   position{line: 1081, col: 25, offset: 26009},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1104, col: 30, offset: 26968},
+										pos:  position{line: 1081, col: 30, offset: 26014},
 										name: "QueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 40, offset: 26978},
+									pos:  position{line: 1081, col: 40, offset: 26024},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1104, col: 43, offset: 26981},
+									pos:        position{line: 1081, col: 43, offset: 26027},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7599,35 +7360,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1105, col: 5, offset: 27010},
+						pos: position{line: 1082, col: 5, offset: 26056},
 						run: (*parser).callonPrimary21,
 						expr: &seqExpr{
-							pos: position{line: 1105, col: 5, offset: 27010},
+							pos: position{line: 1082, col: 5, offset: 26056},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1105, col: 5, offset: 27010},
+									pos:        position{line: 1082, col: 5, offset: 26056},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1105, col: 9, offset: 27014},
+									pos:  position{line: 1082, col: 9, offset: 26060},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1105, col: 12, offset: 27017},
+									pos:   position{line: 1082, col: 12, offset: 26063},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 17, offset: 27022},
+										pos:  position{line: 1082, col: 17, offset: 26068},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1105, col: 22, offset: 27027},
+									pos:  position{line: 1082, col: 22, offset: 26073},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1105, col: 25, offset: 27030},
+									pos:        position{line: 1082, col: 25, offset: 26076},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7642,24 +7403,24 @@ var g = &grammar{
 		},
 		{
 			name: "SubqueryOps",
-			pos:  position{line: 1107, col: 1, offset: 27056},
+			pos:  position{line: 1084, col: 1, offset: 26102},
 			expr: &choiceExpr{
-				pos: position{line: 1107, col: 15, offset: 27070},
+				pos: position{line: 1084, col: 15, offset: 26116},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1107, col: 15, offset: 27070},
+						pos:  position{line: 1084, col: 15, offset: 26116},
 						name: "UNNEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1107, col: 24, offset: 27079},
+						pos:  position{line: 1084, col: 24, offset: 26125},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1107, col: 31, offset: 27086},
+						pos:  position{line: 1084, col: 31, offset: 26132},
 						name: "VALUES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1107, col: 40, offset: 27095},
+						pos:  position{line: 1084, col: 40, offset: 26141},
 						name: "SelectOp",
 					},
 				},
@@ -7669,53 +7430,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1109, col: 1, offset: 27105},
+			pos:  position{line: 1086, col: 1, offset: 26151},
 			expr: &choiceExpr{
-				pos: position{line: 1110, col: 5, offset: 27118},
+				pos: position{line: 1087, col: 5, offset: 26164},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1110, col: 5, offset: 27118},
+						pos: position{line: 1087, col: 5, offset: 26164},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1110, col: 5, offset: 27118},
+							pos: position{line: 1087, col: 5, offset: 26164},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 5, offset: 27118},
+									pos:  position{line: 1087, col: 5, offset: 26164},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 10, offset: 27123},
+									pos:   position{line: 1087, col: 10, offset: 26169},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1110, col: 16, offset: 27129},
+										pos: position{line: 1087, col: 16, offset: 26175},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1110, col: 16, offset: 27129},
+											pos:  position{line: 1087, col: 16, offset: 26175},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 22, offset: 27135},
+									pos:   position{line: 1087, col: 22, offset: 26181},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1110, col: 28, offset: 27141},
+										pos: position{line: 1087, col: 28, offset: 26187},
 										expr: &seqExpr{
-											pos: position{line: 1110, col: 29, offset: 27142},
+											pos: position{line: 1087, col: 29, offset: 26188},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1110, col: 29, offset: 27142},
+													pos:  position{line: 1087, col: 29, offset: 26188},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1110, col: 31, offset: 27144},
+													pos:  position{line: 1087, col: 31, offset: 26190},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1110, col: 36, offset: 27149},
+													pos:  position{line: 1087, col: 36, offset: 26195},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1110, col: 38, offset: 27151},
+													pos:  position{line: 1087, col: 38, offset: 26197},
 													name: "Expr",
 												},
 											},
@@ -7723,24 +7484,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 45, offset: 27158},
+									pos:  position{line: 1087, col: 45, offset: 26204},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 47, offset: 27160},
+									pos:  position{line: 1087, col: 47, offset: 26206},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1110, col: 51, offset: 27164},
+									pos: position{line: 1087, col: 51, offset: 26210},
 									expr: &seqExpr{
-										pos: position{line: 1110, col: 52, offset: 27165},
+										pos: position{line: 1087, col: 52, offset: 26211},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1110, col: 52, offset: 27165},
+												pos:  position{line: 1087, col: 52, offset: 26211},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1110, col: 54, offset: 27167},
+												pos:  position{line: 1087, col: 54, offset: 26213},
 												name: "CASE",
 											},
 										},
@@ -7750,60 +7511,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1134, col: 5, offset: 27816},
+						pos: position{line: 1111, col: 5, offset: 26862},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1134, col: 5, offset: 27816},
+							pos: position{line: 1111, col: 5, offset: 26862},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 5, offset: 27816},
+									pos:  position{line: 1111, col: 5, offset: 26862},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 10, offset: 27821},
+									pos:  position{line: 1111, col: 10, offset: 26867},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 12, offset: 27823},
+									pos:   position{line: 1111, col: 12, offset: 26869},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1134, col: 17, offset: 27828},
+										pos:  position{line: 1111, col: 17, offset: 26874},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 22, offset: 27833},
+									pos:   position{line: 1111, col: 22, offset: 26879},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1134, col: 28, offset: 27839},
+										pos: position{line: 1111, col: 28, offset: 26885},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1134, col: 28, offset: 27839},
+											pos:  position{line: 1111, col: 28, offset: 26885},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 34, offset: 27845},
+									pos:   position{line: 1111, col: 34, offset: 26891},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1134, col: 40, offset: 27851},
+										pos: position{line: 1111, col: 40, offset: 26897},
 										expr: &seqExpr{
-											pos: position{line: 1134, col: 41, offset: 27852},
+											pos: position{line: 1111, col: 41, offset: 26898},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1134, col: 41, offset: 27852},
+													pos:  position{line: 1111, col: 41, offset: 26898},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1134, col: 43, offset: 27854},
+													pos:  position{line: 1111, col: 43, offset: 26900},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1134, col: 48, offset: 27859},
+													pos:  position{line: 1111, col: 48, offset: 26905},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1134, col: 50, offset: 27861},
+													pos:  position{line: 1111, col: 50, offset: 26907},
 													name: "Expr",
 												},
 											},
@@ -7811,24 +7572,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 57, offset: 27868},
+									pos:  position{line: 1111, col: 57, offset: 26914},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 59, offset: 27870},
+									pos:  position{line: 1111, col: 59, offset: 26916},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1134, col: 63, offset: 27874},
+									pos: position{line: 1111, col: 63, offset: 26920},
 									expr: &seqExpr{
-										pos: position{line: 1134, col: 64, offset: 27875},
+										pos: position{line: 1111, col: 64, offset: 26921},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1134, col: 64, offset: 27875},
+												pos:  position{line: 1111, col: 64, offset: 26921},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1134, col: 66, offset: 27877},
+												pos:  position{line: 1111, col: 66, offset: 26923},
 												name: "CASE",
 											},
 										},
@@ -7844,50 +7605,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1147, col: 1, offset: 28183},
+			pos:  position{line: 1124, col: 1, offset: 27229},
 			expr: &actionExpr{
-				pos: position{line: 1148, col: 5, offset: 28192},
+				pos: position{line: 1125, col: 5, offset: 27238},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1148, col: 5, offset: 28192},
+					pos: position{line: 1125, col: 5, offset: 27238},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1148, col: 5, offset: 28192},
+							pos:  position{line: 1125, col: 5, offset: 27238},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1148, col: 7, offset: 28194},
+							pos:  position{line: 1125, col: 7, offset: 27240},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1148, col: 12, offset: 28199},
+							pos:  position{line: 1125, col: 12, offset: 27245},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1148, col: 14, offset: 28201},
+							pos:   position{line: 1125, col: 14, offset: 27247},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1148, col: 19, offset: 28206},
+								pos:  position{line: 1125, col: 19, offset: 27252},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1148, col: 24, offset: 28211},
+							pos:  position{line: 1125, col: 24, offset: 27257},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1148, col: 26, offset: 28213},
+							pos:  position{line: 1125, col: 26, offset: 27259},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1148, col: 31, offset: 28218},
+							pos:  position{line: 1125, col: 31, offset: 27264},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1148, col: 33, offset: 28220},
+							pos:   position{line: 1125, col: 33, offset: 27266},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1148, col: 38, offset: 28225},
+								pos:  position{line: 1125, col: 38, offset: 27271},
 								name: "Expr",
 							},
 						},
@@ -7899,15 +7660,15 @@ var g = &grammar{
 		},
 		{
 			name: "QueryExpr",
-			pos:  position{line: 1157, col: 1, offset: 28380},
+			pos:  position{line: 1134, col: 1, offset: 27426},
 			expr: &actionExpr{
-				pos: position{line: 1158, col: 5, offset: 28394},
+				pos: position{line: 1135, col: 5, offset: 27440},
 				run: (*parser).callonQueryExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 1158, col: 5, offset: 28394},
+					pos:   position{line: 1135, col: 5, offset: 27440},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1158, col: 10, offset: 28399},
+						pos:  position{line: 1135, col: 10, offset: 27445},
 						name: "Seq",
 					},
 				},
@@ -7917,37 +7678,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1166, col: 1, offset: 28537},
+			pos:  position{line: 1143, col: 1, offset: 27583},
 			expr: &actionExpr{
-				pos: position{line: 1167, col: 5, offset: 28548},
+				pos: position{line: 1144, col: 5, offset: 27594},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1167, col: 5, offset: 28548},
+					pos: position{line: 1144, col: 5, offset: 27594},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1167, col: 5, offset: 28548},
+							pos:        position{line: 1144, col: 5, offset: 27594},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1167, col: 9, offset: 28552},
+							pos:  position{line: 1144, col: 9, offset: 27598},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1167, col: 12, offset: 28555},
+							pos:   position{line: 1144, col: 12, offset: 27601},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1167, col: 18, offset: 28561},
+								pos:  position{line: 1144, col: 18, offset: 27607},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1167, col: 30, offset: 28573},
+							pos:  position{line: 1144, col: 30, offset: 27619},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1167, col: 33, offset: 28576},
+							pos:        position{line: 1144, col: 33, offset: 27622},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7960,31 +7721,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1175, col: 1, offset: 28734},
+			pos:  position{line: 1152, col: 1, offset: 27780},
 			expr: &choiceExpr{
-				pos: position{line: 1176, col: 5, offset: 28750},
+				pos: position{line: 1153, col: 5, offset: 27796},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1176, col: 5, offset: 28750},
+						pos: position{line: 1153, col: 5, offset: 27796},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1176, col: 5, offset: 28750},
+							pos: position{line: 1153, col: 5, offset: 27796},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1176, col: 5, offset: 28750},
+									pos:   position{line: 1153, col: 5, offset: 27796},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1176, col: 11, offset: 28756},
+										pos:  position{line: 1153, col: 11, offset: 27802},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1176, col: 22, offset: 28767},
+									pos:   position{line: 1153, col: 22, offset: 27813},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1176, col: 27, offset: 28772},
+										pos: position{line: 1153, col: 27, offset: 27818},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1176, col: 27, offset: 28772},
+											pos:  position{line: 1153, col: 27, offset: 27818},
 											name: "RecordElemTail",
 										},
 									},
@@ -7993,10 +7754,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1179, col: 5, offset: 28835},
+						pos: position{line: 1156, col: 5, offset: 27881},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1179, col: 5, offset: 28835},
+							pos:  position{line: 1156, col: 5, offset: 27881},
 							name: "__",
 						},
 					},
@@ -8007,32 +7768,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1181, col: 1, offset: 28859},
+			pos:  position{line: 1158, col: 1, offset: 27905},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 18, offset: 28876},
+				pos: position{line: 1158, col: 18, offset: 27922},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1181, col: 18, offset: 28876},
+					pos: position{line: 1158, col: 18, offset: 27922},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 18, offset: 28876},
+							pos:  position{line: 1158, col: 18, offset: 27922},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1181, col: 21, offset: 28879},
+							pos:        position{line: 1158, col: 21, offset: 27925},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 25, offset: 28883},
+							pos:  position{line: 1158, col: 25, offset: 27929},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 28, offset: 28886},
+							pos:   position{line: 1158, col: 28, offset: 27932},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 33, offset: 28891},
+								pos:  position{line: 1158, col: 33, offset: 27937},
 								name: "RecordElem",
 							},
 						},
@@ -8044,20 +7805,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1183, col: 1, offset: 28924},
+			pos:  position{line: 1160, col: 1, offset: 27970},
 			expr: &choiceExpr{
-				pos: position{line: 1184, col: 5, offset: 28939},
+				pos: position{line: 1161, col: 5, offset: 27985},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 5, offset: 28939},
+						pos:  position{line: 1161, col: 5, offset: 27985},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1185, col: 5, offset: 28950},
+						pos:  position{line: 1162, col: 5, offset: 27996},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 5, offset: 28964},
+						pos:  position{line: 1163, col: 5, offset: 28010},
 						name: "Identifier",
 					},
 				},
@@ -8067,28 +7828,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1188, col: 1, offset: 28976},
+			pos:  position{line: 1165, col: 1, offset: 28022},
 			expr: &actionExpr{
-				pos: position{line: 1189, col: 5, offset: 28987},
+				pos: position{line: 1166, col: 5, offset: 28033},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1189, col: 5, offset: 28987},
+					pos: position{line: 1166, col: 5, offset: 28033},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1189, col: 5, offset: 28987},
+							pos:        position{line: 1166, col: 5, offset: 28033},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1189, col: 11, offset: 28993},
+							pos:  position{line: 1166, col: 11, offset: 28039},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1189, col: 14, offset: 28996},
+							pos:   position{line: 1166, col: 14, offset: 28042},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1189, col: 19, offset: 29001},
+								pos:  position{line: 1166, col: 19, offset: 28047},
 								name: "Expr",
 							},
 						},
@@ -8100,40 +7861,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1193, col: 1, offset: 29097},
+			pos:  position{line: 1170, col: 1, offset: 28143},
 			expr: &actionExpr{
-				pos: position{line: 1194, col: 5, offset: 29111},
+				pos: position{line: 1171, col: 5, offset: 28157},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1194, col: 5, offset: 29111},
+					pos: position{line: 1171, col: 5, offset: 28157},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1194, col: 5, offset: 29111},
+							pos:   position{line: 1171, col: 5, offset: 28157},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1194, col: 10, offset: 29116},
+								pos:  position{line: 1171, col: 10, offset: 28162},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1194, col: 15, offset: 29121},
+							pos:  position{line: 1171, col: 15, offset: 28167},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1194, col: 18, offset: 29124},
+							pos:        position{line: 1171, col: 18, offset: 28170},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1194, col: 22, offset: 29128},
+							pos:  position{line: 1171, col: 22, offset: 28174},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1194, col: 25, offset: 29131},
+							pos:   position{line: 1171, col: 25, offset: 28177},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1194, col: 31, offset: 29137},
+								pos:  position{line: 1171, col: 31, offset: 28183},
 								name: "Expr",
 							},
 						},
@@ -8145,37 +7906,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1203, col: 1, offset: 29306},
+			pos:  position{line: 1180, col: 1, offset: 28352},
 			expr: &actionExpr{
-				pos: position{line: 1204, col: 5, offset: 29316},
+				pos: position{line: 1181, col: 5, offset: 28362},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1204, col: 5, offset: 29316},
+					pos: position{line: 1181, col: 5, offset: 28362},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1204, col: 5, offset: 29316},
+							pos:        position{line: 1181, col: 5, offset: 28362},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1204, col: 9, offset: 29320},
+							pos:  position{line: 1181, col: 9, offset: 28366},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1204, col: 12, offset: 29323},
+							pos:   position{line: 1181, col: 12, offset: 28369},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1204, col: 18, offset: 29329},
+								pos:  position{line: 1181, col: 18, offset: 28375},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1204, col: 30, offset: 29341},
+							pos:  position{line: 1181, col: 30, offset: 28387},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1204, col: 33, offset: 29344},
+							pos:        position{line: 1181, col: 33, offset: 28390},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8188,37 +7949,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1212, col: 1, offset: 29500},
+			pos:  position{line: 1189, col: 1, offset: 28546},
 			expr: &actionExpr{
-				pos: position{line: 1213, col: 5, offset: 29508},
+				pos: position{line: 1190, col: 5, offset: 28554},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1213, col: 5, offset: 29508},
+					pos: position{line: 1190, col: 5, offset: 28554},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1213, col: 5, offset: 29508},
+							pos:        position{line: 1190, col: 5, offset: 28554},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1213, col: 10, offset: 29513},
+							pos:  position{line: 1190, col: 10, offset: 28559},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1213, col: 13, offset: 29516},
+							pos:   position{line: 1190, col: 13, offset: 28562},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1213, col: 19, offset: 29522},
+								pos:  position{line: 1190, col: 19, offset: 28568},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1213, col: 31, offset: 29534},
+							pos:  position{line: 1190, col: 31, offset: 28580},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1213, col: 34, offset: 29537},
+							pos:        position{line: 1190, col: 34, offset: 28583},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8231,54 +7992,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1221, col: 1, offset: 29690},
+			pos:  position{line: 1198, col: 1, offset: 28736},
 			expr: &choiceExpr{
-				pos: position{line: 1222, col: 5, offset: 29706},
+				pos: position{line: 1199, col: 5, offset: 28752},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1222, col: 5, offset: 29706},
+						pos: position{line: 1199, col: 5, offset: 28752},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1222, col: 5, offset: 29706},
+							pos: position{line: 1199, col: 5, offset: 28752},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1222, col: 5, offset: 29706},
+									pos:   position{line: 1199, col: 5, offset: 28752},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1222, col: 11, offset: 29712},
+										pos:  position{line: 1199, col: 11, offset: 28758},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1222, col: 22, offset: 29723},
+									pos:   position{line: 1199, col: 22, offset: 28769},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1222, col: 27, offset: 29728},
+										pos: position{line: 1199, col: 27, offset: 28774},
 										expr: &actionExpr{
-											pos: position{line: 1222, col: 28, offset: 29729},
+											pos: position{line: 1199, col: 28, offset: 28775},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1222, col: 28, offset: 29729},
+												pos: position{line: 1199, col: 28, offset: 28775},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1222, col: 28, offset: 29729},
+														pos:  position{line: 1199, col: 28, offset: 28775},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1222, col: 31, offset: 29732},
+														pos:        position{line: 1199, col: 31, offset: 28778},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1222, col: 35, offset: 29736},
+														pos:  position{line: 1199, col: 35, offset: 28782},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1222, col: 38, offset: 29739},
+														pos:   position{line: 1199, col: 38, offset: 28785},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1222, col: 40, offset: 29741},
+															pos:  position{line: 1199, col: 40, offset: 28787},
 															name: "VectorElem",
 														},
 													},
@@ -8291,10 +8052,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1225, col: 5, offset: 29823},
+						pos: position{line: 1202, col: 5, offset: 28869},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1225, col: 5, offset: 29823},
+							pos:  position{line: 1202, col: 5, offset: 28869},
 							name: "__",
 						},
 					},
@@ -8305,22 +8066,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1227, col: 1, offset: 29847},
+			pos:  position{line: 1204, col: 1, offset: 28893},
 			expr: &choiceExpr{
-				pos: position{line: 1228, col: 5, offset: 29862},
+				pos: position{line: 1205, col: 5, offset: 28908},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1228, col: 5, offset: 29862},
+						pos:  position{line: 1205, col: 5, offset: 28908},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1229, col: 5, offset: 29873},
+						pos: position{line: 1206, col: 5, offset: 28919},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1229, col: 5, offset: 29873},
+							pos:   position{line: 1206, col: 5, offset: 28919},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1229, col: 7, offset: 29875},
+								pos:  position{line: 1206, col: 7, offset: 28921},
 								name: "Expr",
 							},
 						},
@@ -8332,37 +8093,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1231, col: 1, offset: 29966},
+			pos:  position{line: 1208, col: 1, offset: 29012},
 			expr: &actionExpr{
-				pos: position{line: 1232, col: 5, offset: 29974},
+				pos: position{line: 1209, col: 5, offset: 29020},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1232, col: 5, offset: 29974},
+					pos: position{line: 1209, col: 5, offset: 29020},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1232, col: 5, offset: 29974},
+							pos:        position{line: 1209, col: 5, offset: 29020},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1232, col: 10, offset: 29979},
+							pos:  position{line: 1209, col: 10, offset: 29025},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1232, col: 13, offset: 29982},
+							pos:   position{line: 1209, col: 13, offset: 29028},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1232, col: 19, offset: 29988},
+								pos:  position{line: 1209, col: 19, offset: 29034},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1232, col: 27, offset: 29996},
+							pos:  position{line: 1209, col: 27, offset: 29042},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1232, col: 30, offset: 29999},
+							pos:        position{line: 1209, col: 30, offset: 29045},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8375,31 +8136,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1240, col: 1, offset: 30153},
+			pos:  position{line: 1217, col: 1, offset: 29199},
 			expr: &choiceExpr{
-				pos: position{line: 1241, col: 5, offset: 30165},
+				pos: position{line: 1218, col: 5, offset: 29211},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1241, col: 5, offset: 30165},
+						pos: position{line: 1218, col: 5, offset: 29211},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1241, col: 5, offset: 30165},
+							pos: position{line: 1218, col: 5, offset: 29211},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1241, col: 5, offset: 30165},
+									pos:   position{line: 1218, col: 5, offset: 29211},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1241, col: 11, offset: 30171},
+										pos:  position{line: 1218, col: 11, offset: 29217},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1241, col: 17, offset: 30177},
+									pos:   position{line: 1218, col: 17, offset: 29223},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1241, col: 22, offset: 30182},
+										pos: position{line: 1218, col: 22, offset: 29228},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1241, col: 22, offset: 30182},
+											pos:  position{line: 1218, col: 22, offset: 29228},
 											name: "EntryTail",
 										},
 									},
@@ -8408,10 +8169,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1244, col: 5, offset: 30240},
+						pos: position{line: 1221, col: 5, offset: 29286},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1244, col: 5, offset: 30240},
+							pos:  position{line: 1221, col: 5, offset: 29286},
 							name: "__",
 						},
 					},
@@ -8422,32 +8183,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1247, col: 1, offset: 30265},
+			pos:  position{line: 1224, col: 1, offset: 29311},
 			expr: &actionExpr{
-				pos: position{line: 1247, col: 13, offset: 30277},
+				pos: position{line: 1224, col: 13, offset: 29323},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1247, col: 13, offset: 30277},
+					pos: position{line: 1224, col: 13, offset: 29323},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 13, offset: 30277},
+							pos:  position{line: 1224, col: 13, offset: 29323},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1247, col: 16, offset: 30280},
+							pos:        position{line: 1224, col: 16, offset: 29326},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 20, offset: 30284},
+							pos:  position{line: 1224, col: 20, offset: 29330},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1247, col: 23, offset: 30287},
+							pos:   position{line: 1224, col: 23, offset: 29333},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1247, col: 25, offset: 30289},
+								pos:  position{line: 1224, col: 25, offset: 29335},
 								name: "Entry",
 							},
 						},
@@ -8459,40 +8220,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1249, col: 1, offset: 30314},
+			pos:  position{line: 1226, col: 1, offset: 29360},
 			expr: &actionExpr{
-				pos: position{line: 1250, col: 5, offset: 30324},
+				pos: position{line: 1227, col: 5, offset: 29370},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1250, col: 5, offset: 30324},
+					pos: position{line: 1227, col: 5, offset: 29370},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1250, col: 5, offset: 30324},
+							pos:   position{line: 1227, col: 5, offset: 29370},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1250, col: 9, offset: 30328},
+								pos:  position{line: 1227, col: 9, offset: 29374},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1250, col: 14, offset: 30333},
+							pos:  position{line: 1227, col: 14, offset: 29379},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1250, col: 17, offset: 30336},
+							pos:        position{line: 1227, col: 17, offset: 29382},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1250, col: 21, offset: 30340},
+							pos:  position{line: 1227, col: 21, offset: 29386},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1250, col: 24, offset: 30343},
+							pos:   position{line: 1227, col: 24, offset: 29389},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1250, col: 30, offset: 30349},
+								pos:  position{line: 1227, col: 30, offset: 29395},
 								name: "Expr",
 							},
 						},
@@ -8504,61 +8265,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1254, col: 1, offset: 30452},
+			pos:  position{line: 1231, col: 1, offset: 29498},
 			expr: &actionExpr{
-				pos: position{line: 1255, col: 5, offset: 30462},
+				pos: position{line: 1232, col: 5, offset: 29508},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1255, col: 5, offset: 30462},
+					pos: position{line: 1232, col: 5, offset: 29508},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1255, col: 5, offset: 30462},
+							pos:        position{line: 1232, col: 5, offset: 29508},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1255, col: 9, offset: 30466},
+							pos:  position{line: 1232, col: 9, offset: 29512},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1255, col: 12, offset: 30469},
+							pos:   position{line: 1232, col: 12, offset: 29515},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1255, col: 18, offset: 30475},
+								pos:  position{line: 1232, col: 18, offset: 29521},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1255, col: 23, offset: 30480},
+							pos:   position{line: 1232, col: 23, offset: 29526},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1255, col: 28, offset: 30485},
+								pos: position{line: 1232, col: 28, offset: 29531},
 								expr: &actionExpr{
-									pos: position{line: 1255, col: 29, offset: 30486},
+									pos: position{line: 1232, col: 29, offset: 29532},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1255, col: 29, offset: 30486},
+										pos: position{line: 1232, col: 29, offset: 29532},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1255, col: 29, offset: 30486},
+												pos:  position{line: 1232, col: 29, offset: 29532},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1255, col: 32, offset: 30489},
+												pos:        position{line: 1232, col: 32, offset: 29535},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1255, col: 36, offset: 30493},
+												pos:  position{line: 1232, col: 36, offset: 29539},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1255, col: 39, offset: 30496},
+												pos:   position{line: 1232, col: 39, offset: 29542},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1255, col: 41, offset: 30498},
+													pos:  position{line: 1232, col: 41, offset: 29544},
 													name: "Expr",
 												},
 											},
@@ -8568,11 +8329,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1255, col: 66, offset: 30523},
+							pos:  position{line: 1232, col: 66, offset: 29569},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1255, col: 69, offset: 30526},
+							pos:        position{line: 1232, col: 69, offset: 29572},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8585,39 +8346,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1263, col: 1, offset: 30685},
+			pos:  position{line: 1240, col: 1, offset: 29731},
 			expr: &actionExpr{
-				pos: position{line: 1264, col: 5, offset: 30702},
+				pos: position{line: 1241, col: 5, offset: 29748},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1264, col: 5, offset: 30702},
+					pos: position{line: 1241, col: 5, offset: 29748},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1264, col: 5, offset: 30702},
+							pos:   position{line: 1241, col: 5, offset: 29748},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1264, col: 10, offset: 30707},
+								pos: position{line: 1241, col: 10, offset: 29753},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1264, col: 10, offset: 30707},
+										pos:  position{line: 1241, col: 10, offset: 29753},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1264, col: 17, offset: 30714},
+										pos:  position{line: 1241, col: 17, offset: 29760},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1264, col: 28, offset: 30725},
+							pos:  position{line: 1241, col: 28, offset: 29771},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1264, col: 30, offset: 30727},
+							pos:   position{line: 1241, col: 30, offset: 29773},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1264, col: 32, offset: 30729},
+								pos:  position{line: 1241, col: 32, offset: 29775},
 								name: "StringLiteral",
 							},
 						},
@@ -8629,56 +8390,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1275, col: 1, offset: 30946},
+			pos:  position{line: 1252, col: 1, offset: 29992},
 			expr: &choiceExpr{
-				pos: position{line: 1276, col: 5, offset: 30958},
+				pos: position{line: 1253, col: 5, offset: 30004},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1276, col: 5, offset: 30958},
+						pos:  position{line: 1253, col: 5, offset: 30004},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1277, col: 5, offset: 30974},
+						pos:  position{line: 1254, col: 5, offset: 30020},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1278, col: 5, offset: 30992},
+						pos:  position{line: 1255, col: 5, offset: 30038},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 5, offset: 31004},
+						pos:  position{line: 1256, col: 5, offset: 30050},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1280, col: 5, offset: 31022},
+						pos:  position{line: 1257, col: 5, offset: 30068},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1281, col: 5, offset: 31041},
+						pos:  position{line: 1258, col: 5, offset: 30087},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1282, col: 5, offset: 31058},
+						pos:  position{line: 1259, col: 5, offset: 30104},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1283, col: 5, offset: 31071},
+						pos:  position{line: 1260, col: 5, offset: 30117},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1284, col: 5, offset: 31080},
+						pos:  position{line: 1261, col: 5, offset: 30126},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1285, col: 5, offset: 31097},
+						pos:  position{line: 1262, col: 5, offset: 30143},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1286, col: 5, offset: 31116},
+						pos:  position{line: 1263, col: 5, offset: 30162},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1287, col: 5, offset: 31135},
+						pos:  position{line: 1264, col: 5, offset: 30181},
 						name: "NullLiteral",
 					},
 				},
@@ -8688,28 +8449,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1289, col: 1, offset: 31148},
+			pos:  position{line: 1266, col: 1, offset: 30194},
 			expr: &choiceExpr{
-				pos: position{line: 1290, col: 5, offset: 31166},
+				pos: position{line: 1267, col: 5, offset: 30212},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1290, col: 5, offset: 31166},
+						pos: position{line: 1267, col: 5, offset: 30212},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1290, col: 5, offset: 31166},
+							pos: position{line: 1267, col: 5, offset: 30212},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1290, col: 5, offset: 31166},
+									pos:   position{line: 1267, col: 5, offset: 30212},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1290, col: 7, offset: 31168},
+										pos:  position{line: 1267, col: 7, offset: 30214},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1290, col: 14, offset: 31175},
+									pos: position{line: 1267, col: 14, offset: 30221},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1290, col: 15, offset: 31176},
+										pos:  position{line: 1267, col: 15, offset: 30222},
 										name: "IdentifierRest",
 									},
 								},
@@ -8717,13 +8478,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1293, col: 5, offset: 31256},
+						pos: position{line: 1270, col: 5, offset: 30302},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1293, col: 5, offset: 31256},
+							pos:   position{line: 1270, col: 5, offset: 30302},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1293, col: 7, offset: 31258},
+								pos:  position{line: 1270, col: 7, offset: 30304},
 								name: "IP4Net",
 							},
 						},
@@ -8735,35 +8496,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1297, col: 1, offset: 31327},
+			pos:  position{line: 1274, col: 1, offset: 30373},
 			expr: &choiceExpr{
-				pos: position{line: 1298, col: 5, offset: 31346},
+				pos: position{line: 1275, col: 5, offset: 30392},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1298, col: 5, offset: 31346},
+						pos: position{line: 1275, col: 5, offset: 30392},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1298, col: 5, offset: 31346},
+							pos: position{line: 1275, col: 5, offset: 30392},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1298, col: 5, offset: 31346},
+									pos:   position{line: 1275, col: 5, offset: 30392},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1298, col: 7, offset: 31348},
+										pos:  position{line: 1275, col: 7, offset: 30394},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1298, col: 11, offset: 31352},
+									pos: position{line: 1275, col: 11, offset: 30398},
 									expr: &choiceExpr{
-										pos: position{line: 1298, col: 13, offset: 31354},
+										pos: position{line: 1275, col: 13, offset: 30400},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1298, col: 13, offset: 31354},
+												pos:  position{line: 1275, col: 13, offset: 30400},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1298, col: 30, offset: 31371},
+												pos:  position{line: 1275, col: 30, offset: 30417},
 												name: "TypeLiteral",
 											},
 										},
@@ -8773,13 +8534,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1301, col: 5, offset: 31448},
+						pos: position{line: 1278, col: 5, offset: 30494},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1301, col: 5, offset: 31448},
+							pos:   position{line: 1278, col: 5, offset: 30494},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1301, col: 7, offset: 31450},
+								pos:  position{line: 1278, col: 7, offset: 30496},
 								name: "IP",
 							},
 						},
@@ -8791,15 +8552,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1305, col: 1, offset: 31514},
+			pos:  position{line: 1282, col: 1, offset: 30560},
 			expr: &actionExpr{
-				pos: position{line: 1306, col: 5, offset: 31531},
+				pos: position{line: 1283, col: 5, offset: 30577},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1306, col: 5, offset: 31531},
+					pos:   position{line: 1283, col: 5, offset: 30577},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1306, col: 7, offset: 31533},
+						pos:  position{line: 1283, col: 7, offset: 30579},
 						name: "FloatString",
 					},
 				},
@@ -8809,15 +8570,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1310, col: 1, offset: 31611},
+			pos:  position{line: 1287, col: 1, offset: 30657},
 			expr: &actionExpr{
-				pos: position{line: 1311, col: 5, offset: 31630},
+				pos: position{line: 1288, col: 5, offset: 30676},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1311, col: 5, offset: 31630},
+					pos:   position{line: 1288, col: 5, offset: 30676},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1311, col: 7, offset: 31632},
+						pos:  position{line: 1288, col: 7, offset: 30678},
 						name: "IntString",
 					},
 				},
@@ -8827,23 +8588,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1315, col: 1, offset: 31706},
+			pos:  position{line: 1292, col: 1, offset: 30752},
 			expr: &choiceExpr{
-				pos: position{line: 1316, col: 5, offset: 31725},
+				pos: position{line: 1293, col: 5, offset: 30771},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 31725},
+						pos: position{line: 1293, col: 5, offset: 30771},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1316, col: 5, offset: 31725},
+							pos:  position{line: 1293, col: 5, offset: 30771},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 31783},
+						pos: position{line: 1294, col: 5, offset: 30829},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1317, col: 5, offset: 31783},
+							pos:  position{line: 1294, col: 5, offset: 30829},
 							name: "FALSE",
 						},
 					},
@@ -8854,12 +8615,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1319, col: 1, offset: 31839},
+			pos:  position{line: 1296, col: 1, offset: 30885},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 5, offset: 31855},
+				pos: position{line: 1297, col: 5, offset: 30901},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1320, col: 5, offset: 31855},
+					pos:  position{line: 1297, col: 5, offset: 30901},
 					name: "NULL",
 				},
 			},
@@ -8868,23 +8629,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1322, col: 1, offset: 31905},
+			pos:  position{line: 1299, col: 1, offset: 30951},
 			expr: &actionExpr{
-				pos: position{line: 1323, col: 5, offset: 31922},
+				pos: position{line: 1300, col: 5, offset: 30968},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1323, col: 5, offset: 31922},
+					pos: position{line: 1300, col: 5, offset: 30968},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1323, col: 5, offset: 31922},
+							pos:        position{line: 1300, col: 5, offset: 30968},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1323, col: 10, offset: 31927},
+							pos: position{line: 1300, col: 10, offset: 30973},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1323, col: 10, offset: 31927},
+								pos:  position{line: 1300, col: 10, offset: 30973},
 								name: "HexDigit",
 							},
 						},
@@ -8896,29 +8657,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1327, col: 1, offset: 32001},
+			pos:  position{line: 1304, col: 1, offset: 31047},
 			expr: &actionExpr{
-				pos: position{line: 1328, col: 5, offset: 32017},
+				pos: position{line: 1305, col: 5, offset: 31063},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1328, col: 5, offset: 32017},
+					pos: position{line: 1305, col: 5, offset: 31063},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1328, col: 5, offset: 32017},
+							pos:        position{line: 1305, col: 5, offset: 31063},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1328, col: 9, offset: 32021},
+							pos:   position{line: 1305, col: 9, offset: 31067},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1328, col: 13, offset: 32025},
+								pos:  position{line: 1305, col: 13, offset: 31071},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1328, col: 18, offset: 32030},
+							pos:        position{line: 1305, col: 18, offset: 31076},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8931,27 +8692,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1336, col: 1, offset: 32163},
+			pos:  position{line: 1313, col: 1, offset: 31209},
 			expr: &choiceExpr{
-				pos: position{line: 1337, col: 5, offset: 32179},
+				pos: position{line: 1314, col: 5, offset: 31225},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1337, col: 5, offset: 32179},
+						pos: position{line: 1314, col: 5, offset: 31225},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1337, col: 5, offset: 32179},
+							pos: position{line: 1314, col: 5, offset: 31225},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1337, col: 5, offset: 32179},
+									pos:        position{line: 1314, col: 5, offset: 31225},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1337, col: 9, offset: 32183},
+									pos:   position{line: 1314, col: 9, offset: 31229},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1337, col: 14, offset: 32188},
+										pos:  position{line: 1314, col: 14, offset: 31234},
 										name: "Name",
 									},
 								},
@@ -8959,13 +8720,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1338, col: 5, offset: 32262},
+						pos: position{line: 1315, col: 5, offset: 31308},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1338, col: 5, offset: 32262},
+							pos:   position{line: 1315, col: 5, offset: 31308},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1338, col: 7, offset: 32264},
+								pos:  position{line: 1315, col: 7, offset: 31310},
 								name: "EasyType",
 							},
 						},
@@ -8977,16 +8738,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1346, col: 1, offset: 32400},
+			pos:  position{line: 1323, col: 1, offset: 31446},
 			expr: &choiceExpr{
-				pos: position{line: 1347, col: 5, offset: 32409},
+				pos: position{line: 1324, col: 5, offset: 31455},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1347, col: 5, offset: 32409},
+						pos:  position{line: 1324, col: 5, offset: 31455},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1348, col: 5, offset: 32423},
+						pos:  position{line: 1325, col: 5, offset: 31469},
 						name: "ComponentType",
 					},
 				},
@@ -8996,52 +8757,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1350, col: 1, offset: 32438},
+			pos:  position{line: 1327, col: 1, offset: 31484},
 			expr: &choiceExpr{
-				pos: position{line: 1351, col: 5, offset: 32456},
+				pos: position{line: 1328, col: 5, offset: 31502},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1351, col: 5, offset: 32456},
+						pos:  position{line: 1328, col: 5, offset: 31502},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1352, col: 5, offset: 32469},
+						pos: position{line: 1329, col: 5, offset: 31515},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1352, col: 5, offset: 32469},
+							pos: position{line: 1329, col: 5, offset: 31515},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1352, col: 5, offset: 32469},
+									pos:   position{line: 1329, col: 5, offset: 31515},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1352, col: 10, offset: 32474},
+										pos:  position{line: 1329, col: 10, offset: 31520},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1352, col: 15, offset: 32479},
+									pos:   position{line: 1329, col: 15, offset: 31525},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1352, col: 19, offset: 32483},
+										pos: position{line: 1329, col: 19, offset: 31529},
 										expr: &seqExpr{
-											pos: position{line: 1352, col: 20, offset: 32484},
+											pos: position{line: 1329, col: 20, offset: 31530},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1352, col: 20, offset: 32484},
+													pos:  position{line: 1329, col: 20, offset: 31530},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1352, col: 23, offset: 32487},
+													pos:        position{line: 1329, col: 23, offset: 31533},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1352, col: 27, offset: 32491},
+													pos:  position{line: 1329, col: 27, offset: 31537},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1352, col: 30, offset: 32494},
+													pos:  position{line: 1329, col: 30, offset: 31540},
 													name: "Type",
 												},
 											},
@@ -9058,40 +8819,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1364, col: 1, offset: 32816},
+			pos:  position{line: 1341, col: 1, offset: 31862},
 			expr: &choiceExpr{
-				pos: position{line: 1365, col: 5, offset: 32829},
+				pos: position{line: 1342, col: 5, offset: 31875},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1365, col: 5, offset: 32829},
+						pos: position{line: 1342, col: 5, offset: 31875},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1365, col: 5, offset: 32829},
+							pos: position{line: 1342, col: 5, offset: 31875},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1365, col: 5, offset: 32829},
+									pos:        position{line: 1342, col: 5, offset: 31875},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 9, offset: 32833},
+									pos:  position{line: 1342, col: 9, offset: 31879},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1365, col: 12, offset: 32836},
+									pos:   position{line: 1342, col: 12, offset: 31882},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1365, col: 16, offset: 32840},
+										pos:  position{line: 1342, col: 16, offset: 31886},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 21, offset: 32845},
+									pos:  position{line: 1342, col: 21, offset: 31891},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1365, col: 24, offset: 32848},
+									pos:        position{line: 1342, col: 24, offset: 31894},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9100,23 +8861,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1366, col: 5, offset: 32875},
+						pos: position{line: 1343, col: 5, offset: 31921},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1366, col: 5, offset: 32875},
+							pos: position{line: 1343, col: 5, offset: 31921},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1366, col: 5, offset: 32875},
+									pos:   position{line: 1343, col: 5, offset: 31921},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 10, offset: 32880},
+										pos:  position{line: 1343, col: 10, offset: 31926},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1366, col: 24, offset: 32894},
+									pos: position{line: 1343, col: 24, offset: 31940},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 25, offset: 32895},
+										pos:  position{line: 1343, col: 25, offset: 31941},
 										name: "IdentifierRest",
 									},
 								},
@@ -9124,43 +8885,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1367, col: 5, offset: 32935},
+						pos: position{line: 1344, col: 5, offset: 31981},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1367, col: 5, offset: 32935},
+							pos: position{line: 1344, col: 5, offset: 31981},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1367, col: 5, offset: 32935},
+									pos:  position{line: 1344, col: 5, offset: 31981},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1367, col: 11, offset: 32941},
+									pos:  position{line: 1344, col: 11, offset: 31987},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1367, col: 14, offset: 32944},
+									pos:        position{line: 1344, col: 14, offset: 31990},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1367, col: 18, offset: 32948},
+									pos:  position{line: 1344, col: 18, offset: 31994},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1367, col: 21, offset: 32951},
+									pos:   position{line: 1344, col: 21, offset: 31997},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1367, col: 23, offset: 32953},
+										pos:  position{line: 1344, col: 23, offset: 31999},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1367, col: 28, offset: 32958},
+									pos:  position{line: 1344, col: 28, offset: 32004},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1367, col: 31, offset: 32961},
+									pos:        position{line: 1344, col: 31, offset: 32007},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9169,43 +8930,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1374, col: 5, offset: 33101},
+						pos: position{line: 1351, col: 5, offset: 32147},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1374, col: 5, offset: 33101},
+							pos: position{line: 1351, col: 5, offset: 32147},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1374, col: 5, offset: 33101},
+									pos:  position{line: 1351, col: 5, offset: 32147},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1374, col: 10, offset: 33106},
+									pos:  position{line: 1351, col: 10, offset: 32152},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1374, col: 13, offset: 33109},
+									pos:        position{line: 1351, col: 13, offset: 32155},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1374, col: 17, offset: 33113},
+									pos:  position{line: 1351, col: 17, offset: 32159},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1374, col: 20, offset: 33116},
+									pos:   position{line: 1351, col: 20, offset: 32162},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1374, col: 26, offset: 33122},
+										pos:  position{line: 1351, col: 26, offset: 32168},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1374, col: 32, offset: 33128},
+									pos:  position{line: 1351, col: 32, offset: 32174},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1374, col: 35, offset: 33131},
+									pos:        position{line: 1351, col: 35, offset: 32177},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9214,35 +8975,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1381, col: 5, offset: 33285},
+						pos: position{line: 1358, col: 5, offset: 32331},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1381, col: 5, offset: 33285},
+							pos: position{line: 1358, col: 5, offset: 32331},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1381, col: 5, offset: 33285},
+									pos:        position{line: 1358, col: 5, offset: 32331},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1381, col: 9, offset: 33289},
+									pos:  position{line: 1358, col: 9, offset: 32335},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1381, col: 12, offset: 33292},
+									pos:   position{line: 1358, col: 12, offset: 32338},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1381, col: 19, offset: 33299},
+										pos:  position{line: 1358, col: 19, offset: 32345},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1381, col: 33, offset: 33313},
+									pos:  position{line: 1358, col: 33, offset: 32359},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1381, col: 36, offset: 33316},
+									pos:        position{line: 1358, col: 36, offset: 32362},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9251,35 +9012,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1388, col: 5, offset: 33478},
+						pos: position{line: 1365, col: 5, offset: 32524},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1388, col: 5, offset: 33478},
+							pos: position{line: 1365, col: 5, offset: 32524},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1388, col: 5, offset: 33478},
+									pos:        position{line: 1365, col: 5, offset: 32524},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1388, col: 9, offset: 33482},
+									pos:  position{line: 1365, col: 9, offset: 32528},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1388, col: 12, offset: 33485},
+									pos:   position{line: 1365, col: 12, offset: 32531},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1388, col: 16, offset: 33489},
+										pos:  position{line: 1365, col: 16, offset: 32535},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1388, col: 21, offset: 33494},
+									pos:  position{line: 1365, col: 21, offset: 32540},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1388, col: 24, offset: 33497},
+									pos:        position{line: 1365, col: 24, offset: 32543},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9288,35 +9049,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1395, col: 5, offset: 33639},
+						pos: position{line: 1372, col: 5, offset: 32685},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1395, col: 5, offset: 33639},
+							pos: position{line: 1372, col: 5, offset: 32685},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1395, col: 5, offset: 33639},
+									pos:        position{line: 1372, col: 5, offset: 32685},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1395, col: 10, offset: 33644},
+									pos:  position{line: 1372, col: 10, offset: 32690},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1395, col: 13, offset: 33647},
+									pos:   position{line: 1372, col: 13, offset: 32693},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1395, col: 17, offset: 33651},
+										pos:  position{line: 1372, col: 17, offset: 32697},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1395, col: 22, offset: 33656},
+									pos:  position{line: 1372, col: 22, offset: 32702},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1395, col: 25, offset: 33659},
+									pos:        position{line: 1372, col: 25, offset: 32705},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9325,57 +9086,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1402, col: 5, offset: 33798},
+						pos: position{line: 1379, col: 5, offset: 32844},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1402, col: 5, offset: 33798},
+							pos: position{line: 1379, col: 5, offset: 32844},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1402, col: 5, offset: 33798},
+									pos:        position{line: 1379, col: 5, offset: 32844},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1402, col: 10, offset: 33803},
+									pos:  position{line: 1379, col: 10, offset: 32849},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1402, col: 13, offset: 33806},
+									pos:   position{line: 1379, col: 13, offset: 32852},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1402, col: 21, offset: 33814},
+										pos:  position{line: 1379, col: 21, offset: 32860},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1402, col: 26, offset: 33819},
+									pos:  position{line: 1379, col: 26, offset: 32865},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1402, col: 29, offset: 33822},
+									pos:        position{line: 1379, col: 29, offset: 32868},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1402, col: 33, offset: 33826},
+									pos:  position{line: 1379, col: 33, offset: 32872},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1402, col: 36, offset: 33829},
+									pos:   position{line: 1379, col: 36, offset: 32875},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1402, col: 44, offset: 33837},
+										pos:  position{line: 1379, col: 44, offset: 32883},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1402, col: 49, offset: 33842},
+									pos:  position{line: 1379, col: 49, offset: 32888},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1402, col: 52, offset: 33845},
+									pos:        position{line: 1379, col: 52, offset: 32891},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9390,15 +9151,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1411, col: 1, offset: 34019},
+			pos:  position{line: 1388, col: 1, offset: 33065},
 			expr: &actionExpr{
-				pos: position{line: 1412, col: 5, offset: 34033},
+				pos: position{line: 1389, col: 5, offset: 33079},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1412, col: 5, offset: 34033},
+					pos:   position{line: 1389, col: 5, offset: 33079},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1412, col: 11, offset: 34039},
+						pos:  position{line: 1389, col: 11, offset: 33085},
 						name: "TypeList",
 					},
 				},
@@ -9408,28 +9169,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1420, col: 1, offset: 34176},
+			pos:  position{line: 1397, col: 1, offset: 33222},
 			expr: &actionExpr{
-				pos: position{line: 1421, col: 5, offset: 34189},
+				pos: position{line: 1398, col: 5, offset: 33235},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1421, col: 5, offset: 34189},
+					pos: position{line: 1398, col: 5, offset: 33235},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1421, col: 5, offset: 34189},
+							pos:   position{line: 1398, col: 5, offset: 33235},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1421, col: 11, offset: 34195},
+								pos:  position{line: 1398, col: 11, offset: 33241},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1421, col: 25, offset: 34209},
+							pos:   position{line: 1398, col: 25, offset: 33255},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1421, col: 30, offset: 34214},
+								pos: position{line: 1398, col: 30, offset: 33260},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1421, col: 30, offset: 34214},
+									pos:  position{line: 1398, col: 30, offset: 33260},
 									name: "TypeListTail",
 								},
 							},
@@ -9442,32 +9203,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1425, col: 1, offset: 34272},
+			pos:  position{line: 1402, col: 1, offset: 33318},
 			expr: &actionExpr{
-				pos: position{line: 1425, col: 16, offset: 34287},
+				pos: position{line: 1402, col: 16, offset: 33333},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1425, col: 16, offset: 34287},
+					pos: position{line: 1402, col: 16, offset: 33333},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1425, col: 16, offset: 34287},
+							pos:  position{line: 1402, col: 16, offset: 33333},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1425, col: 19, offset: 34290},
+							pos:        position{line: 1402, col: 19, offset: 33336},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1425, col: 23, offset: 34294},
+							pos:  position{line: 1402, col: 23, offset: 33340},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1425, col: 26, offset: 34297},
+							pos:   position{line: 1402, col: 26, offset: 33343},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1425, col: 30, offset: 34301},
+								pos:  position{line: 1402, col: 30, offset: 33347},
 								name: "ComponentType",
 							},
 						},
@@ -9479,42 +9240,42 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1427, col: 1, offset: 34336},
+			pos:  position{line: 1404, col: 1, offset: 33382},
 			expr: &choiceExpr{
-				pos: position{line: 1428, col: 5, offset: 34354},
+				pos: position{line: 1405, col: 5, offset: 33400},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1428, col: 5, offset: 34354},
+						pos: position{line: 1405, col: 5, offset: 33400},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1428, col: 5, offset: 34354},
+							pos:   position{line: 1405, col: 5, offset: 33400},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1428, col: 7, offset: 34356},
+								pos:  position{line: 1405, col: 7, offset: 33402},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1429, col: 5, offset: 34463},
+						pos: position{line: 1406, col: 5, offset: 33509},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1429, col: 5, offset: 34463},
+							pos:   position{line: 1406, col: 5, offset: 33509},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1429, col: 7, offset: 34465},
+								pos:  position{line: 1406, col: 7, offset: 33511},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1430, col: 5, offset: 34542},
+						pos: position{line: 1407, col: 5, offset: 33588},
 						run: (*parser).callonStringLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1430, col: 5, offset: 34542},
+							pos:   position{line: 1407, col: 5, offset: 33588},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1430, col: 7, offset: 34544},
+								pos:  position{line: 1407, col: 7, offset: 33590},
 								name: "RString",
 							},
 						},
@@ -9526,35 +9287,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1432, col: 1, offset: 34607},
+			pos:  position{line: 1409, col: 1, offset: 33653},
 			expr: &choiceExpr{
-				pos: position{line: 1433, col: 5, offset: 34619},
+				pos: position{line: 1410, col: 5, offset: 33665},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1433, col: 5, offset: 34619},
+						pos: position{line: 1410, col: 5, offset: 33665},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1433, col: 5, offset: 34619},
+							pos: position{line: 1410, col: 5, offset: 33665},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1433, col: 5, offset: 34619},
+									pos:        position{line: 1410, col: 5, offset: 33665},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1433, col: 11, offset: 34625},
+									pos:   position{line: 1410, col: 11, offset: 33671},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1433, col: 13, offset: 34627},
+										pos: position{line: 1410, col: 13, offset: 33673},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1433, col: 13, offset: 34627},
+											pos:  position{line: 1410, col: 13, offset: 33673},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1433, col: 38, offset: 34652},
+									pos:        position{line: 1410, col: 38, offset: 33698},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9563,30 +9324,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1440, col: 5, offset: 34798},
+						pos: position{line: 1417, col: 5, offset: 33844},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1440, col: 5, offset: 34798},
+							pos: position{line: 1417, col: 5, offset: 33844},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1440, col: 5, offset: 34798},
+									pos:        position{line: 1417, col: 5, offset: 33844},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1440, col: 10, offset: 34803},
+									pos:   position{line: 1417, col: 10, offset: 33849},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1440, col: 12, offset: 34805},
+										pos: position{line: 1417, col: 12, offset: 33851},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1440, col: 12, offset: 34805},
+											pos:  position{line: 1417, col: 12, offset: 33851},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1440, col: 37, offset: 34830},
+									pos:        position{line: 1417, col: 37, offset: 33876},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9601,24 +9362,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1448, col: 1, offset: 34973},
+			pos:  position{line: 1425, col: 1, offset: 34019},
 			expr: &choiceExpr{
-				pos: position{line: 1449, col: 5, offset: 35001},
+				pos: position{line: 1426, col: 5, offset: 34047},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1449, col: 5, offset: 35001},
+						pos:  position{line: 1426, col: 5, offset: 34047},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1450, col: 5, offset: 35017},
+						pos: position{line: 1427, col: 5, offset: 34063},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1450, col: 5, offset: 35017},
+							pos:   position{line: 1427, col: 5, offset: 34063},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1450, col: 7, offset: 35019},
+								pos: position{line: 1427, col: 7, offset: 34065},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1450, col: 7, offset: 35019},
+									pos:  position{line: 1427, col: 7, offset: 34065},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9631,27 +9392,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1454, col: 1, offset: 35142},
+			pos:  position{line: 1431, col: 1, offset: 34188},
 			expr: &choiceExpr{
-				pos: position{line: 1455, col: 5, offset: 35170},
+				pos: position{line: 1432, col: 5, offset: 34216},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1455, col: 5, offset: 35170},
+						pos: position{line: 1432, col: 5, offset: 34216},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1455, col: 5, offset: 35170},
+							pos: position{line: 1432, col: 5, offset: 34216},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1455, col: 5, offset: 35170},
+									pos:        position{line: 1432, col: 5, offset: 34216},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1455, col: 10, offset: 35175},
+									pos:   position{line: 1432, col: 10, offset: 34221},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1455, col: 12, offset: 35177},
+										pos:        position{line: 1432, col: 12, offset: 34223},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9661,25 +9422,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1456, col: 5, offset: 35203},
+						pos: position{line: 1433, col: 5, offset: 34249},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1456, col: 5, offset: 35203},
+							pos: position{line: 1433, col: 5, offset: 34249},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1456, col: 5, offset: 35203},
+									pos: position{line: 1433, col: 5, offset: 34249},
 									expr: &litMatcher{
-										pos:        position{line: 1456, col: 7, offset: 35205},
+										pos:        position{line: 1433, col: 7, offset: 34251},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1456, col: 12, offset: 35210},
+									pos:   position{line: 1433, col: 12, offset: 34256},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1456, col: 14, offset: 35212},
+										pos:  position{line: 1433, col: 14, offset: 34258},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9693,24 +9454,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1458, col: 1, offset: 35248},
+			pos:  position{line: 1435, col: 1, offset: 34294},
 			expr: &choiceExpr{
-				pos: position{line: 1459, col: 5, offset: 35276},
+				pos: position{line: 1436, col: 5, offset: 34322},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1459, col: 5, offset: 35276},
+						pos:  position{line: 1436, col: 5, offset: 34322},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1460, col: 5, offset: 35292},
+						pos: position{line: 1437, col: 5, offset: 34338},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1460, col: 5, offset: 35292},
+							pos:   position{line: 1437, col: 5, offset: 34338},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1460, col: 7, offset: 35294},
+								pos: position{line: 1437, col: 7, offset: 34340},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1460, col: 7, offset: 35294},
+									pos:  position{line: 1437, col: 7, offset: 34340},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9723,27 +9484,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1464, col: 1, offset: 35417},
+			pos:  position{line: 1441, col: 1, offset: 34463},
 			expr: &choiceExpr{
-				pos: position{line: 1465, col: 5, offset: 35445},
+				pos: position{line: 1442, col: 5, offset: 34491},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1465, col: 5, offset: 35445},
+						pos: position{line: 1442, col: 5, offset: 34491},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1465, col: 5, offset: 35445},
+							pos: position{line: 1442, col: 5, offset: 34491},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1465, col: 5, offset: 35445},
+									pos:        position{line: 1442, col: 5, offset: 34491},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1465, col: 10, offset: 35450},
+									pos:   position{line: 1442, col: 10, offset: 34496},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1465, col: 12, offset: 35452},
+										pos:        position{line: 1442, col: 12, offset: 34498},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9753,25 +9514,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1466, col: 5, offset: 35478},
+						pos: position{line: 1443, col: 5, offset: 34524},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1466, col: 5, offset: 35478},
+							pos: position{line: 1443, col: 5, offset: 34524},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1466, col: 5, offset: 35478},
+									pos: position{line: 1443, col: 5, offset: 34524},
 									expr: &litMatcher{
-										pos:        position{line: 1466, col: 7, offset: 35480},
+										pos:        position{line: 1443, col: 7, offset: 34526},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1466, col: 12, offset: 35485},
+									pos:   position{line: 1443, col: 12, offset: 34531},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1466, col: 14, offset: 35487},
+										pos:  position{line: 1443, col: 14, offset: 34533},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9785,37 +9546,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1468, col: 1, offset: 35523},
+			pos:  position{line: 1445, col: 1, offset: 34569},
 			expr: &actionExpr{
-				pos: position{line: 1469, col: 5, offset: 35539},
+				pos: position{line: 1446, col: 5, offset: 34585},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1469, col: 5, offset: 35539},
+					pos: position{line: 1446, col: 5, offset: 34585},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1469, col: 5, offset: 35539},
+							pos:        position{line: 1446, col: 5, offset: 34585},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1469, col: 9, offset: 35543},
+							pos:  position{line: 1446, col: 9, offset: 34589},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1469, col: 12, offset: 35546},
+							pos:   position{line: 1446, col: 12, offset: 34592},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1469, col: 14, offset: 35548},
+								pos:  position{line: 1446, col: 14, offset: 34594},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1469, col: 19, offset: 35553},
+							pos:  position{line: 1446, col: 19, offset: 34599},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1469, col: 22, offset: 35556},
+							pos:        position{line: 1446, col: 22, offset: 34602},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9828,129 +9589,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1477, col: 1, offset: 35691},
+			pos:  position{line: 1454, col: 1, offset: 34737},
 			expr: &actionExpr{
-				pos: position{line: 1478, col: 5, offset: 35709},
+				pos: position{line: 1455, col: 5, offset: 34755},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1478, col: 9, offset: 35713},
+					pos: position{line: 1455, col: 9, offset: 34759},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1478, col: 9, offset: 35713},
+							pos:        position{line: 1455, col: 9, offset: 34759},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1478, col: 19, offset: 35723},
+							pos:        position{line: 1455, col: 19, offset: 34769},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1478, col: 30, offset: 35734},
+							pos:        position{line: 1455, col: 30, offset: 34780},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1478, col: 41, offset: 35745},
+							pos:        position{line: 1455, col: 41, offset: 34791},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1479, col: 9, offset: 35762},
+							pos:        position{line: 1456, col: 9, offset: 34808},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1479, col: 18, offset: 35771},
+							pos:        position{line: 1456, col: 18, offset: 34817},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1479, col: 28, offset: 35781},
+							pos:        position{line: 1456, col: 28, offset: 34827},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1479, col: 38, offset: 35791},
+							pos:        position{line: 1456, col: 38, offset: 34837},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1480, col: 9, offset: 35807},
+							pos:        position{line: 1457, col: 9, offset: 34853},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1480, col: 21, offset: 35819},
+							pos:        position{line: 1457, col: 21, offset: 34865},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1480, col: 33, offset: 35831},
+							pos:        position{line: 1457, col: 33, offset: 34877},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1481, col: 9, offset: 35849},
+							pos:        position{line: 1458, col: 9, offset: 34895},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1481, col: 18, offset: 35858},
+							pos:        position{line: 1458, col: 18, offset: 34904},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1482, col: 9, offset: 35875},
+							pos:        position{line: 1459, col: 9, offset: 34921},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1482, col: 22, offset: 35888},
+							pos:        position{line: 1459, col: 22, offset: 34934},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1483, col: 9, offset: 35903},
+							pos:        position{line: 1460, col: 9, offset: 34949},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1484, col: 9, offset: 35919},
+							pos:        position{line: 1461, col: 9, offset: 34965},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1484, col: 16, offset: 35926},
+							pos:        position{line: 1461, col: 16, offset: 34972},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1485, col: 9, offset: 35940},
+							pos:        position{line: 1462, col: 9, offset: 34986},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1485, col: 18, offset: 35949},
+							pos:        position{line: 1462, col: 18, offset: 34995},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9963,31 +9724,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1493, col: 1, offset: 36134},
+			pos:  position{line: 1470, col: 1, offset: 35180},
 			expr: &choiceExpr{
-				pos: position{line: 1494, col: 5, offset: 36152},
+				pos: position{line: 1471, col: 5, offset: 35198},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1494, col: 5, offset: 36152},
+						pos: position{line: 1471, col: 5, offset: 35198},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1494, col: 5, offset: 36152},
+							pos: position{line: 1471, col: 5, offset: 35198},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1494, col: 5, offset: 36152},
+									pos:   position{line: 1471, col: 5, offset: 35198},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1494, col: 11, offset: 36158},
+										pos:  position{line: 1471, col: 11, offset: 35204},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1494, col: 21, offset: 36168},
+									pos:   position{line: 1471, col: 21, offset: 35214},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1494, col: 26, offset: 36173},
+										pos: position{line: 1471, col: 26, offset: 35219},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1494, col: 26, offset: 36173},
+											pos:  position{line: 1471, col: 26, offset: 35219},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9996,10 +9757,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1497, col: 5, offset: 36239},
+						pos: position{line: 1474, col: 5, offset: 35285},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1497, col: 5, offset: 36239},
+							pos:        position{line: 1474, col: 5, offset: 35285},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10012,32 +9773,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1499, col: 1, offset: 36263},
+			pos:  position{line: 1476, col: 1, offset: 35309},
 			expr: &actionExpr{
-				pos: position{line: 1499, col: 21, offset: 36283},
+				pos: position{line: 1476, col: 21, offset: 35329},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1499, col: 21, offset: 36283},
+					pos: position{line: 1476, col: 21, offset: 35329},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1499, col: 21, offset: 36283},
+							pos:  position{line: 1476, col: 21, offset: 35329},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1499, col: 24, offset: 36286},
+							pos:        position{line: 1476, col: 24, offset: 35332},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1499, col: 28, offset: 36290},
+							pos:  position{line: 1476, col: 28, offset: 35336},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1499, col: 31, offset: 36293},
+							pos:   position{line: 1476, col: 31, offset: 35339},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1499, col: 35, offset: 36297},
+								pos:  position{line: 1476, col: 35, offset: 35343},
 								name: "TypeField",
 							},
 						},
@@ -10049,40 +9810,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1501, col: 1, offset: 36328},
+			pos:  position{line: 1478, col: 1, offset: 35374},
 			expr: &actionExpr{
-				pos: position{line: 1502, col: 5, offset: 36342},
+				pos: position{line: 1479, col: 5, offset: 35388},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1502, col: 5, offset: 36342},
+					pos: position{line: 1479, col: 5, offset: 35388},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1502, col: 5, offset: 36342},
+							pos:   position{line: 1479, col: 5, offset: 35388},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1502, col: 10, offset: 36347},
+								pos:  position{line: 1479, col: 10, offset: 35393},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1502, col: 15, offset: 36352},
+							pos:  position{line: 1479, col: 15, offset: 35398},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1502, col: 18, offset: 36355},
+							pos:        position{line: 1479, col: 18, offset: 35401},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1502, col: 22, offset: 36359},
+							pos:  position{line: 1479, col: 22, offset: 35405},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1502, col: 25, offset: 36362},
+							pos:   position{line: 1479, col: 25, offset: 35408},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1502, col: 29, offset: 36366},
+								pos:  position{line: 1479, col: 29, offset: 35412},
 								name: "Type",
 							},
 						},
@@ -10094,26 +9855,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1510, col: 1, offset: 36515},
+			pos:  position{line: 1487, col: 1, offset: 35561},
 			expr: &actionExpr{
-				pos: position{line: 1511, col: 4, offset: 36523},
+				pos: position{line: 1488, col: 4, offset: 35569},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1511, col: 4, offset: 36523},
+					pos:   position{line: 1488, col: 4, offset: 35569},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1511, col: 7, offset: 36526},
+						pos: position{line: 1488, col: 7, offset: 35572},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1511, col: 7, offset: 36526},
+								pos:  position{line: 1488, col: 7, offset: 35572},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1511, col: 24, offset: 36543},
+								pos:  position{line: 1488, col: 24, offset: 35589},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1511, col: 45, offset: 36564},
+								pos:  position{line: 1488, col: 45, offset: 35610},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10125,51 +9886,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1515, col: 1, offset: 36664},
+			pos:  position{line: 1492, col: 1, offset: 35710},
 			expr: &actionExpr{
-				pos: position{line: 1516, col: 5, offset: 36674},
+				pos: position{line: 1493, col: 5, offset: 35720},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1516, col: 5, offset: 36674},
+					pos: position{line: 1493, col: 5, offset: 35720},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1516, col: 5, offset: 36674},
+							pos:   position{line: 1493, col: 5, offset: 35720},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1516, col: 11, offset: 36680},
+								pos:  position{line: 1493, col: 11, offset: 35726},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1516, col: 16, offset: 36685},
+							pos:   position{line: 1493, col: 16, offset: 35731},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1516, col: 21, offset: 36690},
+								pos: position{line: 1493, col: 21, offset: 35736},
 								expr: &actionExpr{
-									pos: position{line: 1516, col: 22, offset: 36691},
+									pos: position{line: 1493, col: 22, offset: 35737},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1516, col: 22, offset: 36691},
+										pos: position{line: 1493, col: 22, offset: 35737},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1516, col: 22, offset: 36691},
+												pos:  position{line: 1493, col: 22, offset: 35737},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1516, col: 25, offset: 36694},
+												pos:        position{line: 1493, col: 25, offset: 35740},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1516, col: 29, offset: 36698},
+												pos:  position{line: 1493, col: 29, offset: 35744},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1516, col: 32, offset: 36701},
+												pos:   position{line: 1493, col: 32, offset: 35747},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1516, col: 37, offset: 36706},
+													pos:  position{line: 1493, col: 37, offset: 35752},
 													name: "Name",
 												},
 											},
@@ -10186,15 +9947,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1520, col: 1, offset: 36778},
+			pos:  position{line: 1497, col: 1, offset: 35824},
 			expr: &actionExpr{
-				pos: position{line: 1521, col: 5, offset: 36793},
+				pos: position{line: 1498, col: 5, offset: 35839},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1521, col: 5, offset: 36793},
+					pos:   position{line: 1498, col: 5, offset: 35839},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1521, col: 8, offset: 36796},
+						pos:  position{line: 1498, col: 8, offset: 35842},
 						name: "IdentifierName",
 					},
 				},
@@ -10204,51 +9965,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1529, col: 1, offset: 36929},
+			pos:  position{line: 1506, col: 1, offset: 35975},
 			expr: &actionExpr{
-				pos: position{line: 1530, col: 5, offset: 36945},
+				pos: position{line: 1507, col: 5, offset: 35991},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1530, col: 5, offset: 36945},
+					pos: position{line: 1507, col: 5, offset: 35991},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1530, col: 5, offset: 36945},
+							pos:   position{line: 1507, col: 5, offset: 35991},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1530, col: 11, offset: 36951},
+								pos:  position{line: 1507, col: 11, offset: 35997},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1530, col: 22, offset: 36962},
+							pos:   position{line: 1507, col: 22, offset: 36008},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1530, col: 27, offset: 36967},
+								pos: position{line: 1507, col: 27, offset: 36013},
 								expr: &actionExpr{
-									pos: position{line: 1530, col: 28, offset: 36968},
+									pos: position{line: 1507, col: 28, offset: 36014},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1530, col: 28, offset: 36968},
+										pos: position{line: 1507, col: 28, offset: 36014},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1530, col: 28, offset: 36968},
+												pos:  position{line: 1507, col: 28, offset: 36014},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1530, col: 31, offset: 36971},
+												pos:        position{line: 1507, col: 31, offset: 36017},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1530, col: 35, offset: 36975},
+												pos:  position{line: 1507, col: 35, offset: 36021},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1530, col: 38, offset: 36978},
+												pos:   position{line: 1507, col: 38, offset: 36024},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1530, col: 43, offset: 36983},
+													pos:  position{line: 1507, col: 43, offset: 36029},
 													name: "Identifier",
 												},
 											},
@@ -10265,22 +10026,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1534, col: 1, offset: 37061},
+			pos:  position{line: 1511, col: 1, offset: 36107},
 			expr: &choiceExpr{
-				pos: position{line: 1535, col: 5, offset: 37079},
+				pos: position{line: 1512, col: 5, offset: 36125},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1535, col: 5, offset: 37079},
+						pos:  position{line: 1512, col: 5, offset: 36125},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1536, col: 5, offset: 37094},
+						pos: position{line: 1513, col: 5, offset: 36140},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1536, col: 5, offset: 37094},
+							pos:   position{line: 1513, col: 5, offset: 36140},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1536, col: 7, offset: 37096},
+								pos:  position{line: 1513, col: 7, offset: 36142},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10292,29 +10053,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1538, col: 1, offset: 37181},
+			pos:  position{line: 1515, col: 1, offset: 36227},
 			expr: &choiceExpr{
-				pos: position{line: 1539, col: 5, offset: 37200},
+				pos: position{line: 1516, col: 5, offset: 36246},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1539, col: 5, offset: 37200},
+						pos: position{line: 1516, col: 5, offset: 36246},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1539, col: 5, offset: 37200},
+							pos: position{line: 1516, col: 5, offset: 36246},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1539, col: 5, offset: 37200},
+									pos: position{line: 1516, col: 5, offset: 36246},
 									expr: &seqExpr{
-										pos: position{line: 1539, col: 7, offset: 37202},
+										pos: position{line: 1516, col: 7, offset: 36248},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1539, col: 7, offset: 37202},
+												pos:  position{line: 1516, col: 7, offset: 36248},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1539, col: 15, offset: 37210},
+												pos: position{line: 1516, col: 15, offset: 36256},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1539, col: 16, offset: 37211},
+													pos:  position{line: 1516, col: 16, offset: 36257},
 													name: "IdentifierRest",
 												},
 											},
@@ -10322,13 +10083,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1539, col: 32, offset: 37227},
+									pos:  position{line: 1516, col: 32, offset: 36273},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1539, col: 48, offset: 37243},
+									pos: position{line: 1516, col: 48, offset: 36289},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1539, col: 48, offset: 37243},
+										pos:  position{line: 1516, col: 48, offset: 36289},
 										name: "IdentifierRest",
 									},
 								},
@@ -10336,7 +10097,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1540, col: 5, offset: 37294},
+						pos:  position{line: 1517, col: 5, offset: 36340},
 						name: "BacktickString",
 					},
 				},
@@ -10346,22 +10107,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1542, col: 1, offset: 37310},
+			pos:  position{line: 1519, col: 1, offset: 36356},
 			expr: &choiceExpr{
-				pos: position{line: 1543, col: 5, offset: 37330},
+				pos: position{line: 1520, col: 5, offset: 36376},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1543, col: 5, offset: 37330},
+						pos:  position{line: 1520, col: 5, offset: 36376},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1544, col: 5, offset: 37348},
+						pos:        position{line: 1521, col: 5, offset: 36394},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1545, col: 5, offset: 37356},
+						pos:        position{line: 1522, col: 5, offset: 36402},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10373,24 +10134,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1547, col: 1, offset: 37361},
+			pos:  position{line: 1524, col: 1, offset: 36407},
 			expr: &choiceExpr{
-				pos: position{line: 1548, col: 5, offset: 37380},
+				pos: position{line: 1525, col: 5, offset: 36426},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1548, col: 5, offset: 37380},
+						pos:  position{line: 1525, col: 5, offset: 36426},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1549, col: 5, offset: 37400},
+						pos:  position{line: 1526, col: 5, offset: 36446},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1550, col: 5, offset: 37425},
+						pos:  position{line: 1527, col: 5, offset: 36471},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1551, col: 5, offset: 37442},
+						pos:  position{line: 1528, col: 5, offset: 36488},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10400,24 +10161,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1553, col: 1, offset: 37471},
+			pos:  position{line: 1530, col: 1, offset: 36517},
 			expr: &choiceExpr{
-				pos: position{line: 1554, col: 5, offset: 37483},
+				pos: position{line: 1531, col: 5, offset: 36529},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1554, col: 5, offset: 37483},
+						pos:  position{line: 1531, col: 5, offset: 36529},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1555, col: 5, offset: 37502},
+						pos:  position{line: 1532, col: 5, offset: 36548},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1556, col: 5, offset: 37518},
+						pos:  position{line: 1533, col: 5, offset: 36564},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1557, col: 5, offset: 37526},
+						pos:  position{line: 1534, col: 5, offset: 36572},
 						name: "Infinity",
 					},
 				},
@@ -10427,25 +10188,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1559, col: 1, offset: 37536},
+			pos:  position{line: 1536, col: 1, offset: 36582},
 			expr: &actionExpr{
-				pos: position{line: 1560, col: 5, offset: 37545},
+				pos: position{line: 1537, col: 5, offset: 36591},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1560, col: 5, offset: 37545},
+					pos: position{line: 1537, col: 5, offset: 36591},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1560, col: 5, offset: 37545},
+							pos:  position{line: 1537, col: 5, offset: 36591},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1560, col: 14, offset: 37554},
+							pos:        position{line: 1537, col: 14, offset: 36600},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1560, col: 18, offset: 37558},
+							pos:  position{line: 1537, col: 18, offset: 36604},
 							name: "FullTime",
 						},
 					},
@@ -10456,32 +10217,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1564, col: 1, offset: 37634},
+			pos:  position{line: 1541, col: 1, offset: 36680},
 			expr: &seqExpr{
-				pos: position{line: 1564, col: 12, offset: 37645},
+				pos: position{line: 1541, col: 12, offset: 36691},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1564, col: 12, offset: 37645},
+						pos:  position{line: 1541, col: 12, offset: 36691},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 15, offset: 37648},
+						pos:        position{line: 1541, col: 15, offset: 36694},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1564, col: 19, offset: 37652},
+						pos:  position{line: 1541, col: 19, offset: 36698},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 22, offset: 37655},
+						pos:        position{line: 1541, col: 22, offset: 36701},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1564, col: 26, offset: 37659},
+						pos:  position{line: 1541, col: 26, offset: 36705},
 						name: "D2",
 					},
 				},
@@ -10491,33 +10252,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1566, col: 1, offset: 37663},
+			pos:  position{line: 1543, col: 1, offset: 36709},
 			expr: &seqExpr{
-				pos: position{line: 1566, col: 6, offset: 37668},
+				pos: position{line: 1543, col: 6, offset: 36714},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1566, col: 6, offset: 37668},
+						pos:        position{line: 1543, col: 6, offset: 36714},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1566, col: 11, offset: 37673},
+						pos:        position{line: 1543, col: 11, offset: 36719},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1566, col: 16, offset: 37678},
+						pos:        position{line: 1543, col: 16, offset: 36724},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1566, col: 21, offset: 37683},
+						pos:        position{line: 1543, col: 21, offset: 36729},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10530,19 +10291,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1567, col: 1, offset: 37689},
+			pos:  position{line: 1544, col: 1, offset: 36735},
 			expr: &seqExpr{
-				pos: position{line: 1567, col: 6, offset: 37694},
+				pos: position{line: 1544, col: 6, offset: 36740},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1567, col: 6, offset: 37694},
+						pos:        position{line: 1544, col: 6, offset: 36740},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1567, col: 11, offset: 37699},
+						pos:        position{line: 1544, col: 11, offset: 36745},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10555,16 +10316,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1569, col: 1, offset: 37706},
+			pos:  position{line: 1546, col: 1, offset: 36752},
 			expr: &seqExpr{
-				pos: position{line: 1569, col: 12, offset: 37717},
+				pos: position{line: 1546, col: 12, offset: 36763},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1569, col: 12, offset: 37717},
+						pos:  position{line: 1546, col: 12, offset: 36763},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1569, col: 24, offset: 37729},
+						pos:  position{line: 1546, col: 24, offset: 36775},
 						name: "TimeOffset",
 					},
 				},
@@ -10574,49 +10335,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1571, col: 1, offset: 37741},
+			pos:  position{line: 1548, col: 1, offset: 36787},
 			expr: &seqExpr{
-				pos: position{line: 1571, col: 15, offset: 37755},
+				pos: position{line: 1548, col: 15, offset: 36801},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1571, col: 15, offset: 37755},
+						pos:  position{line: 1548, col: 15, offset: 36801},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1571, col: 18, offset: 37758},
+						pos:        position{line: 1548, col: 18, offset: 36804},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1571, col: 22, offset: 37762},
+						pos:  position{line: 1548, col: 22, offset: 36808},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1571, col: 25, offset: 37765},
+						pos:        position{line: 1548, col: 25, offset: 36811},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1571, col: 29, offset: 37769},
+						pos:  position{line: 1548, col: 29, offset: 36815},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1571, col: 32, offset: 37772},
+						pos: position{line: 1548, col: 32, offset: 36818},
 						expr: &seqExpr{
-							pos: position{line: 1571, col: 33, offset: 37773},
+							pos: position{line: 1548, col: 33, offset: 36819},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1571, col: 33, offset: 37773},
+									pos:        position{line: 1548, col: 33, offset: 36819},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1571, col: 37, offset: 37777},
+									pos: position{line: 1548, col: 37, offset: 36823},
 									expr: &charClassMatcher{
-										pos:        position{line: 1571, col: 37, offset: 37777},
+										pos:        position{line: 1548, col: 37, offset: 36823},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10633,30 +10394,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1573, col: 1, offset: 37787},
+			pos:  position{line: 1550, col: 1, offset: 36833},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 5, offset: 37802},
+				pos: position{line: 1551, col: 5, offset: 36848},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1574, col: 5, offset: 37802},
+						pos:        position{line: 1551, col: 5, offset: 36848},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1575, col: 5, offset: 37810},
+						pos: position{line: 1552, col: 5, offset: 36856},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1575, col: 6, offset: 37811},
+								pos: position{line: 1552, col: 6, offset: 36857},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1575, col: 6, offset: 37811},
+										pos:        position{line: 1552, col: 6, offset: 36857},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1575, col: 12, offset: 37817},
+										pos:        position{line: 1552, col: 12, offset: 36863},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10664,34 +10425,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1575, col: 17, offset: 37822},
+								pos:  position{line: 1552, col: 17, offset: 36868},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1575, col: 20, offset: 37825},
+								pos:        position{line: 1552, col: 20, offset: 36871},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1575, col: 24, offset: 37829},
+								pos:  position{line: 1552, col: 24, offset: 36875},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1575, col: 27, offset: 37832},
+								pos: position{line: 1552, col: 27, offset: 36878},
 								expr: &seqExpr{
-									pos: position{line: 1575, col: 28, offset: 37833},
+									pos: position{line: 1552, col: 28, offset: 36879},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1575, col: 28, offset: 37833},
+											pos:        position{line: 1552, col: 28, offset: 36879},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1575, col: 32, offset: 37837},
+											pos: position{line: 1552, col: 32, offset: 36883},
 											expr: &charClassMatcher{
-												pos:        position{line: 1575, col: 32, offset: 37837},
+												pos:        position{line: 1552, col: 32, offset: 36883},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10710,33 +10471,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1577, col: 1, offset: 37847},
+			pos:  position{line: 1554, col: 1, offset: 36893},
 			expr: &actionExpr{
-				pos: position{line: 1578, col: 5, offset: 37860},
+				pos: position{line: 1555, col: 5, offset: 36906},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1578, col: 5, offset: 37860},
+					pos: position{line: 1555, col: 5, offset: 36906},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1578, col: 5, offset: 37860},
+							pos: position{line: 1555, col: 5, offset: 36906},
 							expr: &litMatcher{
-								pos:        position{line: 1578, col: 5, offset: 37860},
+								pos:        position{line: 1555, col: 5, offset: 36906},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1578, col: 10, offset: 37865},
+							pos: position{line: 1555, col: 10, offset: 36911},
 							expr: &seqExpr{
-								pos: position{line: 1578, col: 11, offset: 37866},
+								pos: position{line: 1555, col: 11, offset: 36912},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1578, col: 11, offset: 37866},
+										pos:  position{line: 1555, col: 11, offset: 36912},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1578, col: 19, offset: 37874},
+										pos:  position{line: 1555, col: 19, offset: 36920},
 										name: "TimeUnit",
 									},
 								},
@@ -10750,27 +10511,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1582, col: 1, offset: 37956},
+			pos:  position{line: 1559, col: 1, offset: 37002},
 			expr: &seqExpr{
-				pos: position{line: 1582, col: 11, offset: 37966},
+				pos: position{line: 1559, col: 11, offset: 37012},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1582, col: 11, offset: 37966},
+						pos:  position{line: 1559, col: 11, offset: 37012},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1582, col: 16, offset: 37971},
+						pos: position{line: 1559, col: 16, offset: 37017},
 						expr: &seqExpr{
-							pos: position{line: 1582, col: 17, offset: 37972},
+							pos: position{line: 1559, col: 17, offset: 37018},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1582, col: 17, offset: 37972},
+									pos:        position{line: 1559, col: 17, offset: 37018},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1582, col: 21, offset: 37976},
+									pos:  position{line: 1559, col: 21, offset: 37022},
 									name: "UInt",
 								},
 							},
@@ -10783,60 +10544,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1584, col: 1, offset: 37984},
+			pos:  position{line: 1561, col: 1, offset: 37030},
 			expr: &choiceExpr{
-				pos: position{line: 1585, col: 5, offset: 37997},
+				pos: position{line: 1562, col: 5, offset: 37043},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1585, col: 5, offset: 37997},
+						pos:        position{line: 1562, col: 5, offset: 37043},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1586, col: 5, offset: 38006},
+						pos:        position{line: 1563, col: 5, offset: 37052},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1587, col: 5, offset: 38015},
+						pos:        position{line: 1564, col: 5, offset: 37061},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1588, col: 5, offset: 38024},
+						pos:        position{line: 1565, col: 5, offset: 37070},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1589, col: 5, offset: 38032},
+						pos:        position{line: 1566, col: 5, offset: 37078},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1590, col: 5, offset: 38040},
+						pos:        position{line: 1567, col: 5, offset: 37086},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1591, col: 5, offset: 38048},
+						pos:        position{line: 1568, col: 5, offset: 37094},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1592, col: 5, offset: 38056},
+						pos:        position{line: 1569, col: 5, offset: 37102},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1593, col: 5, offset: 38064},
+						pos:        position{line: 1570, col: 5, offset: 37110},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10848,45 +10609,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1595, col: 1, offset: 38069},
+			pos:  position{line: 1572, col: 1, offset: 37115},
 			expr: &actionExpr{
-				pos: position{line: 1596, col: 5, offset: 38076},
+				pos: position{line: 1573, col: 5, offset: 37122},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1596, col: 5, offset: 38076},
+					pos: position{line: 1573, col: 5, offset: 37122},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1596, col: 5, offset: 38076},
+							pos:  position{line: 1573, col: 5, offset: 37122},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1596, col: 10, offset: 38081},
+							pos:        position{line: 1573, col: 10, offset: 37127},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1596, col: 14, offset: 38085},
+							pos:  position{line: 1573, col: 14, offset: 37131},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1596, col: 19, offset: 38090},
+							pos:        position{line: 1573, col: 19, offset: 37136},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1596, col: 23, offset: 38094},
+							pos:  position{line: 1573, col: 23, offset: 37140},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1596, col: 28, offset: 38099},
+							pos:        position{line: 1573, col: 28, offset: 37145},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1596, col: 32, offset: 38103},
+							pos:  position{line: 1573, col: 32, offset: 37149},
 							name: "UInt",
 						},
 					},
@@ -10897,43 +10658,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1598, col: 1, offset: 38140},
+			pos:  position{line: 1575, col: 1, offset: 37186},
 			expr: &actionExpr{
-				pos: position{line: 1599, col: 5, offset: 38148},
+				pos: position{line: 1576, col: 5, offset: 37194},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1599, col: 5, offset: 38148},
+					pos: position{line: 1576, col: 5, offset: 37194},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1599, col: 5, offset: 38148},
+							pos: position{line: 1576, col: 5, offset: 37194},
 							expr: &seqExpr{
-								pos: position{line: 1599, col: 7, offset: 38150},
+								pos: position{line: 1576, col: 7, offset: 37196},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1599, col: 7, offset: 38150},
+										pos:  position{line: 1576, col: 7, offset: 37196},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1599, col: 11, offset: 38154},
+										pos:        position{line: 1576, col: 11, offset: 37200},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1599, col: 15, offset: 38158},
+										pos:  position{line: 1576, col: 15, offset: 37204},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1599, col: 19, offset: 38162},
+										pos: position{line: 1576, col: 19, offset: 37208},
 										expr: &choiceExpr{
-											pos: position{line: 1599, col: 21, offset: 38164},
+											pos: position{line: 1576, col: 21, offset: 37210},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1599, col: 21, offset: 38164},
+													pos:  position{line: 1576, col: 21, offset: 37210},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1599, col: 32, offset: 38175},
+													pos:        position{line: 1576, col: 32, offset: 37221},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10945,10 +10706,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1599, col: 38, offset: 38181},
+							pos:   position{line: 1576, col: 38, offset: 37227},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 40, offset: 38183},
+								pos:  position{line: 1576, col: 40, offset: 37229},
 								name: "IP6Variations",
 							},
 						},
@@ -10960,32 +10721,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1603, col: 1, offset: 38347},
+			pos:  position{line: 1580, col: 1, offset: 37393},
 			expr: &choiceExpr{
-				pos: position{line: 1604, col: 5, offset: 38365},
+				pos: position{line: 1581, col: 5, offset: 37411},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1604, col: 5, offset: 38365},
+						pos: position{line: 1581, col: 5, offset: 37411},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1604, col: 5, offset: 38365},
+							pos: position{line: 1581, col: 5, offset: 37411},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1604, col: 5, offset: 38365},
+									pos:   position{line: 1581, col: 5, offset: 37411},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1604, col: 7, offset: 38367},
+										pos: position{line: 1581, col: 7, offset: 37413},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1604, col: 7, offset: 38367},
+											pos:  position{line: 1581, col: 7, offset: 37413},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1604, col: 17, offset: 38377},
+									pos:   position{line: 1581, col: 17, offset: 37423},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1604, col: 19, offset: 38379},
+										pos:  position{line: 1581, col: 19, offset: 37425},
 										name: "IP6Tail",
 									},
 								},
@@ -10993,52 +10754,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1607, col: 5, offset: 38443},
+						pos: position{line: 1584, col: 5, offset: 37489},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1607, col: 5, offset: 38443},
+							pos: position{line: 1584, col: 5, offset: 37489},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1607, col: 5, offset: 38443},
+									pos:   position{line: 1584, col: 5, offset: 37489},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1607, col: 7, offset: 38445},
+										pos:  position{line: 1584, col: 7, offset: 37491},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1607, col: 11, offset: 38449},
+									pos:   position{line: 1584, col: 11, offset: 37495},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1607, col: 13, offset: 38451},
+										pos: position{line: 1584, col: 13, offset: 37497},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1607, col: 13, offset: 38451},
+											pos:  position{line: 1584, col: 13, offset: 37497},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1607, col: 23, offset: 38461},
+									pos:        position{line: 1584, col: 23, offset: 37507},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1607, col: 28, offset: 38466},
+									pos:   position{line: 1584, col: 28, offset: 37512},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1607, col: 30, offset: 38468},
+										pos: position{line: 1584, col: 30, offset: 37514},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1607, col: 30, offset: 38468},
+											pos:  position{line: 1584, col: 30, offset: 37514},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1607, col: 40, offset: 38478},
+									pos:   position{line: 1584, col: 40, offset: 37524},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1607, col: 42, offset: 38480},
+										pos:  position{line: 1584, col: 42, offset: 37526},
 										name: "IP6Tail",
 									},
 								},
@@ -11046,33 +10807,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1610, col: 5, offset: 38579},
+						pos: position{line: 1587, col: 5, offset: 37625},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1610, col: 5, offset: 38579},
+							pos: position{line: 1587, col: 5, offset: 37625},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1610, col: 5, offset: 38579},
+									pos:        position{line: 1587, col: 5, offset: 37625},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1610, col: 10, offset: 38584},
+									pos:   position{line: 1587, col: 10, offset: 37630},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1610, col: 12, offset: 38586},
+										pos: position{line: 1587, col: 12, offset: 37632},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1610, col: 12, offset: 38586},
+											pos:  position{line: 1587, col: 12, offset: 37632},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1610, col: 22, offset: 38596},
+									pos:   position{line: 1587, col: 22, offset: 37642},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1610, col: 24, offset: 38598},
+										pos:  position{line: 1587, col: 24, offset: 37644},
 										name: "IP6Tail",
 									},
 								},
@@ -11080,40 +10841,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1613, col: 5, offset: 38669},
+						pos: position{line: 1590, col: 5, offset: 37715},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1613, col: 5, offset: 38669},
+							pos: position{line: 1590, col: 5, offset: 37715},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1613, col: 5, offset: 38669},
+									pos:   position{line: 1590, col: 5, offset: 37715},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1613, col: 7, offset: 38671},
+										pos:  position{line: 1590, col: 7, offset: 37717},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1613, col: 11, offset: 38675},
+									pos:   position{line: 1590, col: 11, offset: 37721},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1613, col: 13, offset: 38677},
+										pos: position{line: 1590, col: 13, offset: 37723},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1613, col: 13, offset: 38677},
+											pos:  position{line: 1590, col: 13, offset: 37723},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1613, col: 23, offset: 38687},
+									pos:        position{line: 1590, col: 23, offset: 37733},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1613, col: 28, offset: 38692},
+									pos: position{line: 1590, col: 28, offset: 37738},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1613, col: 29, offset: 38693},
+										pos:  position{line: 1590, col: 29, offset: 37739},
 										name: "TypeAsValue",
 									},
 								},
@@ -11121,10 +10882,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1616, col: 5, offset: 38768},
+						pos: position{line: 1593, col: 5, offset: 37814},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1616, col: 5, offset: 38768},
+							pos:        position{line: 1593, col: 5, offset: 37814},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11137,16 +10898,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1620, col: 1, offset: 38805},
+			pos:  position{line: 1597, col: 1, offset: 37851},
 			expr: &choiceExpr{
-				pos: position{line: 1621, col: 5, offset: 38817},
+				pos: position{line: 1598, col: 5, offset: 37863},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1621, col: 5, offset: 38817},
+						pos:  position{line: 1598, col: 5, offset: 37863},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1622, col: 5, offset: 38824},
+						pos:  position{line: 1599, col: 5, offset: 37870},
 						name: "Hex",
 					},
 				},
@@ -11156,24 +10917,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1624, col: 1, offset: 38829},
+			pos:  position{line: 1601, col: 1, offset: 37875},
 			expr: &actionExpr{
-				pos: position{line: 1624, col: 12, offset: 38840},
+				pos: position{line: 1601, col: 12, offset: 37886},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1624, col: 12, offset: 38840},
+					pos: position{line: 1601, col: 12, offset: 37886},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1624, col: 12, offset: 38840},
+							pos:        position{line: 1601, col: 12, offset: 37886},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1624, col: 16, offset: 38844},
+							pos:   position{line: 1601, col: 16, offset: 37890},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1624, col: 18, offset: 38846},
+								pos:  position{line: 1601, col: 18, offset: 37892},
 								name: "Hex",
 							},
 						},
@@ -11185,23 +10946,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1626, col: 1, offset: 38884},
+			pos:  position{line: 1603, col: 1, offset: 37930},
 			expr: &actionExpr{
-				pos: position{line: 1626, col: 12, offset: 38895},
+				pos: position{line: 1603, col: 12, offset: 37941},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1626, col: 12, offset: 38895},
+					pos: position{line: 1603, col: 12, offset: 37941},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1626, col: 12, offset: 38895},
+							pos:   position{line: 1603, col: 12, offset: 37941},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1626, col: 14, offset: 38897},
+								pos:  position{line: 1603, col: 14, offset: 37943},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1626, col: 18, offset: 38901},
+							pos:        position{line: 1603, col: 18, offset: 37947},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11214,32 +10975,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1628, col: 1, offset: 38939},
+			pos:  position{line: 1605, col: 1, offset: 37985},
 			expr: &actionExpr{
-				pos: position{line: 1629, col: 5, offset: 38950},
+				pos: position{line: 1606, col: 5, offset: 37996},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1629, col: 5, offset: 38950},
+					pos: position{line: 1606, col: 5, offset: 37996},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1629, col: 5, offset: 38950},
+							pos:   position{line: 1606, col: 5, offset: 37996},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1629, col: 7, offset: 38952},
+								pos:  position{line: 1606, col: 7, offset: 37998},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1629, col: 10, offset: 38955},
+							pos:        position{line: 1606, col: 10, offset: 38001},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1629, col: 14, offset: 38959},
+							pos:   position{line: 1606, col: 14, offset: 38005},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1629, col: 16, offset: 38961},
+								pos:  position{line: 1606, col: 16, offset: 38007},
 								name: "UIntString",
 							},
 						},
@@ -11251,32 +11012,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1633, col: 1, offset: 39029},
+			pos:  position{line: 1610, col: 1, offset: 38075},
 			expr: &actionExpr{
-				pos: position{line: 1634, col: 5, offset: 39040},
+				pos: position{line: 1611, col: 5, offset: 38086},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1634, col: 5, offset: 39040},
+					pos: position{line: 1611, col: 5, offset: 38086},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1634, col: 5, offset: 39040},
+							pos:   position{line: 1611, col: 5, offset: 38086},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1634, col: 7, offset: 39042},
+								pos:  position{line: 1611, col: 7, offset: 38088},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1634, col: 11, offset: 39046},
+							pos:        position{line: 1611, col: 11, offset: 38092},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1634, col: 15, offset: 39050},
+							pos:   position{line: 1611, col: 15, offset: 38096},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1634, col: 17, offset: 39052},
+								pos:  position{line: 1611, col: 17, offset: 38098},
 								name: "UIntString",
 							},
 						},
@@ -11288,15 +11049,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1638, col: 1, offset: 39120},
+			pos:  position{line: 1615, col: 1, offset: 38166},
 			expr: &actionExpr{
-				pos: position{line: 1639, col: 4, offset: 39128},
+				pos: position{line: 1616, col: 4, offset: 38174},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1639, col: 4, offset: 39128},
+					pos:   position{line: 1616, col: 4, offset: 38174},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1639, col: 6, offset: 39130},
+						pos:  position{line: 1616, col: 6, offset: 38176},
 						name: "UIntString",
 					},
 				},
@@ -11306,16 +11067,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1641, col: 1, offset: 39170},
+			pos:  position{line: 1618, col: 1, offset: 38216},
 			expr: &choiceExpr{
-				pos: position{line: 1642, col: 5, offset: 39184},
+				pos: position{line: 1619, col: 5, offset: 38230},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 5, offset: 39184},
+						pos:  position{line: 1619, col: 5, offset: 38230},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1643, col: 5, offset: 39199},
+						pos:  position{line: 1620, col: 5, offset: 38245},
 						name: "MinusIntString",
 					},
 				},
@@ -11325,14 +11086,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1645, col: 1, offset: 39215},
+			pos:  position{line: 1622, col: 1, offset: 38261},
 			expr: &actionExpr{
-				pos: position{line: 1645, col: 14, offset: 39228},
+				pos: position{line: 1622, col: 14, offset: 38274},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1645, col: 14, offset: 39228},
+					pos: position{line: 1622, col: 14, offset: 38274},
 					expr: &charClassMatcher{
-						pos:        position{line: 1645, col: 14, offset: 39228},
+						pos:        position{line: 1622, col: 14, offset: 38274},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11345,21 +11106,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1647, col: 1, offset: 39267},
+			pos:  position{line: 1624, col: 1, offset: 38313},
 			expr: &actionExpr{
-				pos: position{line: 1648, col: 5, offset: 39286},
+				pos: position{line: 1625, col: 5, offset: 38332},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1648, col: 5, offset: 39286},
+					pos: position{line: 1625, col: 5, offset: 38332},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1648, col: 5, offset: 39286},
+							pos:        position{line: 1625, col: 5, offset: 38332},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1648, col: 9, offset: 39290},
+							pos:  position{line: 1625, col: 9, offset: 38336},
 							name: "UIntString",
 						},
 					},
@@ -11370,29 +11131,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1650, col: 1, offset: 39333},
+			pos:  position{line: 1627, col: 1, offset: 38379},
 			expr: &choiceExpr{
-				pos: position{line: 1651, col: 5, offset: 39349},
+				pos: position{line: 1628, col: 5, offset: 38395},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1651, col: 5, offset: 39349},
+						pos: position{line: 1628, col: 5, offset: 38395},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1651, col: 5, offset: 39349},
+							pos: position{line: 1628, col: 5, offset: 38395},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1651, col: 5, offset: 39349},
+									pos: position{line: 1628, col: 5, offset: 38395},
 									expr: &litMatcher{
-										pos:        position{line: 1651, col: 5, offset: 39349},
+										pos:        position{line: 1628, col: 5, offset: 38395},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1651, col: 10, offset: 39354},
+									pos: position{line: 1628, col: 10, offset: 38400},
 									expr: &charClassMatcher{
-										pos:        position{line: 1651, col: 10, offset: 39354},
+										pos:        position{line: 1628, col: 10, offset: 38400},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11400,15 +11161,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1651, col: 17, offset: 39361},
+									pos:        position{line: 1628, col: 17, offset: 38407},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1651, col: 21, offset: 39365},
+									pos: position{line: 1628, col: 21, offset: 38411},
 									expr: &charClassMatcher{
-										pos:        position{line: 1651, col: 21, offset: 39365},
+										pos:        position{line: 1628, col: 21, offset: 38411},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11416,9 +11177,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1651, col: 28, offset: 39372},
+									pos: position{line: 1628, col: 28, offset: 38418},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1651, col: 28, offset: 39372},
+										pos:  position{line: 1628, col: 28, offset: 38418},
 										name: "ExponentPart",
 									},
 								},
@@ -11426,30 +11187,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1652, col: 5, offset: 39421},
+						pos: position{line: 1629, col: 5, offset: 38467},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1652, col: 5, offset: 39421},
+							pos: position{line: 1629, col: 5, offset: 38467},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1652, col: 5, offset: 39421},
+									pos: position{line: 1629, col: 5, offset: 38467},
 									expr: &litMatcher{
-										pos:        position{line: 1652, col: 5, offset: 39421},
+										pos:        position{line: 1629, col: 5, offset: 38467},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1652, col: 10, offset: 39426},
+									pos:        position{line: 1629, col: 10, offset: 38472},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1652, col: 14, offset: 39430},
+									pos: position{line: 1629, col: 14, offset: 38476},
 									expr: &charClassMatcher{
-										pos:        position{line: 1652, col: 14, offset: 39430},
+										pos:        position{line: 1629, col: 14, offset: 38476},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11457,9 +11218,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1652, col: 21, offset: 39437},
+									pos: position{line: 1629, col: 21, offset: 38483},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1652, col: 21, offset: 39437},
+										pos:  position{line: 1629, col: 21, offset: 38483},
 										name: "ExponentPart",
 									},
 								},
@@ -11467,17 +11228,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1653, col: 5, offset: 39486},
+						pos: position{line: 1630, col: 5, offset: 38532},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1653, col: 6, offset: 39487},
+							pos: position{line: 1630, col: 6, offset: 38533},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1653, col: 6, offset: 39487},
+									pos:  position{line: 1630, col: 6, offset: 38533},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1653, col: 12, offset: 39493},
+									pos:  position{line: 1630, col: 12, offset: 38539},
 									name: "Infinity",
 								},
 							},
@@ -11490,20 +11251,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1656, col: 1, offset: 39536},
+			pos:  position{line: 1633, col: 1, offset: 38582},
 			expr: &seqExpr{
-				pos: position{line: 1656, col: 16, offset: 39551},
+				pos: position{line: 1633, col: 16, offset: 38597},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1656, col: 16, offset: 39551},
+						pos:        position{line: 1633, col: 16, offset: 38597},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1656, col: 21, offset: 39556},
+						pos: position{line: 1633, col: 21, offset: 38602},
 						expr: &charClassMatcher{
-							pos:        position{line: 1656, col: 21, offset: 39556},
+							pos:        position{line: 1633, col: 21, offset: 38602},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11511,7 +11272,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1656, col: 27, offset: 39562},
+						pos:  position{line: 1633, col: 27, offset: 38608},
 						name: "UIntString",
 					},
 				},
@@ -11521,9 +11282,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1658, col: 1, offset: 39574},
+			pos:  position{line: 1635, col: 1, offset: 38620},
 			expr: &litMatcher{
-				pos:        position{line: 1658, col: 7, offset: 39580},
+				pos:        position{line: 1635, col: 7, offset: 38626},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11533,23 +11294,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1660, col: 1, offset: 39587},
+			pos:  position{line: 1637, col: 1, offset: 38633},
 			expr: &seqExpr{
-				pos: position{line: 1660, col: 12, offset: 39598},
+				pos: position{line: 1637, col: 12, offset: 38644},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1660, col: 12, offset: 39598},
+						pos: position{line: 1637, col: 12, offset: 38644},
 						expr: &choiceExpr{
-							pos: position{line: 1660, col: 13, offset: 39599},
+							pos: position{line: 1637, col: 13, offset: 38645},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1660, col: 13, offset: 39599},
+									pos:        position{line: 1637, col: 13, offset: 38645},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1660, col: 19, offset: 39605},
+									pos:        position{line: 1637, col: 19, offset: 38651},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11558,7 +11319,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1660, col: 25, offset: 39611},
+						pos:        position{line: 1637, col: 25, offset: 38657},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11570,14 +11331,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1662, col: 1, offset: 39618},
+			pos:  position{line: 1639, col: 1, offset: 38664},
 			expr: &actionExpr{
-				pos: position{line: 1662, col: 7, offset: 39624},
+				pos: position{line: 1639, col: 7, offset: 38670},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1662, col: 7, offset: 39624},
+					pos: position{line: 1639, col: 7, offset: 38670},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1662, col: 7, offset: 39624},
+						pos:  position{line: 1639, col: 7, offset: 38670},
 						name: "HexDigit",
 					},
 				},
@@ -11587,9 +11348,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1664, col: 1, offset: 39666},
+			pos:  position{line: 1641, col: 1, offset: 38712},
 			expr: &charClassMatcher{
-				pos:        position{line: 1664, col: 12, offset: 39677},
+				pos:        position{line: 1641, col: 12, offset: 38723},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11600,32 +11361,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1666, col: 1, offset: 39690},
+			pos:  position{line: 1643, col: 1, offset: 38736},
 			expr: &actionExpr{
-				pos: position{line: 1667, col: 5, offset: 39713},
+				pos: position{line: 1644, col: 5, offset: 38759},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1667, col: 5, offset: 39713},
+					pos: position{line: 1644, col: 5, offset: 38759},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1667, col: 5, offset: 39713},
+							pos:        position{line: 1644, col: 5, offset: 38759},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1667, col: 9, offset: 39717},
+							pos:   position{line: 1644, col: 9, offset: 38763},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1667, col: 11, offset: 39719},
+								pos: position{line: 1644, col: 11, offset: 38765},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1667, col: 11, offset: 39719},
+									pos:  position{line: 1644, col: 11, offset: 38765},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 29, offset: 39737},
+							pos:        position{line: 1644, col: 29, offset: 38783},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11638,32 +11399,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1669, col: 1, offset: 39771},
+			pos:  position{line: 1646, col: 1, offset: 38817},
 			expr: &actionExpr{
-				pos: position{line: 1670, col: 5, offset: 39794},
+				pos: position{line: 1647, col: 5, offset: 38840},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1670, col: 5, offset: 39794},
+					pos: position{line: 1647, col: 5, offset: 38840},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1670, col: 5, offset: 39794},
+							pos:        position{line: 1647, col: 5, offset: 38840},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1670, col: 9, offset: 39798},
+							pos:   position{line: 1647, col: 9, offset: 38844},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1670, col: 11, offset: 39800},
+								pos: position{line: 1647, col: 11, offset: 38846},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1670, col: 11, offset: 39800},
+									pos:  position{line: 1647, col: 11, offset: 38846},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1670, col: 29, offset: 39818},
+							pos:        position{line: 1647, col: 29, offset: 38864},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11676,57 +11437,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1672, col: 1, offset: 39852},
+			pos:  position{line: 1649, col: 1, offset: 38898},
 			expr: &choiceExpr{
-				pos: position{line: 1673, col: 5, offset: 39873},
+				pos: position{line: 1650, col: 5, offset: 38919},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1673, col: 5, offset: 39873},
+						pos: position{line: 1650, col: 5, offset: 38919},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1673, col: 5, offset: 39873},
+							pos: position{line: 1650, col: 5, offset: 38919},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1673, col: 5, offset: 39873},
+									pos: position{line: 1650, col: 5, offset: 38919},
 									expr: &choiceExpr{
-										pos: position{line: 1673, col: 7, offset: 39875},
+										pos: position{line: 1650, col: 7, offset: 38921},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1673, col: 7, offset: 39875},
+												pos:        position{line: 1650, col: 7, offset: 38921},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1673, col: 13, offset: 39881},
+												pos:  position{line: 1650, col: 13, offset: 38927},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1673, col: 26, offset: 39894,
+									line: 1650, col: 26, offset: 38940,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1674, col: 5, offset: 39931},
+						pos: position{line: 1651, col: 5, offset: 38977},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1674, col: 5, offset: 39931},
+							pos: position{line: 1651, col: 5, offset: 38977},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1674, col: 5, offset: 39931},
+									pos:        position{line: 1651, col: 5, offset: 38977},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1674, col: 10, offset: 39936},
+									pos:   position{line: 1651, col: 10, offset: 38982},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1674, col: 12, offset: 39938},
+										pos:  position{line: 1651, col: 12, offset: 38984},
 										name: "EscapeSequence",
 									},
 								},
@@ -11740,32 +11501,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1676, col: 1, offset: 39972},
+			pos:  position{line: 1653, col: 1, offset: 39018},
 			expr: &choiceExpr{
-				pos: position{line: 1677, col: 5, offset: 39984},
+				pos: position{line: 1654, col: 5, offset: 39030},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1677, col: 5, offset: 39984},
+						pos: position{line: 1654, col: 5, offset: 39030},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1677, col: 5, offset: 39984},
+							pos: position{line: 1654, col: 5, offset: 39030},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1677, col: 5, offset: 39984},
+									pos:        position{line: 1654, col: 5, offset: 39030},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1677, col: 10, offset: 39989},
+									pos:   position{line: 1654, col: 10, offset: 39035},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1677, col: 12, offset: 39991},
+										pos:  position{line: 1654, col: 12, offset: 39037},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1677, col: 27, offset: 40006},
+									pos:        position{line: 1654, col: 27, offset: 39052},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11774,33 +11535,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1678, col: 5, offset: 40041},
+						pos: position{line: 1655, col: 5, offset: 39087},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1678, col: 5, offset: 40041},
+							pos: position{line: 1655, col: 5, offset: 39087},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1678, col: 5, offset: 40041},
+									pos:        position{line: 1655, col: 5, offset: 39087},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1678, col: 9, offset: 40045},
+									pos:        position{line: 1655, col: 9, offset: 39091},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1678, col: 13, offset: 40049},
+									pos:   position{line: 1655, col: 13, offset: 39095},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1678, col: 15, offset: 40051},
+										pos:  position{line: 1655, col: 15, offset: 39097},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1678, col: 30, offset: 40066},
+									pos:        position{line: 1655, col: 30, offset: 39112},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11815,26 +11576,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1680, col: 1, offset: 40098},
+			pos:  position{line: 1657, col: 1, offset: 39144},
 			expr: &actionExpr{
-				pos: position{line: 1681, col: 5, offset: 40117},
+				pos: position{line: 1658, col: 5, offset: 39163},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1681, col: 5, offset: 40117},
+					pos: position{line: 1658, col: 5, offset: 39163},
 					expr: &seqExpr{
-						pos: position{line: 1681, col: 6, offset: 40118},
+						pos: position{line: 1658, col: 6, offset: 39164},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1681, col: 6, offset: 40118},
+								pos: position{line: 1658, col: 6, offset: 39164},
 								expr: &litMatcher{
-									pos:        position{line: 1681, col: 7, offset: 40119},
+									pos:        position{line: 1658, col: 7, offset: 39165},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1681, col: 11, offset: 40123,
+								line: 1658, col: 11, offset: 39169,
 							},
 						},
 					},
@@ -11845,26 +11606,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1683, col: 1, offset: 40159},
+			pos:  position{line: 1660, col: 1, offset: 39205},
 			expr: &actionExpr{
-				pos: position{line: 1684, col: 5, offset: 40178},
+				pos: position{line: 1661, col: 5, offset: 39224},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1684, col: 5, offset: 40178},
+					pos: position{line: 1661, col: 5, offset: 39224},
 					expr: &seqExpr{
-						pos: position{line: 1684, col: 6, offset: 40179},
+						pos: position{line: 1661, col: 6, offset: 39225},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1684, col: 6, offset: 40179},
+								pos: position{line: 1661, col: 6, offset: 39225},
 								expr: &litMatcher{
-									pos:        position{line: 1684, col: 7, offset: 40180},
+									pos:        position{line: 1661, col: 7, offset: 39226},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1684, col: 11, offset: 40184,
+								line: 1661, col: 11, offset: 39230,
 							},
 						},
 					},
@@ -11875,32 +11636,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1686, col: 1, offset: 40220},
+			pos:  position{line: 1663, col: 1, offset: 39266},
 			expr: &actionExpr{
-				pos: position{line: 1687, col: 5, offset: 40239},
+				pos: position{line: 1664, col: 5, offset: 39285},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1687, col: 5, offset: 40239},
+					pos: position{line: 1664, col: 5, offset: 39285},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1687, col: 5, offset: 40239},
+							pos:        position{line: 1664, col: 5, offset: 39285},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1687, col: 9, offset: 40243},
+							pos:   position{line: 1664, col: 9, offset: 39289},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1687, col: 11, offset: 40245},
+								pos: position{line: 1664, col: 11, offset: 39291},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1687, col: 11, offset: 40245},
+									pos:  position{line: 1664, col: 11, offset: 39291},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1687, col: 25, offset: 40259},
+							pos:        position{line: 1664, col: 25, offset: 39305},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11913,57 +11674,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1689, col: 1, offset: 40293},
+			pos:  position{line: 1666, col: 1, offset: 39339},
 			expr: &choiceExpr{
-				pos: position{line: 1690, col: 5, offset: 40310},
+				pos: position{line: 1667, col: 5, offset: 39356},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1690, col: 5, offset: 40310},
+						pos: position{line: 1667, col: 5, offset: 39356},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1690, col: 5, offset: 40310},
+							pos: position{line: 1667, col: 5, offset: 39356},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1690, col: 5, offset: 40310},
+									pos: position{line: 1667, col: 5, offset: 39356},
 									expr: &choiceExpr{
-										pos: position{line: 1690, col: 7, offset: 40312},
+										pos: position{line: 1667, col: 7, offset: 39358},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1690, col: 7, offset: 40312},
+												pos:        position{line: 1667, col: 7, offset: 39358},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1690, col: 13, offset: 40318},
+												pos:  position{line: 1667, col: 13, offset: 39364},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1690, col: 26, offset: 40331,
+									line: 1667, col: 26, offset: 39377,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1691, col: 5, offset: 40368},
+						pos: position{line: 1668, col: 5, offset: 39414},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1691, col: 5, offset: 40368},
+							pos: position{line: 1668, col: 5, offset: 39414},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1691, col: 5, offset: 40368},
+									pos:        position{line: 1668, col: 5, offset: 39414},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1691, col: 10, offset: 40373},
+									pos:   position{line: 1668, col: 10, offset: 39419},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1691, col: 12, offset: 40375},
+										pos:  position{line: 1668, col: 12, offset: 39421},
 										name: "EscapeSequence",
 									},
 								},
@@ -11977,28 +11738,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1693, col: 1, offset: 40409},
+			pos:  position{line: 1670, col: 1, offset: 39455},
 			expr: &actionExpr{
-				pos: position{line: 1694, col: 5, offset: 40421},
+				pos: position{line: 1671, col: 5, offset: 39467},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1694, col: 5, offset: 40421},
+					pos: position{line: 1671, col: 5, offset: 39467},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1694, col: 5, offset: 40421},
+							pos:   position{line: 1671, col: 5, offset: 39467},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1694, col: 10, offset: 40426},
+								pos:  position{line: 1671, col: 10, offset: 39472},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1694, col: 23, offset: 40439},
+							pos:   position{line: 1671, col: 23, offset: 39485},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1694, col: 28, offset: 40444},
+								pos: position{line: 1671, col: 28, offset: 39490},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1694, col: 28, offset: 40444},
+									pos:  position{line: 1671, col: 28, offset: 39490},
 									name: "KeyWordRest",
 								},
 							},
@@ -12011,16 +11772,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1696, col: 1, offset: 40506},
+			pos:  position{line: 1673, col: 1, offset: 39552},
 			expr: &choiceExpr{
-				pos: position{line: 1697, col: 5, offset: 40523},
+				pos: position{line: 1674, col: 5, offset: 39569},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1697, col: 5, offset: 40523},
+						pos:  position{line: 1674, col: 5, offset: 39569},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1698, col: 5, offset: 40540},
+						pos:  position{line: 1675, col: 5, offset: 39586},
 						name: "KeyWordEsc",
 					},
 				},
@@ -12030,16 +11791,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1700, col: 1, offset: 40552},
+			pos:  position{line: 1677, col: 1, offset: 39598},
 			expr: &choiceExpr{
-				pos: position{line: 1701, col: 5, offset: 40568},
+				pos: position{line: 1678, col: 5, offset: 39614},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1701, col: 5, offset: 40568},
+						pos:  position{line: 1678, col: 5, offset: 39614},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1702, col: 5, offset: 40585},
+						pos:        position{line: 1679, col: 5, offset: 39631},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12052,19 +11813,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1704, col: 1, offset: 40592},
+			pos:  position{line: 1681, col: 1, offset: 39638},
 			expr: &actionExpr{
-				pos: position{line: 1704, col: 16, offset: 40607},
+				pos: position{line: 1681, col: 16, offset: 39653},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1704, col: 17, offset: 40608},
+					pos: position{line: 1681, col: 17, offset: 39654},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1704, col: 17, offset: 40608},
+							pos:  position{line: 1681, col: 17, offset: 39654},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1704, col: 33, offset: 40624},
+							pos:        position{line: 1681, col: 33, offset: 39670},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12078,31 +11839,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1706, col: 1, offset: 40668},
+			pos:  position{line: 1683, col: 1, offset: 39714},
 			expr: &actionExpr{
-				pos: position{line: 1706, col: 14, offset: 40681},
+				pos: position{line: 1683, col: 14, offset: 39727},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1706, col: 14, offset: 40681},
+					pos: position{line: 1683, col: 14, offset: 39727},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1706, col: 14, offset: 40681},
+							pos:        position{line: 1683, col: 14, offset: 39727},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1706, col: 19, offset: 40686},
+							pos:   position{line: 1683, col: 19, offset: 39732},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1706, col: 22, offset: 40689},
+								pos: position{line: 1683, col: 22, offset: 39735},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1706, col: 22, offset: 40689},
+										pos:  position{line: 1683, col: 22, offset: 39735},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1706, col: 38, offset: 40705},
+										pos:  position{line: 1683, col: 38, offset: 39751},
 										name: "EscapeSequence",
 									},
 								},
@@ -12116,42 +11877,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1708, col: 1, offset: 40740},
+			pos:  position{line: 1685, col: 1, offset: 39786},
 			expr: &actionExpr{
-				pos: position{line: 1709, col: 5, offset: 40756},
+				pos: position{line: 1686, col: 5, offset: 39802},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1709, col: 5, offset: 40756},
+					pos: position{line: 1686, col: 5, offset: 39802},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1709, col: 5, offset: 40756},
+							pos: position{line: 1686, col: 5, offset: 39802},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1709, col: 6, offset: 40757},
+								pos:  position{line: 1686, col: 6, offset: 39803},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1709, col: 22, offset: 40773},
+							pos: position{line: 1686, col: 22, offset: 39819},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1709, col: 23, offset: 40774},
+								pos:  position{line: 1686, col: 23, offset: 39820},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1709, col: 35, offset: 40786},
+							pos:   position{line: 1686, col: 35, offset: 39832},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1709, col: 40, offset: 40791},
+								pos:  position{line: 1686, col: 40, offset: 39837},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1709, col: 50, offset: 40801},
+							pos:   position{line: 1686, col: 50, offset: 39847},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1709, col: 55, offset: 40806},
+								pos: position{line: 1686, col: 55, offset: 39852},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1709, col: 55, offset: 40806},
+									pos:  position{line: 1686, col: 55, offset: 39852},
 									name: "GlobRest",
 								},
 							},
@@ -12164,28 +11925,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1713, col: 1, offset: 40875},
+			pos:  position{line: 1690, col: 1, offset: 39921},
 			expr: &choiceExpr{
-				pos: position{line: 1713, col: 19, offset: 40893},
+				pos: position{line: 1690, col: 19, offset: 39939},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1713, col: 19, offset: 40893},
+						pos:  position{line: 1690, col: 19, offset: 39939},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1713, col: 34, offset: 40908},
+						pos: position{line: 1690, col: 34, offset: 39954},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1713, col: 34, offset: 40908},
+								pos: position{line: 1690, col: 34, offset: 39954},
 								expr: &litMatcher{
-									pos:        position{line: 1713, col: 34, offset: 40908},
+									pos:        position{line: 1690, col: 34, offset: 39954},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1713, col: 39, offset: 40913},
+								pos:  position{line: 1690, col: 39, offset: 39959},
 								name: "KeyWordRest",
 							},
 						},
@@ -12197,19 +11958,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1714, col: 1, offset: 40925},
+			pos:  position{line: 1691, col: 1, offset: 39971},
 			expr: &seqExpr{
-				pos: position{line: 1714, col: 15, offset: 40939},
+				pos: position{line: 1691, col: 15, offset: 39985},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1714, col: 15, offset: 40939},
+						pos: position{line: 1691, col: 15, offset: 39985},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1714, col: 15, offset: 40939},
+							pos:  position{line: 1691, col: 15, offset: 39985},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1714, col: 28, offset: 40952},
+						pos:        position{line: 1691, col: 28, offset: 39998},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12221,23 +11982,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1716, col: 1, offset: 40957},
+			pos:  position{line: 1693, col: 1, offset: 40003},
 			expr: &choiceExpr{
-				pos: position{line: 1717, col: 5, offset: 40971},
+				pos: position{line: 1694, col: 5, offset: 40017},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1717, col: 5, offset: 40971},
+						pos:  position{line: 1694, col: 5, offset: 40017},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1718, col: 5, offset: 40988},
+						pos:  position{line: 1695, col: 5, offset: 40034},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1719, col: 5, offset: 41000},
+						pos: position{line: 1696, col: 5, offset: 40046},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1719, col: 5, offset: 41000},
+							pos:        position{line: 1696, col: 5, offset: 40046},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12250,16 +12011,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1721, col: 1, offset: 41025},
+			pos:  position{line: 1698, col: 1, offset: 40071},
 			expr: &choiceExpr{
-				pos: position{line: 1722, col: 5, offset: 41038},
+				pos: position{line: 1699, col: 5, offset: 40084},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1722, col: 5, offset: 41038},
+						pos:  position{line: 1699, col: 5, offset: 40084},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1723, col: 5, offset: 41052},
+						pos:        position{line: 1700, col: 5, offset: 40098},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12272,31 +12033,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1725, col: 1, offset: 41059},
+			pos:  position{line: 1702, col: 1, offset: 40105},
 			expr: &actionExpr{
-				pos: position{line: 1725, col: 11, offset: 41069},
+				pos: position{line: 1702, col: 11, offset: 40115},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1725, col: 11, offset: 41069},
+					pos: position{line: 1702, col: 11, offset: 40115},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1725, col: 11, offset: 41069},
+							pos:        position{line: 1702, col: 11, offset: 40115},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1725, col: 16, offset: 41074},
+							pos:   position{line: 1702, col: 16, offset: 40120},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1725, col: 19, offset: 41077},
+								pos: position{line: 1702, col: 19, offset: 40123},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1725, col: 19, offset: 41077},
+										pos:  position{line: 1702, col: 19, offset: 40123},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1725, col: 32, offset: 41090},
+										pos:  position{line: 1702, col: 32, offset: 40136},
 										name: "EscapeSequence",
 									},
 								},
@@ -12310,32 +12071,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1727, col: 1, offset: 41125},
+			pos:  position{line: 1704, col: 1, offset: 40171},
 			expr: &choiceExpr{
-				pos: position{line: 1728, col: 5, offset: 41140},
+				pos: position{line: 1705, col: 5, offset: 40186},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1728, col: 5, offset: 41140},
+						pos: position{line: 1705, col: 5, offset: 40186},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1728, col: 5, offset: 41140},
+							pos:        position{line: 1705, col: 5, offset: 40186},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1729, col: 5, offset: 41168},
+						pos: position{line: 1706, col: 5, offset: 40214},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1729, col: 5, offset: 41168},
+							pos:        position{line: 1706, col: 5, offset: 40214},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1730, col: 5, offset: 41198},
+						pos:        position{line: 1707, col: 5, offset: 40244},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12348,57 +12109,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1732, col: 1, offset: 41204},
+			pos:  position{line: 1709, col: 1, offset: 40250},
 			expr: &choiceExpr{
-				pos: position{line: 1733, col: 5, offset: 41225},
+				pos: position{line: 1710, col: 5, offset: 40271},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1733, col: 5, offset: 41225},
+						pos: position{line: 1710, col: 5, offset: 40271},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1733, col: 5, offset: 41225},
+							pos: position{line: 1710, col: 5, offset: 40271},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1733, col: 5, offset: 41225},
+									pos: position{line: 1710, col: 5, offset: 40271},
 									expr: &choiceExpr{
-										pos: position{line: 1733, col: 7, offset: 41227},
+										pos: position{line: 1710, col: 7, offset: 40273},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1733, col: 7, offset: 41227},
+												pos:        position{line: 1710, col: 7, offset: 40273},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1733, col: 13, offset: 41233},
+												pos:  position{line: 1710, col: 13, offset: 40279},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1733, col: 26, offset: 41246,
+									line: 1710, col: 26, offset: 40292,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1734, col: 5, offset: 41283},
+						pos: position{line: 1711, col: 5, offset: 40329},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1734, col: 5, offset: 41283},
+							pos: position{line: 1711, col: 5, offset: 40329},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1734, col: 5, offset: 41283},
+									pos:        position{line: 1711, col: 5, offset: 40329},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1734, col: 10, offset: 41288},
+									pos:   position{line: 1711, col: 10, offset: 40334},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1734, col: 12, offset: 41290},
+										pos:  position{line: 1711, col: 12, offset: 40336},
 										name: "EscapeSequence",
 									},
 								},
@@ -12412,16 +12173,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1736, col: 1, offset: 41324},
+			pos:  position{line: 1713, col: 1, offset: 40370},
 			expr: &choiceExpr{
-				pos: position{line: 1737, col: 5, offset: 41343},
+				pos: position{line: 1714, col: 5, offset: 40389},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1737, col: 5, offset: 41343},
+						pos:  position{line: 1714, col: 5, offset: 40389},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1738, col: 5, offset: 41364},
+						pos:  position{line: 1715, col: 5, offset: 40410},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12431,87 +12192,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1740, col: 1, offset: 41379},
+			pos:  position{line: 1717, col: 1, offset: 40425},
 			expr: &choiceExpr{
-				pos: position{line: 1741, col: 5, offset: 41400},
+				pos: position{line: 1718, col: 5, offset: 40446},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1741, col: 5, offset: 41400},
+						pos:        position{line: 1718, col: 5, offset: 40446},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1742, col: 5, offset: 41408},
+						pos: position{line: 1719, col: 5, offset: 40454},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1742, col: 5, offset: 41408},
+							pos:        position{line: 1719, col: 5, offset: 40454},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1743, col: 5, offset: 41448},
+						pos:        position{line: 1720, col: 5, offset: 40494},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1744, col: 5, offset: 41457},
+						pos: position{line: 1721, col: 5, offset: 40503},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1744, col: 5, offset: 41457},
+							pos:        position{line: 1721, col: 5, offset: 40503},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1745, col: 5, offset: 41486},
+						pos: position{line: 1722, col: 5, offset: 40532},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1745, col: 5, offset: 41486},
+							pos:        position{line: 1722, col: 5, offset: 40532},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1746, col: 5, offset: 41515},
+						pos: position{line: 1723, col: 5, offset: 40561},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1746, col: 5, offset: 41515},
+							pos:        position{line: 1723, col: 5, offset: 40561},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1747, col: 5, offset: 41544},
+						pos: position{line: 1724, col: 5, offset: 40590},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1747, col: 5, offset: 41544},
+							pos:        position{line: 1724, col: 5, offset: 40590},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1748, col: 5, offset: 41573},
+						pos: position{line: 1725, col: 5, offset: 40619},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1748, col: 5, offset: 41573},
+							pos:        position{line: 1725, col: 5, offset: 40619},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1749, col: 5, offset: 41602},
+						pos: position{line: 1726, col: 5, offset: 40648},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1749, col: 5, offset: 41602},
+							pos:        position{line: 1726, col: 5, offset: 40648},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12524,32 +12285,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1751, col: 1, offset: 41628},
+			pos:  position{line: 1728, col: 1, offset: 40674},
 			expr: &choiceExpr{
-				pos: position{line: 1752, col: 5, offset: 41646},
+				pos: position{line: 1729, col: 5, offset: 40692},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1752, col: 5, offset: 41646},
+						pos: position{line: 1729, col: 5, offset: 40692},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1752, col: 5, offset: 41646},
+							pos:        position{line: 1729, col: 5, offset: 40692},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1753, col: 5, offset: 41674},
+						pos: position{line: 1730, col: 5, offset: 40720},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1753, col: 5, offset: 41674},
+							pos:        position{line: 1730, col: 5, offset: 40720},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1754, col: 5, offset: 41702},
+						pos:        position{line: 1731, col: 5, offset: 40748},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12562,42 +12323,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1756, col: 1, offset: 41708},
+			pos:  position{line: 1733, col: 1, offset: 40754},
 			expr: &choiceExpr{
-				pos: position{line: 1757, col: 5, offset: 41726},
+				pos: position{line: 1734, col: 5, offset: 40772},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1757, col: 5, offset: 41726},
+						pos: position{line: 1734, col: 5, offset: 40772},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1757, col: 5, offset: 41726},
+							pos: position{line: 1734, col: 5, offset: 40772},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1757, col: 5, offset: 41726},
+									pos:        position{line: 1734, col: 5, offset: 40772},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1757, col: 9, offset: 41730},
+									pos:   position{line: 1734, col: 9, offset: 40776},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1757, col: 16, offset: 41737},
+										pos: position{line: 1734, col: 16, offset: 40783},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1757, col: 16, offset: 41737},
+												pos:  position{line: 1734, col: 16, offset: 40783},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1757, col: 25, offset: 41746},
+												pos:  position{line: 1734, col: 25, offset: 40792},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1757, col: 34, offset: 41755},
+												pos:  position{line: 1734, col: 34, offset: 40801},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1757, col: 43, offset: 41764},
+												pos:  position{line: 1734, col: 43, offset: 40810},
 												name: "HexDigit",
 											},
 										},
@@ -12607,65 +12368,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1760, col: 5, offset: 41827},
+						pos: position{line: 1737, col: 5, offset: 40873},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1760, col: 5, offset: 41827},
+							pos: position{line: 1737, col: 5, offset: 40873},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1760, col: 5, offset: 41827},
+									pos:        position{line: 1737, col: 5, offset: 40873},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1760, col: 9, offset: 41831},
+									pos:        position{line: 1737, col: 9, offset: 40877},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1760, col: 13, offset: 41835},
+									pos:   position{line: 1737, col: 13, offset: 40881},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1760, col: 20, offset: 41842},
+										pos: position{line: 1737, col: 20, offset: 40888},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1760, col: 20, offset: 41842},
+												pos:  position{line: 1737, col: 20, offset: 40888},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1760, col: 29, offset: 41851},
+												pos: position{line: 1737, col: 29, offset: 40897},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1760, col: 29, offset: 41851},
+													pos:  position{line: 1737, col: 29, offset: 40897},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1760, col: 39, offset: 41861},
+												pos: position{line: 1737, col: 39, offset: 40907},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1760, col: 39, offset: 41861},
+													pos:  position{line: 1737, col: 39, offset: 40907},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1760, col: 49, offset: 41871},
+												pos: position{line: 1737, col: 49, offset: 40917},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1760, col: 49, offset: 41871},
+													pos:  position{line: 1737, col: 49, offset: 40917},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1760, col: 59, offset: 41881},
+												pos: position{line: 1737, col: 59, offset: 40927},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1760, col: 59, offset: 41881},
+													pos:  position{line: 1737, col: 59, offset: 40927},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1760, col: 69, offset: 41891},
+												pos: position{line: 1737, col: 69, offset: 40937},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1760, col: 69, offset: 41891},
+													pos:  position{line: 1737, col: 69, offset: 40937},
 													name: "HexDigit",
 												},
 											},
@@ -12673,7 +12434,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1760, col: 80, offset: 41902},
+									pos:        position{line: 1737, col: 80, offset: 40948},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12687,91 +12448,10 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "RegexpPattern",
-			pos:  position{line: 1764, col: 1, offset: 41956},
-			expr: &actionExpr{
-				pos: position{line: 1765, col: 5, offset: 41974},
-				run: (*parser).callonRegexpPattern1,
-				expr: &seqExpr{
-					pos: position{line: 1765, col: 5, offset: 41974},
-					exprs: []any{
-						&litMatcher{
-							pos:        position{line: 1765, col: 5, offset: 41974},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 1765, col: 9, offset: 41978},
-							label: "body",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1765, col: 14, offset: 41983},
-								name: "RegexpBody",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 1765, col: 25, offset: 41994},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&notExpr{
-							pos: position{line: 1765, col: 29, offset: 41998},
-							expr: &ruleRefExpr{
-								pos:  position{line: 1765, col: 30, offset: 41999},
-								name: "KeyWordStart",
-							},
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
-			name: "RegexpBody",
-			pos:  position{line: 1767, col: 1, offset: 42034},
-			expr: &actionExpr{
-				pos: position{line: 1768, col: 5, offset: 42049},
-				run: (*parser).callonRegexpBody1,
-				expr: &oneOrMoreExpr{
-					pos: position{line: 1768, col: 5, offset: 42049},
-					expr: &choiceExpr{
-						pos: position{line: 1768, col: 6, offset: 42050},
-						alternatives: []any{
-							&charClassMatcher{
-								pos:        position{line: 1768, col: 6, offset: 42050},
-								val:        "[^/\\\\]",
-								chars:      []rune{'/', '\\'},
-								ignoreCase: false,
-								inverted:   true,
-							},
-							&seqExpr{
-								pos: position{line: 1768, col: 15, offset: 42059},
-								exprs: []any{
-									&litMatcher{
-										pos:        position{line: 1768, col: 15, offset: 42059},
-										val:        "\\",
-										ignoreCase: false,
-										want:       "\"\\\\\"",
-									},
-									&anyMatcher{
-										line: 1768, col: 20, offset: 42064,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
 			name: "EscapedChar",
-			pos:  position{line: 1770, col: 1, offset: 42100},
+			pos:  position{line: 1742, col: 1, offset: 41003},
 			expr: &charClassMatcher{
-				pos:        position{line: 1771, col: 5, offset: 42116},
+				pos:        position{line: 1743, col: 5, offset: 41019},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12783,11 +12463,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1773, col: 1, offset: 42131},
+			pos:  position{line: 1745, col: 1, offset: 41034},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1773, col: 5, offset: 42135},
+				pos: position{line: 1745, col: 5, offset: 41038},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1773, col: 5, offset: 42135},
+					pos:  position{line: 1745, col: 5, offset: 41038},
 					name: "AnySpace",
 				},
 			},
@@ -12796,11 +12476,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1775, col: 1, offset: 42146},
+			pos:  position{line: 1747, col: 1, offset: 41049},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1775, col: 6, offset: 42151},
+				pos: position{line: 1747, col: 6, offset: 41054},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1775, col: 6, offset: 42151},
+					pos:  position{line: 1747, col: 6, offset: 41054},
 					name: "AnySpace",
 				},
 			},
@@ -12809,20 +12489,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1777, col: 1, offset: 42162},
+			pos:  position{line: 1749, col: 1, offset: 41065},
 			expr: &choiceExpr{
-				pos: position{line: 1778, col: 5, offset: 42175},
+				pos: position{line: 1750, col: 5, offset: 41078},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1778, col: 5, offset: 42175},
+						pos:  position{line: 1750, col: 5, offset: 41078},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1779, col: 5, offset: 42190},
+						pos:  position{line: 1751, col: 5, offset: 41093},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1780, col: 5, offset: 42209},
+						pos:  position{line: 1752, col: 5, offset: 41112},
 						name: "Comment",
 					},
 				},
@@ -12832,32 +12512,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1782, col: 1, offset: 42218},
+			pos:  position{line: 1754, col: 1, offset: 41121},
 			expr: &choiceExpr{
-				pos: position{line: 1783, col: 5, offset: 42236},
+				pos: position{line: 1755, col: 5, offset: 41139},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1783, col: 5, offset: 42236},
+						pos:  position{line: 1755, col: 5, offset: 41139},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1784, col: 5, offset: 42243},
+						pos:  position{line: 1756, col: 5, offset: 41146},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1785, col: 5, offset: 42250},
+						pos:  position{line: 1757, col: 5, offset: 41153},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1786, col: 5, offset: 42257},
+						pos:  position{line: 1758, col: 5, offset: 41160},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1787, col: 5, offset: 42264},
+						pos:  position{line: 1759, col: 5, offset: 41167},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1788, col: 5, offset: 42271},
+						pos:  position{line: 1760, col: 5, offset: 41174},
 						name: "Nl",
 					},
 				},
@@ -12867,16 +12547,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1790, col: 1, offset: 42275},
+			pos:  position{line: 1762, col: 1, offset: 41178},
 			expr: &choiceExpr{
-				pos: position{line: 1791, col: 5, offset: 42300},
+				pos: position{line: 1763, col: 5, offset: 41203},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1791, col: 5, offset: 42300},
+						pos:  position{line: 1763, col: 5, offset: 41203},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1792, col: 5, offset: 42307},
+						pos:  position{line: 1764, col: 5, offset: 41210},
 						name: "Mc",
 					},
 				},
@@ -12886,9 +12566,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1794, col: 1, offset: 42311},
+			pos:  position{line: 1766, col: 1, offset: 41214},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1795, col: 5, offset: 42328},
+				pos:  position{line: 1767, col: 5, offset: 41231},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12896,9 +12576,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1797, col: 1, offset: 42332},
+			pos:  position{line: 1769, col: 1, offset: 41235},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1798, col: 5, offset: 42364},
+				pos:  position{line: 1770, col: 5, offset: 41267},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12906,9 +12586,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1804, col: 1, offset: 42545},
+			pos:  position{line: 1776, col: 1, offset: 41448},
 			expr: &charClassMatcher{
-				pos:        position{line: 1804, col: 6, offset: 42550},
+				pos:        position{line: 1776, col: 6, offset: 41453},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12920,9 +12600,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1807, col: 1, offset: 46702},
+			pos:  position{line: 1779, col: 1, offset: 45605},
 			expr: &charClassMatcher{
-				pos:        position{line: 1807, col: 6, offset: 46707},
+				pos:        position{line: 1779, col: 6, offset: 45610},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12934,9 +12614,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1810, col: 1, offset: 47192},
+			pos:  position{line: 1782, col: 1, offset: 46095},
 			expr: &charClassMatcher{
-				pos:        position{line: 1810, col: 6, offset: 47197},
+				pos:        position{line: 1782, col: 6, offset: 46100},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12948,9 +12628,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1813, col: 1, offset: 50644},
+			pos:  position{line: 1785, col: 1, offset: 49547},
 			expr: &charClassMatcher{
-				pos:        position{line: 1813, col: 6, offset: 50649},
+				pos:        position{line: 1785, col: 6, offset: 49552},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12962,9 +12642,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1816, col: 1, offset: 50755},
+			pos:  position{line: 1788, col: 1, offset: 49658},
 			expr: &charClassMatcher{
-				pos:        position{line: 1816, col: 6, offset: 50760},
+				pos:        position{line: 1788, col: 6, offset: 49663},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12976,9 +12656,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1819, col: 1, offset: 54761},
+			pos:  position{line: 1791, col: 1, offset: 53664},
 			expr: &charClassMatcher{
-				pos:        position{line: 1819, col: 6, offset: 54766},
+				pos:        position{line: 1791, col: 6, offset: 53669},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12990,9 +12670,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1822, col: 1, offset: 55954},
+			pos:  position{line: 1794, col: 1, offset: 54857},
 			expr: &charClassMatcher{
-				pos:        position{line: 1822, col: 6, offset: 55959},
+				pos:        position{line: 1794, col: 6, offset: 54862},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -13004,9 +12684,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1825, col: 1, offset: 58139},
+			pos:  position{line: 1797, col: 1, offset: 57042},
 			expr: &charClassMatcher{
-				pos:        position{line: 1825, col: 6, offset: 58144},
+				pos:        position{line: 1797, col: 6, offset: 57047},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -13017,9 +12697,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1828, col: 1, offset: 58647},
+			pos:  position{line: 1800, col: 1, offset: 57550},
 			expr: &charClassMatcher{
-				pos:        position{line: 1828, col: 6, offset: 58652},
+				pos:        position{line: 1800, col: 6, offset: 57555},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -13031,9 +12711,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1831, col: 1, offset: 58766},
+			pos:  position{line: 1803, col: 1, offset: 57669},
 			expr: &charClassMatcher{
-				pos:        position{line: 1831, col: 6, offset: 58771},
+				pos:        position{line: 1803, col: 6, offset: 57674},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -13045,9 +12725,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1834, col: 1, offset: 58852},
+			pos:  position{line: 1806, col: 1, offset: 57755},
 			expr: &charClassMatcher{
-				pos:        position{line: 1834, col: 6, offset: 58857},
+				pos:        position{line: 1806, col: 6, offset: 57760},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13059,9 +12739,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1836, col: 1, offset: 58910},
+			pos:  position{line: 1808, col: 1, offset: 57813},
 			expr: &anyMatcher{
-				line: 1837, col: 5, offset: 58930,
+				line: 1809, col: 5, offset: 57833,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13069,48 +12749,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1839, col: 1, offset: 58933},
+			pos:         position{line: 1811, col: 1, offset: 57836},
 			expr: &choiceExpr{
-				pos: position{line: 1840, col: 5, offset: 58961},
+				pos: position{line: 1812, col: 5, offset: 57864},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1840, col: 5, offset: 58961},
+						pos:        position{line: 1812, col: 5, offset: 57864},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1841, col: 5, offset: 58970},
+						pos:        position{line: 1813, col: 5, offset: 57873},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1842, col: 5, offset: 58979},
+						pos:        position{line: 1814, col: 5, offset: 57882},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1843, col: 5, offset: 58988},
+						pos:        position{line: 1815, col: 5, offset: 57891},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1844, col: 5, offset: 58996},
+						pos:        position{line: 1816, col: 5, offset: 57899},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1845, col: 5, offset: 59009},
+						pos:        position{line: 1817, col: 5, offset: 57912},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1846, col: 5, offset: 59022},
+						pos:  position{line: 1818, col: 5, offset: 57925},
 						name: "Zs",
 					},
 				},
@@ -13120,9 +12800,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1848, col: 1, offset: 59026},
+			pos:  position{line: 1820, col: 1, offset: 57929},
 			expr: &charClassMatcher{
-				pos:        position{line: 1849, col: 5, offset: 59045},
+				pos:        position{line: 1821, col: 5, offset: 57948},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13134,16 +12814,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1851, col: 1, offset: 59065},
+			pos:         position{line: 1823, col: 1, offset: 57968},
 			expr: &choiceExpr{
-				pos: position{line: 1852, col: 5, offset: 59087},
+				pos: position{line: 1824, col: 5, offset: 57990},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1852, col: 5, offset: 59087},
+						pos:  position{line: 1824, col: 5, offset: 57990},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1853, col: 5, offset: 59108},
+						pos:  position{line: 1825, col: 5, offset: 58011},
 						name: "SingleLineComment",
 					},
 				},
@@ -13153,39 +12833,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1855, col: 1, offset: 59127},
+			pos:  position{line: 1827, col: 1, offset: 58030},
 			expr: &seqExpr{
-				pos: position{line: 1856, col: 5, offset: 59148},
+				pos: position{line: 1828, col: 5, offset: 58051},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1856, col: 5, offset: 59148},
+						pos:        position{line: 1828, col: 5, offset: 58051},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1856, col: 10, offset: 59153},
+						pos: position{line: 1828, col: 10, offset: 58056},
 						expr: &seqExpr{
-							pos: position{line: 1856, col: 11, offset: 59154},
+							pos: position{line: 1828, col: 11, offset: 58057},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1856, col: 11, offset: 59154},
+									pos: position{line: 1828, col: 11, offset: 58057},
 									expr: &litMatcher{
-										pos:        position{line: 1856, col: 12, offset: 59155},
+										pos:        position{line: 1828, col: 12, offset: 58058},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1856, col: 17, offset: 59160},
+									pos:  position{line: 1828, col: 17, offset: 58063},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1856, col: 35, offset: 59178},
+						pos:        position{line: 1828, col: 35, offset: 58081},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13197,30 +12877,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1858, col: 1, offset: 59184},
+			pos:  position{line: 1830, col: 1, offset: 58087},
 			expr: &seqExpr{
-				pos: position{line: 1859, col: 5, offset: 59206},
+				pos: position{line: 1831, col: 5, offset: 58109},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1859, col: 5, offset: 59206},
+						pos:        position{line: 1831, col: 5, offset: 58109},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1859, col: 10, offset: 59211},
+						pos: position{line: 1831, col: 10, offset: 58114},
 						expr: &seqExpr{
-							pos: position{line: 1859, col: 11, offset: 59212},
+							pos: position{line: 1831, col: 11, offset: 58115},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1859, col: 11, offset: 59212},
+									pos: position{line: 1831, col: 11, offset: 58115},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1859, col: 12, offset: 59213},
+										pos:  position{line: 1831, col: 12, offset: 58116},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1859, col: 27, offset: 59228},
+									pos:  position{line: 1831, col: 27, offset: 58131},
 									name: "SourceCharacter",
 								},
 							},
@@ -13233,19 +12913,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1861, col: 1, offset: 59247},
+			pos:  position{line: 1833, col: 1, offset: 58150},
 			expr: &seqExpr{
-				pos: position{line: 1861, col: 7, offset: 59253},
+				pos: position{line: 1833, col: 7, offset: 58156},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1861, col: 7, offset: 59253},
+						pos: position{line: 1833, col: 7, offset: 58156},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1861, col: 7, offset: 59253},
+							pos:  position{line: 1833, col: 7, offset: 58156},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1861, col: 19, offset: 59265},
+						pos:  position{line: 1833, col: 19, offset: 58168},
 						name: "LineTerminator",
 					},
 				},
@@ -13255,16 +12935,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1863, col: 1, offset: 59281},
+			pos:  position{line: 1835, col: 1, offset: 58184},
 			expr: &choiceExpr{
-				pos: position{line: 1863, col: 7, offset: 59287},
+				pos: position{line: 1835, col: 7, offset: 58190},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1863, col: 7, offset: 59287},
+						pos:  position{line: 1835, col: 7, offset: 58190},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1863, col: 11, offset: 59291},
+						pos:  position{line: 1835, col: 11, offset: 58194},
 						name: "EOF",
 					},
 				},
@@ -13274,11 +12954,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1865, col: 1, offset: 59296},
+			pos:  position{line: 1837, col: 1, offset: 58199},
 			expr: &notExpr{
-				pos: position{line: 1865, col: 7, offset: 59302},
+				pos: position{line: 1837, col: 7, offset: 58205},
 				expr: &anyMatcher{
-					line: 1865, col: 8, offset: 59303,
+					line: 1837, col: 8, offset: 58206,
 				},
 			},
 			leader:        false,
@@ -13286,11 +12966,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1867, col: 1, offset: 59306},
+			pos:  position{line: 1839, col: 1, offset: 58209},
 			expr: &notExpr{
-				pos: position{line: 1867, col: 8, offset: 59313},
+				pos: position{line: 1839, col: 8, offset: 58216},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1867, col: 9, offset: 59314},
+					pos:  position{line: 1839, col: 9, offset: 58217},
 					name: "KeyWordChars",
 				},
 			},
@@ -13299,15 +12979,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1871, col: 1, offset: 59350},
+			pos:  position{line: 1843, col: 1, offset: 58253},
 			expr: &actionExpr{
-				pos: position{line: 1872, col: 5, offset: 59362},
+				pos: position{line: 1844, col: 5, offset: 58265},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1872, col: 5, offset: 59362},
+					pos:   position{line: 1844, col: 5, offset: 58265},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1872, col: 7, offset: 59364},
+						pos:  position{line: 1844, col: 7, offset: 58267},
 						name: "Seq",
 					},
 				},
@@ -13317,9 +12997,9 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1880, col: 1, offset: 59510},
+			pos:  position{line: 1852, col: 1, offset: 58413},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1880, col: 12, offset: 59521},
+				pos:  position{line: 1852, col: 12, offset: 58424},
 				name: "SelectExpr",
 			},
 			leader:        false,
@@ -13327,73 +13007,73 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1882, col: 1, offset: 59533},
+			pos:  position{line: 1854, col: 1, offset: 58436},
 			expr: &actionExpr{
-				pos: position{line: 1883, col: 5, offset: 59548},
+				pos: position{line: 1855, col: 5, offset: 58451},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1883, col: 5, offset: 59548},
+					pos: position{line: 1855, col: 5, offset: 58451},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1883, col: 5, offset: 59548},
+							pos:   position{line: 1855, col: 5, offset: 58451},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1883, col: 10, offset: 59553},
+								pos:  position{line: 1855, col: 10, offset: 58456},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1884, col: 5, offset: 59571},
+							pos:   position{line: 1856, col: 5, offset: 58474},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1885, col: 9, offset: 59586},
+								pos: position{line: 1857, col: 9, offset: 58489},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1885, col: 9, offset: 59586},
+										pos:  position{line: 1857, col: 9, offset: 58489},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1886, col: 9, offset: 59607},
+										pos:  position{line: 1858, col: 9, offset: 58510},
 										name: "Select",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1887, col: 9, offset: 59622},
+										pos:  position{line: 1859, col: 9, offset: 58525},
 										name: "FromSelect",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1888, col: 9, offset: 59641},
+										pos:  position{line: 1860, col: 9, offset: 58544},
 										name: "SQLValues",
 									},
 									&actionExpr{
-										pos: position{line: 1889, col: 9, offset: 59659},
+										pos: position{line: 1861, col: 9, offset: 58562},
 										run: (*parser).callonSelectExpr11,
 										expr: &seqExpr{
-											pos: position{line: 1889, col: 9, offset: 59659},
+											pos: position{line: 1861, col: 9, offset: 58562},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1889, col: 9, offset: 59659},
+													pos:        position{line: 1861, col: 9, offset: 58562},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1889, col: 13, offset: 59663},
+													pos:  position{line: 1861, col: 13, offset: 58566},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1889, col: 16, offset: 59666},
+													pos:   position{line: 1861, col: 16, offset: 58569},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1889, col: 18, offset: 59668},
+														pos:  position{line: 1861, col: 18, offset: 58571},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1889, col: 26, offset: 59676},
+													pos:  position{line: 1861, col: 26, offset: 58579},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1889, col: 28, offset: 59678},
+													pos:        position{line: 1861, col: 28, offset: 58581},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13405,18 +13085,18 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1891, col: 5, offset: 59715},
+							pos:   position{line: 1863, col: 5, offset: 58618},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1891, col: 13, offset: 59723},
+								pos:  position{line: 1863, col: 13, offset: 58626},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1892, col: 5, offset: 59744},
+							pos:   position{line: 1864, col: 5, offset: 58647},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1892, col: 10, offset: 59749},
+								pos:  position{line: 1864, col: 10, offset: 58652},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -13428,74 +13108,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1912, col: 1, offset: 60150},
+			pos:  position{line: 1884, col: 1, offset: 59053},
 			expr: &actionExpr{
-				pos: position{line: 1913, col: 5, offset: 60161},
+				pos: position{line: 1885, col: 5, offset: 59064},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1913, col: 5, offset: 60161},
+					pos: position{line: 1885, col: 5, offset: 59064},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1913, col: 5, offset: 60161},
+							pos:  position{line: 1885, col: 5, offset: 59064},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1914, col: 5, offset: 60172},
+							pos:   position{line: 1886, col: 5, offset: 59075},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1914, col: 14, offset: 60181},
+								pos:  position{line: 1886, col: 14, offset: 59084},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1915, col: 5, offset: 60197},
+							pos:   position{line: 1887, col: 5, offset: 59100},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1915, col: 11, offset: 60203},
+								pos:  position{line: 1887, col: 11, offset: 59106},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1918, col: 5, offset: 60342},
+							pos:  position{line: 1890, col: 5, offset: 59245},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1918, col: 7, offset: 60344},
+							pos:   position{line: 1890, col: 7, offset: 59247},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1918, col: 17, offset: 60354},
+								pos:  position{line: 1890, col: 17, offset: 59257},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1919, col: 5, offset: 60368},
+							pos:   position{line: 1891, col: 5, offset: 59271},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1919, col: 10, offset: 60373},
+								pos:  position{line: 1891, col: 10, offset: 59276},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1920, col: 5, offset: 60391},
+							pos:   position{line: 1892, col: 5, offset: 59294},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1920, col: 11, offset: 60397},
+								pos:  position{line: 1892, col: 11, offset: 59300},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1921, col: 5, offset: 60416},
+							pos:   position{line: 1893, col: 5, offset: 59319},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1921, col: 11, offset: 60422},
+								pos:  position{line: 1893, col: 11, offset: 59325},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1922, col: 5, offset: 60441},
+							pos:   position{line: 1894, col: 5, offset: 59344},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1922, col: 12, offset: 60448},
+								pos:  position{line: 1894, col: 12, offset: 59351},
 								name: "OptHavingClause",
 							},
 						},
@@ -13507,78 +13187,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1948, col: 1, offset: 61063},
+			pos:  position{line: 1920, col: 1, offset: 59966},
 			expr: &actionExpr{
-				pos: position{line: 1949, col: 5, offset: 61078},
+				pos: position{line: 1921, col: 5, offset: 59981},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1949, col: 5, offset: 61078},
+					pos: position{line: 1921, col: 5, offset: 59981},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1949, col: 5, offset: 61078},
+							pos:   position{line: 1921, col: 5, offset: 59981},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1949, col: 10, offset: 61083},
+								pos:  position{line: 1921, col: 10, offset: 59986},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1949, col: 17, offset: 61090},
+							pos:  position{line: 1921, col: 17, offset: 59993},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1949, col: 19, offset: 61092},
+							pos:  position{line: 1921, col: 19, offset: 59995},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1950, col: 5, offset: 61103},
+							pos:   position{line: 1922, col: 5, offset: 60006},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1950, col: 14, offset: 61112},
+								pos:  position{line: 1922, col: 14, offset: 60015},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1951, col: 5, offset: 61128},
+							pos:   position{line: 1923, col: 5, offset: 60031},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1951, col: 11, offset: 61134},
+								pos:  position{line: 1923, col: 11, offset: 60037},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1954, col: 5, offset: 61273},
+							pos:  position{line: 1926, col: 5, offset: 60176},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1954, col: 7, offset: 61275},
+							pos:   position{line: 1926, col: 7, offset: 60178},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1954, col: 17, offset: 61285},
+								pos:  position{line: 1926, col: 17, offset: 60188},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1955, col: 5, offset: 61299},
+							pos:   position{line: 1927, col: 5, offset: 60202},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1955, col: 11, offset: 61305},
+								pos:  position{line: 1927, col: 11, offset: 60208},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1956, col: 5, offset: 61324},
+							pos:   position{line: 1928, col: 5, offset: 60227},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1956, col: 11, offset: 61330},
+								pos:  position{line: 1928, col: 11, offset: 60233},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1957, col: 5, offset: 61349},
+							pos:   position{line: 1929, col: 5, offset: 60252},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1957, col: 12, offset: 61356},
+								pos:  position{line: 1929, col: 12, offset: 60259},
 								name: "OptHavingClause",
 							},
 						},
@@ -13590,26 +13270,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 1981, col: 1, offset: 61938},
+			pos:  position{line: 1953, col: 1, offset: 60841},
 			expr: &actionExpr{
-				pos: position{line: 1982, col: 5, offset: 61952},
+				pos: position{line: 1954, col: 5, offset: 60855},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 1982, col: 5, offset: 61952},
+					pos: position{line: 1954, col: 5, offset: 60855},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 5, offset: 61952},
+							pos:  position{line: 1954, col: 5, offset: 60855},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 12, offset: 61959},
+							pos:  position{line: 1954, col: 12, offset: 60862},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 15, offset: 61962},
+							pos:   position{line: 1954, col: 15, offset: 60865},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 22, offset: 61969},
+								pos:  position{line: 1954, col: 22, offset: 60872},
 								name: "SQLTuples",
 							},
 						},
@@ -13621,26 +13301,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 1990, col: 1, offset: 62126},
+			pos:  position{line: 1962, col: 1, offset: 61029},
 			expr: &actionExpr{
-				pos: position{line: 1991, col: 5, offset: 62139},
+				pos: position{line: 1963, col: 5, offset: 61042},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 1991, col: 5, offset: 62139},
+					pos: position{line: 1963, col: 5, offset: 61042},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1991, col: 5, offset: 62139},
+							pos:  position{line: 1963, col: 5, offset: 61042},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1991, col: 12, offset: 62146},
+							pos:  position{line: 1963, col: 12, offset: 61049},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1991, col: 14, offset: 62148},
+							pos:   position{line: 1963, col: 14, offset: 61051},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1991, col: 20, offset: 62154},
+								pos:  position{line: 1963, col: 20, offset: 61057},
 								name: "Exprs",
 							},
 						},
@@ -13652,51 +13332,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 2000, col: 1, offset: 62301},
+			pos:  position{line: 1972, col: 1, offset: 61204},
 			expr: &actionExpr{
-				pos: position{line: 2001, col: 5, offset: 62315},
+				pos: position{line: 1973, col: 5, offset: 61218},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 2001, col: 5, offset: 62315},
+					pos: position{line: 1973, col: 5, offset: 61218},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2001, col: 5, offset: 62315},
+							pos:   position{line: 1973, col: 5, offset: 61218},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2001, col: 11, offset: 62321},
+								pos:  position{line: 1973, col: 11, offset: 61224},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2001, col: 20, offset: 62330},
+							pos:   position{line: 1973, col: 20, offset: 61233},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2001, col: 25, offset: 62335},
+								pos: position{line: 1973, col: 25, offset: 61238},
 								expr: &actionExpr{
-									pos: position{line: 2001, col: 26, offset: 62336},
+									pos: position{line: 1973, col: 26, offset: 61239},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 2001, col: 26, offset: 62336},
+										pos: position{line: 1973, col: 26, offset: 61239},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2001, col: 26, offset: 62336},
+												pos:  position{line: 1973, col: 26, offset: 61239},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2001, col: 29, offset: 62339},
+												pos:        position{line: 1973, col: 29, offset: 61242},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2001, col: 33, offset: 62343},
+												pos:  position{line: 1973, col: 33, offset: 61246},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2001, col: 36, offset: 62346},
+												pos:   position{line: 1973, col: 36, offset: 61249},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2001, col: 38, offset: 62348},
+													pos:  position{line: 1973, col: 38, offset: 61251},
 													name: "SQLTuple",
 												},
 											},
@@ -13713,37 +13393,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 2005, col: 1, offset: 62425},
+			pos:  position{line: 1977, col: 1, offset: 61328},
 			expr: &actionExpr{
-				pos: position{line: 2006, col: 5, offset: 62438},
+				pos: position{line: 1978, col: 5, offset: 61341},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 2006, col: 5, offset: 62438},
+					pos: position{line: 1978, col: 5, offset: 61341},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2006, col: 5, offset: 62438},
+							pos:        position{line: 1978, col: 5, offset: 61341},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2006, col: 9, offset: 62442},
+							pos:  position{line: 1978, col: 9, offset: 61345},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2006, col: 12, offset: 62445},
+							pos:   position{line: 1978, col: 12, offset: 61348},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2006, col: 18, offset: 62451},
+								pos:  position{line: 1978, col: 18, offset: 61354},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2006, col: 24, offset: 62457},
+							pos:  position{line: 1978, col: 24, offset: 61360},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2006, col: 27, offset: 62460},
+							pos:        position{line: 1978, col: 27, offset: 61363},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13756,49 +13436,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 2014, col: 1, offset: 62604},
+			pos:  position{line: 1986, col: 1, offset: 61507},
 			expr: &choiceExpr{
-				pos: position{line: 2015, col: 5, offset: 62620},
+				pos: position{line: 1987, col: 5, offset: 61523},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2015, col: 5, offset: 62620},
+						pos: position{line: 1987, col: 5, offset: 61523},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2015, col: 5, offset: 62620},
+							pos: position{line: 1987, col: 5, offset: 61523},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2015, col: 5, offset: 62620},
+									pos:  position{line: 1987, col: 5, offset: 61523},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2015, col: 7, offset: 62622},
+									pos:  position{line: 1987, col: 7, offset: 61525},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2016, col: 5, offset: 62659},
+						pos: position{line: 1988, col: 5, offset: 61562},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2016, col: 5, offset: 62659},
+							pos: position{line: 1988, col: 5, offset: 61562},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2016, col: 5, offset: 62659},
+									pos:  position{line: 1988, col: 5, offset: 61562},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2016, col: 7, offset: 62661},
+									pos:  position{line: 1988, col: 7, offset: 61564},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2017, col: 5, offset: 62697},
+						pos: position{line: 1989, col: 5, offset: 61600},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2017, col: 5, offset: 62697},
+							pos:        position{line: 1989, col: 5, offset: 61600},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13811,57 +13491,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2019, col: 1, offset: 62736},
+			pos:  position{line: 1991, col: 1, offset: 61639},
 			expr: &choiceExpr{
-				pos: position{line: 2020, col: 5, offset: 62755},
+				pos: position{line: 1992, col: 5, offset: 61658},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2020, col: 5, offset: 62755},
+						pos: position{line: 1992, col: 5, offset: 61658},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2020, col: 5, offset: 62755},
+							pos: position{line: 1992, col: 5, offset: 61658},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2020, col: 5, offset: 62755},
+									pos:  position{line: 1992, col: 5, offset: 61658},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2020, col: 7, offset: 62757},
+									pos:  position{line: 1992, col: 7, offset: 61660},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2020, col: 10, offset: 62760},
+									pos:  position{line: 1992, col: 10, offset: 61663},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2020, col: 12, offset: 62762},
+									pos:  position{line: 1992, col: 12, offset: 61665},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2021, col: 5, offset: 62794},
+						pos: position{line: 1993, col: 5, offset: 61697},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2021, col: 5, offset: 62794},
+							pos: position{line: 1993, col: 5, offset: 61697},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2021, col: 5, offset: 62794},
+									pos:  position{line: 1993, col: 5, offset: 61697},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2021, col: 7, offset: 62796},
+									pos:  position{line: 1993, col: 7, offset: 61699},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2022, col: 5, offset: 62867},
+						pos: position{line: 1994, col: 5, offset: 61770},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2022, col: 5, offset: 62867},
+							pos:        position{line: 1994, col: 5, offset: 61770},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13874,19 +13554,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2024, col: 1, offset: 62910},
+			pos:  position{line: 1996, col: 1, offset: 61813},
 			expr: &choiceExpr{
-				pos: position{line: 2025, col: 5, offset: 62928},
+				pos: position{line: 1997, col: 5, offset: 61831},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2025, col: 5, offset: 62928},
+						pos:  position{line: 1997, col: 5, offset: 61831},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2026, col: 5, offset: 62943},
+						pos: position{line: 1998, col: 5, offset: 61846},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2026, col: 5, offset: 62943},
+							pos:        position{line: 1998, col: 5, offset: 61846},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13899,39 +13579,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2028, col: 1, offset: 62976},
+			pos:  position{line: 2000, col: 1, offset: 61879},
 			expr: &actionExpr{
-				pos: position{line: 2029, col: 5, offset: 62991},
+				pos: position{line: 2001, col: 5, offset: 61894},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2029, col: 5, offset: 62991},
+					pos: position{line: 2001, col: 5, offset: 61894},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2029, col: 5, offset: 62991},
+							pos:  position{line: 2001, col: 5, offset: 61894},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2029, col: 10, offset: 62996},
+							pos:   position{line: 2001, col: 10, offset: 61899},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2029, col: 12, offset: 62998},
+								pos:  position{line: 2001, col: 12, offset: 61901},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2029, col: 25, offset: 63011},
+							pos:  position{line: 2001, col: 25, offset: 61914},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2029, col: 27, offset: 63013},
+							pos:   position{line: 2001, col: 27, offset: 61916},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2029, col: 32, offset: 63018},
+								pos:  position{line: 2001, col: 32, offset: 61921},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2029, col: 40, offset: 63026},
+							pos:  position{line: 2001, col: 40, offset: 61929},
 							name: "__",
 						},
 					},
@@ -13942,32 +13622,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2038, col: 1, offset: 63214},
+			pos:  position{line: 2010, col: 1, offset: 62117},
 			expr: &choiceExpr{
-				pos: position{line: 2039, col: 5, offset: 63231},
+				pos: position{line: 2011, col: 5, offset: 62134},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2039, col: 5, offset: 63231},
+						pos: position{line: 2011, col: 5, offset: 62134},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2039, col: 5, offset: 63231},
+							pos: position{line: 2011, col: 5, offset: 62134},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2039, col: 5, offset: 63231},
+									pos:  position{line: 2011, col: 5, offset: 62134},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2039, col: 7, offset: 63233},
+									pos:  position{line: 2011, col: 7, offset: 62136},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2040, col: 5, offset: 63269},
+						pos: position{line: 2012, col: 5, offset: 62172},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2040, col: 5, offset: 63269},
+							pos:        position{line: 2012, col: 5, offset: 62172},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13980,51 +13660,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2042, col: 1, offset: 63308},
+			pos:  position{line: 2014, col: 1, offset: 62211},
 			expr: &actionExpr{
-				pos: position{line: 2042, col: 11, offset: 63318},
+				pos: position{line: 2014, col: 11, offset: 62221},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2042, col: 11, offset: 63318},
+					pos: position{line: 2014, col: 11, offset: 62221},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2042, col: 11, offset: 63318},
+							pos:   position{line: 2014, col: 11, offset: 62221},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2042, col: 17, offset: 63324},
+								pos:  position{line: 2014, col: 17, offset: 62227},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2042, col: 21, offset: 63328},
+							pos:   position{line: 2014, col: 21, offset: 62231},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2042, col: 26, offset: 63333},
+								pos: position{line: 2014, col: 26, offset: 62236},
 								expr: &actionExpr{
-									pos: position{line: 2042, col: 28, offset: 63335},
+									pos: position{line: 2014, col: 28, offset: 62238},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2042, col: 28, offset: 63335},
+										pos: position{line: 2014, col: 28, offset: 62238},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2042, col: 28, offset: 63335},
+												pos:  position{line: 2014, col: 28, offset: 62238},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2042, col: 31, offset: 63338},
+												pos:        position{line: 2014, col: 31, offset: 62241},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2042, col: 35, offset: 63342},
+												pos:  position{line: 2014, col: 35, offset: 62245},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2042, col: 38, offset: 63345},
+												pos:   position{line: 2014, col: 38, offset: 62248},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2042, col: 42, offset: 63349},
+													pos:  position{line: 2014, col: 42, offset: 62252},
 													name: "Cte",
 												},
 											},
@@ -14041,65 +13721,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2046, col: 1, offset: 63417},
+			pos:  position{line: 2018, col: 1, offset: 62320},
 			expr: &actionExpr{
-				pos: position{line: 2047, col: 5, offset: 63425},
+				pos: position{line: 2019, col: 5, offset: 62328},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2047, col: 5, offset: 63425},
+					pos: position{line: 2019, col: 5, offset: 62328},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2047, col: 5, offset: 63425},
+							pos:   position{line: 2019, col: 5, offset: 62328},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2047, col: 10, offset: 63430},
+								pos:  position{line: 2019, col: 10, offset: 62333},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2047, col: 24, offset: 63444},
+							pos:  position{line: 2019, col: 24, offset: 62347},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2047, col: 26, offset: 63446},
+							pos:  position{line: 2019, col: 26, offset: 62349},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2047, col: 29, offset: 63449},
+							pos:   position{line: 2019, col: 29, offset: 62352},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2047, col: 31, offset: 63451},
+								pos:  position{line: 2019, col: 31, offset: 62354},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2047, col: 47, offset: 63467},
+							pos:  position{line: 2019, col: 47, offset: 62370},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2047, col: 50, offset: 63470},
+							pos:        position{line: 2019, col: 50, offset: 62373},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2047, col: 54, offset: 63474},
+							pos:  position{line: 2019, col: 54, offset: 62377},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2047, col: 57, offset: 63477},
+							pos:   position{line: 2019, col: 57, offset: 62380},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2047, col: 59, offset: 63479},
+								pos:  position{line: 2019, col: 59, offset: 62382},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2047, col: 67, offset: 63487},
+							pos:  position{line: 2019, col: 67, offset: 62390},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2047, col: 70, offset: 63490},
+							pos:        position{line: 2019, col: 70, offset: 62393},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14112,65 +13792,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2056, col: 1, offset: 63676},
+			pos:  position{line: 2028, col: 1, offset: 62579},
 			expr: &choiceExpr{
-				pos: position{line: 2057, col: 5, offset: 63696},
+				pos: position{line: 2029, col: 5, offset: 62599},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2057, col: 5, offset: 63696},
+						pos: position{line: 2029, col: 5, offset: 62599},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2057, col: 5, offset: 63696},
+							pos: position{line: 2029, col: 5, offset: 62599},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 5, offset: 63696},
+									pos:  position{line: 2029, col: 5, offset: 62599},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 7, offset: 63698},
+									pos:  position{line: 2029, col: 7, offset: 62601},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 20, offset: 63711},
+									pos:  position{line: 2029, col: 20, offset: 62614},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2058, col: 5, offset: 63750},
+						pos: position{line: 2030, col: 5, offset: 62653},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2058, col: 5, offset: 63750},
+							pos: position{line: 2030, col: 5, offset: 62653},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2058, col: 5, offset: 63750},
+									pos:  position{line: 2030, col: 5, offset: 62653},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2058, col: 7, offset: 63752},
+									pos:  position{line: 2030, col: 7, offset: 62655},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2058, col: 11, offset: 63756},
+									pos:  position{line: 2030, col: 11, offset: 62659},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2058, col: 13, offset: 63758},
+									pos:  position{line: 2030, col: 13, offset: 62661},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2058, col: 26, offset: 63771},
+									pos:  position{line: 2030, col: 26, offset: 62674},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2059, col: 5, offset: 63802},
+						pos: position{line: 2031, col: 5, offset: 62705},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2059, col: 5, offset: 63802},
+							pos:        position{line: 2031, col: 5, offset: 62705},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14183,25 +13863,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2061, col: 1, offset: 63857},
+			pos:  position{line: 2033, col: 1, offset: 62760},
 			expr: &choiceExpr{
-				pos: position{line: 2062, col: 5, offset: 63874},
+				pos: position{line: 2034, col: 5, offset: 62777},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2062, col: 5, offset: 63874},
+						pos: position{line: 2034, col: 5, offset: 62777},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2062, col: 5, offset: 63874},
+								pos:  position{line: 2034, col: 5, offset: 62777},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2062, col: 7, offset: 63876},
+								pos:  position{line: 2034, col: 7, offset: 62779},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2063, col: 5, offset: 63884},
+						pos:        position{line: 2035, col: 5, offset: 62787},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14213,25 +13893,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2065, col: 1, offset: 63888},
+			pos:  position{line: 2037, col: 1, offset: 62791},
 			expr: &choiceExpr{
-				pos: position{line: 2066, col: 5, offset: 63906},
+				pos: position{line: 2038, col: 5, offset: 62809},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2066, col: 5, offset: 63906},
+						pos: position{line: 2038, col: 5, offset: 62809},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2066, col: 5, offset: 63906},
+							pos: position{line: 2038, col: 5, offset: 62809},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2066, col: 5, offset: 63906},
+									pos:  position{line: 2038, col: 5, offset: 62809},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2066, col: 7, offset: 63908},
+									pos:   position{line: 2038, col: 7, offset: 62811},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2066, col: 12, offset: 63913},
+										pos:  position{line: 2038, col: 12, offset: 62816},
 										name: "FromOp",
 									},
 								},
@@ -14239,10 +13919,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2069, col: 5, offset: 63955},
+						pos: position{line: 2041, col: 5, offset: 62858},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2069, col: 5, offset: 63955},
+							pos:        position{line: 2041, col: 5, offset: 62858},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14255,27 +13935,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2071, col: 1, offset: 63996},
+			pos:  position{line: 2043, col: 1, offset: 62899},
 			expr: &choiceExpr{
-				pos: position{line: 2072, col: 5, offset: 64015},
+				pos: position{line: 2044, col: 5, offset: 62918},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2072, col: 5, offset: 64015},
+						pos: position{line: 2044, col: 5, offset: 62918},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2072, col: 5, offset: 64015},
+							pos:   position{line: 2044, col: 5, offset: 62918},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2072, col: 11, offset: 64021},
+								pos:  position{line: 2044, col: 11, offset: 62924},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2073, col: 5, offset: 64063},
+						pos: position{line: 2045, col: 5, offset: 62966},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2073, col: 5, offset: 64063},
+							pos:        position{line: 2045, col: 5, offset: 62966},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14288,25 +13968,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2075, col: 1, offset: 64108},
+			pos:  position{line: 2047, col: 1, offset: 63011},
 			expr: &choiceExpr{
-				pos: position{line: 2076, col: 5, offset: 64127},
+				pos: position{line: 2048, col: 5, offset: 63030},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2076, col: 5, offset: 64127},
+						pos: position{line: 2048, col: 5, offset: 63030},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2076, col: 5, offset: 64127},
+							pos: position{line: 2048, col: 5, offset: 63030},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2076, col: 5, offset: 64127},
+									pos:  position{line: 2048, col: 5, offset: 63030},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2076, col: 7, offset: 64129},
+									pos:   position{line: 2048, col: 7, offset: 63032},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2076, col: 13, offset: 64135},
+										pos:  position{line: 2048, col: 13, offset: 63038},
 										name: "GroupClause",
 									},
 								},
@@ -14314,10 +13994,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2077, col: 5, offset: 64173},
+						pos: position{line: 2049, col: 5, offset: 63076},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2077, col: 5, offset: 64173},
+							pos:        position{line: 2049, col: 5, offset: 63076},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14330,34 +14010,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2079, col: 1, offset: 64214},
+			pos:  position{line: 2051, col: 1, offset: 63117},
 			expr: &actionExpr{
-				pos: position{line: 2080, col: 5, offset: 64230},
+				pos: position{line: 2052, col: 5, offset: 63133},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2080, col: 5, offset: 64230},
+					pos: position{line: 2052, col: 5, offset: 63133},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2080, col: 5, offset: 64230},
+							pos:  position{line: 2052, col: 5, offset: 63133},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2080, col: 11, offset: 64236},
+							pos:  position{line: 2052, col: 11, offset: 63139},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2080, col: 13, offset: 64238},
+							pos:  position{line: 2052, col: 13, offset: 63141},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2080, col: 16, offset: 64241},
+							pos:  position{line: 2052, col: 16, offset: 63144},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2080, col: 18, offset: 64243},
+							pos:   position{line: 2052, col: 18, offset: 63146},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 23, offset: 64248},
+								pos:  position{line: 2052, col: 23, offset: 63151},
 								name: "GroupByList",
 							},
 						},
@@ -14369,51 +14049,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2082, col: 1, offset: 64282},
+			pos:  position{line: 2054, col: 1, offset: 63185},
 			expr: &actionExpr{
-				pos: position{line: 2083, col: 5, offset: 64298},
+				pos: position{line: 2055, col: 5, offset: 63201},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2083, col: 5, offset: 64298},
+					pos: position{line: 2055, col: 5, offset: 63201},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2083, col: 5, offset: 64298},
+							pos:   position{line: 2055, col: 5, offset: 63201},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2083, col: 11, offset: 64304},
+								pos:  position{line: 2055, col: 11, offset: 63207},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2083, col: 23, offset: 64316},
+							pos:   position{line: 2055, col: 23, offset: 63219},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2083, col: 28, offset: 64321},
+								pos: position{line: 2055, col: 28, offset: 63224},
 								expr: &actionExpr{
-									pos: position{line: 2083, col: 30, offset: 64323},
+									pos: position{line: 2055, col: 30, offset: 63226},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2083, col: 30, offset: 64323},
+										pos: position{line: 2055, col: 30, offset: 63226},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2083, col: 30, offset: 64323},
+												pos:  position{line: 2055, col: 30, offset: 63226},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2083, col: 33, offset: 64326},
+												pos:        position{line: 2055, col: 33, offset: 63229},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2083, col: 37, offset: 64330},
+												pos:  position{line: 2055, col: 37, offset: 63233},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2083, col: 40, offset: 64333},
+												pos:   position{line: 2055, col: 40, offset: 63236},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2083, col: 42, offset: 64335},
+													pos:  position{line: 2055, col: 42, offset: 63238},
 													name: "GroupByItem",
 												},
 											},
@@ -14430,9 +14110,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2087, col: 1, offset: 64416},
+			pos:  position{line: 2059, col: 1, offset: 63319},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2087, col: 15, offset: 64430},
+				pos:  position{line: 2059, col: 15, offset: 63333},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14440,25 +14120,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2089, col: 1, offset: 64436},
+			pos:  position{line: 2061, col: 1, offset: 63339},
 			expr: &choiceExpr{
-				pos: position{line: 2090, col: 5, offset: 64456},
+				pos: position{line: 2062, col: 5, offset: 63359},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2090, col: 5, offset: 64456},
+						pos: position{line: 2062, col: 5, offset: 63359},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2090, col: 5, offset: 64456},
+							pos: position{line: 2062, col: 5, offset: 63359},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 5, offset: 64456},
+									pos:  position{line: 2062, col: 5, offset: 63359},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2090, col: 7, offset: 64458},
+									pos:   position{line: 2062, col: 7, offset: 63361},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2090, col: 9, offset: 64460},
+										pos:  position{line: 2062, col: 9, offset: 63363},
 										name: "HavingClause",
 									},
 								},
@@ -14466,10 +14146,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2091, col: 5, offset: 64495},
+						pos: position{line: 2063, col: 5, offset: 63398},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2091, col: 5, offset: 64495},
+							pos:        position{line: 2063, col: 5, offset: 63398},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14482,26 +14162,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2093, col: 1, offset: 64519},
+			pos:  position{line: 2065, col: 1, offset: 63422},
 			expr: &actionExpr{
-				pos: position{line: 2094, col: 5, offset: 64536},
+				pos: position{line: 2066, col: 5, offset: 63439},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2094, col: 5, offset: 64536},
+					pos: position{line: 2066, col: 5, offset: 63439},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2094, col: 5, offset: 64536},
+							pos:  position{line: 2066, col: 5, offset: 63439},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2094, col: 12, offset: 64543},
+							pos:  position{line: 2066, col: 12, offset: 63446},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2094, col: 14, offset: 64545},
+							pos:   position{line: 2066, col: 14, offset: 63448},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2094, col: 16, offset: 64547},
+								pos:  position{line: 2066, col: 16, offset: 63450},
 								name: "Expr",
 							},
 						},
@@ -14513,49 +14193,49 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2096, col: 1, offset: 64571},
+			pos:  position{line: 2068, col: 1, offset: 63474},
 			expr: &choiceExpr{
-				pos: position{line: 2097, col: 5, offset: 64589},
+				pos: position{line: 2069, col: 5, offset: 63492},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2097, col: 5, offset: 64589},
+						pos:  position{line: 2069, col: 5, offset: 63492},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2098, col: 5, offset: 64603},
+						pos:  position{line: 2070, col: 5, offset: 63506},
 						name: "ConditionJoin",
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2100, col: 1, offset: 64618},
+			pos:  position{line: 2072, col: 1, offset: 63521},
 			expr: &actionExpr{
-				pos: position{line: 2101, col: 5, offset: 64632},
+				pos: position{line: 2073, col: 5, offset: 63535},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2101, col: 5, offset: 64632},
+					pos: position{line: 2073, col: 5, offset: 63535},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2101, col: 5, offset: 64632},
+							pos:   position{line: 2073, col: 5, offset: 63535},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2101, col: 10, offset: 64637},
+								pos:  position{line: 2073, col: 10, offset: 63540},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2101, col: 19, offset: 64646},
+							pos:  position{line: 2073, col: 19, offset: 63549},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2101, col: 31, offset: 64658},
+							pos:   position{line: 2073, col: 31, offset: 63561},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2101, col: 37, offset: 64664},
+								pos:  position{line: 2073, col: 37, offset: 63567},
 								name: "FromElem",
 							},
 						},
@@ -14567,50 +14247,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2110, col: 1, offset: 64872},
+			pos:  position{line: 2082, col: 1, offset: 63775},
 			expr: &choiceExpr{
-				pos: position{line: 2111, col: 5, offset: 64888},
+				pos: position{line: 2083, col: 5, offset: 63791},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2111, col: 5, offset: 64888},
+						pos: position{line: 2083, col: 5, offset: 63791},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2111, col: 5, offset: 64888},
+								pos:  position{line: 2083, col: 5, offset: 63791},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2111, col: 8, offset: 64891},
+								pos:        position{line: 2083, col: 8, offset: 63794},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2111, col: 12, offset: 64895},
+								pos:  position{line: 2083, col: 12, offset: 63798},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2112, col: 5, offset: 64902},
+						pos: position{line: 2084, col: 5, offset: 63805},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2112, col: 5, offset: 64902},
+								pos:  position{line: 2084, col: 5, offset: 63805},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2112, col: 7, offset: 64904},
+								pos:  position{line: 2084, col: 7, offset: 63807},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2112, col: 13, offset: 64910},
+								pos:  position{line: 2084, col: 13, offset: 63813},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2112, col: 15, offset: 64912},
+								pos:  position{line: 2084, col: 15, offset: 63815},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2112, col: 20, offset: 64917},
+								pos:  position{line: 2084, col: 20, offset: 63820},
 								name: "_",
 							},
 						},
@@ -14622,50 +14302,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2114, col: 1, offset: 64920},
+			pos:  position{line: 2086, col: 1, offset: 63823},
 			expr: &actionExpr{
-				pos: position{line: 2115, col: 5, offset: 64938},
+				pos: position{line: 2087, col: 5, offset: 63841},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2115, col: 5, offset: 64938},
+					pos: position{line: 2087, col: 5, offset: 63841},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2115, col: 5, offset: 64938},
+							pos:   position{line: 2087, col: 5, offset: 63841},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2115, col: 10, offset: 64943},
+								pos:  position{line: 2087, col: 10, offset: 63846},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2115, col: 19, offset: 64952},
+							pos:   position{line: 2087, col: 19, offset: 63855},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2115, col: 25, offset: 64958},
+								pos:  position{line: 2087, col: 25, offset: 63861},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2115, col: 38, offset: 64971},
+							pos:  position{line: 2087, col: 38, offset: 63874},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2115, col: 40, offset: 64973},
+							pos:   position{line: 2087, col: 40, offset: 63876},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2115, col: 46, offset: 64979},
+								pos:  position{line: 2087, col: 46, offset: 63882},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2115, col: 55, offset: 64988},
+							pos:  position{line: 2087, col: 55, offset: 63891},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2115, col: 57, offset: 64990},
+							pos:   position{line: 2087, col: 57, offset: 63893},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2115, col: 59, offset: 64992},
+								pos:  position{line: 2087, col: 59, offset: 63895},
 								name: "JoinCond",
 							},
 						},
@@ -14677,161 +14357,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2126, col: 1, offset: 65261},
+			pos:  position{line: 2098, col: 1, offset: 64164},
 			expr: &choiceExpr{
-				pos: position{line: 2127, col: 5, offset: 65278},
+				pos: position{line: 2099, col: 5, offset: 64181},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2127, col: 5, offset: 65278},
+						pos: position{line: 2099, col: 5, offset: 64181},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2127, col: 5, offset: 65278},
+							pos: position{line: 2099, col: 5, offset: 64181},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2127, col: 5, offset: 65278},
+									pos: position{line: 2099, col: 5, offset: 64181},
 									expr: &seqExpr{
-										pos: position{line: 2127, col: 6, offset: 65279},
+										pos: position{line: 2099, col: 6, offset: 64182},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2127, col: 6, offset: 65279},
+												pos:  position{line: 2099, col: 6, offset: 64182},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2127, col: 8, offset: 65281},
+												pos:  position{line: 2099, col: 8, offset: 64184},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 16, offset: 65289},
+									pos:  position{line: 2099, col: 16, offset: 64192},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2127, col: 18, offset: 65291},
+									pos:  position{line: 2099, col: 18, offset: 64194},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2128, col: 5, offset: 65336},
+						pos: position{line: 2100, col: 5, offset: 64239},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2128, col: 5, offset: 65336},
+							pos: position{line: 2100, col: 5, offset: 64239},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 5, offset: 65336},
+									pos:  position{line: 2100, col: 5, offset: 64239},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 7, offset: 65338},
+									pos:  position{line: 2100, col: 7, offset: 64241},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2128, col: 12, offset: 65343},
+									pos: position{line: 2100, col: 12, offset: 64246},
 									expr: &seqExpr{
-										pos: position{line: 2128, col: 13, offset: 65344},
+										pos: position{line: 2100, col: 13, offset: 64247},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2128, col: 13, offset: 65344},
+												pos:  position{line: 2100, col: 13, offset: 64247},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2128, col: 15, offset: 65346},
+												pos:  position{line: 2100, col: 15, offset: 64249},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 23, offset: 65354},
+									pos:  position{line: 2100, col: 23, offset: 64257},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 25, offset: 65356},
+									pos:  position{line: 2100, col: 25, offset: 64259},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2129, col: 5, offset: 65390},
+						pos: position{line: 2101, col: 5, offset: 64293},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2129, col: 5, offset: 65390},
+							pos: position{line: 2101, col: 5, offset: 64293},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 5, offset: 65390},
+									pos:  position{line: 2101, col: 5, offset: 64293},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 7, offset: 65392},
+									pos:  position{line: 2101, col: 7, offset: 64295},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2129, col: 12, offset: 65397},
+									pos: position{line: 2101, col: 12, offset: 64300},
 									expr: &seqExpr{
-										pos: position{line: 2129, col: 13, offset: 65398},
+										pos: position{line: 2101, col: 13, offset: 64301},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2129, col: 13, offset: 65398},
+												pos:  position{line: 2101, col: 13, offset: 64301},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2129, col: 15, offset: 65400},
+												pos:  position{line: 2101, col: 15, offset: 64303},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 23, offset: 65408},
+									pos:  position{line: 2101, col: 23, offset: 64311},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 25, offset: 65410},
+									pos:  position{line: 2101, col: 25, offset: 64313},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2130, col: 5, offset: 65444},
+						pos: position{line: 2102, col: 5, offset: 64347},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2130, col: 5, offset: 65444},
+							pos: position{line: 2102, col: 5, offset: 64347},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 5, offset: 65444},
+									pos:  position{line: 2102, col: 5, offset: 64347},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 7, offset: 65446},
+									pos:  position{line: 2102, col: 7, offset: 64349},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2130, col: 13, offset: 65452},
+									pos: position{line: 2102, col: 13, offset: 64355},
 									expr: &seqExpr{
-										pos: position{line: 2130, col: 14, offset: 65453},
+										pos: position{line: 2102, col: 14, offset: 64356},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2130, col: 14, offset: 65453},
+												pos:  position{line: 2102, col: 14, offset: 64356},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2130, col: 16, offset: 65455},
+												pos:  position{line: 2102, col: 16, offset: 64358},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 24, offset: 65463},
+									pos:  position{line: 2102, col: 24, offset: 64366},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 26, offset: 65465},
+									pos:  position{line: 2102, col: 26, offset: 64368},
 									name: "JOIN",
 								},
 							},
@@ -14844,29 +14524,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2132, col: 1, offset: 65497},
+			pos:  position{line: 2104, col: 1, offset: 64400},
 			expr: &choiceExpr{
-				pos: position{line: 2133, col: 5, offset: 65510},
+				pos: position{line: 2105, col: 5, offset: 64413},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2133, col: 5, offset: 65510},
+						pos: position{line: 2105, col: 5, offset: 64413},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2133, col: 5, offset: 65510},
+							pos: position{line: 2105, col: 5, offset: 64413},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2133, col: 5, offset: 65510},
+									pos:  position{line: 2105, col: 5, offset: 64413},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2133, col: 8, offset: 65513},
+									pos:  position{line: 2105, col: 8, offset: 64416},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2133, col: 10, offset: 65515},
+									pos:   position{line: 2105, col: 10, offset: 64418},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2133, col: 12, offset: 65517},
+										pos:  position{line: 2105, col: 12, offset: 64420},
 										name: "Expr",
 									},
 								},
@@ -14874,43 +14554,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2140, col: 5, offset: 65670},
+						pos: position{line: 2112, col: 5, offset: 64573},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2140, col: 5, offset: 65670},
+							pos: position{line: 2112, col: 5, offset: 64573},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2140, col: 5, offset: 65670},
+									pos:  position{line: 2112, col: 5, offset: 64573},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2140, col: 11, offset: 65676},
+									pos:  position{line: 2112, col: 11, offset: 64579},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2140, col: 14, offset: 65679},
+									pos:        position{line: 2112, col: 14, offset: 64582},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2140, col: 18, offset: 65683},
+									pos:  position{line: 2112, col: 18, offset: 64586},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2140, col: 21, offset: 65686},
+									pos:   position{line: 2112, col: 21, offset: 64589},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2140, col: 28, offset: 65693},
+										pos:  position{line: 2112, col: 28, offset: 64596},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2140, col: 34, offset: 65699},
+									pos:  position{line: 2112, col: 34, offset: 64602},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2140, col: 37, offset: 65702},
+									pos:        position{line: 2112, col: 37, offset: 64605},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14925,40 +14605,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2148, col: 1, offset: 65872},
+			pos:  position{line: 2120, col: 1, offset: 64775},
 			expr: &choiceExpr{
-				pos: position{line: 2149, col: 5, offset: 65890},
+				pos: position{line: 2121, col: 5, offset: 64793},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2149, col: 5, offset: 65890},
+						pos: position{line: 2121, col: 5, offset: 64793},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2149, col: 5, offset: 65890},
+							pos: position{line: 2121, col: 5, offset: 64793},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2149, col: 5, offset: 65890},
+									pos:  position{line: 2121, col: 5, offset: 64793},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2149, col: 7, offset: 65892},
+									pos:  position{line: 2121, col: 7, offset: 64795},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2149, col: 12, offset: 65897},
+									pos:  position{line: 2121, col: 12, offset: 64800},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2149, col: 14, offset: 65899},
+									pos:  position{line: 2121, col: 14, offset: 64802},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2155, col: 5, offset: 66028},
+						pos: position{line: 2127, col: 5, offset: 64931},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2155, col: 5, offset: 66028},
+							pos:        position{line: 2127, col: 5, offset: 64931},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14971,25 +14651,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2157, col: 1, offset: 66077},
+			pos:  position{line: 2129, col: 1, offset: 64980},
 			expr: &choiceExpr{
-				pos: position{line: 2158, col: 5, offset: 66090},
+				pos: position{line: 2130, col: 5, offset: 64993},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2158, col: 5, offset: 66090},
+						pos: position{line: 2130, col: 5, offset: 64993},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2158, col: 5, offset: 66090},
+							pos: position{line: 2130, col: 5, offset: 64993},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2158, col: 5, offset: 66090},
+									pos:  position{line: 2130, col: 5, offset: 64993},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2158, col: 7, offset: 66092},
+									pos:   position{line: 2130, col: 7, offset: 64995},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2158, col: 9, offset: 66094},
+										pos:  position{line: 2130, col: 9, offset: 64997},
 										name: "AliasClause",
 									},
 								},
@@ -14997,10 +14677,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2159, col: 5, offset: 66128},
+						pos: position{line: 2131, col: 5, offset: 65031},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2159, col: 5, offset: 66128},
+							pos:        position{line: 2131, col: 5, offset: 65031},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15013,51 +14693,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2161, col: 1, offset: 66165},
+			pos:  position{line: 2133, col: 1, offset: 65068},
 			expr: &actionExpr{
-				pos: position{line: 2162, col: 4, offset: 66180},
+				pos: position{line: 2134, col: 4, offset: 65083},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2162, col: 4, offset: 66180},
+					pos: position{line: 2134, col: 4, offset: 65083},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2162, col: 4, offset: 66180},
+							pos: position{line: 2134, col: 4, offset: 65083},
 							expr: &seqExpr{
-								pos: position{line: 2162, col: 5, offset: 66181},
+								pos: position{line: 2134, col: 5, offset: 65084},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2162, col: 5, offset: 66181},
+										pos:  position{line: 2134, col: 5, offset: 65084},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2162, col: 8, offset: 66184},
+										pos:  position{line: 2134, col: 8, offset: 65087},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2162, col: 12, offset: 66188},
+							pos: position{line: 2134, col: 12, offset: 65091},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2162, col: 13, offset: 66189},
+								pos:  position{line: 2134, col: 13, offset: 65092},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2162, col: 22, offset: 66198},
+							pos:   position{line: 2134, col: 22, offset: 65101},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2162, col: 27, offset: 66203},
+								pos:  position{line: 2134, col: 27, offset: 65106},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2162, col: 42, offset: 66218},
+							pos:   position{line: 2134, col: 42, offset: 65121},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2162, col: 47, offset: 66223},
+								pos: position{line: 2134, col: 47, offset: 65126},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2162, col: 47, offset: 66223},
+									pos:  position{line: 2134, col: 47, offset: 65126},
 									name: "Columns",
 								},
 							},
@@ -15070,65 +14750,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2170, col: 1, offset: 66422},
+			pos:  position{line: 2142, col: 1, offset: 65325},
 			expr: &actionExpr{
-				pos: position{line: 2171, col: 5, offset: 66434},
+				pos: position{line: 2143, col: 5, offset: 65337},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2171, col: 5, offset: 66434},
+					pos: position{line: 2143, col: 5, offset: 65337},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2171, col: 5, offset: 66434},
+							pos:  position{line: 2143, col: 5, offset: 65337},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2171, col: 8, offset: 66437},
+							pos:        position{line: 2143, col: 8, offset: 65340},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2171, col: 12, offset: 66441},
+							pos:  position{line: 2143, col: 12, offset: 65344},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2171, col: 15, offset: 66444},
+							pos:   position{line: 2143, col: 15, offset: 65347},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2171, col: 21, offset: 66450},
+								pos:  position{line: 2143, col: 21, offset: 65353},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2171, col: 35, offset: 66464},
+							pos:   position{line: 2143, col: 35, offset: 65367},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2171, col: 40, offset: 66469},
+								pos: position{line: 2143, col: 40, offset: 65372},
 								expr: &actionExpr{
-									pos: position{line: 2171, col: 42, offset: 66471},
+									pos: position{line: 2143, col: 42, offset: 65374},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2171, col: 42, offset: 66471},
+										pos: position{line: 2143, col: 42, offset: 65374},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2171, col: 42, offset: 66471},
+												pos:  position{line: 2143, col: 42, offset: 65374},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2171, col: 45, offset: 66474},
+												pos:        position{line: 2143, col: 45, offset: 65377},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2171, col: 49, offset: 66478},
+												pos:  position{line: 2143, col: 49, offset: 65381},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2171, col: 52, offset: 66481},
+												pos:   position{line: 2143, col: 52, offset: 65384},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2171, col: 54, offset: 66483},
+													pos:  position{line: 2143, col: 54, offset: 65386},
 													name: "SQLIdentifier",
 												},
 											},
@@ -15138,11 +14818,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2171, col: 87, offset: 66516},
+							pos:  position{line: 2143, col: 87, offset: 65419},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2171, col: 90, offset: 66519},
+							pos:        position{line: 2143, col: 90, offset: 65422},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -15155,51 +14835,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2175, col: 1, offset: 66590},
+			pos:  position{line: 2147, col: 1, offset: 65493},
 			expr: &actionExpr{
-				pos: position{line: 2176, col: 5, offset: 66604},
+				pos: position{line: 2148, col: 5, offset: 65507},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2176, col: 5, offset: 66604},
+					pos: position{line: 2148, col: 5, offset: 65507},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2176, col: 5, offset: 66604},
+							pos:   position{line: 2148, col: 5, offset: 65507},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2176, col: 11, offset: 66610},
+								pos:  position{line: 2148, col: 11, offset: 65513},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2176, col: 22, offset: 66621},
+							pos:   position{line: 2148, col: 22, offset: 65524},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2176, col: 27, offset: 66626},
+								pos: position{line: 2148, col: 27, offset: 65529},
 								expr: &actionExpr{
-									pos: position{line: 2176, col: 29, offset: 66628},
+									pos: position{line: 2148, col: 29, offset: 65531},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2176, col: 29, offset: 66628},
+										pos: position{line: 2148, col: 29, offset: 65531},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2176, col: 29, offset: 66628},
+												pos:  position{line: 2148, col: 29, offset: 65531},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2176, col: 32, offset: 66631},
+												pos:        position{line: 2148, col: 32, offset: 65534},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2176, col: 36, offset: 66635},
+												pos:  position{line: 2148, col: 36, offset: 65538},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2176, col: 39, offset: 66638},
+												pos:   position{line: 2148, col: 39, offset: 65541},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2176, col: 41, offset: 66640},
+													pos:  position{line: 2148, col: 41, offset: 65543},
 													name: "SelectElem",
 												},
 											},
@@ -15216,38 +14896,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2185, col: 1, offset: 66875},
+			pos:  position{line: 2157, col: 1, offset: 65778},
 			expr: &choiceExpr{
-				pos: position{line: 2186, col: 5, offset: 66890},
+				pos: position{line: 2158, col: 5, offset: 65793},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2186, col: 5, offset: 66890},
+						pos: position{line: 2158, col: 5, offset: 65793},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2186, col: 5, offset: 66890},
+							pos: position{line: 2158, col: 5, offset: 65793},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2186, col: 5, offset: 66890},
+									pos:   position{line: 2158, col: 5, offset: 65793},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2186, col: 11, offset: 66896},
+										pos: position{line: 2158, col: 11, offset: 65799},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2186, col: 11, offset: 66896},
+												pos:  position{line: 2158, col: 11, offset: 65799},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2186, col: 25, offset: 66910},
+												pos:  position{line: 2158, col: 25, offset: 65813},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2186, col: 31, offset: 66916},
+									pos:   position{line: 2158, col: 31, offset: 65819},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2186, col: 34, offset: 66919},
+										pos:  position{line: 2158, col: 34, offset: 65822},
 										name: "OptAsClause",
 									},
 								},
@@ -15255,10 +14935,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2197, col: 5, offset: 67147},
+						pos: position{line: 2169, col: 5, offset: 66050},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2197, col: 5, offset: 67147},
+							pos:        position{line: 2169, col: 5, offset: 66050},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15271,33 +14951,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2202, col: 1, offset: 67252},
+			pos:  position{line: 2174, col: 1, offset: 66155},
 			expr: &choiceExpr{
-				pos: position{line: 2203, col: 5, offset: 67268},
+				pos: position{line: 2175, col: 5, offset: 66171},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2203, col: 5, offset: 67268},
+						pos: position{line: 2175, col: 5, offset: 66171},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2203, col: 5, offset: 67268},
+							pos: position{line: 2175, col: 5, offset: 66171},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2203, col: 5, offset: 67268},
+									pos:  position{line: 2175, col: 5, offset: 66171},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2203, col: 7, offset: 67270},
+									pos:  position{line: 2175, col: 7, offset: 66173},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2203, col: 10, offset: 67273},
+									pos:  position{line: 2175, col: 10, offset: 66176},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2203, col: 12, offset: 67275},
+									pos:   position{line: 2175, col: 12, offset: 66178},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2203, col: 15, offset: 67278},
+										pos:  position{line: 2175, col: 15, offset: 66181},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15305,27 +14985,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2204, col: 5, offset: 67315},
+						pos: position{line: 2176, col: 5, offset: 66218},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2204, col: 5, offset: 67315},
+							pos: position{line: 2176, col: 5, offset: 66218},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2204, col: 5, offset: 67315},
+									pos:  position{line: 2176, col: 5, offset: 66218},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2204, col: 7, offset: 67317},
+									pos: position{line: 2176, col: 7, offset: 66220},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2204, col: 8, offset: 67318},
+										pos:  position{line: 2176, col: 8, offset: 66221},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2204, col: 17, offset: 67327},
+									pos:   position{line: 2176, col: 17, offset: 66230},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2204, col: 20, offset: 67330},
+										pos:  position{line: 2176, col: 20, offset: 66233},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15333,10 +15013,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2205, col: 5, offset: 67367},
+						pos: position{line: 2177, col: 5, offset: 66270},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2205, col: 5, offset: 67367},
+							pos:        position{line: 2177, col: 5, offset: 66270},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15349,41 +15029,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2207, col: 1, offset: 67392},
+			pos:  position{line: 2179, col: 1, offset: 66295},
 			expr: &choiceExpr{
-				pos: position{line: 2208, col: 5, offset: 67413},
+				pos: position{line: 2180, col: 5, offset: 66316},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2208, col: 5, offset: 67413},
+						pos: position{line: 2180, col: 5, offset: 66316},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2208, col: 5, offset: 67413},
+							pos: position{line: 2180, col: 5, offset: 66316},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2208, col: 5, offset: 67413},
+									pos:  position{line: 2180, col: 5, offset: 66316},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2208, col: 7, offset: 67415},
+									pos:  position{line: 2180, col: 7, offset: 66318},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2208, col: 13, offset: 67421},
+									pos:  position{line: 2180, col: 13, offset: 66324},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2208, col: 15, offset: 67423},
+									pos:  position{line: 2180, col: 15, offset: 66326},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2208, col: 18, offset: 67426},
+									pos:  position{line: 2180, col: 18, offset: 66329},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2208, col: 20, offset: 67428},
+									pos:   position{line: 2180, col: 20, offset: 66331},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2208, col: 25, offset: 67433},
+										pos:  position{line: 2180, col: 25, offset: 66336},
 										name: "OrderByList",
 									},
 								},
@@ -15391,10 +15071,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2215, col: 5, offset: 67597},
+						pos: position{line: 2187, col: 5, offset: 66500},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2215, col: 5, offset: 67597},
+							pos:        position{line: 2187, col: 5, offset: 66500},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15407,51 +15087,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2217, col: 1, offset: 67630},
+			pos:  position{line: 2189, col: 1, offset: 66533},
 			expr: &actionExpr{
-				pos: position{line: 2218, col: 5, offset: 67646},
+				pos: position{line: 2190, col: 5, offset: 66549},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2218, col: 5, offset: 67646},
+					pos: position{line: 2190, col: 5, offset: 66549},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2218, col: 5, offset: 67646},
+							pos:   position{line: 2190, col: 5, offset: 66549},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2218, col: 11, offset: 67652},
+								pos:  position{line: 2190, col: 11, offset: 66555},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2218, col: 23, offset: 67664},
+							pos:   position{line: 2190, col: 23, offset: 66567},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2218, col: 28, offset: 67669},
+								pos: position{line: 2190, col: 28, offset: 66572},
 								expr: &actionExpr{
-									pos: position{line: 2218, col: 30, offset: 67671},
+									pos: position{line: 2190, col: 30, offset: 66574},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2218, col: 30, offset: 67671},
+										pos: position{line: 2190, col: 30, offset: 66574},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2218, col: 30, offset: 67671},
+												pos:  position{line: 2190, col: 30, offset: 66574},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2218, col: 33, offset: 67674},
+												pos:        position{line: 2190, col: 33, offset: 66577},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2218, col: 37, offset: 67678},
+												pos:  position{line: 2190, col: 37, offset: 66581},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2218, col: 40, offset: 67681},
+												pos:   position{line: 2190, col: 40, offset: 66584},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2218, col: 42, offset: 67683},
+													pos:  position{line: 2190, col: 42, offset: 66586},
 													name: "OrderByItem",
 												},
 											},
@@ -15468,34 +15148,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2222, col: 1, offset: 67784},
+			pos:  position{line: 2194, col: 1, offset: 66687},
 			expr: &actionExpr{
-				pos: position{line: 2223, col: 5, offset: 67800},
+				pos: position{line: 2195, col: 5, offset: 66703},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2223, col: 5, offset: 67800},
+					pos: position{line: 2195, col: 5, offset: 66703},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2223, col: 5, offset: 67800},
+							pos:   position{line: 2195, col: 5, offset: 66703},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2223, col: 7, offset: 67802},
+								pos:  position{line: 2195, col: 7, offset: 66705},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2223, col: 12, offset: 67807},
+							pos:   position{line: 2195, col: 12, offset: 66710},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2223, col: 18, offset: 67813},
+								pos:  position{line: 2195, col: 18, offset: 66716},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2223, col: 29, offset: 67824},
+							pos:   position{line: 2195, col: 29, offset: 66727},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2223, col: 35, offset: 67830},
+								pos:  position{line: 2195, col: 35, offset: 66733},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15507,49 +15187,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2234, col: 1, offset: 68080},
+			pos:  position{line: 2206, col: 1, offset: 66983},
 			expr: &choiceExpr{
-				pos: position{line: 2235, col: 5, offset: 68095},
+				pos: position{line: 2207, col: 5, offset: 66998},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2235, col: 5, offset: 68095},
+						pos: position{line: 2207, col: 5, offset: 66998},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2235, col: 5, offset: 68095},
+							pos: position{line: 2207, col: 5, offset: 66998},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2235, col: 5, offset: 68095},
+									pos:  position{line: 2207, col: 5, offset: 66998},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2235, col: 7, offset: 68097},
+									pos:  position{line: 2207, col: 7, offset: 67000},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2236, col: 5, offset: 68169},
+						pos: position{line: 2208, col: 5, offset: 67072},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2236, col: 5, offset: 68169},
+							pos: position{line: 2208, col: 5, offset: 67072},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2236, col: 5, offset: 68169},
+									pos:  position{line: 2208, col: 5, offset: 67072},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2236, col: 7, offset: 68171},
+									pos:  position{line: 2208, col: 7, offset: 67074},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2237, col: 5, offset: 68243},
+						pos: position{line: 2209, col: 5, offset: 67146},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2237, col: 5, offset: 68243},
+							pos:        position{line: 2209, col: 5, offset: 67146},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15562,65 +15242,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2239, col: 1, offset: 68275},
+			pos:  position{line: 2211, col: 1, offset: 67178},
 			expr: &choiceExpr{
-				pos: position{line: 2240, col: 5, offset: 68293},
+				pos: position{line: 2212, col: 5, offset: 67196},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2240, col: 5, offset: 68293},
+						pos: position{line: 2212, col: 5, offset: 67196},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2240, col: 5, offset: 68293},
+							pos: position{line: 2212, col: 5, offset: 67196},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 5, offset: 68293},
+									pos:  position{line: 2212, col: 5, offset: 67196},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 7, offset: 68295},
+									pos:  position{line: 2212, col: 7, offset: 67198},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 13, offset: 68301},
+									pos:  position{line: 2212, col: 13, offset: 67204},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 15, offset: 68303},
+									pos:  position{line: 2212, col: 15, offset: 67206},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2241, col: 5, offset: 68379},
+						pos: position{line: 2213, col: 5, offset: 67282},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2241, col: 5, offset: 68379},
+							pos: position{line: 2213, col: 5, offset: 67282},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2241, col: 5, offset: 68379},
+									pos:  position{line: 2213, col: 5, offset: 67282},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2241, col: 7, offset: 68381},
+									pos:  position{line: 2213, col: 7, offset: 67284},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2241, col: 13, offset: 68387},
+									pos:  position{line: 2213, col: 13, offset: 67290},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2241, col: 15, offset: 68389},
+									pos:  position{line: 2213, col: 15, offset: 67292},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2242, col: 5, offset: 68464},
+						pos: position{line: 2214, col: 5, offset: 67367},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2242, col: 5, offset: 68464},
+							pos:        position{line: 2214, col: 5, offset: 67367},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15633,25 +15313,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2244, col: 1, offset: 68509},
+			pos:  position{line: 2216, col: 1, offset: 67412},
 			expr: &choiceExpr{
-				pos: position{line: 2245, col: 5, offset: 68531},
+				pos: position{line: 2217, col: 5, offset: 67434},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2245, col: 5, offset: 68531},
+						pos: position{line: 2217, col: 5, offset: 67434},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2245, col: 5, offset: 68531},
+							pos: position{line: 2217, col: 5, offset: 67434},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2245, col: 5, offset: 68531},
+									pos:  position{line: 2217, col: 5, offset: 67434},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2245, col: 7, offset: 68533},
+									pos:   position{line: 2217, col: 7, offset: 67436},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2245, col: 10, offset: 68536},
+										pos:  position{line: 2217, col: 10, offset: 67439},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15659,10 +15339,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2246, col: 5, offset: 68574},
+						pos: position{line: 2218, col: 5, offset: 67477},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2246, col: 5, offset: 68574},
+							pos:        position{line: 2218, col: 5, offset: 67477},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15675,29 +15355,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2248, col: 1, offset: 68615},
+			pos:  position{line: 2220, col: 1, offset: 67518},
 			expr: &choiceExpr{
-				pos: position{line: 2249, col: 5, offset: 68634},
+				pos: position{line: 2221, col: 5, offset: 67537},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2249, col: 5, offset: 68634},
+						pos: position{line: 2221, col: 5, offset: 67537},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2249, col: 5, offset: 68634},
+							pos: position{line: 2221, col: 5, offset: 67537},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2249, col: 5, offset: 68634},
+									pos:   position{line: 2221, col: 5, offset: 67537},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2249, col: 7, offset: 68636},
+										pos:  position{line: 2221, col: 7, offset: 67539},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2249, col: 19, offset: 68648},
+									pos:   position{line: 2221, col: 19, offset: 67551},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2249, col: 21, offset: 68650},
+										pos:  position{line: 2221, col: 21, offset: 67553},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15705,24 +15385,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2262, col: 5, offset: 68914},
+						pos: position{line: 2234, col: 5, offset: 67817},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2262, col: 5, offset: 68914},
+							pos: position{line: 2234, col: 5, offset: 67817},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2262, col: 5, offset: 68914},
+									pos:   position{line: 2234, col: 5, offset: 67817},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2262, col: 7, offset: 68916},
+										pos:  position{line: 2234, col: 7, offset: 67819},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2262, col: 20, offset: 68929},
+									pos:   position{line: 2234, col: 20, offset: 67832},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2262, col: 22, offset: 68931},
+										pos:  position{line: 2234, col: 22, offset: 67834},
 										name: "OptLimitClause",
 									},
 								},
@@ -15736,25 +15416,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2274, col: 1, offset: 69160},
+			pos:  position{line: 2246, col: 1, offset: 68063},
 			expr: &choiceExpr{
-				pos: position{line: 2275, col: 5, offset: 69179},
+				pos: position{line: 2247, col: 5, offset: 68082},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2275, col: 5, offset: 69179},
+						pos: position{line: 2247, col: 5, offset: 68082},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2275, col: 5, offset: 69179},
+							pos: position{line: 2247, col: 5, offset: 68082},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2275, col: 5, offset: 69179},
+									pos:  position{line: 2247, col: 5, offset: 68082},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2275, col: 7, offset: 69181},
+									pos:   position{line: 2247, col: 7, offset: 68084},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2275, col: 9, offset: 69183},
+										pos:  position{line: 2247, col: 9, offset: 68086},
 										name: "LimitClause",
 									},
 								},
@@ -15762,10 +15442,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2276, col: 5, offset: 69217},
+						pos: position{line: 2248, col: 5, offset: 68120},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2276, col: 5, offset: 69217},
+							pos:        position{line: 2248, col: 5, offset: 68120},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15778,50 +15458,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2278, col: 1, offset: 69254},
+			pos:  position{line: 2250, col: 1, offset: 68157},
 			expr: &choiceExpr{
-				pos: position{line: 2279, col: 5, offset: 69270},
+				pos: position{line: 2251, col: 5, offset: 68173},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2279, col: 5, offset: 69270},
+						pos: position{line: 2251, col: 5, offset: 68173},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2279, col: 5, offset: 69270},
+							pos: position{line: 2251, col: 5, offset: 68173},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2279, col: 5, offset: 69270},
+									pos:  position{line: 2251, col: 5, offset: 68173},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2279, col: 11, offset: 69276},
+									pos:  position{line: 2251, col: 11, offset: 68179},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2279, col: 13, offset: 69278},
+									pos:  position{line: 2251, col: 13, offset: 68181},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2280, col: 5, offset: 69306},
+						pos: position{line: 2252, col: 5, offset: 68209},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2280, col: 5, offset: 69306},
+							pos: position{line: 2252, col: 5, offset: 68209},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2280, col: 5, offset: 69306},
+									pos:  position{line: 2252, col: 5, offset: 68209},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2280, col: 11, offset: 69312},
+									pos:  position{line: 2252, col: 11, offset: 68215},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2280, col: 13, offset: 69314},
+									pos:   position{line: 2252, col: 13, offset: 68217},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2280, col: 15, offset: 69316},
+										pos:  position{line: 2252, col: 15, offset: 68219},
 										name: "Expr",
 									},
 								},
@@ -15835,25 +15515,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2282, col: 1, offset: 69340},
+			pos:  position{line: 2254, col: 1, offset: 68243},
 			expr: &choiceExpr{
-				pos: position{line: 2283, col: 5, offset: 69360},
+				pos: position{line: 2255, col: 5, offset: 68263},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2283, col: 5, offset: 69360},
+						pos: position{line: 2255, col: 5, offset: 68263},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2283, col: 5, offset: 69360},
+							pos: position{line: 2255, col: 5, offset: 68263},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2283, col: 5, offset: 69360},
+									pos:  position{line: 2255, col: 5, offset: 68263},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2283, col: 7, offset: 69362},
+									pos:   position{line: 2255, col: 7, offset: 68265},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2283, col: 9, offset: 69364},
+										pos:  position{line: 2255, col: 9, offset: 68267},
 										name: "OffsetClause",
 									},
 								},
@@ -15861,10 +15541,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2284, col: 5, offset: 69400},
+						pos: position{line: 2256, col: 5, offset: 68303},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2284, col: 5, offset: 69400},
+							pos:        position{line: 2256, col: 5, offset: 68303},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15877,26 +15557,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2286, col: 1, offset: 69425},
+			pos:  position{line: 2258, col: 1, offset: 68328},
 			expr: &actionExpr{
-				pos: position{line: 2287, col: 5, offset: 69442},
+				pos: position{line: 2259, col: 5, offset: 68345},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2287, col: 5, offset: 69442},
+					pos: position{line: 2259, col: 5, offset: 68345},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2287, col: 5, offset: 69442},
+							pos:  position{line: 2259, col: 5, offset: 68345},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2287, col: 12, offset: 69449},
+							pos:  position{line: 2259, col: 12, offset: 68352},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2287, col: 14, offset: 69451},
+							pos:   position{line: 2259, col: 14, offset: 68354},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2287, col: 16, offset: 69453},
+								pos:  position{line: 2259, col: 16, offset: 68356},
 								name: "Expr",
 							},
 						},
@@ -15908,38 +15588,38 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2289, col: 1, offset: 69478},
+			pos:  position{line: 2261, col: 1, offset: 68381},
 			expr: &actionExpr{
-				pos: position{line: 2290, col: 5, offset: 69495},
+				pos: position{line: 2262, col: 5, offset: 68398},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2290, col: 5, offset: 69495},
+					pos: position{line: 2262, col: 5, offset: 68398},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2290, col: 5, offset: 69495},
+							pos:   position{line: 2262, col: 5, offset: 68398},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2290, col: 10, offset: 69500},
+								pos:  position{line: 2262, col: 10, offset: 68403},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2290, col: 21, offset: 69511},
+							pos:   position{line: 2262, col: 21, offset: 68414},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2290, col: 30, offset: 69520},
+								pos:  position{line: 2262, col: 30, offset: 68423},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2290, col: 36, offset: 69526},
+							pos:  position{line: 2262, col: 36, offset: 68429},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2290, col: 38, offset: 69528},
+							pos:   position{line: 2262, col: 38, offset: 68431},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2290, col: 44, offset: 69534},
+								pos:  position{line: 2262, col: 44, offset: 68437},
 								name: "SelectExpr",
 							},
 						},
@@ -15951,60 +15631,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2300, col: 1, offset: 69761},
+			pos:  position{line: 2272, col: 1, offset: 68664},
 			expr: &choiceExpr{
-				pos: position{line: 2301, col: 5, offset: 69771},
+				pos: position{line: 2273, col: 5, offset: 68674},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2301, col: 5, offset: 69771},
+						pos: position{line: 2273, col: 5, offset: 68674},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2301, col: 5, offset: 69771},
+							pos: position{line: 2273, col: 5, offset: 68674},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2301, col: 5, offset: 69771},
+									pos:  position{line: 2273, col: 5, offset: 68674},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2301, col: 7, offset: 69773},
+									pos:  position{line: 2273, col: 7, offset: 68676},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2301, col: 13, offset: 69779},
+									pos:  position{line: 2273, col: 13, offset: 68682},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2301, col: 15, offset: 69781},
+									pos:  position{line: 2273, col: 15, offset: 68684},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2302, col: 5, offset: 69817},
+						pos: position{line: 2274, col: 5, offset: 68720},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2302, col: 5, offset: 69817},
+							pos: position{line: 2274, col: 5, offset: 68720},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2302, col: 5, offset: 69817},
+									pos:  position{line: 2274, col: 5, offset: 68720},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2302, col: 7, offset: 69819},
+									pos:  position{line: 2274, col: 7, offset: 68722},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2302, col: 13, offset: 69825},
+									pos: position{line: 2274, col: 13, offset: 68728},
 									expr: &seqExpr{
-										pos: position{line: 2302, col: 14, offset: 69826},
+										pos: position{line: 2274, col: 14, offset: 68729},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2302, col: 14, offset: 69826},
+												pos:  position{line: 2274, col: 14, offset: 68729},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2302, col: 16, offset: 69828},
+												pos:  position{line: 2274, col: 16, offset: 68731},
 												name: "DISTINCT",
 											},
 										},
@@ -16020,84 +15700,84 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2305, col: 1, offset: 69880},
+			pos:  position{line: 2277, col: 1, offset: 68783},
 			expr: &choiceExpr{
-				pos: position{line: 2306, col: 5, offset: 69895},
+				pos: position{line: 2278, col: 5, offset: 68798},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2306, col: 5, offset: 69895},
+						pos:  position{line: 2278, col: 5, offset: 68798},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2306, col: 12, offset: 69902},
+						pos:  position{line: 2278, col: 12, offset: 68805},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2306, col: 20, offset: 69910},
+						pos:  position{line: 2278, col: 20, offset: 68813},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2306, col: 29, offset: 69919},
+						pos:  position{line: 2278, col: 29, offset: 68822},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2306, col: 38, offset: 69928},
+						pos:  position{line: 2278, col: 38, offset: 68831},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2307, col: 5, offset: 69942},
+						pos:  position{line: 2279, col: 5, offset: 68845},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2307, col: 13, offset: 69950},
+						pos:  position{line: 2279, col: 13, offset: 68853},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2307, col: 20, offset: 69957},
+						pos:  position{line: 2279, col: 20, offset: 68860},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2307, col: 28, offset: 69965},
+						pos:  position{line: 2279, col: 28, offset: 68868},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2307, col: 36, offset: 69973},
+						pos:  position{line: 2279, col: 36, offset: 68876},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2307, col: 44, offset: 69981},
+						pos:  position{line: 2279, col: 44, offset: 68884},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2308, col: 5, offset: 69990},
+						pos:  position{line: 2280, col: 5, offset: 68893},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2309, col: 5, offset: 70000},
+						pos:  position{line: 2281, col: 5, offset: 68903},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2310, col: 5, offset: 70010},
+						pos:  position{line: 2282, col: 5, offset: 68913},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2311, col: 5, offset: 70021},
+						pos:  position{line: 2283, col: 5, offset: 68924},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2312, col: 5, offset: 70031},
+						pos:  position{line: 2284, col: 5, offset: 68934},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2313, col: 5, offset: 70041},
+						pos:  position{line: 2285, col: 5, offset: 68944},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2314, col: 5, offset: 70050},
+						pos:  position{line: 2286, col: 5, offset: 68953},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2315, col: 5, offset: 70060},
+						pos:  position{line: 2287, col: 5, offset: 68963},
 						name: "ON",
 					},
 				},
@@ -16107,20 +15787,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2317, col: 1, offset: 70064},
+			pos:  position{line: 2289, col: 1, offset: 68967},
 			expr: &seqExpr{
-				pos: position{line: 2317, col: 14, offset: 70077},
+				pos: position{line: 2289, col: 14, offset: 68980},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2317, col: 14, offset: 70077},
+						pos:        position{line: 2289, col: 14, offset: 68980},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2317, col: 33, offset: 70096},
+						pos: position{line: 2289, col: 33, offset: 68999},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2317, col: 34, offset: 70097},
+							pos:  position{line: 2289, col: 34, offset: 69000},
 							name: "IdentifierRest",
 						},
 					},
@@ -16131,20 +15811,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2318, col: 1, offset: 70112},
+			pos:  position{line: 2290, col: 1, offset: 69015},
 			expr: &seqExpr{
-				pos: position{line: 2318, col: 14, offset: 70125},
+				pos: position{line: 2290, col: 14, offset: 69028},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2318, col: 14, offset: 70125},
+						pos:        position{line: 2290, col: 14, offset: 69028},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2318, col: 33, offset: 70144},
+						pos: position{line: 2290, col: 33, offset: 69047},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2318, col: 34, offset: 70145},
+							pos:  position{line: 2290, col: 34, offset: 69048},
 							name: "IdentifierRest",
 						},
 					},
@@ -16155,23 +15835,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2319, col: 1, offset: 70160},
+			pos:  position{line: 2291, col: 1, offset: 69063},
 			expr: &actionExpr{
-				pos: position{line: 2319, col: 14, offset: 70173},
+				pos: position{line: 2291, col: 14, offset: 69076},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2319, col: 14, offset: 70173},
+					pos: position{line: 2291, col: 14, offset: 69076},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2319, col: 14, offset: 70173},
+							pos:        position{line: 2291, col: 14, offset: 69076},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2319, col: 33, offset: 70192},
+							pos: position{line: 2291, col: 33, offset: 69095},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2319, col: 34, offset: 70193},
+								pos:  position{line: 2291, col: 34, offset: 69096},
 								name: "IdentifierRest",
 							},
 						},
@@ -16183,20 +15863,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2320, col: 1, offset: 70230},
+			pos:  position{line: 2292, col: 1, offset: 69133},
 			expr: &seqExpr{
-				pos: position{line: 2320, col: 14, offset: 70243},
+				pos: position{line: 2292, col: 14, offset: 69146},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2320, col: 14, offset: 70243},
+						pos:        position{line: 2292, col: 14, offset: 69146},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2320, col: 33, offset: 70262},
+						pos: position{line: 2292, col: 33, offset: 69165},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2320, col: 34, offset: 70263},
+							pos:  position{line: 2292, col: 34, offset: 69166},
 							name: "IdentifierRest",
 						},
 					},
@@ -16207,20 +15887,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2321, col: 1, offset: 70278},
+			pos:  position{line: 2293, col: 1, offset: 69181},
 			expr: &seqExpr{
-				pos: position{line: 2321, col: 14, offset: 70291},
+				pos: position{line: 2293, col: 14, offset: 69194},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2321, col: 14, offset: 70291},
+						pos:        position{line: 2293, col: 14, offset: 69194},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2321, col: 33, offset: 70310},
+						pos: position{line: 2293, col: 33, offset: 69213},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2321, col: 34, offset: 70311},
+							pos:  position{line: 2293, col: 34, offset: 69214},
 							name: "IdentifierRest",
 						},
 					},
@@ -16231,23 +15911,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2322, col: 1, offset: 70326},
+			pos:  position{line: 2294, col: 1, offset: 69229},
 			expr: &actionExpr{
-				pos: position{line: 2322, col: 14, offset: 70339},
+				pos: position{line: 2294, col: 14, offset: 69242},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2322, col: 14, offset: 70339},
+					pos: position{line: 2294, col: 14, offset: 69242},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2322, col: 14, offset: 70339},
+							pos:        position{line: 2294, col: 14, offset: 69242},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2322, col: 33, offset: 70358},
+							pos: position{line: 2294, col: 33, offset: 69261},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2322, col: 34, offset: 70359},
+								pos:  position{line: 2294, col: 34, offset: 69262},
 								name: "IdentifierRest",
 							},
 						},
@@ -16259,20 +15939,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2323, col: 1, offset: 70396},
+			pos:  position{line: 2295, col: 1, offset: 69299},
 			expr: &seqExpr{
-				pos: position{line: 2323, col: 14, offset: 70409},
+				pos: position{line: 2295, col: 14, offset: 69312},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2323, col: 14, offset: 70409},
+						pos:        position{line: 2295, col: 14, offset: 69312},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2323, col: 33, offset: 70428},
+						pos: position{line: 2295, col: 33, offset: 69331},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2323, col: 34, offset: 70429},
+							pos:  position{line: 2295, col: 34, offset: 69332},
 							name: "IdentifierRest",
 						},
 					},
@@ -16283,20 +15963,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2324, col: 1, offset: 70444},
+			pos:  position{line: 2296, col: 1, offset: 69347},
 			expr: &seqExpr{
-				pos: position{line: 2324, col: 14, offset: 70457},
+				pos: position{line: 2296, col: 14, offset: 69360},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2324, col: 14, offset: 70457},
+						pos:        position{line: 2296, col: 14, offset: 69360},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2324, col: 33, offset: 70476},
+						pos: position{line: 2296, col: 33, offset: 69379},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2324, col: 34, offset: 70477},
+							pos:  position{line: 2296, col: 34, offset: 69380},
 							name: "IdentifierRest",
 						},
 					},
@@ -16307,20 +15987,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2325, col: 1, offset: 70492},
+			pos:  position{line: 2297, col: 1, offset: 69395},
 			expr: &seqExpr{
-				pos: position{line: 2325, col: 14, offset: 70505},
+				pos: position{line: 2297, col: 14, offset: 69408},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2325, col: 14, offset: 70505},
+						pos:        position{line: 2297, col: 14, offset: 69408},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2325, col: 33, offset: 70524},
+						pos: position{line: 2297, col: 33, offset: 69427},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2325, col: 34, offset: 70525},
+							pos:  position{line: 2297, col: 34, offset: 69428},
 							name: "IdentifierRest",
 						},
 					},
@@ -16331,20 +16011,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2326, col: 1, offset: 70540},
+			pos:  position{line: 2298, col: 1, offset: 69443},
 			expr: &seqExpr{
-				pos: position{line: 2326, col: 14, offset: 70553},
+				pos: position{line: 2298, col: 14, offset: 69456},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2326, col: 14, offset: 70553},
+						pos:        position{line: 2298, col: 14, offset: 69456},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2326, col: 33, offset: 70572},
+						pos: position{line: 2298, col: 33, offset: 69475},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2326, col: 34, offset: 70573},
+							pos:  position{line: 2298, col: 34, offset: 69476},
 							name: "IdentifierRest",
 						},
 					},
@@ -16355,20 +16035,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2327, col: 1, offset: 70588},
+			pos:  position{line: 2299, col: 1, offset: 69491},
 			expr: &seqExpr{
-				pos: position{line: 2327, col: 14, offset: 70601},
+				pos: position{line: 2299, col: 14, offset: 69504},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2327, col: 14, offset: 70601},
+						pos:        position{line: 2299, col: 14, offset: 69504},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2327, col: 33, offset: 70620},
+						pos: position{line: 2299, col: 33, offset: 69523},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2327, col: 34, offset: 70621},
+							pos:  position{line: 2299, col: 34, offset: 69524},
 							name: "IdentifierRest",
 						},
 					},
@@ -16379,20 +16059,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2328, col: 1, offset: 70636},
+			pos:  position{line: 2300, col: 1, offset: 69539},
 			expr: &seqExpr{
-				pos: position{line: 2328, col: 14, offset: 70649},
+				pos: position{line: 2300, col: 14, offset: 69552},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2328, col: 14, offset: 70649},
+						pos:        position{line: 2300, col: 14, offset: 69552},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2328, col: 33, offset: 70668},
+						pos: position{line: 2300, col: 33, offset: 69571},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2328, col: 34, offset: 70669},
+							pos:  position{line: 2300, col: 34, offset: 69572},
 							name: "IdentifierRest",
 						},
 					},
@@ -16403,20 +16083,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2329, col: 1, offset: 70684},
+			pos:  position{line: 2301, col: 1, offset: 69587},
 			expr: &seqExpr{
-				pos: position{line: 2329, col: 14, offset: 70697},
+				pos: position{line: 2301, col: 14, offset: 69600},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2329, col: 14, offset: 70697},
+						pos:        position{line: 2301, col: 14, offset: 69600},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2329, col: 33, offset: 70716},
+						pos: position{line: 2301, col: 33, offset: 69619},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2329, col: 34, offset: 70717},
+							pos:  position{line: 2301, col: 34, offset: 69620},
 							name: "IdentifierRest",
 						},
 					},
@@ -16427,20 +16107,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2330, col: 1, offset: 70732},
+			pos:  position{line: 2302, col: 1, offset: 69635},
 			expr: &seqExpr{
-				pos: position{line: 2330, col: 14, offset: 70745},
+				pos: position{line: 2302, col: 14, offset: 69648},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2330, col: 14, offset: 70745},
+						pos:        position{line: 2302, col: 14, offset: 69648},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2330, col: 33, offset: 70764},
+						pos: position{line: 2302, col: 33, offset: 69667},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2330, col: 34, offset: 70765},
+							pos:  position{line: 2302, col: 34, offset: 69668},
 							name: "IdentifierRest",
 						},
 					},
@@ -16451,20 +16131,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2331, col: 1, offset: 70780},
+			pos:  position{line: 2303, col: 1, offset: 69683},
 			expr: &seqExpr{
-				pos: position{line: 2331, col: 14, offset: 70793},
+				pos: position{line: 2303, col: 14, offset: 69696},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2331, col: 14, offset: 70793},
+						pos:        position{line: 2303, col: 14, offset: 69696},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2331, col: 33, offset: 70812},
+						pos: position{line: 2303, col: 33, offset: 69715},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2331, col: 34, offset: 70813},
+							pos:  position{line: 2303, col: 34, offset: 69716},
 							name: "IdentifierRest",
 						},
 					},
@@ -16475,20 +16155,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2332, col: 1, offset: 70828},
+			pos:  position{line: 2304, col: 1, offset: 69731},
 			expr: &seqExpr{
-				pos: position{line: 2332, col: 14, offset: 70841},
+				pos: position{line: 2304, col: 14, offset: 69744},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2332, col: 14, offset: 70841},
+						pos:        position{line: 2304, col: 14, offset: 69744},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2332, col: 33, offset: 70860},
+						pos: position{line: 2304, col: 33, offset: 69763},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2332, col: 34, offset: 70861},
+							pos:  position{line: 2304, col: 34, offset: 69764},
 							name: "IdentifierRest",
 						},
 					},
@@ -16499,23 +16179,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2333, col: 1, offset: 70876},
+			pos:  position{line: 2305, col: 1, offset: 69779},
 			expr: &actionExpr{
-				pos: position{line: 2333, col: 14, offset: 70889},
+				pos: position{line: 2305, col: 14, offset: 69792},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2333, col: 14, offset: 70889},
+					pos: position{line: 2305, col: 14, offset: 69792},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2333, col: 14, offset: 70889},
+							pos:        position{line: 2305, col: 14, offset: 69792},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2333, col: 33, offset: 70908},
+							pos: position{line: 2305, col: 33, offset: 69811},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2333, col: 34, offset: 70909},
+								pos:  position{line: 2305, col: 34, offset: 69812},
 								name: "IdentifierRest",
 							},
 						},
@@ -16527,20 +16207,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2334, col: 1, offset: 70947},
+			pos:  position{line: 2306, col: 1, offset: 69850},
 			expr: &seqExpr{
-				pos: position{line: 2334, col: 14, offset: 70960},
+				pos: position{line: 2306, col: 14, offset: 69863},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2334, col: 14, offset: 70960},
+						pos:        position{line: 2306, col: 14, offset: 69863},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2334, col: 33, offset: 70979},
+						pos: position{line: 2306, col: 33, offset: 69882},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2334, col: 34, offset: 70980},
+							pos:  position{line: 2306, col: 34, offset: 69883},
 							name: "IdentifierRest",
 						},
 					},
@@ -16551,20 +16231,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2335, col: 1, offset: 70995},
+			pos:  position{line: 2307, col: 1, offset: 69898},
 			expr: &seqExpr{
-				pos: position{line: 2335, col: 14, offset: 71008},
+				pos: position{line: 2307, col: 14, offset: 69911},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2335, col: 14, offset: 71008},
+						pos:        position{line: 2307, col: 14, offset: 69911},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2335, col: 33, offset: 71027},
+						pos: position{line: 2307, col: 33, offset: 69930},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2335, col: 34, offset: 71028},
+							pos:  position{line: 2307, col: 34, offset: 69931},
 							name: "IdentifierRest",
 						},
 					},
@@ -16575,23 +16255,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2336, col: 1, offset: 71043},
+			pos:  position{line: 2308, col: 1, offset: 69946},
 			expr: &actionExpr{
-				pos: position{line: 2336, col: 14, offset: 71056},
+				pos: position{line: 2308, col: 14, offset: 69959},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2336, col: 14, offset: 71056},
+					pos: position{line: 2308, col: 14, offset: 69959},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2336, col: 14, offset: 71056},
+							pos:        position{line: 2308, col: 14, offset: 69959},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2336, col: 33, offset: 71075},
+							pos: position{line: 2308, col: 33, offset: 69978},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2336, col: 34, offset: 71076},
+								pos:  position{line: 2308, col: 34, offset: 69979},
 								name: "IdentifierRest",
 							},
 						},
@@ -16603,20 +16283,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2337, col: 1, offset: 71114},
+			pos:  position{line: 2309, col: 1, offset: 70017},
 			expr: &seqExpr{
-				pos: position{line: 2337, col: 14, offset: 71127},
+				pos: position{line: 2309, col: 14, offset: 70030},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2337, col: 14, offset: 71127},
+						pos:        position{line: 2309, col: 14, offset: 70030},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2337, col: 33, offset: 71146},
+						pos: position{line: 2309, col: 33, offset: 70049},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2337, col: 34, offset: 71147},
+							pos:  position{line: 2309, col: 34, offset: 70050},
 							name: "IdentifierRest",
 						},
 					},
@@ -16627,20 +16307,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2338, col: 1, offset: 71162},
+			pos:  position{line: 2310, col: 1, offset: 70065},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 71175},
+				pos: position{line: 2310, col: 14, offset: 70078},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 71175},
+						pos:        position{line: 2310, col: 14, offset: 70078},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 71194},
+						pos: position{line: 2310, col: 33, offset: 70097},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 71195},
+							pos:  position{line: 2310, col: 34, offset: 70098},
 							name: "IdentifierRest",
 						},
 					},
@@ -16651,20 +16331,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2339, col: 1, offset: 71210},
+			pos:  position{line: 2311, col: 1, offset: 70113},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 71223},
+				pos: position{line: 2311, col: 14, offset: 70126},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 71223},
+						pos:        position{line: 2311, col: 14, offset: 70126},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 71242},
+						pos: position{line: 2311, col: 33, offset: 70145},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 71243},
+							pos:  position{line: 2311, col: 34, offset: 70146},
 							name: "IdentifierRest",
 						},
 					},
@@ -16675,20 +16355,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2340, col: 1, offset: 71258},
+			pos:  position{line: 2312, col: 1, offset: 70161},
 			expr: &seqExpr{
-				pos: position{line: 2340, col: 14, offset: 71271},
+				pos: position{line: 2312, col: 14, offset: 70174},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2340, col: 14, offset: 71271},
+						pos:        position{line: 2312, col: 14, offset: 70174},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2340, col: 33, offset: 71290},
+						pos: position{line: 2312, col: 33, offset: 70193},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2340, col: 34, offset: 71291},
+							pos:  position{line: 2312, col: 34, offset: 70194},
 							name: "IdentifierRest",
 						},
 					},
@@ -16699,20 +16379,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2341, col: 1, offset: 71306},
+			pos:  position{line: 2313, col: 1, offset: 70209},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 71319},
+				pos: position{line: 2313, col: 14, offset: 70222},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 71319},
+						pos:        position{line: 2313, col: 14, offset: 70222},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 71338},
+						pos: position{line: 2313, col: 33, offset: 70241},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 71339},
+							pos:  position{line: 2313, col: 34, offset: 70242},
 							name: "IdentifierRest",
 						},
 					},
@@ -16723,20 +16403,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2342, col: 1, offset: 71354},
+			pos:  position{line: 2314, col: 1, offset: 70257},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 71367},
+				pos: position{line: 2314, col: 14, offset: 70270},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 71367},
+						pos:        position{line: 2314, col: 14, offset: 70270},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 71386},
+						pos: position{line: 2314, col: 33, offset: 70289},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 71387},
+							pos:  position{line: 2314, col: 34, offset: 70290},
 							name: "IdentifierRest",
 						},
 					},
@@ -16747,20 +16427,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2343, col: 1, offset: 71402},
+			pos:  position{line: 2315, col: 1, offset: 70305},
 			expr: &seqExpr{
-				pos: position{line: 2343, col: 14, offset: 71415},
+				pos: position{line: 2315, col: 14, offset: 70318},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2343, col: 14, offset: 71415},
+						pos:        position{line: 2315, col: 14, offset: 70318},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2343, col: 33, offset: 71434},
+						pos: position{line: 2315, col: 33, offset: 70337},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2343, col: 34, offset: 71435},
+							pos:  position{line: 2315, col: 34, offset: 70338},
 							name: "IdentifierRest",
 						},
 					},
@@ -16771,20 +16451,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2344, col: 1, offset: 71450},
+			pos:  position{line: 2316, col: 1, offset: 70353},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 71463},
+				pos: position{line: 2316, col: 14, offset: 70366},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 71463},
+						pos:        position{line: 2316, col: 14, offset: 70366},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 71482},
+						pos: position{line: 2316, col: 33, offset: 70385},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 71483},
+							pos:  position{line: 2316, col: 34, offset: 70386},
 							name: "IdentifierRest",
 						},
 					},
@@ -16795,20 +16475,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2345, col: 1, offset: 71498},
+			pos:  position{line: 2317, col: 1, offset: 70401},
 			expr: &seqExpr{
-				pos: position{line: 2345, col: 14, offset: 71511},
+				pos: position{line: 2317, col: 14, offset: 70414},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2345, col: 14, offset: 71511},
+						pos:        position{line: 2317, col: 14, offset: 70414},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2345, col: 33, offset: 71530},
+						pos: position{line: 2317, col: 33, offset: 70433},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2345, col: 34, offset: 71531},
+							pos:  position{line: 2317, col: 34, offset: 70434},
 							name: "IdentifierRest",
 						},
 					},
@@ -16819,20 +16499,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2346, col: 1, offset: 71546},
+			pos:  position{line: 2318, col: 1, offset: 70449},
 			expr: &seqExpr{
-				pos: position{line: 2346, col: 14, offset: 71559},
+				pos: position{line: 2318, col: 14, offset: 70462},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2346, col: 14, offset: 71559},
+						pos:        position{line: 2318, col: 14, offset: 70462},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2346, col: 33, offset: 71578},
+						pos: position{line: 2318, col: 33, offset: 70481},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2346, col: 34, offset: 71579},
+							pos:  position{line: 2318, col: 34, offset: 70482},
 							name: "IdentifierRest",
 						},
 					},
@@ -16843,20 +16523,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2347, col: 1, offset: 71594},
+			pos:  position{line: 2319, col: 1, offset: 70497},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 71607},
+				pos: position{line: 2319, col: 14, offset: 70510},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 71607},
+						pos:        position{line: 2319, col: 14, offset: 70510},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 71626},
+						pos: position{line: 2319, col: 33, offset: 70529},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 71627},
+							pos:  position{line: 2319, col: 34, offset: 70530},
 							name: "IdentifierRest",
 						},
 					},
@@ -16867,20 +16547,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2348, col: 1, offset: 71642},
+			pos:  position{line: 2320, col: 1, offset: 70545},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 71655},
+				pos: position{line: 2320, col: 14, offset: 70558},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 71655},
+						pos:        position{line: 2320, col: 14, offset: 70558},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 71674},
+						pos: position{line: 2320, col: 33, offset: 70577},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 71675},
+							pos:  position{line: 2320, col: 34, offset: 70578},
 							name: "IdentifierRest",
 						},
 					},
@@ -16891,20 +16571,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2349, col: 1, offset: 71690},
+			pos:  position{line: 2321, col: 1, offset: 70593},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 71703},
+				pos: position{line: 2321, col: 14, offset: 70606},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 71703},
+						pos:        position{line: 2321, col: 14, offset: 70606},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 71722},
+						pos: position{line: 2321, col: 33, offset: 70625},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 71723},
+							pos:  position{line: 2321, col: 34, offset: 70626},
 							name: "IdentifierRest",
 						},
 					},
@@ -16915,20 +16595,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2350, col: 1, offset: 71738},
+			pos:  position{line: 2322, col: 1, offset: 70641},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 71751},
+				pos: position{line: 2322, col: 14, offset: 70654},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 71751},
+						pos:        position{line: 2322, col: 14, offset: 70654},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 71770},
+						pos: position{line: 2322, col: 33, offset: 70673},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 71771},
+							pos:  position{line: 2322, col: 34, offset: 70674},
 							name: "IdentifierRest",
 						},
 					},
@@ -16939,20 +16619,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2351, col: 1, offset: 71786},
+			pos:  position{line: 2323, col: 1, offset: 70689},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 71799},
+				pos: position{line: 2323, col: 14, offset: 70702},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 71799},
+						pos:        position{line: 2323, col: 14, offset: 70702},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 71818},
+						pos: position{line: 2323, col: 33, offset: 70721},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 71819},
+							pos:  position{line: 2323, col: 34, offset: 70722},
 							name: "IdentifierRest",
 						},
 					},
@@ -16963,20 +16643,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2352, col: 1, offset: 71834},
+			pos:  position{line: 2324, col: 1, offset: 70737},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 71847},
+				pos: position{line: 2324, col: 14, offset: 70750},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 71847},
+						pos:        position{line: 2324, col: 14, offset: 70750},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 71866},
+						pos: position{line: 2324, col: 33, offset: 70769},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 71867},
+							pos:  position{line: 2324, col: 34, offset: 70770},
 							name: "IdentifierRest",
 						},
 					},
@@ -16987,20 +16667,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2353, col: 1, offset: 71882},
+			pos:  position{line: 2325, col: 1, offset: 70785},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 71895},
+				pos: position{line: 2325, col: 14, offset: 70798},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 71895},
+						pos:        position{line: 2325, col: 14, offset: 70798},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 71914},
+						pos: position{line: 2325, col: 33, offset: 70817},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 71915},
+							pos:  position{line: 2325, col: 34, offset: 70818},
 							name: "IdentifierRest",
 						},
 					},
@@ -17011,44 +16691,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2354, col: 1, offset: 71930},
+			pos:  position{line: 2326, col: 1, offset: 70833},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 71943},
+				pos: position{line: 2326, col: 14, offset: 70846},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 71943},
+						pos:        position{line: 2326, col: 14, offset: 70846},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 71962},
+						pos: position{line: 2326, col: 33, offset: 70865},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 71963},
-							name: "IdentifierRest",
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
-			name: "GREP",
-			pos:  position{line: 2355, col: 1, offset: 71978},
-			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 71991},
-				exprs: []any{
-					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 71991},
-						val:        "grep",
-						ignoreCase: true,
-						want:       "\"GREP\"i",
-					},
-					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 72010},
-						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 72011},
+							pos:  position{line: 2326, col: 34, offset: 70866},
 							name: "IdentifierRest",
 						},
 					},
@@ -17059,20 +16715,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2356, col: 1, offset: 72026},
+			pos:  position{line: 2327, col: 1, offset: 70881},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 72039},
+				pos: position{line: 2327, col: 14, offset: 70894},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 72039},
+						pos:        position{line: 2327, col: 14, offset: 70894},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 72058},
+						pos: position{line: 2327, col: 33, offset: 70913},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 72059},
+							pos:  position{line: 2327, col: 34, offset: 70914},
 							name: "IdentifierRest",
 						},
 					},
@@ -17083,20 +16739,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2357, col: 1, offset: 72074},
+			pos:  position{line: 2328, col: 1, offset: 70929},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 72087},
+				pos: position{line: 2328, col: 14, offset: 70942},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 72087},
+						pos:        position{line: 2328, col: 14, offset: 70942},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 72106},
+						pos: position{line: 2328, col: 33, offset: 70961},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 72107},
+							pos:  position{line: 2328, col: 34, offset: 70962},
 							name: "IdentifierRest",
 						},
 					},
@@ -17107,20 +16763,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2358, col: 1, offset: 72122},
+			pos:  position{line: 2329, col: 1, offset: 70977},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 72135},
+				pos: position{line: 2329, col: 14, offset: 70990},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 72135},
+						pos:        position{line: 2329, col: 14, offset: 70990},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 72154},
+						pos: position{line: 2329, col: 33, offset: 71009},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 72155},
+							pos:  position{line: 2329, col: 34, offset: 71010},
 							name: "IdentifierRest",
 						},
 					},
@@ -17131,20 +16787,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2359, col: 1, offset: 72170},
+			pos:  position{line: 2330, col: 1, offset: 71025},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 72183},
+				pos: position{line: 2330, col: 14, offset: 71038},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 72183},
+						pos:        position{line: 2330, col: 14, offset: 71038},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 72202},
+						pos: position{line: 2330, col: 33, offset: 71057},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 72203},
+							pos:  position{line: 2330, col: 34, offset: 71058},
 							name: "IdentifierRest",
 						},
 					},
@@ -17155,20 +16811,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2360, col: 1, offset: 72218},
+			pos:  position{line: 2331, col: 1, offset: 71073},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 72231},
+				pos: position{line: 2331, col: 14, offset: 71086},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 72231},
+						pos:        position{line: 2331, col: 14, offset: 71086},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 72250},
+						pos: position{line: 2331, col: 33, offset: 71105},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 72251},
+							pos:  position{line: 2331, col: 34, offset: 71106},
 							name: "IdentifierRest",
 						},
 					},
@@ -17179,20 +16835,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2361, col: 1, offset: 72266},
+			pos:  position{line: 2332, col: 1, offset: 71121},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 72279},
+				pos: position{line: 2332, col: 14, offset: 71134},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 72279},
+						pos:        position{line: 2332, col: 14, offset: 71134},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 72298},
+						pos: position{line: 2332, col: 33, offset: 71153},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 72299},
+							pos:  position{line: 2332, col: 34, offset: 71154},
 							name: "IdentifierRest",
 						},
 					},
@@ -17203,20 +16859,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2362, col: 1, offset: 72314},
+			pos:  position{line: 2333, col: 1, offset: 71169},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 72327},
+				pos: position{line: 2333, col: 14, offset: 71182},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 72327},
+						pos:        position{line: 2333, col: 14, offset: 71182},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 72346},
+						pos: position{line: 2333, col: 33, offset: 71201},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 72347},
+							pos:  position{line: 2333, col: 34, offset: 71202},
 							name: "IdentifierRest",
 						},
 					},
@@ -17227,20 +16883,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2363, col: 1, offset: 72362},
+			pos:  position{line: 2334, col: 1, offset: 71217},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 72375},
+				pos: position{line: 2334, col: 14, offset: 71230},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 72375},
+						pos:        position{line: 2334, col: 14, offset: 71230},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 72394},
+						pos: position{line: 2334, col: 33, offset: 71249},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 72395},
+							pos:  position{line: 2334, col: 34, offset: 71250},
 							name: "IdentifierRest",
 						},
 					},
@@ -17251,20 +16907,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2364, col: 1, offset: 72410},
+			pos:  position{line: 2335, col: 1, offset: 71265},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 72423},
+				pos: position{line: 2335, col: 14, offset: 71278},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 72423},
+						pos:        position{line: 2335, col: 14, offset: 71278},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 72442},
+						pos: position{line: 2335, col: 33, offset: 71297},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 72443},
+							pos:  position{line: 2335, col: 34, offset: 71298},
 							name: "IdentifierRest",
 						},
 					},
@@ -17275,20 +16931,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2365, col: 1, offset: 72458},
+			pos:  position{line: 2336, col: 1, offset: 71313},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 72471},
+				pos: position{line: 2336, col: 14, offset: 71326},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 72471},
+						pos:        position{line: 2336, col: 14, offset: 71326},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 72490},
+						pos: position{line: 2336, col: 33, offset: 71345},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 72491},
+							pos:  position{line: 2336, col: 34, offset: 71346},
 							name: "IdentifierRest",
 						},
 					},
@@ -17299,20 +16955,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2366, col: 1, offset: 72506},
+			pos:  position{line: 2337, col: 1, offset: 71361},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 72519},
+				pos: position{line: 2337, col: 14, offset: 71374},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 72519},
+						pos:        position{line: 2337, col: 14, offset: 71374},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 72538},
+						pos: position{line: 2337, col: 33, offset: 71393},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 72539},
+							pos:  position{line: 2337, col: 34, offset: 71394},
 							name: "IdentifierRest",
 						},
 					},
@@ -17323,20 +16979,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2367, col: 1, offset: 72554},
+			pos:  position{line: 2338, col: 1, offset: 71409},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 72567},
+				pos: position{line: 2338, col: 14, offset: 71422},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 72567},
+						pos:        position{line: 2338, col: 14, offset: 71422},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 72586},
+						pos: position{line: 2338, col: 33, offset: 71441},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 72587},
+							pos:  position{line: 2338, col: 34, offset: 71442},
 							name: "IdentifierRest",
 						},
 					},
@@ -17347,20 +17003,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2368, col: 1, offset: 72602},
+			pos:  position{line: 2339, col: 1, offset: 71457},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 16, offset: 72617},
+				pos: position{line: 2339, col: 16, offset: 71472},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 16, offset: 72617},
+						pos:        position{line: 2339, col: 16, offset: 71472},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 72634},
+						pos: position{line: 2339, col: 33, offset: 71489},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 72635},
+							pos:  position{line: 2339, col: 34, offset: 71490},
 							name: "IdentifierRest",
 						},
 					},
@@ -17371,20 +17027,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2369, col: 1, offset: 72650},
+			pos:  position{line: 2340, col: 1, offset: 71505},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 72663},
+				pos: position{line: 2340, col: 14, offset: 71518},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 72663},
+						pos:        position{line: 2340, col: 14, offset: 71518},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 72682},
+						pos: position{line: 2340, col: 33, offset: 71537},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 72683},
+							pos:  position{line: 2340, col: 34, offset: 71538},
 							name: "IdentifierRest",
 						},
 					},
@@ -17395,20 +17051,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2370, col: 1, offset: 72698},
+			pos:  position{line: 2341, col: 1, offset: 71553},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 72711},
+				pos: position{line: 2341, col: 14, offset: 71566},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 72711},
+						pos:        position{line: 2341, col: 14, offset: 71566},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 72730},
+						pos: position{line: 2341, col: 33, offset: 71585},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 72731},
+							pos:  position{line: 2341, col: 34, offset: 71586},
 							name: "IdentifierRest",
 						},
 					},
@@ -17419,20 +17075,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2371, col: 1, offset: 72746},
+			pos:  position{line: 2342, col: 1, offset: 71601},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 72759},
+				pos: position{line: 2342, col: 14, offset: 71614},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 72759},
+						pos:        position{line: 2342, col: 14, offset: 71614},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 72778},
+						pos: position{line: 2342, col: 33, offset: 71633},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 72779},
+							pos:  position{line: 2342, col: 34, offset: 71634},
 							name: "IdentifierRest",
 						},
 					},
@@ -17443,20 +17099,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2372, col: 1, offset: 72794},
+			pos:  position{line: 2343, col: 1, offset: 71649},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 72807},
+				pos: position{line: 2343, col: 14, offset: 71662},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 72807},
+						pos:        position{line: 2343, col: 14, offset: 71662},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 72826},
+						pos: position{line: 2343, col: 33, offset: 71681},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 72827},
+							pos:  position{line: 2343, col: 34, offset: 71682},
 							name: "IdentifierRest",
 						},
 					},
@@ -17467,20 +17123,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2373, col: 1, offset: 72842},
+			pos:  position{line: 2344, col: 1, offset: 71697},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 72855},
+				pos: position{line: 2344, col: 14, offset: 71710},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 72855},
+						pos:        position{line: 2344, col: 14, offset: 71710},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 72874},
+						pos: position{line: 2344, col: 33, offset: 71729},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 72875},
+							pos:  position{line: 2344, col: 34, offset: 71730},
 							name: "IdentifierRest",
 						},
 					},
@@ -17491,20 +17147,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2374, col: 1, offset: 72890},
+			pos:  position{line: 2345, col: 1, offset: 71745},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 72903},
+				pos: position{line: 2345, col: 14, offset: 71758},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 72903},
+						pos:        position{line: 2345, col: 14, offset: 71758},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 72922},
+						pos: position{line: 2345, col: 33, offset: 71777},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 72923},
+							pos:  position{line: 2345, col: 34, offset: 71778},
 							name: "IdentifierRest",
 						},
 					},
@@ -17515,20 +17171,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2375, col: 1, offset: 72938},
+			pos:  position{line: 2346, col: 1, offset: 71793},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 72951},
+				pos: position{line: 2346, col: 14, offset: 71806},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 72951},
+						pos:        position{line: 2346, col: 14, offset: 71806},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 72970},
+						pos: position{line: 2346, col: 33, offset: 71825},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 72971},
+							pos:  position{line: 2346, col: 34, offset: 71826},
 							name: "IdentifierRest",
 						},
 					},
@@ -17539,23 +17195,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2376, col: 1, offset: 72986},
+			pos:  position{line: 2347, col: 1, offset: 71841},
 			expr: &actionExpr{
-				pos: position{line: 2376, col: 14, offset: 72999},
+				pos: position{line: 2347, col: 14, offset: 71854},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2376, col: 14, offset: 72999},
+					pos: position{line: 2347, col: 14, offset: 71854},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2376, col: 14, offset: 72999},
+							pos:        position{line: 2347, col: 14, offset: 71854},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2376, col: 33, offset: 73018},
+							pos: position{line: 2347, col: 33, offset: 71873},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2376, col: 34, offset: 73019},
+								pos:  position{line: 2347, col: 34, offset: 71874},
 								name: "IdentifierRest",
 							},
 						},
@@ -17567,20 +17223,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2377, col: 1, offset: 73055},
+			pos:  position{line: 2348, col: 1, offset: 71910},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 73068},
+				pos: position{line: 2348, col: 14, offset: 71923},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 73068},
+						pos:        position{line: 2348, col: 14, offset: 71923},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 73087},
+						pos: position{line: 2348, col: 33, offset: 71942},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 73088},
+							pos:  position{line: 2348, col: 34, offset: 71943},
 							name: "IdentifierRest",
 						},
 					},
@@ -17591,20 +17247,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2378, col: 1, offset: 73103},
+			pos:  position{line: 2349, col: 1, offset: 71958},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 73116},
+				pos: position{line: 2349, col: 14, offset: 71971},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 73116},
+						pos:        position{line: 2349, col: 14, offset: 71971},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 73135},
+						pos: position{line: 2349, col: 33, offset: 71990},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 73136},
+							pos:  position{line: 2349, col: 34, offset: 71991},
 							name: "IdentifierRest",
 						},
 					},
@@ -17615,20 +17271,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2379, col: 1, offset: 73151},
+			pos:  position{line: 2350, col: 1, offset: 72006},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 73164},
+				pos: position{line: 2350, col: 14, offset: 72019},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 73164},
+						pos:        position{line: 2350, col: 14, offset: 72019},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 73183},
+						pos: position{line: 2350, col: 33, offset: 72038},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 73184},
+							pos:  position{line: 2350, col: 34, offset: 72039},
 							name: "IdentifierRest",
 						},
 					},
@@ -17639,20 +17295,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2380, col: 1, offset: 73199},
+			pos:  position{line: 2351, col: 1, offset: 72054},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 73212},
+				pos: position{line: 2351, col: 14, offset: 72067},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 73212},
+						pos:        position{line: 2351, col: 14, offset: 72067},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 73231},
+						pos: position{line: 2351, col: 33, offset: 72086},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 73232},
+							pos:  position{line: 2351, col: 34, offset: 72087},
 							name: "IdentifierRest",
 						},
 					},
@@ -17663,20 +17319,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2381, col: 1, offset: 73247},
+			pos:  position{line: 2352, col: 1, offset: 72102},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 73260},
+				pos: position{line: 2352, col: 14, offset: 72115},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 73260},
+						pos:        position{line: 2352, col: 14, offset: 72115},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 73279},
+						pos: position{line: 2352, col: 33, offset: 72134},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 73280},
+							pos:  position{line: 2352, col: 34, offset: 72135},
 							name: "IdentifierRest",
 						},
 					},
@@ -17687,20 +17343,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2382, col: 1, offset: 73295},
+			pos:  position{line: 2353, col: 1, offset: 72150},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 73308},
+				pos: position{line: 2353, col: 14, offset: 72163},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 73308},
+						pos:        position{line: 2353, col: 14, offset: 72163},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 73327},
+						pos: position{line: 2353, col: 33, offset: 72182},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 73328},
+							pos:  position{line: 2353, col: 34, offset: 72183},
 							name: "IdentifierRest",
 						},
 					},
@@ -17711,68 +17367,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2383, col: 1, offset: 73343},
+			pos:  position{line: 2354, col: 1, offset: 72198},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 73356},
+				pos: position{line: 2354, col: 14, offset: 72211},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 73356},
+						pos:        position{line: 2354, col: 14, offset: 72211},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 73375},
+						pos: position{line: 2354, col: 33, offset: 72230},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 73376},
-							name: "IdentifierRest",
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
-			name: "REGEXP",
-			pos:  position{line: 2384, col: 1, offset: 73391},
-			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 73404},
-				exprs: []any{
-					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 73404},
-						val:        "regexp",
-						ignoreCase: true,
-						want:       "\"REGEXP\"i",
-					},
-					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 73423},
-						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 73424},
-							name: "IdentifierRest",
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
-			name: "REGEXP_REPLACE",
-			pos:  position{line: 2385, col: 1, offset: 73439},
-			expr: &seqExpr{
-				pos: position{line: 2385, col: 18, offset: 73456},
-				exprs: []any{
-					&litMatcher{
-						pos:        position{line: 2385, col: 18, offset: 73456},
-						val:        "regexp_replace",
-						ignoreCase: true,
-						want:       "\"REGEXP_REPLACE\"i",
-					},
-					&notExpr{
-						pos: position{line: 2385, col: 36, offset: 73474},
-						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 37, offset: 73475},
+							pos:  position{line: 2354, col: 34, offset: 72231},
 							name: "IdentifierRest",
 						},
 					},
@@ -17783,20 +17391,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2386, col: 1, offset: 73490},
+			pos:  position{line: 2355, col: 1, offset: 72246},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 73503},
+				pos: position{line: 2355, col: 14, offset: 72259},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 73503},
+						pos:        position{line: 2355, col: 14, offset: 72259},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 73522},
+						pos: position{line: 2355, col: 33, offset: 72278},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 73523},
+							pos:  position{line: 2355, col: 34, offset: 72279},
 							name: "IdentifierRest",
 						},
 					},
@@ -17807,20 +17415,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2387, col: 1, offset: 73538},
+			pos:  position{line: 2356, col: 1, offset: 72294},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 73551},
+				pos: position{line: 2356, col: 14, offset: 72307},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 73551},
+						pos:        position{line: 2356, col: 14, offset: 72307},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 73570},
+						pos: position{line: 2356, col: 33, offset: 72326},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 73571},
+							pos:  position{line: 2356, col: 34, offset: 72327},
 							name: "IdentifierRest",
 						},
 					},
@@ -17831,20 +17439,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2388, col: 1, offset: 73586},
+			pos:  position{line: 2357, col: 1, offset: 72342},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 73599},
+				pos: position{line: 2357, col: 14, offset: 72355},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 73599},
+						pos:        position{line: 2357, col: 14, offset: 72355},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 73618},
+						pos: position{line: 2357, col: 33, offset: 72374},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 73619},
+							pos:  position{line: 2357, col: 34, offset: 72375},
 							name: "IdentifierRest",
 						},
 					},
@@ -17855,20 +17463,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2389, col: 1, offset: 73634},
+			pos:  position{line: 2358, col: 1, offset: 72390},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 73647},
+				pos: position{line: 2358, col: 14, offset: 72403},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 73647},
+						pos:        position{line: 2358, col: 14, offset: 72403},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 73666},
+						pos: position{line: 2358, col: 33, offset: 72422},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 73667},
+							pos:  position{line: 2358, col: 34, offset: 72423},
 							name: "IdentifierRest",
 						},
 					},
@@ -17879,20 +17487,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2390, col: 1, offset: 73682},
+			pos:  position{line: 2359, col: 1, offset: 72438},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 14, offset: 73695},
+				pos: position{line: 2359, col: 14, offset: 72451},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 14, offset: 73695},
+						pos:        position{line: 2359, col: 14, offset: 72451},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 73714},
+						pos: position{line: 2359, col: 33, offset: 72470},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 73715},
+							pos:  position{line: 2359, col: 34, offset: 72471},
 							name: "IdentifierRest",
 						},
 					},
@@ -17903,20 +17511,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2391, col: 1, offset: 73730},
+			pos:  position{line: 2360, col: 1, offset: 72486},
 			expr: &seqExpr{
-				pos: position{line: 2391, col: 14, offset: 73743},
+				pos: position{line: 2360, col: 14, offset: 72499},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2391, col: 14, offset: 73743},
+						pos:        position{line: 2360, col: 14, offset: 72499},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2391, col: 33, offset: 73762},
+						pos: position{line: 2360, col: 33, offset: 72518},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2391, col: 34, offset: 73763},
+							pos:  position{line: 2360, col: 34, offset: 72519},
 							name: "IdentifierRest",
 						},
 					},
@@ -17927,20 +17535,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2392, col: 1, offset: 73778},
+			pos:  position{line: 2361, col: 1, offset: 72534},
 			expr: &seqExpr{
-				pos: position{line: 2392, col: 14, offset: 73791},
+				pos: position{line: 2361, col: 14, offset: 72547},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2392, col: 14, offset: 73791},
+						pos:        position{line: 2361, col: 14, offset: 72547},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2392, col: 33, offset: 73810},
+						pos: position{line: 2361, col: 33, offset: 72566},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2392, col: 34, offset: 73811},
+							pos:  position{line: 2361, col: 34, offset: 72567},
 							name: "IdentifierRest",
 						},
 					},
@@ -17951,20 +17559,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2393, col: 1, offset: 73826},
+			pos:  position{line: 2362, col: 1, offset: 72582},
 			expr: &seqExpr{
-				pos: position{line: 2393, col: 14, offset: 73839},
+				pos: position{line: 2362, col: 14, offset: 72595},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2393, col: 14, offset: 73839},
+						pos:        position{line: 2362, col: 14, offset: 72595},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2393, col: 33, offset: 73858},
+						pos: position{line: 2362, col: 33, offset: 72614},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2393, col: 34, offset: 73859},
+							pos:  position{line: 2362, col: 34, offset: 72615},
 							name: "IdentifierRest",
 						},
 					},
@@ -17975,20 +17583,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2394, col: 1, offset: 73874},
+			pos:  position{line: 2363, col: 1, offset: 72630},
 			expr: &seqExpr{
-				pos: position{line: 2394, col: 14, offset: 73887},
+				pos: position{line: 2363, col: 14, offset: 72643},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2394, col: 14, offset: 73887},
+						pos:        position{line: 2363, col: 14, offset: 72643},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2394, col: 33, offset: 73906},
+						pos: position{line: 2363, col: 33, offset: 72662},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2394, col: 34, offset: 73907},
+							pos:  position{line: 2363, col: 34, offset: 72663},
 							name: "IdentifierRest",
 						},
 					},
@@ -17999,20 +17607,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2395, col: 1, offset: 73922},
+			pos:  position{line: 2364, col: 1, offset: 72678},
 			expr: &seqExpr{
-				pos: position{line: 2395, col: 14, offset: 73935},
+				pos: position{line: 2364, col: 14, offset: 72691},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2395, col: 14, offset: 73935},
+						pos:        position{line: 2364, col: 14, offset: 72691},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2395, col: 33, offset: 73954},
+						pos: position{line: 2364, col: 33, offset: 72710},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2395, col: 34, offset: 73955},
+							pos:  position{line: 2364, col: 34, offset: 72711},
 							name: "IdentifierRest",
 						},
 					},
@@ -18023,20 +17631,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2396, col: 1, offset: 73970},
+			pos:  position{line: 2365, col: 1, offset: 72726},
 			expr: &seqExpr{
-				pos: position{line: 2396, col: 14, offset: 73983},
+				pos: position{line: 2365, col: 14, offset: 72739},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2396, col: 14, offset: 73983},
+						pos:        position{line: 2365, col: 14, offset: 72739},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2396, col: 33, offset: 74002},
+						pos: position{line: 2365, col: 33, offset: 72758},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2396, col: 34, offset: 74003},
+							pos:  position{line: 2365, col: 34, offset: 72759},
 							name: "IdentifierRest",
 						},
 					},
@@ -18047,20 +17655,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2397, col: 1, offset: 74018},
+			pos:  position{line: 2366, col: 1, offset: 72774},
 			expr: &seqExpr{
-				pos: position{line: 2397, col: 14, offset: 74031},
+				pos: position{line: 2366, col: 14, offset: 72787},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2397, col: 14, offset: 74031},
+						pos:        position{line: 2366, col: 14, offset: 72787},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2397, col: 33, offset: 74050},
+						pos: position{line: 2366, col: 33, offset: 72806},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2397, col: 34, offset: 74051},
+							pos:  position{line: 2366, col: 34, offset: 72807},
 							name: "IdentifierRest",
 						},
 					},
@@ -18071,20 +17679,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2398, col: 1, offset: 74066},
+			pos:  position{line: 2367, col: 1, offset: 72822},
 			expr: &seqExpr{
-				pos: position{line: 2398, col: 14, offset: 74079},
+				pos: position{line: 2367, col: 14, offset: 72835},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2398, col: 14, offset: 74079},
+						pos:        position{line: 2367, col: 14, offset: 72835},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2398, col: 33, offset: 74098},
+						pos: position{line: 2367, col: 33, offset: 72854},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2398, col: 34, offset: 74099},
+							pos:  position{line: 2367, col: 34, offset: 72855},
 							name: "IdentifierRest",
 						},
 					},
@@ -18095,23 +17703,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2399, col: 1, offset: 74114},
+			pos:  position{line: 2368, col: 1, offset: 72870},
 			expr: &actionExpr{
-				pos: position{line: 2399, col: 14, offset: 74127},
+				pos: position{line: 2368, col: 14, offset: 72883},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2399, col: 14, offset: 74127},
+					pos: position{line: 2368, col: 14, offset: 72883},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2399, col: 14, offset: 74127},
+							pos:        position{line: 2368, col: 14, offset: 72883},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2399, col: 33, offset: 74146},
+							pos: position{line: 2368, col: 33, offset: 72902},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2399, col: 34, offset: 74147},
+								pos:  position{line: 2368, col: 34, offset: 72903},
 								name: "IdentifierRest",
 							},
 						},
@@ -18123,20 +17731,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2400, col: 1, offset: 74190},
+			pos:  position{line: 2369, col: 1, offset: 72946},
 			expr: &seqExpr{
-				pos: position{line: 2400, col: 14, offset: 74203},
+				pos: position{line: 2369, col: 14, offset: 72959},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2400, col: 14, offset: 74203},
+						pos:        position{line: 2369, col: 14, offset: 72959},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2400, col: 33, offset: 74222},
+						pos: position{line: 2369, col: 33, offset: 72978},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2400, col: 34, offset: 74223},
+							pos:  position{line: 2369, col: 34, offset: 72979},
 							name: "IdentifierRest",
 						},
 					},
@@ -18147,20 +17755,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2401, col: 1, offset: 74238},
+			pos:  position{line: 2370, col: 1, offset: 72994},
 			expr: &seqExpr{
-				pos: position{line: 2401, col: 14, offset: 74251},
+				pos: position{line: 2370, col: 14, offset: 73007},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2401, col: 14, offset: 74251},
+						pos:        position{line: 2370, col: 14, offset: 73007},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2401, col: 33, offset: 74270},
+						pos: position{line: 2370, col: 33, offset: 73026},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2401, col: 34, offset: 74271},
+							pos:  position{line: 2370, col: 34, offset: 73027},
 							name: "IdentifierRest",
 						},
 					},
@@ -18171,20 +17779,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2402, col: 1, offset: 74286},
+			pos:  position{line: 2371, col: 1, offset: 73042},
 			expr: &seqExpr{
-				pos: position{line: 2402, col: 14, offset: 74299},
+				pos: position{line: 2371, col: 14, offset: 73055},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2402, col: 14, offset: 74299},
+						pos:        position{line: 2371, col: 14, offset: 73055},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2402, col: 33, offset: 74318},
+						pos: position{line: 2371, col: 33, offset: 73074},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2402, col: 34, offset: 74319},
+							pos:  position{line: 2371, col: 34, offset: 73075},
 							name: "IdentifierRest",
 						},
 					},
@@ -18195,20 +17803,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2403, col: 1, offset: 74334},
+			pos:  position{line: 2372, col: 1, offset: 73090},
 			expr: &seqExpr{
-				pos: position{line: 2403, col: 14, offset: 74347},
+				pos: position{line: 2372, col: 14, offset: 73103},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2403, col: 14, offset: 74347},
+						pos:        position{line: 2372, col: 14, offset: 73103},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2403, col: 33, offset: 74366},
+						pos: position{line: 2372, col: 33, offset: 73122},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2403, col: 34, offset: 74367},
+							pos:  position{line: 2372, col: 34, offset: 73123},
 							name: "IdentifierRest",
 						},
 					},
@@ -18219,20 +17827,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2404, col: 1, offset: 74382},
+			pos:  position{line: 2373, col: 1, offset: 73138},
 			expr: &seqExpr{
-				pos: position{line: 2404, col: 14, offset: 74395},
+				pos: position{line: 2373, col: 14, offset: 73151},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2404, col: 14, offset: 74395},
+						pos:        position{line: 2373, col: 14, offset: 73151},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2404, col: 33, offset: 74414},
+						pos: position{line: 2373, col: 33, offset: 73170},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2404, col: 34, offset: 74415},
+							pos:  position{line: 2373, col: 34, offset: 73171},
 							name: "IdentifierRest",
 						},
 					},
@@ -18243,20 +17851,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2405, col: 1, offset: 74430},
+			pos:  position{line: 2374, col: 1, offset: 73186},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 74443},
+				pos: position{line: 2374, col: 14, offset: 73199},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 74443},
+						pos:        position{line: 2374, col: 14, offset: 73199},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 74462},
+						pos: position{line: 2374, col: 33, offset: 73218},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 74463},
+							pos:  position{line: 2374, col: 34, offset: 73219},
 							name: "IdentifierRest",
 						},
 					},
@@ -18267,20 +17875,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2406, col: 1, offset: 74478},
+			pos:  position{line: 2375, col: 1, offset: 73234},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 74491},
+				pos: position{line: 2375, col: 14, offset: 73247},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 74491},
+						pos:        position{line: 2375, col: 14, offset: 73247},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 74510},
+						pos: position{line: 2375, col: 33, offset: 73266},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 74511},
+							pos:  position{line: 2375, col: 34, offset: 73267},
 							name: "IdentifierRest",
 						},
 					},
@@ -18291,20 +17899,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2407, col: 1, offset: 74526},
+			pos:  position{line: 2376, col: 1, offset: 73282},
 			expr: &seqExpr{
-				pos: position{line: 2407, col: 14, offset: 74539},
+				pos: position{line: 2376, col: 14, offset: 73295},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2407, col: 14, offset: 74539},
+						pos:        position{line: 2376, col: 14, offset: 73295},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2407, col: 33, offset: 74558},
+						pos: position{line: 2376, col: 33, offset: 73314},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2407, col: 34, offset: 74559},
+							pos:  position{line: 2376, col: 34, offset: 73315},
 							name: "IdentifierRest",
 						},
 					},
@@ -18315,20 +17923,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2408, col: 1, offset: 74574},
+			pos:  position{line: 2377, col: 1, offset: 73330},
 			expr: &seqExpr{
-				pos: position{line: 2408, col: 14, offset: 74587},
+				pos: position{line: 2377, col: 14, offset: 73343},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2408, col: 14, offset: 74587},
+						pos:        position{line: 2377, col: 14, offset: 73343},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2408, col: 33, offset: 74606},
+						pos: position{line: 2377, col: 33, offset: 73362},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2408, col: 34, offset: 74607},
+							pos:  position{line: 2377, col: 34, offset: 73363},
 							name: "IdentifierRest",
 						},
 					},
@@ -18339,20 +17947,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2409, col: 1, offset: 74622},
+			pos:  position{line: 2378, col: 1, offset: 73378},
 			expr: &seqExpr{
-				pos: position{line: 2409, col: 14, offset: 74635},
+				pos: position{line: 2378, col: 14, offset: 73391},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2409, col: 14, offset: 74635},
+						pos:        position{line: 2378, col: 14, offset: 73391},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2409, col: 33, offset: 74654},
+						pos: position{line: 2378, col: 33, offset: 73410},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2409, col: 34, offset: 74655},
+							pos:  position{line: 2378, col: 34, offset: 73411},
 							name: "IdentifierRest",
 						},
 					},
@@ -18363,20 +17971,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2410, col: 1, offset: 74670},
+			pos:  position{line: 2379, col: 1, offset: 73426},
 			expr: &seqExpr{
-				pos: position{line: 2410, col: 14, offset: 74683},
+				pos: position{line: 2379, col: 14, offset: 73439},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2410, col: 14, offset: 74683},
+						pos:        position{line: 2379, col: 14, offset: 73439},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2410, col: 33, offset: 74702},
+						pos: position{line: 2379, col: 33, offset: 73458},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2410, col: 34, offset: 74703},
+							pos:  position{line: 2379, col: 34, offset: 73459},
 							name: "IdentifierRest",
 						},
 					},
@@ -18387,20 +17995,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2411, col: 1, offset: 74718},
+			pos:  position{line: 2380, col: 1, offset: 73474},
 			expr: &seqExpr{
-				pos: position{line: 2411, col: 14, offset: 74731},
+				pos: position{line: 2380, col: 14, offset: 73487},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2411, col: 14, offset: 74731},
+						pos:        position{line: 2380, col: 14, offset: 73487},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2411, col: 33, offset: 74750},
+						pos: position{line: 2380, col: 33, offset: 73506},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2411, col: 34, offset: 74751},
+							pos:  position{line: 2380, col: 34, offset: 73507},
 							name: "IdentifierRest",
 						},
 					},
@@ -18789,6 +18397,16 @@ func (p *parser) callonRegexp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRegexp1(stack["pattern"])
+}
+
+func (c *current) onRegexpBody1() (any, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonRegexpBody1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRegexpBody1()
 }
 
 func (c *current) onAggregation2(keys, limit any) (any, error) {
@@ -20559,31 +20177,7 @@ func (p *parser) callonCast1() (any, error) {
 	return p.cur.onCast1(stack["typ"], stack["expr"])
 }
 
-func (c *current) onFunction3(arg0, arg1, where any) (any, error) {
-	id := &ast.ID{Kind: "ID", Name: "regexp", Loc: ast.NewLoc(c.pos.offset, c.pos.offset+6)}
-	return newCall(c, id, []any{arg0, arg1}, where), nil
-
-}
-
-func (p *parser) callonFunction3() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFunction3(stack["arg0"], stack["arg1"], stack["where"])
-}
-
-func (c *current) onFunction21(arg0, arg1, arg2, where any) (any, error) {
-	id := &ast.ID{Kind: "ID", Name: "regexp_replace", Loc: ast.NewLoc(c.pos.offset, c.pos.offset+14)}
-	return newCall(c, id, []any{arg0, arg1, arg2}, where), nil
-
-}
-
-func (p *parser) callonFunction21() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFunction21(stack["arg0"], stack["arg1"], stack["arg2"], stack["where"])
-}
-
-func (c *current) onFunction44(part, e, where any) (any, error) {
+func (c *current) onFunction2(part, e, where any) (any, error) {
 	return &ast.CallExtract{
 		Kind: "CallExtract",
 		Part: part.(ast.Expr),
@@ -20593,13 +20187,13 @@ func (c *current) onFunction44(part, e, where any) (any, error) {
 
 }
 
-func (p *parser) callonFunction44() (any, error) {
+func (p *parser) callonFunction2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction44(stack["part"], stack["e"], stack["where"])
+	return p.cur.onFunction2(stack["part"], stack["e"], stack["where"])
 }
 
-func (c *current) onFunction64(body any) (any, error) {
+func (c *current) onFunction22(body any) (any, error) {
 	return &ast.Exists{
 		Kind: "Exists",
 		Body: sliceOf[ast.Op](body),
@@ -20608,13 +20202,13 @@ func (c *current) onFunction64(body any) (any, error) {
 
 }
 
-func (p *parser) callonFunction64() (any, error) {
+func (p *parser) callonFunction22() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction64(stack["body"])
+	return p.cur.onFunction22(stack["body"])
 }
 
-func (c *current) onFunction76(e, typ any) (any, error) {
+func (c *current) onFunction34(e, typ any) (any, error) {
 	return &ast.SQLCast{
 		Kind: "SQLCast",
 		Expr: e.(ast.Expr),
@@ -20624,33 +20218,33 @@ func (c *current) onFunction76(e, typ any) (any, error) {
 
 }
 
-func (p *parser) callonFunction76() (any, error) {
+func (p *parser) callonFunction34() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction76(stack["e"], stack["typ"])
+	return p.cur.onFunction34(stack["e"], stack["typ"])
 }
 
-func (c *current) onFunction105(e any) (any, error) {
+func (c *current) onFunction63(e any) (any, error) {
 	return e, nil
 }
 
-func (p *parser) callonFunction105() (any, error) {
+func (p *parser) callonFunction63() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction105(stack["e"])
+	return p.cur.onFunction63(stack["e"])
 }
 
-func (c *current) onFunction114(e any) (any, error) {
+func (c *current) onFunction72(e any) (any, error) {
 	return e, nil
 }
 
-func (p *parser) callonFunction114() (any, error) {
+func (p *parser) callonFunction72() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction114(stack["e"])
+	return p.cur.onFunction72(stack["e"])
 }
 
-func (c *current) onFunction93(expr, from, for_ any) (any, error) {
+func (c *current) onFunction51(expr, from, for_ any) (any, error) {
 	s := &ast.SQLSubstring{
 		Kind: "SQLSubstring",
 		Expr: expr.(ast.Expr),
@@ -20666,31 +20260,21 @@ func (c *current) onFunction93(expr, from, for_ any) (any, error) {
 
 }
 
-func (p *parser) callonFunction93() (any, error) {
+func (p *parser) callonFunction51() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction93(stack["expr"], stack["from"], stack["for_"])
+	return p.cur.onFunction51(stack["expr"], stack["from"], stack["for_"])
 }
 
-func (c *current) onFunction122(fn, args, where any) (any, error) {
+func (c *current) onFunction80(fn, args, where any) (any, error) {
 	return newCall(c, fn, args, where), nil
 
 }
 
-func (p *parser) callonFunction122() (any, error) {
+func (p *parser) callonFunction80() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction122(stack["fn"], stack["args"], stack["where"])
-}
-
-func (c *current) onRegexpPrimitive1(pat any) (any, error) {
-	return newPrimitive(c, "string", pat.(string)), nil
-}
-
-func (p *parser) callonRegexpPrimitive1() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpPrimitive1(stack["pat"])
+	return p.cur.onFunction80(stack["fn"], stack["args"], stack["where"])
 }
 
 func (c *current) onFunctionArgs3() (any, error) {
@@ -20701,35 +20285,6 @@ func (p *parser) callonFunctionArgs3() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFunctionArgs3()
-}
-
-func (c *current) onGrep15(e any) (any, error) {
-	return e, nil
-}
-
-func (p *parser) callonGrep15() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onGrep15(stack["e"])
-}
-
-func (c *current) onGrep1(pattern, opt any) (any, error) {
-	g := &ast.Grep{
-		Kind:    "Grep",
-		Pattern: pattern.(ast.Expr),
-		Loc:     loc(c),
-	}
-	if opt != nil {
-		g.Expr = opt.(ast.Expr)
-	}
-	return g, nil
-
-}
-
-func (p *parser) callonGrep1() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onGrep1(stack["pattern"], stack["opt"])
 }
 
 func (c *current) onExprs7(e any) (any, error) {
@@ -22227,26 +21782,6 @@ func (p *parser) callonUnicodeEscape11() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnicodeEscape11(stack["chars"])
-}
-
-func (c *current) onRegexpPattern1(body any) (any, error) {
-	return body, nil
-}
-
-func (p *parser) callonRegexpPattern1() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpPattern1(stack["body"])
-}
-
-func (c *current) onRegexpBody1() (any, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonRegexpBody1() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpBody1()
 }
 
 func (c *current) onSQLPipe1(s any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -156,7 +156,7 @@ SearchPredicate
 
 SearchValue
   = Literal
-  / !RegexpPattern v:KeyWord {
+  / !Regexp v:KeyWord {
       return newPrimitive(c, "string", v.(string)), nil
     }
 
@@ -166,9 +166,12 @@ Glob
     }
 
 Regexp
-  = pattern:RegexpPattern {
+  = "/" pattern:RegexpBody "/" !KeyWordStart {
       return &ast.Regexp{Kind:"Regexp", Pattern:pattern.(string), Loc: loc(c)}, nil
     }
+
+RegexpBody
+  = ([^/\\] / "\\" .)+ { return string(c.text), nil }
 
 /// === Aggregations ===
 
@@ -897,7 +900,7 @@ ComparisonExpr
         Loc: loc(c),
       }, nil
     }
-  / lhs:AdditiveExpr opAndRHS:(__ Comparator __ AdditiveExpr / __ ("~" { return string(c.text), nil }) __ Regexp)? {
+  / lhs:AdditiveExpr opAndRHS:(__ Comparator __ AdditiveExpr / __ ("~" { return string(c.text), nil }) __ AdditiveExpr)? {
       if opAndRHS == nil {
         return lhs, nil
       }
@@ -1014,17 +1017,7 @@ Cast
     }
 
 Function
-  = Grep
-  // Special case to handle `regexp(/x/, y)` and `regexp_replace(x, /y/, z)`.
-  / REGEXP __ "(" __ arg0:RegexpPrimitive __ "," __ arg1:Expr __ ")" where:WhereClause? {
-      id := &ast.ID{Kind: "ID", Name: "regexp", Loc: ast.NewLoc(c.pos.offset, c.pos.offset+6)}
-      return newCall(c, id, []any{arg0, arg1}, where), nil
-    }
-  / REGEXP_REPLACE __ "(" __ arg0:Expr __ "," __ arg1:RegexpPrimitive __ "," __ arg2:Expr __ ")" where:WhereClause? {
-      id := &ast.ID{Kind: "ID", Name: "regexp_replace", Loc: ast.NewLoc(c.pos.offset, c.pos.offset+14)}
-      return newCall(c, id, []any{arg0, arg1, arg2}, where), nil
-    }
-  / !FuncGuard EXTRACT __ "(" __ part:Expr _ FROM _ e:Expr __ ")" where:WhereClause? {
+  = !FuncGuard EXTRACT __ "(" __ part:Expr _ FROM _ e:Expr __ ")" where:WhereClause? {
       return &ast.CallExtract{
         Kind: "CallExtract",
         Part: part.(ast.Expr),
@@ -1066,25 +1059,9 @@ Function
     }
   / CountStar
 
-RegexpPrimitive
-  = pat:RegexpPattern { return newPrimitive(c, "string", pat.(string)), nil }
-
 FunctionArgs
   = Exprs
   / __ { return []any{}, nil }
-
-Grep
-  = GREP __ "(" __ pattern:(Regexp / Glob / Expr) __ opt:("," __ e:Expr __ { return e, nil })? ")" {
-      g := &ast.Grep{
-          Kind: "Grep",
-          Pattern: pattern.(ast.Expr),
-          Loc: loc(c),
-      }
-      if opt != nil {
-          g.Expr = opt.(ast.Expr)
-      }
-      return g, nil
-    }
 
 Exprs
   = first:Expr rest:(__ "," __ e:Expr { return e, nil })* {
@@ -1761,11 +1738,6 @@ UnicodeEscape
       return makeUnicodeChar(chars), nil
     }
 
-RegexpPattern
-  = "/" body:RegexpBody "/" !KeyWordStart { return body, nil }
-
-RegexpBody
-  = ([^/\\] / "\\" .)+ { return string(c.text), nil }
 
 EscapedChar
   = [\x00-\x1f\\]
@@ -2352,7 +2324,6 @@ FROM       = "FROM"i            !IdentifierRest
 FULL       = "FULL"i            !IdentifierRest
 FUNC       = "FUNC"i            !IdentifierRest
 FUSE       = "FUSE"i            !IdentifierRest
-GREP       = "GREP"i            !IdentifierRest
 GROUP      = "GROUP"i           !IdentifierRest
 HAVING     = "HAVING"i          !IdentifierRest
 HEAD       = "HEAD"i            !IdentifierRest
@@ -2381,8 +2352,6 @@ OUTPUT     = "OUTPUT"i          !IdentifierRest
 PASS       = "PASS"i            !IdentifierRest
 PUT        = "PUT"i             !IdentifierRest
 RECURSIVE  = "RECURSIVE"i       !IdentifierRest
-REGEXP     = "REGEXP"i          !IdentifierRest
-REGEXP_REPLACE = "REGEXP_REPLACE"i !IdentifierRest
 RENAME     = "RENAME"i          !IdentifierRest
 RIGHT      = "RIGHT"i           !IdentifierRest
 SHAPES     = "SHAPES"i          !IdentifierRest

--- a/compiler/parser/ztests/glob-mul.yaml
+++ b/compiler/parser/ztests/glob-mul.yaml
@@ -1,5 +1,5 @@
 script: |
-  super -s -c "grep(a*b,s)" in.sup
+  super -s -c "grep('a.*b',s)" in.sup
   echo ===
   super -s -c "s==a*b+1" in.sup
 

--- a/compiler/parser/ztests/match-double.yaml
+++ b/compiler/parser/ztests/match-double.yaml
@@ -1,4 +1,4 @@
-spq: '? grep("a") grep("b")'
+spq: '? grep("a", this) grep("b", this)'
 
 vector: true
 

--- a/compiler/parser/ztests/match.yaml
+++ b/compiler/parser/ztests/match.yaml
@@ -1,4 +1,4 @@
-spq: grep("a")
+spq: grep("a", this)
 
 vector: true
 

--- a/compiler/parser/ztests/unnest-expr.yaml
+++ b/compiler/parser/ztests/unnest-expr.yaml
@@ -8,7 +8,7 @@ script: |
   echo === function
   super compile -C 'quiet((unnest a | ?b))'
   echo === grep
-  super compile -C 'grep(/regexp/, (unnest a | ?b))'
+  super compile -C 'grep("regexp", (unnest a | ?b))'
 
 outputs:
   - name: stdout
@@ -35,7 +35,7 @@ outputs:
         | search b
       ))
       === grep
-      where grep(/regexp/,(
+      where grep("regexp", (
           unnest a
           | search b
         ))

--- a/compiler/parser/ztests/where-search.yaml
+++ b/compiler/parser/ztests/where-search.yaml
@@ -1,5 +1,5 @@
 script: |
-  super -s -c 'count() where grep("foo")' in.sup
+  super -s -c 'count() where grep("foo", this)' in.sup
   echo ===
   super -s -c "?foo | count()" in.sup
 

--- a/compiler/ztests/anycase-funcs.yaml
+++ b/compiler/ztests/anycase-funcs.yaml
@@ -3,7 +3,7 @@ script: |
   echo ===
   super -s -c 'values LOWER(s),Collect(LoweR(s))' in.sup
   echo ===
-  super -s -c 'Grep(G*)' in.sup
+  super -s -c 'Grep("G.*", this)' in.sup
   echo ===
   super -s -c 'values {s,match:RegEXP("(f|B).*", s)}' in.sup
   echo ===

--- a/compiler/ztests/pruner-regexp.yaml
+++ b/compiler/ztests/pruner-regexp.yaml
@@ -2,9 +2,9 @@ script: |
   export SUPER_VAM=1
   super compile -C -O 'from test.csup | where x LIKE "cslab%"'
   echo // ===
-  super compile -C -O 'from test.csup | where grep(/^csla[bB].*/, x)'
+  super compile -C -O 'from test.csup | where grep("^csla[bB].*", x)'
   echo // ===
-  super compile -C -O 'from test.csup | where grep(/csla[bB].*/, x)'
+  super compile -C -O 'from test.csup | where grep("csla[bB].*", x)'
   echo // ===
   echo '{x:"a"}' | super -f csup -o x.csup -
   super -s -c "SELECT x FROM x.csup WHERE x LIKE 'a%'"
@@ -20,7 +20,7 @@ outputs:
            expr compare("cslab", x.max, true)<=0 and compare("cslac", x.min, true)>0
            fields x.max,x.min
         )
-      | where regexp_search(/(?s)^cslab.*?$/, x)
+      | where regexp_search(r"(?s)^cslab.*?$", x)
       | output main
       // ===
       file test.csup format csup
@@ -28,11 +28,11 @@ outputs:
            expr compare("csla", x.max, true)<=0 and compare("cslb", x.min, true)>0
            fields x.max,x.min
         )
-      | where regexp_search(/^csla[bB].*/, x)
+      | where regexp_search(r"^csla[bB].*", x)
       | output main
       // ===
       file test.csup format csup
-      | where regexp_search(/csla[bB].*/, x)
+      | where regexp_search(r"csla[bB].*", x)
       | output main
       // ===
       {x:"a"}

--- a/compiler/ztests/regexp-search.yaml
+++ b/compiler/ztests/regexp-search.yaml
@@ -1,4 +1,4 @@
-spq: values grep(*foo*)
+spq: values grep('.*foo.*', this)
 
 vector: true
 

--- a/docs/language/aggregates/count.md
+++ b/docs/language/aggregates/count.md
@@ -69,7 +69,7 @@ count() by k | sort
 A simple count with no input values returns no output:
 ```mdtest-spq
 # spq
-where grep("bar") | count()
+where grep("bar", this) | count()
 # input
 1
 "foo"
@@ -80,7 +80,7 @@ where grep("bar") | count()
 Count can return an explicit zero when using a `where` clause in the aggregation:
 ```mdtest-spq
 # spq
-count() where grep("bar")
+count() where grep("bar", this)
 # input
 1
 "foo"

--- a/docs/language/functions/grep.md
+++ b/docs/language/functions/grep.md
@@ -5,7 +5,7 @@
 ### Synopsis
 
 ```
-grep(<pattern> [, e: any]) -> bool
+grep(<pattern>, e: any) -> bool
 ```
 
 ### Description
@@ -36,7 +36,7 @@ if a complex type,
 _Reach into nested records_
 ```mdtest-spq
 # spq
-grep("baz")
+grep("baz", this)
 # input
 {foo:10}
 {bar:{s:"baz"}}
@@ -47,7 +47,7 @@ grep("baz")
 _It only matches string fields_
 ```mdtest-spq
 # spq
-grep("10")
+grep("10", this)
 # input
 {foo:10}
 {bar:{s:"baz"}}
@@ -57,7 +57,7 @@ grep("10")
 _Match a field name_
 ```mdtest-spq
 # spq
-grep("foo")
+grep("foo", this)
 # input
 {foo:10}
 {bar:{s:"baz"}}
@@ -68,7 +68,7 @@ grep("foo")
 _Regular expression_
 ```mdtest-spq
 # spq
-grep(/foo|baz/)
+grep('foo|baz', this)
 # input
 {foo:10}
 {bar:{s:"baz"}}
@@ -80,7 +80,7 @@ grep(/foo|baz/)
 _Glob with a second argument_
 ```mdtest-spq
 # spq
-grep(b*, s)
+grep('^b.*', s)
 # input
 {s:"bar"}
 {s:"foo"}

--- a/docs/language/functions/regexp.md
+++ b/docs/language/functions/regexp.md
@@ -5,7 +5,7 @@
 ### Synopsis
 
 ```
-regexp(re: string|regexp, s: string) -> any
+regexp(re: string, s: string) -> any
 ```
 
 ### Description
@@ -20,7 +20,7 @@ groups) if there are any. A null value indicates no match.
 Regexp returns an array of the match and its subexpressions:
 ```mdtest-spq
 # spq
-values regexp(/foo(.?) (\w+) fr.*/, this)
+values regexp('foo(.?) (\\w+) fr.*', this)
 # input
 "seafood fool friend"
 # expected output

--- a/docs/language/functions/regexp_replace.md
+++ b/docs/language/functions/regexp_replace.md
@@ -5,7 +5,7 @@
 ### Synopsis
 
 ```
-regexp_replace(s: string, re: string|regexp, new: string) -> string
+regexp_replace(s: string, re: string, new: string) -> string
 ```
 
 ### Description
@@ -33,7 +33,7 @@ Replace regular expression matches with a letter:
 
 ```mdtest-spq
 # spq
-values regexp_replace(this, /ax*b/, "T")
+values regexp_replace(this, 'ax*b', "T")
 # input
 "-ab-axxb-"
 # expected output
@@ -44,7 +44,7 @@ Replace regular expression matches using numeric references to submatches:
 ```mdtest-spq
 # spq
 values regexp_replace(this,
-                     /(\w+):\s+(\w+)$/,
+                     r'(\w+):\s+(\w+)$',
                      "$1=$2")
 # input
 "option: value"
@@ -56,7 +56,7 @@ Replace regular expression matches using named references:
 ```mdtest-spq
 # spq
 values regexp_replace(this,
-                     /(?P<key>\w+):\s+(?P<value>\w+)$/,
+                     r'(?P<key>\w+):\s+(?P<value>\w+)$',
                      "$key=$value")
 # input
 "option: value"
@@ -68,7 +68,7 @@ Wrap a named reference in curly braces to avoid ambiguity:
 ```mdtest-spq
 # spq
 values regexp_replace(this,
-                     /(?P<key>\w+):\s+(?P<value>\w+)$/,
+                     r'(?P<key>\w+):\s+(?P<value>\w+)$',
                      "$key=${value}AppendedText")
 # input
 "option: value"

--- a/docs/language/search-expressions.md
+++ b/docs/language/search-expressions.md
@@ -44,7 +44,7 @@ Regular expressions may also appear in the [`grep`](functions/grep.md),
 [`regexp`](functions/regexp.md), and [`regexp_replace`](functions/regexp_replace.md) functions:
 ```mdtest-spq {data-layout="stacked"}
 # spq
-values {ba_start:grep(/^ba.*/, s),last_s_char:regexp(/(.)$/,s)[1]}
+values {ba_start:grep('^ba.*', s),last_s_char:regexp('(.)$',s)[1]}
 # input
 "foo"
 {s:"bar"}
@@ -122,7 +122,7 @@ and
 Globs may also appear in the [`grep` function](functions/grep.md):
 ```mdtest-spq
 # spq
-values grep(ba*, s)
+values grep('^ba.*', s)
 # input
 "foo" {s:"bar"} {s:"baz"} {foo:1}
 # expected output

--- a/lake/ztests/appmeta.yaml
+++ b/lake/ztests/appmeta.yaml
@@ -5,7 +5,7 @@ script: |
   super db load -q -use logs -meta '"original"' babble.sup
   super db load -q -use logs -meta '"normalized-v1"' babble.sup
   super db load -q -use logs -meta '"normalized-v2"' babble.sup
-  super db -c "from logs@main:log | grep(normalized*, meta) | sort date | cut meta" | super -s -
+  super db -c "from logs@main:log | grep('normalized.*', meta) | sort date | cut meta" | super -s -
 
 inputs:
   - name: babble.sup

--- a/runtime/sam/expr/filter_test.go
+++ b/runtime/sam/expr/filter_test.go
@@ -354,10 +354,10 @@ func TestFilters(t *testing.T) {
 		{"s != 'hello'", false},
 
 		// Also smoke test that globs work...
-		{"grep(hell*, s)", true},
-		{"grep(ell*, s)", false},
-		{"!grep(hell*, s)", false},
-		{"!grep(ell*, s)", true},
+		{"grep('hell.*', s)", true},
+		{"grep('^ell.*', s)", false},
+		{"!grep('hell.*', s)", false},
+		{"!grep('^ell.*', s)", true},
 	})
 
 	// Test ip comparisons

--- a/runtime/sam/expr/function/function.go
+++ b/runtime/sam/expr/function/function.go
@@ -62,6 +62,7 @@ func New(sctx *super.Context, name string, narg int) (expr.Function, field.Path,
 	case "floor":
 		f = &Floor{sctx: sctx}
 	case "grep":
+		argmin = 2
 		argmax = 2
 		f = &Grep{sctx: sctx}
 	case "grok":

--- a/runtime/vam/expr/function/function.go
+++ b/runtime/vam/expr/function/function.go
@@ -49,6 +49,7 @@ func New(sctx *super.Context, name string, narg int) (expr.Function, field.Path,
 	case "floor":
 		f = &Floor{sctx}
 	case "grep":
+		argmin = 2
 		argmax = 2
 		f = &Grep{sctx: sctx}
 	case "grok":

--- a/runtime/ztests/expr/function/grep.yaml
+++ b/runtime/ztests/expr/function/grep.yaml
@@ -3,7 +3,7 @@
 # time.
 
 spq: |
-  [grep(pattern),grep(pattern,input)]
+  [grep(pattern,this),grep(pattern,input)]
 
 vector: true
 

--- a/runtime/ztests/expr/function/now.yaml
+++ b/runtime/ztests/expr/function/now.yaml
@@ -1,7 +1,7 @@
 spq: |
   const t1 = now()
   values t1, now()
-  | values string(this) ~ /[0-9TZ:\-\.]+/
+  | values string(this) ~ '[0-9TZ:\\-\\.]+'
 
 vector: true
 

--- a/runtime/ztests/expr/regexp.yaml
+++ b/runtime/ztests/expr/regexp.yaml
@@ -1,4 +1,4 @@
-spq: values this ~ /^foo.*bar$/
+spq: values this ~ '^foo.*bar$'
 
 vector: true
 

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -131,14 +131,6 @@ func (c *canon) expr(e ast.Expr, parent string) {
 		c.write("/%s/", e.Pattern)
 	case *ast.Glob:
 		c.write(e.Pattern)
-	case *ast.Grep:
-		c.write("grep(")
-		c.expr(e.Pattern, "")
-		if e.Expr != nil {
-			c.write(",")
-			c.expr(e.Expr, "")
-		}
-		c.write(")")
 	case *ast.IndexExpr:
 		c.expr(e.Expr, "")
 		c.write("[")
@@ -932,7 +924,7 @@ func IsBool(e ast.Expr) bool {
 			}
 		}
 		return false
-	case *ast.Grep, *ast.Regexp, *ast.Glob:
+	case *ast.Regexp, *ast.Glob:
 		return true
 	default:
 		return false

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -171,9 +171,9 @@ func (c *canonDAG) expr(e dag.Expr, parent string) {
 		}
 		c.write("}|")
 	case *dag.RegexpSearch:
-		c.write("regexp_search(/")
+		c.write("regexp_search(r\"")
 		c.write(e.Pattern)
-		c.write("/, ")
+		c.write("\", ")
 		c.expr(e.Expr, "")
 		c.write(")")
 	case *dag.RegexpMatch:

--- a/zfmt/ztests/switch.yaml
+++ b/zfmt/ztests/switch.yaml
@@ -1,20 +1,20 @@
 script: |
-  super compile -C 'switch case grep("a") ( head ) case grep("c") ( tail )'
+  super compile -C 'switch case grep("a", this) ( head ) case grep("c", this) ( tail )'
   echo ===
-  super compile -C -dag 'switch case grep("a") ( head ) case grep("c") ( tail )'
+  super compile -C -dag 'switch case grep("a", this) ( head ) case grep("c", this) ( tail )'
   echo ===
-  super compile -C 'switch case grep("a") ( head ) default ( tail )'
+  super compile -C 'switch case grep("a", this) ( head ) default ( tail )'
   echo ===
-  super compile -C -dag 'switch case grep("a") ( head ) default ( tail )'
+  super compile -C -dag 'switch case grep("a", this) ( head ) default ( tail )'
 
 outputs:
   - name: stdout
     data: |
       switch
-      case grep("a") (
+      case grep("a", this) (
         head
       )
-      case grep("c") (
+      case grep("c", this) (
         tail
       )
       ===
@@ -30,7 +30,7 @@ outputs:
         )
       ===
       switch
-      case grep("a") (
+      case grep("a", this) (
         head
       )
       default (


### PR DESCRIPTION
This commit cleans up the regexp/grep syntax by isolating the regexp pattern and glob syntax to search expressions and using conventional strings for the functions regexp(), regexp_replace(), and grep().  This allowed us to remove a bunch of special case syntax for these functions from the PEG grammar.

This change means that globbing is no longer available for grep, which now uses only regular expressions.  If we want to allow globbing, we can enable that with a function that converts glob strings to regexps or perhaps introduce a g"glob" style string.

We also removed the implied "this" argument from grep and now require two arguments.

Detailed docs updates are forthcoming in the book branch.