### PR TITLE
vam/expr.conditional: Fix non-boolean predicate results

### DIFF
--- a/runtime/ztests/expr/conditional-err.yaml
+++ b/runtime/ztests/expr/conditional-err.yaml
@@ -1,0 +1,12 @@
+spq: |
+  values x ? "foo" : "bar"
+
+vector: true
+
+input: |
+  1
+  {x:1}
+
+output: |
+  error({message:"?-operator: bool predicate required",on:error("missing")})
+  error({message:"?-operator: bool predicate required",on:1})


### PR DESCRIPTION
This commits fixes an issue in the vam version of conditional expressions where a predicate returning a non-boolean, non-error value would return the value itself and not an error.