### PR TITLE
rename QueryExpr to Subquery and delete traverse.Expr

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -303,7 +303,7 @@ type TupleExpr struct {
 	Loc   `json:"loc"`
 }
 
-type QueryExpr struct {
+type Subquery struct {
 	Kind string `json:"kind" unpack:""`
 	Body Seq    `json:"body"`
 	Loc  `json:"loc"`
@@ -372,7 +372,7 @@ func (*SQLTimeValue) exprNode() {}
 func (*FString) exprNode()      {}
 func (*Primitive) exprNode()    {}
 func (*TypeValue) exprNode()    {}
-func (*QueryExpr) exprNode()    {}
+func (*Subquery) exprNode()     {}
 
 type ConstDecl struct {
 	Kind string `json:"kind" unpack:""`

--- a/compiler/dag/expr.go
+++ b/compiler/dag/expr.go
@@ -83,7 +83,7 @@ type (
 		Kind    string  `json:"kind" unpack:""`
 		Entries []Entry `json:"entries"`
 	}
-	QueryExpr struct {
+	Subquery struct {
 		Kind       string `json:"kind" unpack:""`
 		Correlated bool   `json:"correlated"`
 		Body       Seq    `json:"body"`
@@ -147,13 +147,13 @@ func (*IsNullExpr) exprNode()   {}
 func (*Literal) exprNode()      {}
 func (*MapCall) exprNode()      {}
 func (*MapExpr) exprNode()      {}
-func (*QueryExpr) exprNode()    {}
 func (*RecordExpr) exprNode()   {}
 func (*RegexpMatch) exprNode()  {}
 func (*RegexpSearch) exprNode() {}
 func (*Search) exprNode()       {}
 func (*SetExpr) exprNode()      {}
 func (*SliceExpr) exprNode()    {}
+func (*Subquery) exprNode()     {}
 func (*This) exprNode()         {}
 func (*UnaryExpr) exprNode()    {}
 

--- a/compiler/optimizer/demand.go
+++ b/compiler/optimizer/demand.go
@@ -190,7 +190,7 @@ func demandForExpr(expr dag.Expr) demand.Demand {
 			d = demand.Union(d, demandForExpr(e.Value))
 		}
 		return d
-	case *dag.QueryExpr:
+	case *dag.Subquery:
 		return demand.Union(DemandForSeq(expr.Body, demand.All())...)
 	case *dag.RecordExpr:
 		d := demand.None()

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -4474,7 +4474,7 @@ var g = &grammar{
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
@@ -7332,15 +7332,15 @@ var g = &grammar{
 									label: "expr",
 									expr: &ruleRefExpr{
 										pos:  position{line: 1074, col: 30, offset: 25746},
-										name: "QueryExpr",
+										name: "Subquery",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1074, col: 40, offset: 25756},
+									pos:  position{line: 1074, col: 39, offset: 25755},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1074, col: 43, offset: 25759},
+									pos:        position{line: 1074, col: 42, offset: 25758},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7349,35 +7349,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1075, col: 5, offset: 25788},
+						pos: position{line: 1075, col: 5, offset: 25787},
 						run: (*parser).callonPrimary21,
 						expr: &seqExpr{
-							pos: position{line: 1075, col: 5, offset: 25788},
+							pos: position{line: 1075, col: 5, offset: 25787},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1075, col: 5, offset: 25788},
+									pos:        position{line: 1075, col: 5, offset: 25787},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1075, col: 9, offset: 25792},
+									pos:  position{line: 1075, col: 9, offset: 25791},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1075, col: 12, offset: 25795},
+									pos:   position{line: 1075, col: 12, offset: 25794},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1075, col: 17, offset: 25800},
+										pos:  position{line: 1075, col: 17, offset: 25799},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1075, col: 22, offset: 25805},
+									pos:  position{line: 1075, col: 22, offset: 25804},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1075, col: 25, offset: 25808},
+									pos:        position{line: 1075, col: 25, offset: 25807},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7392,24 +7392,24 @@ var g = &grammar{
 		},
 		{
 			name: "SubqueryOps",
-			pos:  position{line: 1077, col: 1, offset: 25834},
+			pos:  position{line: 1077, col: 1, offset: 25833},
 			expr: &choiceExpr{
-				pos: position{line: 1077, col: 15, offset: 25848},
+				pos: position{line: 1077, col: 15, offset: 25847},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 15, offset: 25848},
+						pos:  position{line: 1077, col: 15, offset: 25847},
 						name: "UNNEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 24, offset: 25857},
+						pos:  position{line: 1077, col: 24, offset: 25856},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 31, offset: 25864},
+						pos:  position{line: 1077, col: 31, offset: 25863},
 						name: "VALUES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 40, offset: 25873},
+						pos:  position{line: 1077, col: 40, offset: 25872},
 						name: "SelectOp",
 					},
 				},
@@ -7419,53 +7419,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1079, col: 1, offset: 25883},
+			pos:  position{line: 1079, col: 1, offset: 25882},
 			expr: &choiceExpr{
-				pos: position{line: 1080, col: 5, offset: 25896},
+				pos: position{line: 1080, col: 5, offset: 25895},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 25896},
+						pos: position{line: 1080, col: 5, offset: 25895},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1080, col: 5, offset: 25896},
+							pos: position{line: 1080, col: 5, offset: 25895},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 5, offset: 25896},
+									pos:  position{line: 1080, col: 5, offset: 25895},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 10, offset: 25901},
+									pos:   position{line: 1080, col: 10, offset: 25900},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1080, col: 16, offset: 25907},
+										pos: position{line: 1080, col: 16, offset: 25906},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1080, col: 16, offset: 25907},
+											pos:  position{line: 1080, col: 16, offset: 25906},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 22, offset: 25913},
+									pos:   position{line: 1080, col: 22, offset: 25912},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1080, col: 28, offset: 25919},
+										pos: position{line: 1080, col: 28, offset: 25918},
 										expr: &seqExpr{
-											pos: position{line: 1080, col: 29, offset: 25920},
+											pos: position{line: 1080, col: 29, offset: 25919},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1080, col: 29, offset: 25920},
+													pos:  position{line: 1080, col: 29, offset: 25919},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1080, col: 31, offset: 25922},
+													pos:  position{line: 1080, col: 31, offset: 25921},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1080, col: 36, offset: 25927},
+													pos:  position{line: 1080, col: 36, offset: 25926},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1080, col: 38, offset: 25929},
+													pos:  position{line: 1080, col: 38, offset: 25928},
 													name: "Expr",
 												},
 											},
@@ -7473,24 +7473,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 45, offset: 25936},
+									pos:  position{line: 1080, col: 45, offset: 25935},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 47, offset: 25938},
+									pos:  position{line: 1080, col: 47, offset: 25937},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1080, col: 51, offset: 25942},
+									pos: position{line: 1080, col: 51, offset: 25941},
 									expr: &seqExpr{
-										pos: position{line: 1080, col: 52, offset: 25943},
+										pos: position{line: 1080, col: 52, offset: 25942},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1080, col: 52, offset: 25943},
+												pos:  position{line: 1080, col: 52, offset: 25942},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1080, col: 54, offset: 25945},
+												pos:  position{line: 1080, col: 54, offset: 25944},
 												name: "CASE",
 											},
 										},
@@ -7500,60 +7500,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1104, col: 5, offset: 26594},
+						pos: position{line: 1104, col: 5, offset: 26593},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1104, col: 5, offset: 26594},
+							pos: position{line: 1104, col: 5, offset: 26593},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 5, offset: 26594},
+									pos:  position{line: 1104, col: 5, offset: 26593},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 10, offset: 26599},
+									pos:  position{line: 1104, col: 10, offset: 26598},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1104, col: 12, offset: 26601},
+									pos:   position{line: 1104, col: 12, offset: 26600},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1104, col: 17, offset: 26606},
+										pos:  position{line: 1104, col: 17, offset: 26605},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1104, col: 22, offset: 26611},
+									pos:   position{line: 1104, col: 22, offset: 26610},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1104, col: 28, offset: 26617},
+										pos: position{line: 1104, col: 28, offset: 26616},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1104, col: 28, offset: 26617},
+											pos:  position{line: 1104, col: 28, offset: 26616},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1104, col: 34, offset: 26623},
+									pos:   position{line: 1104, col: 34, offset: 26622},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1104, col: 40, offset: 26629},
+										pos: position{line: 1104, col: 40, offset: 26628},
 										expr: &seqExpr{
-											pos: position{line: 1104, col: 41, offset: 26630},
+											pos: position{line: 1104, col: 41, offset: 26629},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1104, col: 41, offset: 26630},
+													pos:  position{line: 1104, col: 41, offset: 26629},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1104, col: 43, offset: 26632},
+													pos:  position{line: 1104, col: 43, offset: 26631},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1104, col: 48, offset: 26637},
+													pos:  position{line: 1104, col: 48, offset: 26636},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1104, col: 50, offset: 26639},
+													pos:  position{line: 1104, col: 50, offset: 26638},
 													name: "Expr",
 												},
 											},
@@ -7561,24 +7561,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 57, offset: 26646},
+									pos:  position{line: 1104, col: 57, offset: 26645},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 59, offset: 26648},
+									pos:  position{line: 1104, col: 59, offset: 26647},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1104, col: 63, offset: 26652},
+									pos: position{line: 1104, col: 63, offset: 26651},
 									expr: &seqExpr{
-										pos: position{line: 1104, col: 64, offset: 26653},
+										pos: position{line: 1104, col: 64, offset: 26652},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1104, col: 64, offset: 26653},
+												pos:  position{line: 1104, col: 64, offset: 26652},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1104, col: 66, offset: 26655},
+												pos:  position{line: 1104, col: 66, offset: 26654},
 												name: "CASE",
 											},
 										},
@@ -7594,50 +7594,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1117, col: 1, offset: 26961},
+			pos:  position{line: 1117, col: 1, offset: 26960},
 			expr: &actionExpr{
-				pos: position{line: 1118, col: 5, offset: 26970},
+				pos: position{line: 1118, col: 5, offset: 26969},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1118, col: 5, offset: 26970},
+					pos: position{line: 1118, col: 5, offset: 26969},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 5, offset: 26970},
+							pos:  position{line: 1118, col: 5, offset: 26969},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 7, offset: 26972},
+							pos:  position{line: 1118, col: 7, offset: 26971},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 12, offset: 26977},
+							pos:  position{line: 1118, col: 12, offset: 26976},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1118, col: 14, offset: 26979},
+							pos:   position{line: 1118, col: 14, offset: 26978},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1118, col: 19, offset: 26984},
+								pos:  position{line: 1118, col: 19, offset: 26983},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 24, offset: 26989},
+							pos:  position{line: 1118, col: 24, offset: 26988},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 26, offset: 26991},
+							pos:  position{line: 1118, col: 26, offset: 26990},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 31, offset: 26996},
+							pos:  position{line: 1118, col: 31, offset: 26995},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1118, col: 33, offset: 26998},
+							pos:   position{line: 1118, col: 33, offset: 26997},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1118, col: 38, offset: 27003},
+								pos:  position{line: 1118, col: 38, offset: 27002},
 								name: "Expr",
 							},
 						},
@@ -7648,16 +7648,16 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "QueryExpr",
-			pos:  position{line: 1127, col: 1, offset: 27158},
+			name: "Subquery",
+			pos:  position{line: 1127, col: 1, offset: 27157},
 			expr: &actionExpr{
-				pos: position{line: 1128, col: 5, offset: 27172},
-				run: (*parser).callonQueryExpr1,
+				pos: position{line: 1128, col: 5, offset: 27170},
+				run: (*parser).callonSubquery1,
 				expr: &labeledExpr{
-					pos:   position{line: 1128, col: 5, offset: 27172},
+					pos:   position{line: 1128, col: 5, offset: 27170},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1128, col: 10, offset: 27177},
+						pos:  position{line: 1128, col: 10, offset: 27175},
 						name: "Seq",
 					},
 				},
@@ -7667,37 +7667,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1136, col: 1, offset: 27315},
+			pos:  position{line: 1136, col: 1, offset: 27311},
 			expr: &actionExpr{
-				pos: position{line: 1137, col: 5, offset: 27326},
+				pos: position{line: 1137, col: 5, offset: 27322},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1137, col: 5, offset: 27326},
+					pos: position{line: 1137, col: 5, offset: 27322},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1137, col: 5, offset: 27326},
+							pos:        position{line: 1137, col: 5, offset: 27322},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1137, col: 9, offset: 27330},
+							pos:  position{line: 1137, col: 9, offset: 27326},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1137, col: 12, offset: 27333},
+							pos:   position{line: 1137, col: 12, offset: 27329},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1137, col: 18, offset: 27339},
+								pos:  position{line: 1137, col: 18, offset: 27335},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1137, col: 30, offset: 27351},
+							pos:  position{line: 1137, col: 30, offset: 27347},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1137, col: 33, offset: 27354},
+							pos:        position{line: 1137, col: 33, offset: 27350},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7710,31 +7710,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1145, col: 1, offset: 27512},
+			pos:  position{line: 1145, col: 1, offset: 27508},
 			expr: &choiceExpr{
-				pos: position{line: 1146, col: 5, offset: 27528},
+				pos: position{line: 1146, col: 5, offset: 27524},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1146, col: 5, offset: 27528},
+						pos: position{line: 1146, col: 5, offset: 27524},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1146, col: 5, offset: 27528},
+							pos: position{line: 1146, col: 5, offset: 27524},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1146, col: 5, offset: 27528},
+									pos:   position{line: 1146, col: 5, offset: 27524},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1146, col: 11, offset: 27534},
+										pos:  position{line: 1146, col: 11, offset: 27530},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1146, col: 22, offset: 27545},
+									pos:   position{line: 1146, col: 22, offset: 27541},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1146, col: 27, offset: 27550},
+										pos: position{line: 1146, col: 27, offset: 27546},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1146, col: 27, offset: 27550},
+											pos:  position{line: 1146, col: 27, offset: 27546},
 											name: "RecordElemTail",
 										},
 									},
@@ -7743,10 +7743,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1149, col: 5, offset: 27613},
+						pos: position{line: 1149, col: 5, offset: 27609},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1149, col: 5, offset: 27613},
+							pos:  position{line: 1149, col: 5, offset: 27609},
 							name: "__",
 						},
 					},
@@ -7757,32 +7757,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1151, col: 1, offset: 27637},
+			pos:  position{line: 1151, col: 1, offset: 27633},
 			expr: &actionExpr{
-				pos: position{line: 1151, col: 18, offset: 27654},
+				pos: position{line: 1151, col: 18, offset: 27650},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1151, col: 18, offset: 27654},
+					pos: position{line: 1151, col: 18, offset: 27650},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1151, col: 18, offset: 27654},
+							pos:  position{line: 1151, col: 18, offset: 27650},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1151, col: 21, offset: 27657},
+							pos:        position{line: 1151, col: 21, offset: 27653},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1151, col: 25, offset: 27661},
+							pos:  position{line: 1151, col: 25, offset: 27657},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1151, col: 28, offset: 27664},
+							pos:   position{line: 1151, col: 28, offset: 27660},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1151, col: 33, offset: 27669},
+								pos:  position{line: 1151, col: 33, offset: 27665},
 								name: "RecordElem",
 							},
 						},
@@ -7794,20 +7794,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1153, col: 1, offset: 27702},
+			pos:  position{line: 1153, col: 1, offset: 27698},
 			expr: &choiceExpr{
-				pos: position{line: 1154, col: 5, offset: 27717},
+				pos: position{line: 1154, col: 5, offset: 27713},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1154, col: 5, offset: 27717},
+						pos:  position{line: 1154, col: 5, offset: 27713},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1155, col: 5, offset: 27728},
+						pos:  position{line: 1155, col: 5, offset: 27724},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1156, col: 5, offset: 27742},
+						pos:  position{line: 1156, col: 5, offset: 27738},
 						name: "Identifier",
 					},
 				},
@@ -7817,28 +7817,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1158, col: 1, offset: 27754},
+			pos:  position{line: 1158, col: 1, offset: 27750},
 			expr: &actionExpr{
-				pos: position{line: 1159, col: 5, offset: 27765},
+				pos: position{line: 1159, col: 5, offset: 27761},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1159, col: 5, offset: 27765},
+					pos: position{line: 1159, col: 5, offset: 27761},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1159, col: 5, offset: 27765},
+							pos:        position{line: 1159, col: 5, offset: 27761},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 11, offset: 27771},
+							pos:  position{line: 1159, col: 11, offset: 27767},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1159, col: 14, offset: 27774},
+							pos:   position{line: 1159, col: 14, offset: 27770},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1159, col: 19, offset: 27779},
+								pos:  position{line: 1159, col: 19, offset: 27775},
 								name: "Expr",
 							},
 						},
@@ -7850,40 +7850,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1163, col: 1, offset: 27875},
+			pos:  position{line: 1163, col: 1, offset: 27871},
 			expr: &actionExpr{
-				pos: position{line: 1164, col: 5, offset: 27889},
+				pos: position{line: 1164, col: 5, offset: 27885},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1164, col: 5, offset: 27889},
+					pos: position{line: 1164, col: 5, offset: 27885},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1164, col: 5, offset: 27889},
+							pos:   position{line: 1164, col: 5, offset: 27885},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1164, col: 10, offset: 27894},
+								pos:  position{line: 1164, col: 10, offset: 27890},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1164, col: 15, offset: 27899},
+							pos:  position{line: 1164, col: 15, offset: 27895},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1164, col: 18, offset: 27902},
+							pos:        position{line: 1164, col: 18, offset: 27898},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1164, col: 22, offset: 27906},
+							pos:  position{line: 1164, col: 22, offset: 27902},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1164, col: 25, offset: 27909},
+							pos:   position{line: 1164, col: 25, offset: 27905},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1164, col: 31, offset: 27915},
+								pos:  position{line: 1164, col: 31, offset: 27911},
 								name: "Expr",
 							},
 						},
@@ -7895,37 +7895,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1173, col: 1, offset: 28084},
+			pos:  position{line: 1173, col: 1, offset: 28080},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 5, offset: 28094},
+				pos: position{line: 1174, col: 5, offset: 28090},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1174, col: 5, offset: 28094},
+					pos: position{line: 1174, col: 5, offset: 28090},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1174, col: 5, offset: 28094},
+							pos:        position{line: 1174, col: 5, offset: 28090},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 9, offset: 28098},
+							pos:  position{line: 1174, col: 9, offset: 28094},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1174, col: 12, offset: 28101},
+							pos:   position{line: 1174, col: 12, offset: 28097},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1174, col: 18, offset: 28107},
+								pos:  position{line: 1174, col: 18, offset: 28103},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 30, offset: 28119},
+							pos:  position{line: 1174, col: 30, offset: 28115},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1174, col: 33, offset: 28122},
+							pos:        position{line: 1174, col: 33, offset: 28118},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -7938,37 +7938,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1182, col: 1, offset: 28278},
+			pos:  position{line: 1182, col: 1, offset: 28274},
 			expr: &actionExpr{
-				pos: position{line: 1183, col: 5, offset: 28286},
+				pos: position{line: 1183, col: 5, offset: 28282},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1183, col: 5, offset: 28286},
+					pos: position{line: 1183, col: 5, offset: 28282},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1183, col: 5, offset: 28286},
+							pos:        position{line: 1183, col: 5, offset: 28282},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 10, offset: 28291},
+							pos:  position{line: 1183, col: 10, offset: 28287},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1183, col: 13, offset: 28294},
+							pos:   position{line: 1183, col: 13, offset: 28290},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1183, col: 19, offset: 28300},
+								pos:  position{line: 1183, col: 19, offset: 28296},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 31, offset: 28312},
+							pos:  position{line: 1183, col: 31, offset: 28308},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1183, col: 34, offset: 28315},
+							pos:        position{line: 1183, col: 34, offset: 28311},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -7981,54 +7981,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1191, col: 1, offset: 28468},
+			pos:  position{line: 1191, col: 1, offset: 28464},
 			expr: &choiceExpr{
-				pos: position{line: 1192, col: 5, offset: 28484},
+				pos: position{line: 1192, col: 5, offset: 28480},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1192, col: 5, offset: 28484},
+						pos: position{line: 1192, col: 5, offset: 28480},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 5, offset: 28484},
+							pos: position{line: 1192, col: 5, offset: 28480},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1192, col: 5, offset: 28484},
+									pos:   position{line: 1192, col: 5, offset: 28480},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 11, offset: 28490},
+										pos:  position{line: 1192, col: 11, offset: 28486},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 22, offset: 28501},
+									pos:   position{line: 1192, col: 22, offset: 28497},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1192, col: 27, offset: 28506},
+										pos: position{line: 1192, col: 27, offset: 28502},
 										expr: &actionExpr{
-											pos: position{line: 1192, col: 28, offset: 28507},
+											pos: position{line: 1192, col: 28, offset: 28503},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1192, col: 28, offset: 28507},
+												pos: position{line: 1192, col: 28, offset: 28503},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1192, col: 28, offset: 28507},
+														pos:  position{line: 1192, col: 28, offset: 28503},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1192, col: 31, offset: 28510},
+														pos:        position{line: 1192, col: 31, offset: 28506},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1192, col: 35, offset: 28514},
+														pos:  position{line: 1192, col: 35, offset: 28510},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1192, col: 38, offset: 28517},
+														pos:   position{line: 1192, col: 38, offset: 28513},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1192, col: 40, offset: 28519},
+															pos:  position{line: 1192, col: 40, offset: 28515},
 															name: "VectorElem",
 														},
 													},
@@ -8041,10 +8041,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1195, col: 5, offset: 28601},
+						pos: position{line: 1195, col: 5, offset: 28597},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1195, col: 5, offset: 28601},
+							pos:  position{line: 1195, col: 5, offset: 28597},
 							name: "__",
 						},
 					},
@@ -8055,22 +8055,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1197, col: 1, offset: 28625},
+			pos:  position{line: 1197, col: 1, offset: 28621},
 			expr: &choiceExpr{
-				pos: position{line: 1198, col: 5, offset: 28640},
+				pos: position{line: 1198, col: 5, offset: 28636},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1198, col: 5, offset: 28640},
+						pos:  position{line: 1198, col: 5, offset: 28636},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1199, col: 5, offset: 28651},
+						pos: position{line: 1199, col: 5, offset: 28647},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1199, col: 5, offset: 28651},
+							pos:   position{line: 1199, col: 5, offset: 28647},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1199, col: 7, offset: 28653},
+								pos:  position{line: 1199, col: 7, offset: 28649},
 								name: "Expr",
 							},
 						},
@@ -8082,37 +8082,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1201, col: 1, offset: 28744},
+			pos:  position{line: 1201, col: 1, offset: 28740},
 			expr: &actionExpr{
-				pos: position{line: 1202, col: 5, offset: 28752},
+				pos: position{line: 1202, col: 5, offset: 28748},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1202, col: 5, offset: 28752},
+					pos: position{line: 1202, col: 5, offset: 28748},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1202, col: 5, offset: 28752},
+							pos:        position{line: 1202, col: 5, offset: 28748},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1202, col: 10, offset: 28757},
+							pos:  position{line: 1202, col: 10, offset: 28753},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1202, col: 13, offset: 28760},
+							pos:   position{line: 1202, col: 13, offset: 28756},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1202, col: 19, offset: 28766},
+								pos:  position{line: 1202, col: 19, offset: 28762},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1202, col: 27, offset: 28774},
+							pos:  position{line: 1202, col: 27, offset: 28770},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1202, col: 30, offset: 28777},
+							pos:        position{line: 1202, col: 30, offset: 28773},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8125,31 +8125,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1210, col: 1, offset: 28931},
+			pos:  position{line: 1210, col: 1, offset: 28927},
 			expr: &choiceExpr{
-				pos: position{line: 1211, col: 5, offset: 28943},
+				pos: position{line: 1211, col: 5, offset: 28939},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1211, col: 5, offset: 28943},
+						pos: position{line: 1211, col: 5, offset: 28939},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1211, col: 5, offset: 28943},
+							pos: position{line: 1211, col: 5, offset: 28939},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1211, col: 5, offset: 28943},
+									pos:   position{line: 1211, col: 5, offset: 28939},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1211, col: 11, offset: 28949},
+										pos:  position{line: 1211, col: 11, offset: 28945},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1211, col: 17, offset: 28955},
+									pos:   position{line: 1211, col: 17, offset: 28951},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1211, col: 22, offset: 28960},
+										pos: position{line: 1211, col: 22, offset: 28956},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1211, col: 22, offset: 28960},
+											pos:  position{line: 1211, col: 22, offset: 28956},
 											name: "EntryTail",
 										},
 									},
@@ -8158,10 +8158,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1214, col: 5, offset: 29018},
+						pos: position{line: 1214, col: 5, offset: 29014},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1214, col: 5, offset: 29018},
+							pos:  position{line: 1214, col: 5, offset: 29014},
 							name: "__",
 						},
 					},
@@ -8172,32 +8172,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1217, col: 1, offset: 29043},
+			pos:  position{line: 1217, col: 1, offset: 29039},
 			expr: &actionExpr{
-				pos: position{line: 1217, col: 13, offset: 29055},
+				pos: position{line: 1217, col: 13, offset: 29051},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1217, col: 13, offset: 29055},
+					pos: position{line: 1217, col: 13, offset: 29051},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1217, col: 13, offset: 29055},
+							pos:  position{line: 1217, col: 13, offset: 29051},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1217, col: 16, offset: 29058},
+							pos:        position{line: 1217, col: 16, offset: 29054},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1217, col: 20, offset: 29062},
+							pos:  position{line: 1217, col: 20, offset: 29058},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1217, col: 23, offset: 29065},
+							pos:   position{line: 1217, col: 23, offset: 29061},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1217, col: 25, offset: 29067},
+								pos:  position{line: 1217, col: 25, offset: 29063},
 								name: "Entry",
 							},
 						},
@@ -8209,40 +8209,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1219, col: 1, offset: 29092},
+			pos:  position{line: 1219, col: 1, offset: 29088},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 5, offset: 29102},
+				pos: position{line: 1220, col: 5, offset: 29098},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 5, offset: 29102},
+					pos: position{line: 1220, col: 5, offset: 29098},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1220, col: 5, offset: 29102},
+							pos:   position{line: 1220, col: 5, offset: 29098},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 9, offset: 29106},
+								pos:  position{line: 1220, col: 9, offset: 29102},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 14, offset: 29111},
+							pos:  position{line: 1220, col: 14, offset: 29107},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1220, col: 17, offset: 29114},
+							pos:        position{line: 1220, col: 17, offset: 29110},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 21, offset: 29118},
+							pos:  position{line: 1220, col: 21, offset: 29114},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1220, col: 24, offset: 29121},
+							pos:   position{line: 1220, col: 24, offset: 29117},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 30, offset: 29127},
+								pos:  position{line: 1220, col: 30, offset: 29123},
 								name: "Expr",
 							},
 						},
@@ -8254,61 +8254,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1224, col: 1, offset: 29230},
+			pos:  position{line: 1224, col: 1, offset: 29226},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 29240},
+				pos: position{line: 1225, col: 5, offset: 29236},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 29240},
+					pos: position{line: 1225, col: 5, offset: 29236},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1225, col: 5, offset: 29240},
+							pos:        position{line: 1225, col: 5, offset: 29236},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 9, offset: 29244},
+							pos:  position{line: 1225, col: 9, offset: 29240},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 12, offset: 29247},
+							pos:   position{line: 1225, col: 12, offset: 29243},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 18, offset: 29253},
+								pos:  position{line: 1225, col: 18, offset: 29249},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 23, offset: 29258},
+							pos:   position{line: 1225, col: 23, offset: 29254},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1225, col: 28, offset: 29263},
+								pos: position{line: 1225, col: 28, offset: 29259},
 								expr: &actionExpr{
-									pos: position{line: 1225, col: 29, offset: 29264},
+									pos: position{line: 1225, col: 29, offset: 29260},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1225, col: 29, offset: 29264},
+										pos: position{line: 1225, col: 29, offset: 29260},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1225, col: 29, offset: 29264},
+												pos:  position{line: 1225, col: 29, offset: 29260},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1225, col: 32, offset: 29267},
+												pos:        position{line: 1225, col: 32, offset: 29263},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1225, col: 36, offset: 29271},
+												pos:  position{line: 1225, col: 36, offset: 29267},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1225, col: 39, offset: 29274},
+												pos:   position{line: 1225, col: 39, offset: 29270},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1225, col: 41, offset: 29276},
+													pos:  position{line: 1225, col: 41, offset: 29272},
 													name: "Expr",
 												},
 											},
@@ -8318,11 +8318,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 66, offset: 29301},
+							pos:  position{line: 1225, col: 66, offset: 29297},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1225, col: 69, offset: 29304},
+							pos:        position{line: 1225, col: 69, offset: 29300},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8335,39 +8335,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1233, col: 1, offset: 29463},
+			pos:  position{line: 1233, col: 1, offset: 29459},
 			expr: &actionExpr{
-				pos: position{line: 1234, col: 5, offset: 29480},
+				pos: position{line: 1234, col: 5, offset: 29476},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1234, col: 5, offset: 29480},
+					pos: position{line: 1234, col: 5, offset: 29476},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1234, col: 5, offset: 29480},
+							pos:   position{line: 1234, col: 5, offset: 29476},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1234, col: 10, offset: 29485},
+								pos: position{line: 1234, col: 10, offset: 29481},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1234, col: 10, offset: 29485},
+										pos:  position{line: 1234, col: 10, offset: 29481},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1234, col: 17, offset: 29492},
+										pos:  position{line: 1234, col: 17, offset: 29488},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 28, offset: 29503},
+							pos:  position{line: 1234, col: 28, offset: 29499},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1234, col: 30, offset: 29505},
+							pos:   position{line: 1234, col: 30, offset: 29501},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1234, col: 32, offset: 29507},
+								pos:  position{line: 1234, col: 32, offset: 29503},
 								name: "StringLiteral",
 							},
 						},
@@ -8379,56 +8379,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1245, col: 1, offset: 29724},
+			pos:  position{line: 1245, col: 1, offset: 29720},
 			expr: &choiceExpr{
-				pos: position{line: 1246, col: 5, offset: 29736},
+				pos: position{line: 1246, col: 5, offset: 29732},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1246, col: 5, offset: 29736},
+						pos:  position{line: 1246, col: 5, offset: 29732},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1247, col: 5, offset: 29752},
+						pos:  position{line: 1247, col: 5, offset: 29748},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1248, col: 5, offset: 29770},
+						pos:  position{line: 1248, col: 5, offset: 29766},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1249, col: 5, offset: 29782},
+						pos:  position{line: 1249, col: 5, offset: 29778},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1250, col: 5, offset: 29800},
+						pos:  position{line: 1250, col: 5, offset: 29796},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1251, col: 5, offset: 29819},
+						pos:  position{line: 1251, col: 5, offset: 29815},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1252, col: 5, offset: 29836},
+						pos:  position{line: 1252, col: 5, offset: 29832},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 5, offset: 29849},
+						pos:  position{line: 1253, col: 5, offset: 29845},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1254, col: 5, offset: 29858},
+						pos:  position{line: 1254, col: 5, offset: 29854},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1255, col: 5, offset: 29875},
+						pos:  position{line: 1255, col: 5, offset: 29871},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1256, col: 5, offset: 29894},
+						pos:  position{line: 1256, col: 5, offset: 29890},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1257, col: 5, offset: 29913},
+						pos:  position{line: 1257, col: 5, offset: 29909},
 						name: "NullLiteral",
 					},
 				},
@@ -8438,28 +8438,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1259, col: 1, offset: 29926},
+			pos:  position{line: 1259, col: 1, offset: 29922},
 			expr: &choiceExpr{
-				pos: position{line: 1260, col: 5, offset: 29944},
+				pos: position{line: 1260, col: 5, offset: 29940},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1260, col: 5, offset: 29944},
+						pos: position{line: 1260, col: 5, offset: 29940},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1260, col: 5, offset: 29944},
+							pos: position{line: 1260, col: 5, offset: 29940},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1260, col: 5, offset: 29944},
+									pos:   position{line: 1260, col: 5, offset: 29940},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1260, col: 7, offset: 29946},
+										pos:  position{line: 1260, col: 7, offset: 29942},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1260, col: 14, offset: 29953},
+									pos: position{line: 1260, col: 14, offset: 29949},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1260, col: 15, offset: 29954},
+										pos:  position{line: 1260, col: 15, offset: 29950},
 										name: "IdentifierRest",
 									},
 								},
@@ -8467,13 +8467,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1263, col: 5, offset: 30034},
+						pos: position{line: 1263, col: 5, offset: 30030},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1263, col: 5, offset: 30034},
+							pos:   position{line: 1263, col: 5, offset: 30030},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1263, col: 7, offset: 30036},
+								pos:  position{line: 1263, col: 7, offset: 30032},
 								name: "IP4Net",
 							},
 						},
@@ -8485,35 +8485,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1267, col: 1, offset: 30105},
+			pos:  position{line: 1267, col: 1, offset: 30101},
 			expr: &choiceExpr{
-				pos: position{line: 1268, col: 5, offset: 30124},
+				pos: position{line: 1268, col: 5, offset: 30120},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1268, col: 5, offset: 30124},
+						pos: position{line: 1268, col: 5, offset: 30120},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1268, col: 5, offset: 30124},
+							pos: position{line: 1268, col: 5, offset: 30120},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1268, col: 5, offset: 30124},
+									pos:   position{line: 1268, col: 5, offset: 30120},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1268, col: 7, offset: 30126},
+										pos:  position{line: 1268, col: 7, offset: 30122},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1268, col: 11, offset: 30130},
+									pos: position{line: 1268, col: 11, offset: 30126},
 									expr: &choiceExpr{
-										pos: position{line: 1268, col: 13, offset: 30132},
+										pos: position{line: 1268, col: 13, offset: 30128},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1268, col: 13, offset: 30132},
+												pos:  position{line: 1268, col: 13, offset: 30128},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1268, col: 30, offset: 30149},
+												pos:  position{line: 1268, col: 30, offset: 30145},
 												name: "TypeLiteral",
 											},
 										},
@@ -8523,13 +8523,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1271, col: 5, offset: 30226},
+						pos: position{line: 1271, col: 5, offset: 30222},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1271, col: 5, offset: 30226},
+							pos:   position{line: 1271, col: 5, offset: 30222},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1271, col: 7, offset: 30228},
+								pos:  position{line: 1271, col: 7, offset: 30224},
 								name: "IP",
 							},
 						},
@@ -8541,15 +8541,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1275, col: 1, offset: 30292},
+			pos:  position{line: 1275, col: 1, offset: 30288},
 			expr: &actionExpr{
-				pos: position{line: 1276, col: 5, offset: 30309},
+				pos: position{line: 1276, col: 5, offset: 30305},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1276, col: 5, offset: 30309},
+					pos:   position{line: 1276, col: 5, offset: 30305},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1276, col: 7, offset: 30311},
+						pos:  position{line: 1276, col: 7, offset: 30307},
 						name: "FloatString",
 					},
 				},
@@ -8559,15 +8559,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1280, col: 1, offset: 30389},
+			pos:  position{line: 1280, col: 1, offset: 30385},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 5, offset: 30408},
+				pos: position{line: 1281, col: 5, offset: 30404},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1281, col: 5, offset: 30408},
+					pos:   position{line: 1281, col: 5, offset: 30404},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1281, col: 7, offset: 30410},
+						pos:  position{line: 1281, col: 7, offset: 30406},
 						name: "IntString",
 					},
 				},
@@ -8577,23 +8577,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1285, col: 1, offset: 30484},
+			pos:  position{line: 1285, col: 1, offset: 30480},
 			expr: &choiceExpr{
-				pos: position{line: 1286, col: 5, offset: 30503},
+				pos: position{line: 1286, col: 5, offset: 30499},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1286, col: 5, offset: 30503},
+						pos: position{line: 1286, col: 5, offset: 30499},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1286, col: 5, offset: 30503},
+							pos:  position{line: 1286, col: 5, offset: 30499},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1287, col: 5, offset: 30561},
+						pos: position{line: 1287, col: 5, offset: 30557},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1287, col: 5, offset: 30561},
+							pos:  position{line: 1287, col: 5, offset: 30557},
 							name: "FALSE",
 						},
 					},
@@ -8604,12 +8604,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1289, col: 1, offset: 30617},
+			pos:  position{line: 1289, col: 1, offset: 30613},
 			expr: &actionExpr{
-				pos: position{line: 1290, col: 5, offset: 30633},
+				pos: position{line: 1290, col: 5, offset: 30629},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1290, col: 5, offset: 30633},
+					pos:  position{line: 1290, col: 5, offset: 30629},
 					name: "NULL",
 				},
 			},
@@ -8618,23 +8618,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1292, col: 1, offset: 30683},
+			pos:  position{line: 1292, col: 1, offset: 30679},
 			expr: &actionExpr{
-				pos: position{line: 1293, col: 5, offset: 30700},
+				pos: position{line: 1293, col: 5, offset: 30696},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1293, col: 5, offset: 30700},
+					pos: position{line: 1293, col: 5, offset: 30696},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1293, col: 5, offset: 30700},
+							pos:        position{line: 1293, col: 5, offset: 30696},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1293, col: 10, offset: 30705},
+							pos: position{line: 1293, col: 10, offset: 30701},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1293, col: 10, offset: 30705},
+								pos:  position{line: 1293, col: 10, offset: 30701},
 								name: "HexDigit",
 							},
 						},
@@ -8646,29 +8646,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1297, col: 1, offset: 30779},
+			pos:  position{line: 1297, col: 1, offset: 30775},
 			expr: &actionExpr{
-				pos: position{line: 1298, col: 5, offset: 30795},
+				pos: position{line: 1298, col: 5, offset: 30791},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1298, col: 5, offset: 30795},
+					pos: position{line: 1298, col: 5, offset: 30791},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1298, col: 5, offset: 30795},
+							pos:        position{line: 1298, col: 5, offset: 30791},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1298, col: 9, offset: 30799},
+							pos:   position{line: 1298, col: 9, offset: 30795},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1298, col: 13, offset: 30803},
+								pos:  position{line: 1298, col: 13, offset: 30799},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1298, col: 18, offset: 30808},
+							pos:        position{line: 1298, col: 18, offset: 30804},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8681,27 +8681,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1306, col: 1, offset: 30941},
+			pos:  position{line: 1306, col: 1, offset: 30937},
 			expr: &choiceExpr{
-				pos: position{line: 1307, col: 5, offset: 30957},
+				pos: position{line: 1307, col: 5, offset: 30953},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1307, col: 5, offset: 30957},
+						pos: position{line: 1307, col: 5, offset: 30953},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1307, col: 5, offset: 30957},
+							pos: position{line: 1307, col: 5, offset: 30953},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1307, col: 5, offset: 30957},
+									pos:        position{line: 1307, col: 5, offset: 30953},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1307, col: 9, offset: 30961},
+									pos:   position{line: 1307, col: 9, offset: 30957},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1307, col: 14, offset: 30966},
+										pos:  position{line: 1307, col: 14, offset: 30962},
 										name: "Name",
 									},
 								},
@@ -8709,13 +8709,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1308, col: 5, offset: 31040},
+						pos: position{line: 1308, col: 5, offset: 31036},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1308, col: 5, offset: 31040},
+							pos:   position{line: 1308, col: 5, offset: 31036},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1308, col: 7, offset: 31042},
+								pos:  position{line: 1308, col: 7, offset: 31038},
 								name: "EasyType",
 							},
 						},
@@ -8727,16 +8727,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1316, col: 1, offset: 31178},
+			pos:  position{line: 1316, col: 1, offset: 31174},
 			expr: &choiceExpr{
-				pos: position{line: 1317, col: 5, offset: 31187},
+				pos: position{line: 1317, col: 5, offset: 31183},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1317, col: 5, offset: 31187},
+						pos:  position{line: 1317, col: 5, offset: 31183},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1318, col: 5, offset: 31201},
+						pos:  position{line: 1318, col: 5, offset: 31197},
 						name: "ComponentType",
 					},
 				},
@@ -8746,52 +8746,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1320, col: 1, offset: 31216},
+			pos:  position{line: 1320, col: 1, offset: 31212},
 			expr: &choiceExpr{
-				pos: position{line: 1321, col: 5, offset: 31234},
+				pos: position{line: 1321, col: 5, offset: 31230},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1321, col: 5, offset: 31234},
+						pos:  position{line: 1321, col: 5, offset: 31230},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1322, col: 5, offset: 31247},
+						pos: position{line: 1322, col: 5, offset: 31243},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1322, col: 5, offset: 31247},
+							pos: position{line: 1322, col: 5, offset: 31243},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1322, col: 5, offset: 31247},
+									pos:   position{line: 1322, col: 5, offset: 31243},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1322, col: 10, offset: 31252},
+										pos:  position{line: 1322, col: 10, offset: 31248},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1322, col: 15, offset: 31257},
+									pos:   position{line: 1322, col: 15, offset: 31253},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1322, col: 19, offset: 31261},
+										pos: position{line: 1322, col: 19, offset: 31257},
 										expr: &seqExpr{
-											pos: position{line: 1322, col: 20, offset: 31262},
+											pos: position{line: 1322, col: 20, offset: 31258},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1322, col: 20, offset: 31262},
+													pos:  position{line: 1322, col: 20, offset: 31258},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1322, col: 23, offset: 31265},
+													pos:        position{line: 1322, col: 23, offset: 31261},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1322, col: 27, offset: 31269},
+													pos:  position{line: 1322, col: 27, offset: 31265},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1322, col: 30, offset: 31272},
+													pos:  position{line: 1322, col: 30, offset: 31268},
 													name: "Type",
 												},
 											},
@@ -8808,40 +8808,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1334, col: 1, offset: 31594},
+			pos:  position{line: 1334, col: 1, offset: 31590},
 			expr: &choiceExpr{
-				pos: position{line: 1335, col: 5, offset: 31607},
+				pos: position{line: 1335, col: 5, offset: 31603},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1335, col: 5, offset: 31607},
+						pos: position{line: 1335, col: 5, offset: 31603},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1335, col: 5, offset: 31607},
+							pos: position{line: 1335, col: 5, offset: 31603},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1335, col: 5, offset: 31607},
+									pos:        position{line: 1335, col: 5, offset: 31603},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1335, col: 9, offset: 31611},
+									pos:  position{line: 1335, col: 9, offset: 31607},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1335, col: 12, offset: 31614},
+									pos:   position{line: 1335, col: 12, offset: 31610},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1335, col: 16, offset: 31618},
+										pos:  position{line: 1335, col: 16, offset: 31614},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1335, col: 21, offset: 31623},
+									pos:  position{line: 1335, col: 21, offset: 31619},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1335, col: 24, offset: 31626},
+									pos:        position{line: 1335, col: 24, offset: 31622},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8850,23 +8850,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1336, col: 5, offset: 31653},
+						pos: position{line: 1336, col: 5, offset: 31649},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1336, col: 5, offset: 31653},
+							pos: position{line: 1336, col: 5, offset: 31649},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1336, col: 5, offset: 31653},
+									pos:   position{line: 1336, col: 5, offset: 31649},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1336, col: 10, offset: 31658},
+										pos:  position{line: 1336, col: 10, offset: 31654},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1336, col: 24, offset: 31672},
+									pos: position{line: 1336, col: 24, offset: 31668},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1336, col: 25, offset: 31673},
+										pos:  position{line: 1336, col: 25, offset: 31669},
 										name: "IdentifierRest",
 									},
 								},
@@ -8874,43 +8874,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1337, col: 5, offset: 31713},
+						pos: position{line: 1337, col: 5, offset: 31709},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1337, col: 5, offset: 31713},
+							pos: position{line: 1337, col: 5, offset: 31709},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1337, col: 5, offset: 31713},
+									pos:  position{line: 1337, col: 5, offset: 31709},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1337, col: 11, offset: 31719},
+									pos:  position{line: 1337, col: 11, offset: 31715},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1337, col: 14, offset: 31722},
+									pos:        position{line: 1337, col: 14, offset: 31718},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1337, col: 18, offset: 31726},
+									pos:  position{line: 1337, col: 18, offset: 31722},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1337, col: 21, offset: 31729},
+									pos:   position{line: 1337, col: 21, offset: 31725},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1337, col: 23, offset: 31731},
+										pos:  position{line: 1337, col: 23, offset: 31727},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1337, col: 28, offset: 31736},
+									pos:  position{line: 1337, col: 28, offset: 31732},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1337, col: 31, offset: 31739},
+									pos:        position{line: 1337, col: 31, offset: 31735},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8919,43 +8919,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1344, col: 5, offset: 31879},
+						pos: position{line: 1344, col: 5, offset: 31875},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1344, col: 5, offset: 31879},
+							pos: position{line: 1344, col: 5, offset: 31875},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1344, col: 5, offset: 31879},
+									pos:  position{line: 1344, col: 5, offset: 31875},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1344, col: 10, offset: 31884},
+									pos:  position{line: 1344, col: 10, offset: 31880},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1344, col: 13, offset: 31887},
+									pos:        position{line: 1344, col: 13, offset: 31883},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1344, col: 17, offset: 31891},
+									pos:  position{line: 1344, col: 17, offset: 31887},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1344, col: 20, offset: 31894},
+									pos:   position{line: 1344, col: 20, offset: 31890},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1344, col: 26, offset: 31900},
+										pos:  position{line: 1344, col: 26, offset: 31896},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1344, col: 32, offset: 31906},
+									pos:  position{line: 1344, col: 32, offset: 31902},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1344, col: 35, offset: 31909},
+									pos:        position{line: 1344, col: 35, offset: 31905},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8964,35 +8964,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1351, col: 5, offset: 32063},
+						pos: position{line: 1351, col: 5, offset: 32059},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1351, col: 5, offset: 32063},
+							pos: position{line: 1351, col: 5, offset: 32059},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1351, col: 5, offset: 32063},
+									pos:        position{line: 1351, col: 5, offset: 32059},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1351, col: 9, offset: 32067},
+									pos:  position{line: 1351, col: 9, offset: 32063},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1351, col: 12, offset: 32070},
+									pos:   position{line: 1351, col: 12, offset: 32066},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1351, col: 19, offset: 32077},
+										pos:  position{line: 1351, col: 19, offset: 32073},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1351, col: 33, offset: 32091},
+									pos:  position{line: 1351, col: 33, offset: 32087},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1351, col: 36, offset: 32094},
+									pos:        position{line: 1351, col: 36, offset: 32090},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9001,35 +9001,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1358, col: 5, offset: 32256},
+						pos: position{line: 1358, col: 5, offset: 32252},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1358, col: 5, offset: 32256},
+							pos: position{line: 1358, col: 5, offset: 32252},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1358, col: 5, offset: 32256},
+									pos:        position{line: 1358, col: 5, offset: 32252},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1358, col: 9, offset: 32260},
+									pos:  position{line: 1358, col: 9, offset: 32256},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1358, col: 12, offset: 32263},
+									pos:   position{line: 1358, col: 12, offset: 32259},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1358, col: 16, offset: 32267},
+										pos:  position{line: 1358, col: 16, offset: 32263},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1358, col: 21, offset: 32272},
+									pos:  position{line: 1358, col: 21, offset: 32268},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1358, col: 24, offset: 32275},
+									pos:        position{line: 1358, col: 24, offset: 32271},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9038,35 +9038,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1365, col: 5, offset: 32417},
+						pos: position{line: 1365, col: 5, offset: 32413},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1365, col: 5, offset: 32417},
+							pos: position{line: 1365, col: 5, offset: 32413},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1365, col: 5, offset: 32417},
+									pos:        position{line: 1365, col: 5, offset: 32413},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 10, offset: 32422},
+									pos:  position{line: 1365, col: 10, offset: 32418},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1365, col: 13, offset: 32425},
+									pos:   position{line: 1365, col: 13, offset: 32421},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1365, col: 17, offset: 32429},
+										pos:  position{line: 1365, col: 17, offset: 32425},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 22, offset: 32434},
+									pos:  position{line: 1365, col: 22, offset: 32430},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1365, col: 25, offset: 32437},
+									pos:        position{line: 1365, col: 25, offset: 32433},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9075,57 +9075,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1372, col: 5, offset: 32576},
+						pos: position{line: 1372, col: 5, offset: 32572},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1372, col: 5, offset: 32576},
+							pos: position{line: 1372, col: 5, offset: 32572},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1372, col: 5, offset: 32576},
+									pos:        position{line: 1372, col: 5, offset: 32572},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1372, col: 10, offset: 32581},
+									pos:  position{line: 1372, col: 10, offset: 32577},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1372, col: 13, offset: 32584},
+									pos:   position{line: 1372, col: 13, offset: 32580},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1372, col: 21, offset: 32592},
+										pos:  position{line: 1372, col: 21, offset: 32588},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1372, col: 26, offset: 32597},
+									pos:  position{line: 1372, col: 26, offset: 32593},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1372, col: 29, offset: 32600},
+									pos:        position{line: 1372, col: 29, offset: 32596},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1372, col: 33, offset: 32604},
+									pos:  position{line: 1372, col: 33, offset: 32600},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1372, col: 36, offset: 32607},
+									pos:   position{line: 1372, col: 36, offset: 32603},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1372, col: 44, offset: 32615},
+										pos:  position{line: 1372, col: 44, offset: 32611},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1372, col: 49, offset: 32620},
+									pos:  position{line: 1372, col: 49, offset: 32616},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1372, col: 52, offset: 32623},
+									pos:        position{line: 1372, col: 52, offset: 32619},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9140,15 +9140,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1381, col: 1, offset: 32797},
+			pos:  position{line: 1381, col: 1, offset: 32793},
 			expr: &actionExpr{
-				pos: position{line: 1382, col: 5, offset: 32811},
+				pos: position{line: 1382, col: 5, offset: 32807},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1382, col: 5, offset: 32811},
+					pos:   position{line: 1382, col: 5, offset: 32807},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1382, col: 11, offset: 32817},
+						pos:  position{line: 1382, col: 11, offset: 32813},
 						name: "TypeList",
 					},
 				},
@@ -9158,28 +9158,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1390, col: 1, offset: 32954},
+			pos:  position{line: 1390, col: 1, offset: 32950},
 			expr: &actionExpr{
-				pos: position{line: 1391, col: 5, offset: 32967},
+				pos: position{line: 1391, col: 5, offset: 32963},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1391, col: 5, offset: 32967},
+					pos: position{line: 1391, col: 5, offset: 32963},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1391, col: 5, offset: 32967},
+							pos:   position{line: 1391, col: 5, offset: 32963},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1391, col: 11, offset: 32973},
+								pos:  position{line: 1391, col: 11, offset: 32969},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1391, col: 25, offset: 32987},
+							pos:   position{line: 1391, col: 25, offset: 32983},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1391, col: 30, offset: 32992},
+								pos: position{line: 1391, col: 30, offset: 32988},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1391, col: 30, offset: 32992},
+									pos:  position{line: 1391, col: 30, offset: 32988},
 									name: "TypeListTail",
 								},
 							},
@@ -9192,32 +9192,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1395, col: 1, offset: 33050},
+			pos:  position{line: 1395, col: 1, offset: 33046},
 			expr: &actionExpr{
-				pos: position{line: 1395, col: 16, offset: 33065},
+				pos: position{line: 1395, col: 16, offset: 33061},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1395, col: 16, offset: 33065},
+					pos: position{line: 1395, col: 16, offset: 33061},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1395, col: 16, offset: 33065},
+							pos:  position{line: 1395, col: 16, offset: 33061},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1395, col: 19, offset: 33068},
+							pos:        position{line: 1395, col: 19, offset: 33064},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1395, col: 23, offset: 33072},
+							pos:  position{line: 1395, col: 23, offset: 33068},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1395, col: 26, offset: 33075},
+							pos:   position{line: 1395, col: 26, offset: 33071},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1395, col: 30, offset: 33079},
+								pos:  position{line: 1395, col: 30, offset: 33075},
 								name: "ComponentType",
 							},
 						},
@@ -9229,42 +9229,42 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1397, col: 1, offset: 33114},
+			pos:  position{line: 1397, col: 1, offset: 33110},
 			expr: &choiceExpr{
-				pos: position{line: 1398, col: 5, offset: 33132},
+				pos: position{line: 1398, col: 5, offset: 33128},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1398, col: 5, offset: 33132},
+						pos: position{line: 1398, col: 5, offset: 33128},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1398, col: 5, offset: 33132},
+							pos:   position{line: 1398, col: 5, offset: 33128},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1398, col: 7, offset: 33134},
+								pos:  position{line: 1398, col: 7, offset: 33130},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 33241},
+						pos: position{line: 1399, col: 5, offset: 33237},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1399, col: 5, offset: 33241},
+							pos:   position{line: 1399, col: 5, offset: 33237},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1399, col: 7, offset: 33243},
+								pos:  position{line: 1399, col: 7, offset: 33239},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1400, col: 5, offset: 33320},
+						pos: position{line: 1400, col: 5, offset: 33316},
 						run: (*parser).callonStringLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1400, col: 5, offset: 33320},
+							pos:   position{line: 1400, col: 5, offset: 33316},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1400, col: 7, offset: 33322},
+								pos:  position{line: 1400, col: 7, offset: 33318},
 								name: "RString",
 							},
 						},
@@ -9276,35 +9276,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1402, col: 1, offset: 33385},
+			pos:  position{line: 1402, col: 1, offset: 33381},
 			expr: &choiceExpr{
-				pos: position{line: 1403, col: 5, offset: 33397},
+				pos: position{line: 1403, col: 5, offset: 33393},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1403, col: 5, offset: 33397},
+						pos: position{line: 1403, col: 5, offset: 33393},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1403, col: 5, offset: 33397},
+							pos: position{line: 1403, col: 5, offset: 33393},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1403, col: 5, offset: 33397},
+									pos:        position{line: 1403, col: 5, offset: 33393},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1403, col: 11, offset: 33403},
+									pos:   position{line: 1403, col: 11, offset: 33399},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1403, col: 13, offset: 33405},
+										pos: position{line: 1403, col: 13, offset: 33401},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1403, col: 13, offset: 33405},
+											pos:  position{line: 1403, col: 13, offset: 33401},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1403, col: 38, offset: 33430},
+									pos:        position{line: 1403, col: 38, offset: 33426},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9313,30 +9313,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1410, col: 5, offset: 33576},
+						pos: position{line: 1410, col: 5, offset: 33572},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1410, col: 5, offset: 33576},
+							pos: position{line: 1410, col: 5, offset: 33572},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1410, col: 5, offset: 33576},
+									pos:        position{line: 1410, col: 5, offset: 33572},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1410, col: 10, offset: 33581},
+									pos:   position{line: 1410, col: 10, offset: 33577},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1410, col: 12, offset: 33583},
+										pos: position{line: 1410, col: 12, offset: 33579},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1410, col: 12, offset: 33583},
+											pos:  position{line: 1410, col: 12, offset: 33579},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1410, col: 37, offset: 33608},
+									pos:        position{line: 1410, col: 37, offset: 33604},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9351,24 +9351,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1418, col: 1, offset: 33751},
+			pos:  position{line: 1418, col: 1, offset: 33747},
 			expr: &choiceExpr{
-				pos: position{line: 1419, col: 5, offset: 33779},
+				pos: position{line: 1419, col: 5, offset: 33775},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1419, col: 5, offset: 33779},
+						pos:  position{line: 1419, col: 5, offset: 33775},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1420, col: 5, offset: 33795},
+						pos: position{line: 1420, col: 5, offset: 33791},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1420, col: 5, offset: 33795},
+							pos:   position{line: 1420, col: 5, offset: 33791},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1420, col: 7, offset: 33797},
+								pos: position{line: 1420, col: 7, offset: 33793},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1420, col: 7, offset: 33797},
+									pos:  position{line: 1420, col: 7, offset: 33793},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9381,27 +9381,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1424, col: 1, offset: 33920},
+			pos:  position{line: 1424, col: 1, offset: 33916},
 			expr: &choiceExpr{
-				pos: position{line: 1425, col: 5, offset: 33948},
+				pos: position{line: 1425, col: 5, offset: 33944},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1425, col: 5, offset: 33948},
+						pos: position{line: 1425, col: 5, offset: 33944},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1425, col: 5, offset: 33948},
+							pos: position{line: 1425, col: 5, offset: 33944},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1425, col: 5, offset: 33948},
+									pos:        position{line: 1425, col: 5, offset: 33944},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1425, col: 10, offset: 33953},
+									pos:   position{line: 1425, col: 10, offset: 33949},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1425, col: 12, offset: 33955},
+										pos:        position{line: 1425, col: 12, offset: 33951},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9411,25 +9411,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1426, col: 5, offset: 33981},
+						pos: position{line: 1426, col: 5, offset: 33977},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1426, col: 5, offset: 33981},
+							pos: position{line: 1426, col: 5, offset: 33977},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1426, col: 5, offset: 33981},
+									pos: position{line: 1426, col: 5, offset: 33977},
 									expr: &litMatcher{
-										pos:        position{line: 1426, col: 7, offset: 33983},
+										pos:        position{line: 1426, col: 7, offset: 33979},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1426, col: 12, offset: 33988},
+									pos:   position{line: 1426, col: 12, offset: 33984},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1426, col: 14, offset: 33990},
+										pos:  position{line: 1426, col: 14, offset: 33986},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9443,24 +9443,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1428, col: 1, offset: 34026},
+			pos:  position{line: 1428, col: 1, offset: 34022},
 			expr: &choiceExpr{
-				pos: position{line: 1429, col: 5, offset: 34054},
+				pos: position{line: 1429, col: 5, offset: 34050},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 5, offset: 34054},
+						pos:  position{line: 1429, col: 5, offset: 34050},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1430, col: 5, offset: 34070},
+						pos: position{line: 1430, col: 5, offset: 34066},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1430, col: 5, offset: 34070},
+							pos:   position{line: 1430, col: 5, offset: 34066},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1430, col: 7, offset: 34072},
+								pos: position{line: 1430, col: 7, offset: 34068},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1430, col: 7, offset: 34072},
+									pos:  position{line: 1430, col: 7, offset: 34068},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9473,27 +9473,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1434, col: 1, offset: 34195},
+			pos:  position{line: 1434, col: 1, offset: 34191},
 			expr: &choiceExpr{
-				pos: position{line: 1435, col: 5, offset: 34223},
+				pos: position{line: 1435, col: 5, offset: 34219},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1435, col: 5, offset: 34223},
+						pos: position{line: 1435, col: 5, offset: 34219},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1435, col: 5, offset: 34223},
+							pos: position{line: 1435, col: 5, offset: 34219},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1435, col: 5, offset: 34223},
+									pos:        position{line: 1435, col: 5, offset: 34219},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1435, col: 10, offset: 34228},
+									pos:   position{line: 1435, col: 10, offset: 34224},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1435, col: 12, offset: 34230},
+										pos:        position{line: 1435, col: 12, offset: 34226},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9503,25 +9503,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1436, col: 5, offset: 34256},
+						pos: position{line: 1436, col: 5, offset: 34252},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1436, col: 5, offset: 34256},
+							pos: position{line: 1436, col: 5, offset: 34252},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1436, col: 5, offset: 34256},
+									pos: position{line: 1436, col: 5, offset: 34252},
 									expr: &litMatcher{
-										pos:        position{line: 1436, col: 7, offset: 34258},
+										pos:        position{line: 1436, col: 7, offset: 34254},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1436, col: 12, offset: 34263},
+									pos:   position{line: 1436, col: 12, offset: 34259},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1436, col: 14, offset: 34265},
+										pos:  position{line: 1436, col: 14, offset: 34261},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9535,37 +9535,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1438, col: 1, offset: 34301},
+			pos:  position{line: 1438, col: 1, offset: 34297},
 			expr: &actionExpr{
-				pos: position{line: 1439, col: 5, offset: 34317},
+				pos: position{line: 1439, col: 5, offset: 34313},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1439, col: 5, offset: 34317},
+					pos: position{line: 1439, col: 5, offset: 34313},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1439, col: 5, offset: 34317},
+							pos:        position{line: 1439, col: 5, offset: 34313},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1439, col: 9, offset: 34321},
+							pos:  position{line: 1439, col: 9, offset: 34317},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1439, col: 12, offset: 34324},
+							pos:   position{line: 1439, col: 12, offset: 34320},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1439, col: 14, offset: 34326},
+								pos:  position{line: 1439, col: 14, offset: 34322},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1439, col: 19, offset: 34331},
+							pos:  position{line: 1439, col: 19, offset: 34327},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1439, col: 22, offset: 34334},
+							pos:        position{line: 1439, col: 22, offset: 34330},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9578,129 +9578,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1447, col: 1, offset: 34469},
+			pos:  position{line: 1447, col: 1, offset: 34465},
 			expr: &actionExpr{
-				pos: position{line: 1448, col: 5, offset: 34487},
+				pos: position{line: 1448, col: 5, offset: 34483},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1448, col: 9, offset: 34491},
+					pos: position{line: 1448, col: 9, offset: 34487},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1448, col: 9, offset: 34491},
+							pos:        position{line: 1448, col: 9, offset: 34487},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1448, col: 19, offset: 34501},
+							pos:        position{line: 1448, col: 19, offset: 34497},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1448, col: 30, offset: 34512},
+							pos:        position{line: 1448, col: 30, offset: 34508},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1448, col: 41, offset: 34523},
+							pos:        position{line: 1448, col: 41, offset: 34519},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 9, offset: 34540},
+							pos:        position{line: 1449, col: 9, offset: 34536},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 18, offset: 34549},
+							pos:        position{line: 1449, col: 18, offset: 34545},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 28, offset: 34559},
+							pos:        position{line: 1449, col: 28, offset: 34555},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 38, offset: 34569},
+							pos:        position{line: 1449, col: 38, offset: 34565},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 9, offset: 34585},
+							pos:        position{line: 1450, col: 9, offset: 34581},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 21, offset: 34597},
+							pos:        position{line: 1450, col: 21, offset: 34593},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 33, offset: 34609},
+							pos:        position{line: 1450, col: 33, offset: 34605},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1451, col: 9, offset: 34627},
+							pos:        position{line: 1451, col: 9, offset: 34623},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1451, col: 18, offset: 34636},
+							pos:        position{line: 1451, col: 18, offset: 34632},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1452, col: 9, offset: 34653},
+							pos:        position{line: 1452, col: 9, offset: 34649},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1452, col: 22, offset: 34666},
+							pos:        position{line: 1452, col: 22, offset: 34662},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1453, col: 9, offset: 34681},
+							pos:        position{line: 1453, col: 9, offset: 34677},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 9, offset: 34697},
+							pos:        position{line: 1454, col: 9, offset: 34693},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 16, offset: 34704},
+							pos:        position{line: 1454, col: 16, offset: 34700},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 9, offset: 34718},
+							pos:        position{line: 1455, col: 9, offset: 34714},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 18, offset: 34727},
+							pos:        position{line: 1455, col: 18, offset: 34723},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9713,31 +9713,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1463, col: 1, offset: 34912},
+			pos:  position{line: 1463, col: 1, offset: 34908},
 			expr: &choiceExpr{
-				pos: position{line: 1464, col: 5, offset: 34930},
+				pos: position{line: 1464, col: 5, offset: 34926},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1464, col: 5, offset: 34930},
+						pos: position{line: 1464, col: 5, offset: 34926},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1464, col: 5, offset: 34930},
+							pos: position{line: 1464, col: 5, offset: 34926},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1464, col: 5, offset: 34930},
+									pos:   position{line: 1464, col: 5, offset: 34926},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1464, col: 11, offset: 34936},
+										pos:  position{line: 1464, col: 11, offset: 34932},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1464, col: 21, offset: 34946},
+									pos:   position{line: 1464, col: 21, offset: 34942},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1464, col: 26, offset: 34951},
+										pos: position{line: 1464, col: 26, offset: 34947},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1464, col: 26, offset: 34951},
+											pos:  position{line: 1464, col: 26, offset: 34947},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9746,10 +9746,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1467, col: 5, offset: 35017},
+						pos: position{line: 1467, col: 5, offset: 35013},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1467, col: 5, offset: 35017},
+							pos:        position{line: 1467, col: 5, offset: 35013},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9762,32 +9762,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1469, col: 1, offset: 35041},
+			pos:  position{line: 1469, col: 1, offset: 35037},
 			expr: &actionExpr{
-				pos: position{line: 1469, col: 21, offset: 35061},
+				pos: position{line: 1469, col: 21, offset: 35057},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1469, col: 21, offset: 35061},
+					pos: position{line: 1469, col: 21, offset: 35057},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1469, col: 21, offset: 35061},
+							pos:  position{line: 1469, col: 21, offset: 35057},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1469, col: 24, offset: 35064},
+							pos:        position{line: 1469, col: 24, offset: 35060},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1469, col: 28, offset: 35068},
+							pos:  position{line: 1469, col: 28, offset: 35064},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1469, col: 31, offset: 35071},
+							pos:   position{line: 1469, col: 31, offset: 35067},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1469, col: 35, offset: 35075},
+								pos:  position{line: 1469, col: 35, offset: 35071},
 								name: "TypeField",
 							},
 						},
@@ -9799,40 +9799,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1471, col: 1, offset: 35106},
+			pos:  position{line: 1471, col: 1, offset: 35102},
 			expr: &actionExpr{
-				pos: position{line: 1472, col: 5, offset: 35120},
+				pos: position{line: 1472, col: 5, offset: 35116},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1472, col: 5, offset: 35120},
+					pos: position{line: 1472, col: 5, offset: 35116},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1472, col: 5, offset: 35120},
+							pos:   position{line: 1472, col: 5, offset: 35116},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1472, col: 10, offset: 35125},
+								pos:  position{line: 1472, col: 10, offset: 35121},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1472, col: 15, offset: 35130},
+							pos:  position{line: 1472, col: 15, offset: 35126},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1472, col: 18, offset: 35133},
+							pos:        position{line: 1472, col: 18, offset: 35129},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1472, col: 22, offset: 35137},
+							pos:  position{line: 1472, col: 22, offset: 35133},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1472, col: 25, offset: 35140},
+							pos:   position{line: 1472, col: 25, offset: 35136},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1472, col: 29, offset: 35144},
+								pos:  position{line: 1472, col: 29, offset: 35140},
 								name: "Type",
 							},
 						},
@@ -9844,26 +9844,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1480, col: 1, offset: 35293},
+			pos:  position{line: 1480, col: 1, offset: 35289},
 			expr: &actionExpr{
-				pos: position{line: 1481, col: 4, offset: 35301},
+				pos: position{line: 1481, col: 4, offset: 35297},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1481, col: 4, offset: 35301},
+					pos:   position{line: 1481, col: 4, offset: 35297},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1481, col: 7, offset: 35304},
+						pos: position{line: 1481, col: 7, offset: 35300},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1481, col: 7, offset: 35304},
+								pos:  position{line: 1481, col: 7, offset: 35300},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1481, col: 24, offset: 35321},
+								pos:  position{line: 1481, col: 24, offset: 35317},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1481, col: 45, offset: 35342},
+								pos:  position{line: 1481, col: 45, offset: 35338},
 								name: "SingleQuotedString",
 							},
 						},
@@ -9875,51 +9875,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1485, col: 1, offset: 35442},
+			pos:  position{line: 1485, col: 1, offset: 35438},
 			expr: &actionExpr{
-				pos: position{line: 1486, col: 5, offset: 35452},
+				pos: position{line: 1486, col: 5, offset: 35448},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1486, col: 5, offset: 35452},
+					pos: position{line: 1486, col: 5, offset: 35448},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1486, col: 5, offset: 35452},
+							pos:   position{line: 1486, col: 5, offset: 35448},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1486, col: 11, offset: 35458},
+								pos:  position{line: 1486, col: 11, offset: 35454},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1486, col: 16, offset: 35463},
+							pos:   position{line: 1486, col: 16, offset: 35459},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1486, col: 21, offset: 35468},
+								pos: position{line: 1486, col: 21, offset: 35464},
 								expr: &actionExpr{
-									pos: position{line: 1486, col: 22, offset: 35469},
+									pos: position{line: 1486, col: 22, offset: 35465},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1486, col: 22, offset: 35469},
+										pos: position{line: 1486, col: 22, offset: 35465},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1486, col: 22, offset: 35469},
+												pos:  position{line: 1486, col: 22, offset: 35465},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1486, col: 25, offset: 35472},
+												pos:        position{line: 1486, col: 25, offset: 35468},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1486, col: 29, offset: 35476},
+												pos:  position{line: 1486, col: 29, offset: 35472},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1486, col: 32, offset: 35479},
+												pos:   position{line: 1486, col: 32, offset: 35475},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1486, col: 37, offset: 35484},
+													pos:  position{line: 1486, col: 37, offset: 35480},
 													name: "Name",
 												},
 											},
@@ -9936,15 +9936,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1490, col: 1, offset: 35556},
+			pos:  position{line: 1490, col: 1, offset: 35552},
 			expr: &actionExpr{
-				pos: position{line: 1491, col: 5, offset: 35571},
+				pos: position{line: 1491, col: 5, offset: 35567},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1491, col: 5, offset: 35571},
+					pos:   position{line: 1491, col: 5, offset: 35567},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1491, col: 8, offset: 35574},
+						pos:  position{line: 1491, col: 8, offset: 35570},
 						name: "IdentifierName",
 					},
 				},
@@ -9954,51 +9954,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1499, col: 1, offset: 35707},
+			pos:  position{line: 1499, col: 1, offset: 35703},
 			expr: &actionExpr{
-				pos: position{line: 1500, col: 5, offset: 35723},
+				pos: position{line: 1500, col: 5, offset: 35719},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1500, col: 5, offset: 35723},
+					pos: position{line: 1500, col: 5, offset: 35719},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1500, col: 5, offset: 35723},
+							pos:   position{line: 1500, col: 5, offset: 35719},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1500, col: 11, offset: 35729},
+								pos:  position{line: 1500, col: 11, offset: 35725},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1500, col: 22, offset: 35740},
+							pos:   position{line: 1500, col: 22, offset: 35736},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1500, col: 27, offset: 35745},
+								pos: position{line: 1500, col: 27, offset: 35741},
 								expr: &actionExpr{
-									pos: position{line: 1500, col: 28, offset: 35746},
+									pos: position{line: 1500, col: 28, offset: 35742},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1500, col: 28, offset: 35746},
+										pos: position{line: 1500, col: 28, offset: 35742},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1500, col: 28, offset: 35746},
+												pos:  position{line: 1500, col: 28, offset: 35742},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1500, col: 31, offset: 35749},
+												pos:        position{line: 1500, col: 31, offset: 35745},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1500, col: 35, offset: 35753},
+												pos:  position{line: 1500, col: 35, offset: 35749},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1500, col: 38, offset: 35756},
+												pos:   position{line: 1500, col: 38, offset: 35752},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1500, col: 43, offset: 35761},
+													pos:  position{line: 1500, col: 43, offset: 35757},
 													name: "Identifier",
 												},
 											},
@@ -10015,22 +10015,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1504, col: 1, offset: 35839},
+			pos:  position{line: 1504, col: 1, offset: 35835},
 			expr: &choiceExpr{
-				pos: position{line: 1505, col: 5, offset: 35857},
+				pos: position{line: 1505, col: 5, offset: 35853},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1505, col: 5, offset: 35857},
+						pos:  position{line: 1505, col: 5, offset: 35853},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1506, col: 5, offset: 35872},
+						pos: position{line: 1506, col: 5, offset: 35868},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1506, col: 5, offset: 35872},
+							pos:   position{line: 1506, col: 5, offset: 35868},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1506, col: 7, offset: 35874},
+								pos:  position{line: 1506, col: 7, offset: 35870},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10042,29 +10042,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1508, col: 1, offset: 35959},
+			pos:  position{line: 1508, col: 1, offset: 35955},
 			expr: &choiceExpr{
-				pos: position{line: 1509, col: 5, offset: 35978},
+				pos: position{line: 1509, col: 5, offset: 35974},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1509, col: 5, offset: 35978},
+						pos: position{line: 1509, col: 5, offset: 35974},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1509, col: 5, offset: 35978},
+							pos: position{line: 1509, col: 5, offset: 35974},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1509, col: 5, offset: 35978},
+									pos: position{line: 1509, col: 5, offset: 35974},
 									expr: &seqExpr{
-										pos: position{line: 1509, col: 7, offset: 35980},
+										pos: position{line: 1509, col: 7, offset: 35976},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1509, col: 7, offset: 35980},
+												pos:  position{line: 1509, col: 7, offset: 35976},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1509, col: 15, offset: 35988},
+												pos: position{line: 1509, col: 15, offset: 35984},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1509, col: 16, offset: 35989},
+													pos:  position{line: 1509, col: 16, offset: 35985},
 													name: "IdentifierRest",
 												},
 											},
@@ -10072,13 +10072,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1509, col: 32, offset: 36005},
+									pos:  position{line: 1509, col: 32, offset: 36001},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1509, col: 48, offset: 36021},
+									pos: position{line: 1509, col: 48, offset: 36017},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1509, col: 48, offset: 36021},
+										pos:  position{line: 1509, col: 48, offset: 36017},
 										name: "IdentifierRest",
 									},
 								},
@@ -10086,7 +10086,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1510, col: 5, offset: 36072},
+						pos:  position{line: 1510, col: 5, offset: 36068},
 						name: "BacktickString",
 					},
 				},
@@ -10096,22 +10096,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1512, col: 1, offset: 36088},
+			pos:  position{line: 1512, col: 1, offset: 36084},
 			expr: &choiceExpr{
-				pos: position{line: 1513, col: 5, offset: 36108},
+				pos: position{line: 1513, col: 5, offset: 36104},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1513, col: 5, offset: 36108},
+						pos:  position{line: 1513, col: 5, offset: 36104},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1514, col: 5, offset: 36126},
+						pos:        position{line: 1514, col: 5, offset: 36122},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1515, col: 5, offset: 36134},
+						pos:        position{line: 1515, col: 5, offset: 36130},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10123,24 +10123,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1517, col: 1, offset: 36139},
+			pos:  position{line: 1517, col: 1, offset: 36135},
 			expr: &choiceExpr{
-				pos: position{line: 1518, col: 5, offset: 36158},
+				pos: position{line: 1518, col: 5, offset: 36154},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1518, col: 5, offset: 36158},
+						pos:  position{line: 1518, col: 5, offset: 36154},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1519, col: 5, offset: 36178},
+						pos:  position{line: 1519, col: 5, offset: 36174},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1520, col: 5, offset: 36203},
+						pos:  position{line: 1520, col: 5, offset: 36199},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1521, col: 5, offset: 36220},
+						pos:  position{line: 1521, col: 5, offset: 36216},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10150,24 +10150,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1523, col: 1, offset: 36249},
+			pos:  position{line: 1523, col: 1, offset: 36245},
 			expr: &choiceExpr{
-				pos: position{line: 1524, col: 5, offset: 36261},
+				pos: position{line: 1524, col: 5, offset: 36257},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1524, col: 5, offset: 36261},
+						pos:  position{line: 1524, col: 5, offset: 36257},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1525, col: 5, offset: 36280},
+						pos:  position{line: 1525, col: 5, offset: 36276},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1526, col: 5, offset: 36296},
+						pos:  position{line: 1526, col: 5, offset: 36292},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1527, col: 5, offset: 36304},
+						pos:  position{line: 1527, col: 5, offset: 36300},
 						name: "Infinity",
 					},
 				},
@@ -10177,25 +10177,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1529, col: 1, offset: 36314},
+			pos:  position{line: 1529, col: 1, offset: 36310},
 			expr: &actionExpr{
-				pos: position{line: 1530, col: 5, offset: 36323},
+				pos: position{line: 1530, col: 5, offset: 36319},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1530, col: 5, offset: 36323},
+					pos: position{line: 1530, col: 5, offset: 36319},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1530, col: 5, offset: 36323},
+							pos:  position{line: 1530, col: 5, offset: 36319},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1530, col: 14, offset: 36332},
+							pos:        position{line: 1530, col: 14, offset: 36328},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1530, col: 18, offset: 36336},
+							pos:  position{line: 1530, col: 18, offset: 36332},
 							name: "FullTime",
 						},
 					},
@@ -10206,32 +10206,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1534, col: 1, offset: 36412},
+			pos:  position{line: 1534, col: 1, offset: 36408},
 			expr: &seqExpr{
-				pos: position{line: 1534, col: 12, offset: 36423},
+				pos: position{line: 1534, col: 12, offset: 36419},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 12, offset: 36423},
+						pos:  position{line: 1534, col: 12, offset: 36419},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1534, col: 15, offset: 36426},
+						pos:        position{line: 1534, col: 15, offset: 36422},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 19, offset: 36430},
+						pos:  position{line: 1534, col: 19, offset: 36426},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1534, col: 22, offset: 36433},
+						pos:        position{line: 1534, col: 22, offset: 36429},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 26, offset: 36437},
+						pos:  position{line: 1534, col: 26, offset: 36433},
 						name: "D2",
 					},
 				},
@@ -10241,33 +10241,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1536, col: 1, offset: 36441},
+			pos:  position{line: 1536, col: 1, offset: 36437},
 			expr: &seqExpr{
-				pos: position{line: 1536, col: 6, offset: 36446},
+				pos: position{line: 1536, col: 6, offset: 36442},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 6, offset: 36446},
+						pos:        position{line: 1536, col: 6, offset: 36442},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 11, offset: 36451},
+						pos:        position{line: 1536, col: 11, offset: 36447},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 16, offset: 36456},
+						pos:        position{line: 1536, col: 16, offset: 36452},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 21, offset: 36461},
+						pos:        position{line: 1536, col: 21, offset: 36457},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10280,19 +10280,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1537, col: 1, offset: 36467},
+			pos:  position{line: 1537, col: 1, offset: 36463},
 			expr: &seqExpr{
-				pos: position{line: 1537, col: 6, offset: 36472},
+				pos: position{line: 1537, col: 6, offset: 36468},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1537, col: 6, offset: 36472},
+						pos:        position{line: 1537, col: 6, offset: 36468},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1537, col: 11, offset: 36477},
+						pos:        position{line: 1537, col: 11, offset: 36473},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10305,16 +10305,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1539, col: 1, offset: 36484},
+			pos:  position{line: 1539, col: 1, offset: 36480},
 			expr: &seqExpr{
-				pos: position{line: 1539, col: 12, offset: 36495},
+				pos: position{line: 1539, col: 12, offset: 36491},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1539, col: 12, offset: 36495},
+						pos:  position{line: 1539, col: 12, offset: 36491},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1539, col: 24, offset: 36507},
+						pos:  position{line: 1539, col: 24, offset: 36503},
 						name: "TimeOffset",
 					},
 				},
@@ -10324,49 +10324,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1541, col: 1, offset: 36519},
+			pos:  position{line: 1541, col: 1, offset: 36515},
 			expr: &seqExpr{
-				pos: position{line: 1541, col: 15, offset: 36533},
+				pos: position{line: 1541, col: 15, offset: 36529},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 15, offset: 36533},
+						pos:  position{line: 1541, col: 15, offset: 36529},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1541, col: 18, offset: 36536},
+						pos:        position{line: 1541, col: 18, offset: 36532},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 22, offset: 36540},
+						pos:  position{line: 1541, col: 22, offset: 36536},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1541, col: 25, offset: 36543},
+						pos:        position{line: 1541, col: 25, offset: 36539},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 29, offset: 36547},
+						pos:  position{line: 1541, col: 29, offset: 36543},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1541, col: 32, offset: 36550},
+						pos: position{line: 1541, col: 32, offset: 36546},
 						expr: &seqExpr{
-							pos: position{line: 1541, col: 33, offset: 36551},
+							pos: position{line: 1541, col: 33, offset: 36547},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1541, col: 33, offset: 36551},
+									pos:        position{line: 1541, col: 33, offset: 36547},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1541, col: 37, offset: 36555},
+									pos: position{line: 1541, col: 37, offset: 36551},
 									expr: &charClassMatcher{
-										pos:        position{line: 1541, col: 37, offset: 36555},
+										pos:        position{line: 1541, col: 37, offset: 36551},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10383,30 +10383,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1543, col: 1, offset: 36565},
+			pos:  position{line: 1543, col: 1, offset: 36561},
 			expr: &choiceExpr{
-				pos: position{line: 1544, col: 5, offset: 36580},
+				pos: position{line: 1544, col: 5, offset: 36576},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1544, col: 5, offset: 36580},
+						pos:        position{line: 1544, col: 5, offset: 36576},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1545, col: 5, offset: 36588},
+						pos: position{line: 1545, col: 5, offset: 36584},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1545, col: 6, offset: 36589},
+								pos: position{line: 1545, col: 6, offset: 36585},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1545, col: 6, offset: 36589},
+										pos:        position{line: 1545, col: 6, offset: 36585},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1545, col: 12, offset: 36595},
+										pos:        position{line: 1545, col: 12, offset: 36591},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10414,34 +10414,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 17, offset: 36600},
+								pos:  position{line: 1545, col: 17, offset: 36596},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1545, col: 20, offset: 36603},
+								pos:        position{line: 1545, col: 20, offset: 36599},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 24, offset: 36607},
+								pos:  position{line: 1545, col: 24, offset: 36603},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1545, col: 27, offset: 36610},
+								pos: position{line: 1545, col: 27, offset: 36606},
 								expr: &seqExpr{
-									pos: position{line: 1545, col: 28, offset: 36611},
+									pos: position{line: 1545, col: 28, offset: 36607},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1545, col: 28, offset: 36611},
+											pos:        position{line: 1545, col: 28, offset: 36607},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1545, col: 32, offset: 36615},
+											pos: position{line: 1545, col: 32, offset: 36611},
 											expr: &charClassMatcher{
-												pos:        position{line: 1545, col: 32, offset: 36615},
+												pos:        position{line: 1545, col: 32, offset: 36611},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10460,33 +10460,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1547, col: 1, offset: 36625},
+			pos:  position{line: 1547, col: 1, offset: 36621},
 			expr: &actionExpr{
-				pos: position{line: 1548, col: 5, offset: 36638},
+				pos: position{line: 1548, col: 5, offset: 36634},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1548, col: 5, offset: 36638},
+					pos: position{line: 1548, col: 5, offset: 36634},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1548, col: 5, offset: 36638},
+							pos: position{line: 1548, col: 5, offset: 36634},
 							expr: &litMatcher{
-								pos:        position{line: 1548, col: 5, offset: 36638},
+								pos:        position{line: 1548, col: 5, offset: 36634},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1548, col: 10, offset: 36643},
+							pos: position{line: 1548, col: 10, offset: 36639},
 							expr: &seqExpr{
-								pos: position{line: 1548, col: 11, offset: 36644},
+								pos: position{line: 1548, col: 11, offset: 36640},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1548, col: 11, offset: 36644},
+										pos:  position{line: 1548, col: 11, offset: 36640},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1548, col: 19, offset: 36652},
+										pos:  position{line: 1548, col: 19, offset: 36648},
 										name: "TimeUnit",
 									},
 								},
@@ -10500,27 +10500,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1552, col: 1, offset: 36734},
+			pos:  position{line: 1552, col: 1, offset: 36730},
 			expr: &seqExpr{
-				pos: position{line: 1552, col: 11, offset: 36744},
+				pos: position{line: 1552, col: 11, offset: 36740},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1552, col: 11, offset: 36744},
+						pos:  position{line: 1552, col: 11, offset: 36740},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1552, col: 16, offset: 36749},
+						pos: position{line: 1552, col: 16, offset: 36745},
 						expr: &seqExpr{
-							pos: position{line: 1552, col: 17, offset: 36750},
+							pos: position{line: 1552, col: 17, offset: 36746},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1552, col: 17, offset: 36750},
+									pos:        position{line: 1552, col: 17, offset: 36746},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1552, col: 21, offset: 36754},
+									pos:  position{line: 1552, col: 21, offset: 36750},
 									name: "UInt",
 								},
 							},
@@ -10533,60 +10533,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1554, col: 1, offset: 36762},
+			pos:  position{line: 1554, col: 1, offset: 36758},
 			expr: &choiceExpr{
-				pos: position{line: 1555, col: 5, offset: 36775},
+				pos: position{line: 1555, col: 5, offset: 36771},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1555, col: 5, offset: 36775},
+						pos:        position{line: 1555, col: 5, offset: 36771},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1556, col: 5, offset: 36784},
+						pos:        position{line: 1556, col: 5, offset: 36780},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1557, col: 5, offset: 36793},
+						pos:        position{line: 1557, col: 5, offset: 36789},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1558, col: 5, offset: 36802},
+						pos:        position{line: 1558, col: 5, offset: 36798},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1559, col: 5, offset: 36810},
+						pos:        position{line: 1559, col: 5, offset: 36806},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1560, col: 5, offset: 36818},
+						pos:        position{line: 1560, col: 5, offset: 36814},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1561, col: 5, offset: 36826},
+						pos:        position{line: 1561, col: 5, offset: 36822},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1562, col: 5, offset: 36834},
+						pos:        position{line: 1562, col: 5, offset: 36830},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1563, col: 5, offset: 36842},
+						pos:        position{line: 1563, col: 5, offset: 36838},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10598,45 +10598,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1565, col: 1, offset: 36847},
+			pos:  position{line: 1565, col: 1, offset: 36843},
 			expr: &actionExpr{
-				pos: position{line: 1566, col: 5, offset: 36854},
+				pos: position{line: 1566, col: 5, offset: 36850},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1566, col: 5, offset: 36854},
+					pos: position{line: 1566, col: 5, offset: 36850},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 5, offset: 36854},
+							pos:  position{line: 1566, col: 5, offset: 36850},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 10, offset: 36859},
+							pos:        position{line: 1566, col: 10, offset: 36855},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 14, offset: 36863},
+							pos:  position{line: 1566, col: 14, offset: 36859},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 19, offset: 36868},
+							pos:        position{line: 1566, col: 19, offset: 36864},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 23, offset: 36872},
+							pos:  position{line: 1566, col: 23, offset: 36868},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 28, offset: 36877},
+							pos:        position{line: 1566, col: 28, offset: 36873},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 32, offset: 36881},
+							pos:  position{line: 1566, col: 32, offset: 36877},
 							name: "UInt",
 						},
 					},
@@ -10647,43 +10647,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1568, col: 1, offset: 36918},
+			pos:  position{line: 1568, col: 1, offset: 36914},
 			expr: &actionExpr{
-				pos: position{line: 1569, col: 5, offset: 36926},
+				pos: position{line: 1569, col: 5, offset: 36922},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1569, col: 5, offset: 36926},
+					pos: position{line: 1569, col: 5, offset: 36922},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1569, col: 5, offset: 36926},
+							pos: position{line: 1569, col: 5, offset: 36922},
 							expr: &seqExpr{
-								pos: position{line: 1569, col: 7, offset: 36928},
+								pos: position{line: 1569, col: 7, offset: 36924},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1569, col: 7, offset: 36928},
+										pos:  position{line: 1569, col: 7, offset: 36924},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1569, col: 11, offset: 36932},
+										pos:        position{line: 1569, col: 11, offset: 36928},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1569, col: 15, offset: 36936},
+										pos:  position{line: 1569, col: 15, offset: 36932},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1569, col: 19, offset: 36940},
+										pos: position{line: 1569, col: 19, offset: 36936},
 										expr: &choiceExpr{
-											pos: position{line: 1569, col: 21, offset: 36942},
+											pos: position{line: 1569, col: 21, offset: 36938},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1569, col: 21, offset: 36942},
+													pos:  position{line: 1569, col: 21, offset: 36938},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1569, col: 32, offset: 36953},
+													pos:        position{line: 1569, col: 32, offset: 36949},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10695,10 +10695,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1569, col: 38, offset: 36959},
+							pos:   position{line: 1569, col: 38, offset: 36955},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1569, col: 40, offset: 36961},
+								pos:  position{line: 1569, col: 40, offset: 36957},
 								name: "IP6Variations",
 							},
 						},
@@ -10710,32 +10710,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1573, col: 1, offset: 37125},
+			pos:  position{line: 1573, col: 1, offset: 37121},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 5, offset: 37143},
+				pos: position{line: 1574, col: 5, offset: 37139},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1574, col: 5, offset: 37143},
+						pos: position{line: 1574, col: 5, offset: 37139},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1574, col: 5, offset: 37143},
+							pos: position{line: 1574, col: 5, offset: 37139},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1574, col: 5, offset: 37143},
+									pos:   position{line: 1574, col: 5, offset: 37139},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1574, col: 7, offset: 37145},
+										pos: position{line: 1574, col: 7, offset: 37141},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1574, col: 7, offset: 37145},
+											pos:  position{line: 1574, col: 7, offset: 37141},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1574, col: 17, offset: 37155},
+									pos:   position{line: 1574, col: 17, offset: 37151},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1574, col: 19, offset: 37157},
+										pos:  position{line: 1574, col: 19, offset: 37153},
 										name: "IP6Tail",
 									},
 								},
@@ -10743,52 +10743,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1577, col: 5, offset: 37221},
+						pos: position{line: 1577, col: 5, offset: 37217},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1577, col: 5, offset: 37221},
+							pos: position{line: 1577, col: 5, offset: 37217},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1577, col: 5, offset: 37221},
+									pos:   position{line: 1577, col: 5, offset: 37217},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1577, col: 7, offset: 37223},
+										pos:  position{line: 1577, col: 7, offset: 37219},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 11, offset: 37227},
+									pos:   position{line: 1577, col: 11, offset: 37223},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1577, col: 13, offset: 37229},
+										pos: position{line: 1577, col: 13, offset: 37225},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1577, col: 13, offset: 37229},
+											pos:  position{line: 1577, col: 13, offset: 37225},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1577, col: 23, offset: 37239},
+									pos:        position{line: 1577, col: 23, offset: 37235},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 28, offset: 37244},
+									pos:   position{line: 1577, col: 28, offset: 37240},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1577, col: 30, offset: 37246},
+										pos: position{line: 1577, col: 30, offset: 37242},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1577, col: 30, offset: 37246},
+											pos:  position{line: 1577, col: 30, offset: 37242},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 40, offset: 37256},
+									pos:   position{line: 1577, col: 40, offset: 37252},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1577, col: 42, offset: 37258},
+										pos:  position{line: 1577, col: 42, offset: 37254},
 										name: "IP6Tail",
 									},
 								},
@@ -10796,33 +10796,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1580, col: 5, offset: 37357},
+						pos: position{line: 1580, col: 5, offset: 37353},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1580, col: 5, offset: 37357},
+							pos: position{line: 1580, col: 5, offset: 37353},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1580, col: 5, offset: 37357},
+									pos:        position{line: 1580, col: 5, offset: 37353},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1580, col: 10, offset: 37362},
+									pos:   position{line: 1580, col: 10, offset: 37358},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1580, col: 12, offset: 37364},
+										pos: position{line: 1580, col: 12, offset: 37360},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1580, col: 12, offset: 37364},
+											pos:  position{line: 1580, col: 12, offset: 37360},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1580, col: 22, offset: 37374},
+									pos:   position{line: 1580, col: 22, offset: 37370},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1580, col: 24, offset: 37376},
+										pos:  position{line: 1580, col: 24, offset: 37372},
 										name: "IP6Tail",
 									},
 								},
@@ -10830,40 +10830,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1583, col: 5, offset: 37447},
+						pos: position{line: 1583, col: 5, offset: 37443},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1583, col: 5, offset: 37447},
+							pos: position{line: 1583, col: 5, offset: 37443},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1583, col: 5, offset: 37447},
+									pos:   position{line: 1583, col: 5, offset: 37443},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1583, col: 7, offset: 37449},
+										pos:  position{line: 1583, col: 7, offset: 37445},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1583, col: 11, offset: 37453},
+									pos:   position{line: 1583, col: 11, offset: 37449},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1583, col: 13, offset: 37455},
+										pos: position{line: 1583, col: 13, offset: 37451},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1583, col: 13, offset: 37455},
+											pos:  position{line: 1583, col: 13, offset: 37451},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1583, col: 23, offset: 37465},
+									pos:        position{line: 1583, col: 23, offset: 37461},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1583, col: 28, offset: 37470},
+									pos: position{line: 1583, col: 28, offset: 37466},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1583, col: 29, offset: 37471},
+										pos:  position{line: 1583, col: 29, offset: 37467},
 										name: "TypeAsValue",
 									},
 								},
@@ -10871,10 +10871,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1586, col: 5, offset: 37546},
+						pos: position{line: 1586, col: 5, offset: 37542},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1586, col: 5, offset: 37546},
+							pos:        position{line: 1586, col: 5, offset: 37542},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10887,16 +10887,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1590, col: 1, offset: 37583},
+			pos:  position{line: 1590, col: 1, offset: 37579},
 			expr: &choiceExpr{
-				pos: position{line: 1591, col: 5, offset: 37595},
+				pos: position{line: 1591, col: 5, offset: 37591},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1591, col: 5, offset: 37595},
+						pos:  position{line: 1591, col: 5, offset: 37591},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1592, col: 5, offset: 37602},
+						pos:  position{line: 1592, col: 5, offset: 37598},
 						name: "Hex",
 					},
 				},
@@ -10906,24 +10906,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1594, col: 1, offset: 37607},
+			pos:  position{line: 1594, col: 1, offset: 37603},
 			expr: &actionExpr{
-				pos: position{line: 1594, col: 12, offset: 37618},
+				pos: position{line: 1594, col: 12, offset: 37614},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1594, col: 12, offset: 37618},
+					pos: position{line: 1594, col: 12, offset: 37614},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1594, col: 12, offset: 37618},
+							pos:        position{line: 1594, col: 12, offset: 37614},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1594, col: 16, offset: 37622},
+							pos:   position{line: 1594, col: 16, offset: 37618},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1594, col: 18, offset: 37624},
+								pos:  position{line: 1594, col: 18, offset: 37620},
 								name: "Hex",
 							},
 						},
@@ -10935,23 +10935,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1596, col: 1, offset: 37662},
+			pos:  position{line: 1596, col: 1, offset: 37658},
 			expr: &actionExpr{
-				pos: position{line: 1596, col: 12, offset: 37673},
+				pos: position{line: 1596, col: 12, offset: 37669},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1596, col: 12, offset: 37673},
+					pos: position{line: 1596, col: 12, offset: 37669},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1596, col: 12, offset: 37673},
+							pos:   position{line: 1596, col: 12, offset: 37669},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1596, col: 14, offset: 37675},
+								pos:  position{line: 1596, col: 14, offset: 37671},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1596, col: 18, offset: 37679},
+							pos:        position{line: 1596, col: 18, offset: 37675},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10964,32 +10964,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1598, col: 1, offset: 37717},
+			pos:  position{line: 1598, col: 1, offset: 37713},
 			expr: &actionExpr{
-				pos: position{line: 1599, col: 5, offset: 37728},
+				pos: position{line: 1599, col: 5, offset: 37724},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1599, col: 5, offset: 37728},
+					pos: position{line: 1599, col: 5, offset: 37724},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1599, col: 5, offset: 37728},
+							pos:   position{line: 1599, col: 5, offset: 37724},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 7, offset: 37730},
+								pos:  position{line: 1599, col: 7, offset: 37726},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1599, col: 10, offset: 37733},
+							pos:        position{line: 1599, col: 10, offset: 37729},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1599, col: 14, offset: 37737},
+							pos:   position{line: 1599, col: 14, offset: 37733},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 16, offset: 37739},
+								pos:  position{line: 1599, col: 16, offset: 37735},
 								name: "UIntString",
 							},
 						},
@@ -11001,32 +11001,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1603, col: 1, offset: 37807},
+			pos:  position{line: 1603, col: 1, offset: 37803},
 			expr: &actionExpr{
-				pos: position{line: 1604, col: 5, offset: 37818},
+				pos: position{line: 1604, col: 5, offset: 37814},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1604, col: 5, offset: 37818},
+					pos: position{line: 1604, col: 5, offset: 37814},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1604, col: 5, offset: 37818},
+							pos:   position{line: 1604, col: 5, offset: 37814},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1604, col: 7, offset: 37820},
+								pos:  position{line: 1604, col: 7, offset: 37816},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1604, col: 11, offset: 37824},
+							pos:        position{line: 1604, col: 11, offset: 37820},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1604, col: 15, offset: 37828},
+							pos:   position{line: 1604, col: 15, offset: 37824},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1604, col: 17, offset: 37830},
+								pos:  position{line: 1604, col: 17, offset: 37826},
 								name: "UIntString",
 							},
 						},
@@ -11038,15 +11038,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1608, col: 1, offset: 37898},
+			pos:  position{line: 1608, col: 1, offset: 37894},
 			expr: &actionExpr{
-				pos: position{line: 1609, col: 4, offset: 37906},
+				pos: position{line: 1609, col: 4, offset: 37902},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1609, col: 4, offset: 37906},
+					pos:   position{line: 1609, col: 4, offset: 37902},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1609, col: 6, offset: 37908},
+						pos:  position{line: 1609, col: 6, offset: 37904},
 						name: "UIntString",
 					},
 				},
@@ -11056,16 +11056,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1611, col: 1, offset: 37948},
+			pos:  position{line: 1611, col: 1, offset: 37944},
 			expr: &choiceExpr{
-				pos: position{line: 1612, col: 5, offset: 37962},
+				pos: position{line: 1612, col: 5, offset: 37958},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1612, col: 5, offset: 37962},
+						pos:  position{line: 1612, col: 5, offset: 37958},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1613, col: 5, offset: 37977},
+						pos:  position{line: 1613, col: 5, offset: 37973},
 						name: "MinusIntString",
 					},
 				},
@@ -11075,14 +11075,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1615, col: 1, offset: 37993},
+			pos:  position{line: 1615, col: 1, offset: 37989},
 			expr: &actionExpr{
-				pos: position{line: 1615, col: 14, offset: 38006},
+				pos: position{line: 1615, col: 14, offset: 38002},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1615, col: 14, offset: 38006},
+					pos: position{line: 1615, col: 14, offset: 38002},
 					expr: &charClassMatcher{
-						pos:        position{line: 1615, col: 14, offset: 38006},
+						pos:        position{line: 1615, col: 14, offset: 38002},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11095,21 +11095,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1617, col: 1, offset: 38045},
+			pos:  position{line: 1617, col: 1, offset: 38041},
 			expr: &actionExpr{
-				pos: position{line: 1618, col: 5, offset: 38064},
+				pos: position{line: 1618, col: 5, offset: 38060},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1618, col: 5, offset: 38064},
+					pos: position{line: 1618, col: 5, offset: 38060},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1618, col: 5, offset: 38064},
+							pos:        position{line: 1618, col: 5, offset: 38060},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1618, col: 9, offset: 38068},
+							pos:  position{line: 1618, col: 9, offset: 38064},
 							name: "UIntString",
 						},
 					},
@@ -11120,29 +11120,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1620, col: 1, offset: 38111},
+			pos:  position{line: 1620, col: 1, offset: 38107},
 			expr: &choiceExpr{
-				pos: position{line: 1621, col: 5, offset: 38127},
+				pos: position{line: 1621, col: 5, offset: 38123},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1621, col: 5, offset: 38127},
+						pos: position{line: 1621, col: 5, offset: 38123},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1621, col: 5, offset: 38127},
+							pos: position{line: 1621, col: 5, offset: 38123},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1621, col: 5, offset: 38127},
+									pos: position{line: 1621, col: 5, offset: 38123},
 									expr: &litMatcher{
-										pos:        position{line: 1621, col: 5, offset: 38127},
+										pos:        position{line: 1621, col: 5, offset: 38123},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1621, col: 10, offset: 38132},
+									pos: position{line: 1621, col: 10, offset: 38128},
 									expr: &charClassMatcher{
-										pos:        position{line: 1621, col: 10, offset: 38132},
+										pos:        position{line: 1621, col: 10, offset: 38128},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11150,15 +11150,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1621, col: 17, offset: 38139},
+									pos:        position{line: 1621, col: 17, offset: 38135},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1621, col: 21, offset: 38143},
+									pos: position{line: 1621, col: 21, offset: 38139},
 									expr: &charClassMatcher{
-										pos:        position{line: 1621, col: 21, offset: 38143},
+										pos:        position{line: 1621, col: 21, offset: 38139},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11166,9 +11166,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1621, col: 28, offset: 38150},
+									pos: position{line: 1621, col: 28, offset: 38146},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1621, col: 28, offset: 38150},
+										pos:  position{line: 1621, col: 28, offset: 38146},
 										name: "ExponentPart",
 									},
 								},
@@ -11176,30 +11176,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1622, col: 5, offset: 38199},
+						pos: position{line: 1622, col: 5, offset: 38195},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1622, col: 5, offset: 38199},
+							pos: position{line: 1622, col: 5, offset: 38195},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1622, col: 5, offset: 38199},
+									pos: position{line: 1622, col: 5, offset: 38195},
 									expr: &litMatcher{
-										pos:        position{line: 1622, col: 5, offset: 38199},
+										pos:        position{line: 1622, col: 5, offset: 38195},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1622, col: 10, offset: 38204},
+									pos:        position{line: 1622, col: 10, offset: 38200},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1622, col: 14, offset: 38208},
+									pos: position{line: 1622, col: 14, offset: 38204},
 									expr: &charClassMatcher{
-										pos:        position{line: 1622, col: 14, offset: 38208},
+										pos:        position{line: 1622, col: 14, offset: 38204},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11207,9 +11207,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1622, col: 21, offset: 38215},
+									pos: position{line: 1622, col: 21, offset: 38211},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1622, col: 21, offset: 38215},
+										pos:  position{line: 1622, col: 21, offset: 38211},
 										name: "ExponentPart",
 									},
 								},
@@ -11217,17 +11217,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1623, col: 5, offset: 38264},
+						pos: position{line: 1623, col: 5, offset: 38260},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1623, col: 6, offset: 38265},
+							pos: position{line: 1623, col: 6, offset: 38261},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1623, col: 6, offset: 38265},
+									pos:  position{line: 1623, col: 6, offset: 38261},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1623, col: 12, offset: 38271},
+									pos:  position{line: 1623, col: 12, offset: 38267},
 									name: "Infinity",
 								},
 							},
@@ -11240,20 +11240,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1626, col: 1, offset: 38314},
+			pos:  position{line: 1626, col: 1, offset: 38310},
 			expr: &seqExpr{
-				pos: position{line: 1626, col: 16, offset: 38329},
+				pos: position{line: 1626, col: 16, offset: 38325},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1626, col: 16, offset: 38329},
+						pos:        position{line: 1626, col: 16, offset: 38325},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1626, col: 21, offset: 38334},
+						pos: position{line: 1626, col: 21, offset: 38330},
 						expr: &charClassMatcher{
-							pos:        position{line: 1626, col: 21, offset: 38334},
+							pos:        position{line: 1626, col: 21, offset: 38330},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11261,7 +11261,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1626, col: 27, offset: 38340},
+						pos:  position{line: 1626, col: 27, offset: 38336},
 						name: "UIntString",
 					},
 				},
@@ -11271,9 +11271,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1628, col: 1, offset: 38352},
+			pos:  position{line: 1628, col: 1, offset: 38348},
 			expr: &litMatcher{
-				pos:        position{line: 1628, col: 7, offset: 38358},
+				pos:        position{line: 1628, col: 7, offset: 38354},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11283,23 +11283,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1630, col: 1, offset: 38365},
+			pos:  position{line: 1630, col: 1, offset: 38361},
 			expr: &seqExpr{
-				pos: position{line: 1630, col: 12, offset: 38376},
+				pos: position{line: 1630, col: 12, offset: 38372},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1630, col: 12, offset: 38376},
+						pos: position{line: 1630, col: 12, offset: 38372},
 						expr: &choiceExpr{
-							pos: position{line: 1630, col: 13, offset: 38377},
+							pos: position{line: 1630, col: 13, offset: 38373},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1630, col: 13, offset: 38377},
+									pos:        position{line: 1630, col: 13, offset: 38373},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1630, col: 19, offset: 38383},
+									pos:        position{line: 1630, col: 19, offset: 38379},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11308,7 +11308,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1630, col: 25, offset: 38389},
+						pos:        position{line: 1630, col: 25, offset: 38385},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11320,14 +11320,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1632, col: 1, offset: 38396},
+			pos:  position{line: 1632, col: 1, offset: 38392},
 			expr: &actionExpr{
-				pos: position{line: 1632, col: 7, offset: 38402},
+				pos: position{line: 1632, col: 7, offset: 38398},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1632, col: 7, offset: 38402},
+					pos: position{line: 1632, col: 7, offset: 38398},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1632, col: 7, offset: 38402},
+						pos:  position{line: 1632, col: 7, offset: 38398},
 						name: "HexDigit",
 					},
 				},
@@ -11337,9 +11337,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1634, col: 1, offset: 38444},
+			pos:  position{line: 1634, col: 1, offset: 38440},
 			expr: &charClassMatcher{
-				pos:        position{line: 1634, col: 12, offset: 38455},
+				pos:        position{line: 1634, col: 12, offset: 38451},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11350,32 +11350,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1636, col: 1, offset: 38468},
+			pos:  position{line: 1636, col: 1, offset: 38464},
 			expr: &actionExpr{
-				pos: position{line: 1637, col: 5, offset: 38491},
+				pos: position{line: 1637, col: 5, offset: 38487},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1637, col: 5, offset: 38491},
+					pos: position{line: 1637, col: 5, offset: 38487},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1637, col: 5, offset: 38491},
+							pos:        position{line: 1637, col: 5, offset: 38487},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1637, col: 9, offset: 38495},
+							pos:   position{line: 1637, col: 9, offset: 38491},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1637, col: 11, offset: 38497},
+								pos: position{line: 1637, col: 11, offset: 38493},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1637, col: 11, offset: 38497},
+									pos:  position{line: 1637, col: 11, offset: 38493},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1637, col: 29, offset: 38515},
+							pos:        position{line: 1637, col: 29, offset: 38511},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11388,32 +11388,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1639, col: 1, offset: 38549},
+			pos:  position{line: 1639, col: 1, offset: 38545},
 			expr: &actionExpr{
-				pos: position{line: 1640, col: 5, offset: 38572},
+				pos: position{line: 1640, col: 5, offset: 38568},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1640, col: 5, offset: 38572},
+					pos: position{line: 1640, col: 5, offset: 38568},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1640, col: 5, offset: 38572},
+							pos:        position{line: 1640, col: 5, offset: 38568},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1640, col: 9, offset: 38576},
+							pos:   position{line: 1640, col: 9, offset: 38572},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1640, col: 11, offset: 38578},
+								pos: position{line: 1640, col: 11, offset: 38574},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1640, col: 11, offset: 38578},
+									pos:  position{line: 1640, col: 11, offset: 38574},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1640, col: 29, offset: 38596},
+							pos:        position{line: 1640, col: 29, offset: 38592},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11426,57 +11426,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1642, col: 1, offset: 38630},
+			pos:  position{line: 1642, col: 1, offset: 38626},
 			expr: &choiceExpr{
-				pos: position{line: 1643, col: 5, offset: 38651},
+				pos: position{line: 1643, col: 5, offset: 38647},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1643, col: 5, offset: 38651},
+						pos: position{line: 1643, col: 5, offset: 38647},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1643, col: 5, offset: 38651},
+							pos: position{line: 1643, col: 5, offset: 38647},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1643, col: 5, offset: 38651},
+									pos: position{line: 1643, col: 5, offset: 38647},
 									expr: &choiceExpr{
-										pos: position{line: 1643, col: 7, offset: 38653},
+										pos: position{line: 1643, col: 7, offset: 38649},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1643, col: 7, offset: 38653},
+												pos:        position{line: 1643, col: 7, offset: 38649},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1643, col: 13, offset: 38659},
+												pos:  position{line: 1643, col: 13, offset: 38655},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1643, col: 26, offset: 38672,
+									line: 1643, col: 26, offset: 38668,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1644, col: 5, offset: 38709},
+						pos: position{line: 1644, col: 5, offset: 38705},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1644, col: 5, offset: 38709},
+							pos: position{line: 1644, col: 5, offset: 38705},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1644, col: 5, offset: 38709},
+									pos:        position{line: 1644, col: 5, offset: 38705},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1644, col: 10, offset: 38714},
+									pos:   position{line: 1644, col: 10, offset: 38710},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1644, col: 12, offset: 38716},
+										pos:  position{line: 1644, col: 12, offset: 38712},
 										name: "EscapeSequence",
 									},
 								},
@@ -11490,32 +11490,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1646, col: 1, offset: 38750},
+			pos:  position{line: 1646, col: 1, offset: 38746},
 			expr: &choiceExpr{
-				pos: position{line: 1647, col: 5, offset: 38762},
+				pos: position{line: 1647, col: 5, offset: 38758},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1647, col: 5, offset: 38762},
+						pos: position{line: 1647, col: 5, offset: 38758},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1647, col: 5, offset: 38762},
+							pos: position{line: 1647, col: 5, offset: 38758},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1647, col: 5, offset: 38762},
+									pos:        position{line: 1647, col: 5, offset: 38758},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1647, col: 10, offset: 38767},
+									pos:   position{line: 1647, col: 10, offset: 38763},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1647, col: 12, offset: 38769},
+										pos:  position{line: 1647, col: 12, offset: 38765},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1647, col: 27, offset: 38784},
+									pos:        position{line: 1647, col: 27, offset: 38780},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11524,33 +11524,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1648, col: 5, offset: 38819},
+						pos: position{line: 1648, col: 5, offset: 38815},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1648, col: 5, offset: 38819},
+							pos: position{line: 1648, col: 5, offset: 38815},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1648, col: 5, offset: 38819},
+									pos:        position{line: 1648, col: 5, offset: 38815},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1648, col: 9, offset: 38823},
+									pos:        position{line: 1648, col: 9, offset: 38819},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1648, col: 13, offset: 38827},
+									pos:   position{line: 1648, col: 13, offset: 38823},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1648, col: 15, offset: 38829},
+										pos:  position{line: 1648, col: 15, offset: 38825},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1648, col: 30, offset: 38844},
+									pos:        position{line: 1648, col: 30, offset: 38840},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11565,26 +11565,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1650, col: 1, offset: 38876},
+			pos:  position{line: 1650, col: 1, offset: 38872},
 			expr: &actionExpr{
-				pos: position{line: 1651, col: 5, offset: 38895},
+				pos: position{line: 1651, col: 5, offset: 38891},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1651, col: 5, offset: 38895},
+					pos: position{line: 1651, col: 5, offset: 38891},
 					expr: &seqExpr{
-						pos: position{line: 1651, col: 6, offset: 38896},
+						pos: position{line: 1651, col: 6, offset: 38892},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1651, col: 6, offset: 38896},
+								pos: position{line: 1651, col: 6, offset: 38892},
 								expr: &litMatcher{
-									pos:        position{line: 1651, col: 7, offset: 38897},
+									pos:        position{line: 1651, col: 7, offset: 38893},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1651, col: 11, offset: 38901,
+								line: 1651, col: 11, offset: 38897,
 							},
 						},
 					},
@@ -11595,26 +11595,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1653, col: 1, offset: 38937},
+			pos:  position{line: 1653, col: 1, offset: 38933},
 			expr: &actionExpr{
-				pos: position{line: 1654, col: 5, offset: 38956},
+				pos: position{line: 1654, col: 5, offset: 38952},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1654, col: 5, offset: 38956},
+					pos: position{line: 1654, col: 5, offset: 38952},
 					expr: &seqExpr{
-						pos: position{line: 1654, col: 6, offset: 38957},
+						pos: position{line: 1654, col: 6, offset: 38953},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1654, col: 6, offset: 38957},
+								pos: position{line: 1654, col: 6, offset: 38953},
 								expr: &litMatcher{
-									pos:        position{line: 1654, col: 7, offset: 38958},
+									pos:        position{line: 1654, col: 7, offset: 38954},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1654, col: 11, offset: 38962,
+								line: 1654, col: 11, offset: 38958,
 							},
 						},
 					},
@@ -11625,32 +11625,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1656, col: 1, offset: 38998},
+			pos:  position{line: 1656, col: 1, offset: 38994},
 			expr: &actionExpr{
-				pos: position{line: 1657, col: 5, offset: 39017},
+				pos: position{line: 1657, col: 5, offset: 39013},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1657, col: 5, offset: 39017},
+					pos: position{line: 1657, col: 5, offset: 39013},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1657, col: 5, offset: 39017},
+							pos:        position{line: 1657, col: 5, offset: 39013},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1657, col: 9, offset: 39021},
+							pos:   position{line: 1657, col: 9, offset: 39017},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1657, col: 11, offset: 39023},
+								pos: position{line: 1657, col: 11, offset: 39019},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1657, col: 11, offset: 39023},
+									pos:  position{line: 1657, col: 11, offset: 39019},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1657, col: 25, offset: 39037},
+							pos:        position{line: 1657, col: 25, offset: 39033},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11663,57 +11663,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1659, col: 1, offset: 39071},
+			pos:  position{line: 1659, col: 1, offset: 39067},
 			expr: &choiceExpr{
-				pos: position{line: 1660, col: 5, offset: 39088},
+				pos: position{line: 1660, col: 5, offset: 39084},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1660, col: 5, offset: 39088},
+						pos: position{line: 1660, col: 5, offset: 39084},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1660, col: 5, offset: 39088},
+							pos: position{line: 1660, col: 5, offset: 39084},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1660, col: 5, offset: 39088},
+									pos: position{line: 1660, col: 5, offset: 39084},
 									expr: &choiceExpr{
-										pos: position{line: 1660, col: 7, offset: 39090},
+										pos: position{line: 1660, col: 7, offset: 39086},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1660, col: 7, offset: 39090},
+												pos:        position{line: 1660, col: 7, offset: 39086},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1660, col: 13, offset: 39096},
+												pos:  position{line: 1660, col: 13, offset: 39092},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1660, col: 26, offset: 39109,
+									line: 1660, col: 26, offset: 39105,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1661, col: 5, offset: 39146},
+						pos: position{line: 1661, col: 5, offset: 39142},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1661, col: 5, offset: 39146},
+							pos: position{line: 1661, col: 5, offset: 39142},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1661, col: 5, offset: 39146},
+									pos:        position{line: 1661, col: 5, offset: 39142},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1661, col: 10, offset: 39151},
+									pos:   position{line: 1661, col: 10, offset: 39147},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1661, col: 12, offset: 39153},
+										pos:  position{line: 1661, col: 12, offset: 39149},
 										name: "EscapeSequence",
 									},
 								},
@@ -11727,28 +11727,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1663, col: 1, offset: 39187},
+			pos:  position{line: 1663, col: 1, offset: 39183},
 			expr: &actionExpr{
-				pos: position{line: 1664, col: 5, offset: 39199},
+				pos: position{line: 1664, col: 5, offset: 39195},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1664, col: 5, offset: 39199},
+					pos: position{line: 1664, col: 5, offset: 39195},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1664, col: 5, offset: 39199},
+							pos:   position{line: 1664, col: 5, offset: 39195},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1664, col: 10, offset: 39204},
+								pos:  position{line: 1664, col: 10, offset: 39200},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1664, col: 23, offset: 39217},
+							pos:   position{line: 1664, col: 23, offset: 39213},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1664, col: 28, offset: 39222},
+								pos: position{line: 1664, col: 28, offset: 39218},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1664, col: 28, offset: 39222},
+									pos:  position{line: 1664, col: 28, offset: 39218},
 									name: "KeyWordRest",
 								},
 							},
@@ -11761,16 +11761,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1666, col: 1, offset: 39284},
+			pos:  position{line: 1666, col: 1, offset: 39280},
 			expr: &choiceExpr{
-				pos: position{line: 1667, col: 5, offset: 39301},
+				pos: position{line: 1667, col: 5, offset: 39297},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1667, col: 5, offset: 39301},
+						pos:  position{line: 1667, col: 5, offset: 39297},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1668, col: 5, offset: 39318},
+						pos:  position{line: 1668, col: 5, offset: 39314},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11780,16 +11780,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1670, col: 1, offset: 39330},
+			pos:  position{line: 1670, col: 1, offset: 39326},
 			expr: &choiceExpr{
-				pos: position{line: 1671, col: 5, offset: 39346},
+				pos: position{line: 1671, col: 5, offset: 39342},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1671, col: 5, offset: 39346},
+						pos:  position{line: 1671, col: 5, offset: 39342},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1672, col: 5, offset: 39363},
+						pos:        position{line: 1672, col: 5, offset: 39359},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11802,19 +11802,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1674, col: 1, offset: 39370},
+			pos:  position{line: 1674, col: 1, offset: 39366},
 			expr: &actionExpr{
-				pos: position{line: 1674, col: 16, offset: 39385},
+				pos: position{line: 1674, col: 16, offset: 39381},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1674, col: 17, offset: 39386},
+					pos: position{line: 1674, col: 17, offset: 39382},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1674, col: 17, offset: 39386},
+							pos:  position{line: 1674, col: 17, offset: 39382},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1674, col: 33, offset: 39402},
+							pos:        position{line: 1674, col: 33, offset: 39398},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11828,31 +11828,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1676, col: 1, offset: 39446},
+			pos:  position{line: 1676, col: 1, offset: 39442},
 			expr: &actionExpr{
-				pos: position{line: 1676, col: 14, offset: 39459},
+				pos: position{line: 1676, col: 14, offset: 39455},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1676, col: 14, offset: 39459},
+					pos: position{line: 1676, col: 14, offset: 39455},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1676, col: 14, offset: 39459},
+							pos:        position{line: 1676, col: 14, offset: 39455},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1676, col: 19, offset: 39464},
+							pos:   position{line: 1676, col: 19, offset: 39460},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1676, col: 22, offset: 39467},
+								pos: position{line: 1676, col: 22, offset: 39463},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1676, col: 22, offset: 39467},
+										pos:  position{line: 1676, col: 22, offset: 39463},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1676, col: 38, offset: 39483},
+										pos:  position{line: 1676, col: 38, offset: 39479},
 										name: "EscapeSequence",
 									},
 								},
@@ -11866,42 +11866,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1678, col: 1, offset: 39518},
+			pos:  position{line: 1678, col: 1, offset: 39514},
 			expr: &actionExpr{
-				pos: position{line: 1679, col: 5, offset: 39534},
+				pos: position{line: 1679, col: 5, offset: 39530},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1679, col: 5, offset: 39534},
+					pos: position{line: 1679, col: 5, offset: 39530},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1679, col: 5, offset: 39534},
+							pos: position{line: 1679, col: 5, offset: 39530},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 6, offset: 39535},
+								pos:  position{line: 1679, col: 6, offset: 39531},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1679, col: 22, offset: 39551},
+							pos: position{line: 1679, col: 22, offset: 39547},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 23, offset: 39552},
+								pos:  position{line: 1679, col: 23, offset: 39548},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1679, col: 35, offset: 39564},
+							pos:   position{line: 1679, col: 35, offset: 39560},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 40, offset: 39569},
+								pos:  position{line: 1679, col: 40, offset: 39565},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1679, col: 50, offset: 39579},
+							pos:   position{line: 1679, col: 50, offset: 39575},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1679, col: 55, offset: 39584},
+								pos: position{line: 1679, col: 55, offset: 39580},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1679, col: 55, offset: 39584},
+									pos:  position{line: 1679, col: 55, offset: 39580},
 									name: "GlobRest",
 								},
 							},
@@ -11914,28 +11914,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1683, col: 1, offset: 39653},
+			pos:  position{line: 1683, col: 1, offset: 39649},
 			expr: &choiceExpr{
-				pos: position{line: 1683, col: 19, offset: 39671},
+				pos: position{line: 1683, col: 19, offset: 39667},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1683, col: 19, offset: 39671},
+						pos:  position{line: 1683, col: 19, offset: 39667},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1683, col: 34, offset: 39686},
+						pos: position{line: 1683, col: 34, offset: 39682},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1683, col: 34, offset: 39686},
+								pos: position{line: 1683, col: 34, offset: 39682},
 								expr: &litMatcher{
-									pos:        position{line: 1683, col: 34, offset: 39686},
+									pos:        position{line: 1683, col: 34, offset: 39682},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1683, col: 39, offset: 39691},
+								pos:  position{line: 1683, col: 39, offset: 39687},
 								name: "KeyWordRest",
 							},
 						},
@@ -11947,19 +11947,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1684, col: 1, offset: 39703},
+			pos:  position{line: 1684, col: 1, offset: 39699},
 			expr: &seqExpr{
-				pos: position{line: 1684, col: 15, offset: 39717},
+				pos: position{line: 1684, col: 15, offset: 39713},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1684, col: 15, offset: 39717},
+						pos: position{line: 1684, col: 15, offset: 39713},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1684, col: 15, offset: 39717},
+							pos:  position{line: 1684, col: 15, offset: 39713},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1684, col: 28, offset: 39730},
+						pos:        position{line: 1684, col: 28, offset: 39726},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11971,23 +11971,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1686, col: 1, offset: 39735},
+			pos:  position{line: 1686, col: 1, offset: 39731},
 			expr: &choiceExpr{
-				pos: position{line: 1687, col: 5, offset: 39749},
+				pos: position{line: 1687, col: 5, offset: 39745},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1687, col: 5, offset: 39749},
+						pos:  position{line: 1687, col: 5, offset: 39745},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1688, col: 5, offset: 39766},
+						pos:  position{line: 1688, col: 5, offset: 39762},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1689, col: 5, offset: 39778},
+						pos: position{line: 1689, col: 5, offset: 39774},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1689, col: 5, offset: 39778},
+							pos:        position{line: 1689, col: 5, offset: 39774},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12000,16 +12000,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1691, col: 1, offset: 39803},
+			pos:  position{line: 1691, col: 1, offset: 39799},
 			expr: &choiceExpr{
-				pos: position{line: 1692, col: 5, offset: 39816},
+				pos: position{line: 1692, col: 5, offset: 39812},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1692, col: 5, offset: 39816},
+						pos:  position{line: 1692, col: 5, offset: 39812},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1693, col: 5, offset: 39830},
+						pos:        position{line: 1693, col: 5, offset: 39826},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12022,31 +12022,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1695, col: 1, offset: 39837},
+			pos:  position{line: 1695, col: 1, offset: 39833},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 11, offset: 39847},
+				pos: position{line: 1695, col: 11, offset: 39843},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1695, col: 11, offset: 39847},
+					pos: position{line: 1695, col: 11, offset: 39843},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1695, col: 11, offset: 39847},
+							pos:        position{line: 1695, col: 11, offset: 39843},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1695, col: 16, offset: 39852},
+							pos:   position{line: 1695, col: 16, offset: 39848},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1695, col: 19, offset: 39855},
+								pos: position{line: 1695, col: 19, offset: 39851},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1695, col: 19, offset: 39855},
+										pos:  position{line: 1695, col: 19, offset: 39851},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1695, col: 32, offset: 39868},
+										pos:  position{line: 1695, col: 32, offset: 39864},
 										name: "EscapeSequence",
 									},
 								},
@@ -12060,32 +12060,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1697, col: 1, offset: 39903},
+			pos:  position{line: 1697, col: 1, offset: 39899},
 			expr: &choiceExpr{
-				pos: position{line: 1698, col: 5, offset: 39918},
+				pos: position{line: 1698, col: 5, offset: 39914},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1698, col: 5, offset: 39918},
+						pos: position{line: 1698, col: 5, offset: 39914},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1698, col: 5, offset: 39918},
+							pos:        position{line: 1698, col: 5, offset: 39914},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1699, col: 5, offset: 39946},
+						pos: position{line: 1699, col: 5, offset: 39942},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1699, col: 5, offset: 39946},
+							pos:        position{line: 1699, col: 5, offset: 39942},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1700, col: 5, offset: 39976},
+						pos:        position{line: 1700, col: 5, offset: 39972},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12098,57 +12098,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1702, col: 1, offset: 39982},
+			pos:  position{line: 1702, col: 1, offset: 39978},
 			expr: &choiceExpr{
-				pos: position{line: 1703, col: 5, offset: 40003},
+				pos: position{line: 1703, col: 5, offset: 39999},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1703, col: 5, offset: 40003},
+						pos: position{line: 1703, col: 5, offset: 39999},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1703, col: 5, offset: 40003},
+							pos: position{line: 1703, col: 5, offset: 39999},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1703, col: 5, offset: 40003},
+									pos: position{line: 1703, col: 5, offset: 39999},
 									expr: &choiceExpr{
-										pos: position{line: 1703, col: 7, offset: 40005},
+										pos: position{line: 1703, col: 7, offset: 40001},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1703, col: 7, offset: 40005},
+												pos:        position{line: 1703, col: 7, offset: 40001},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1703, col: 13, offset: 40011},
+												pos:  position{line: 1703, col: 13, offset: 40007},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1703, col: 26, offset: 40024,
+									line: 1703, col: 26, offset: 40020,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1704, col: 5, offset: 40061},
+						pos: position{line: 1704, col: 5, offset: 40057},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1704, col: 5, offset: 40061},
+							pos: position{line: 1704, col: 5, offset: 40057},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1704, col: 5, offset: 40061},
+									pos:        position{line: 1704, col: 5, offset: 40057},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1704, col: 10, offset: 40066},
+									pos:   position{line: 1704, col: 10, offset: 40062},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1704, col: 12, offset: 40068},
+										pos:  position{line: 1704, col: 12, offset: 40064},
 										name: "EscapeSequence",
 									},
 								},
@@ -12162,16 +12162,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1706, col: 1, offset: 40102},
+			pos:  position{line: 1706, col: 1, offset: 40098},
 			expr: &choiceExpr{
-				pos: position{line: 1707, col: 5, offset: 40121},
+				pos: position{line: 1707, col: 5, offset: 40117},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1707, col: 5, offset: 40121},
+						pos:  position{line: 1707, col: 5, offset: 40117},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1708, col: 5, offset: 40142},
+						pos:  position{line: 1708, col: 5, offset: 40138},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12181,87 +12181,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1710, col: 1, offset: 40157},
+			pos:  position{line: 1710, col: 1, offset: 40153},
 			expr: &choiceExpr{
-				pos: position{line: 1711, col: 5, offset: 40178},
+				pos: position{line: 1711, col: 5, offset: 40174},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1711, col: 5, offset: 40178},
+						pos:        position{line: 1711, col: 5, offset: 40174},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1712, col: 5, offset: 40186},
+						pos: position{line: 1712, col: 5, offset: 40182},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1712, col: 5, offset: 40186},
+							pos:        position{line: 1712, col: 5, offset: 40182},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1713, col: 5, offset: 40226},
+						pos:        position{line: 1713, col: 5, offset: 40222},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1714, col: 5, offset: 40235},
+						pos: position{line: 1714, col: 5, offset: 40231},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1714, col: 5, offset: 40235},
+							pos:        position{line: 1714, col: 5, offset: 40231},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1715, col: 5, offset: 40264},
+						pos: position{line: 1715, col: 5, offset: 40260},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1715, col: 5, offset: 40264},
+							pos:        position{line: 1715, col: 5, offset: 40260},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1716, col: 5, offset: 40293},
+						pos: position{line: 1716, col: 5, offset: 40289},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1716, col: 5, offset: 40293},
+							pos:        position{line: 1716, col: 5, offset: 40289},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1717, col: 5, offset: 40322},
+						pos: position{line: 1717, col: 5, offset: 40318},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1717, col: 5, offset: 40322},
+							pos:        position{line: 1717, col: 5, offset: 40318},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1718, col: 5, offset: 40351},
+						pos: position{line: 1718, col: 5, offset: 40347},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1718, col: 5, offset: 40351},
+							pos:        position{line: 1718, col: 5, offset: 40347},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1719, col: 5, offset: 40380},
+						pos: position{line: 1719, col: 5, offset: 40376},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1719, col: 5, offset: 40380},
+							pos:        position{line: 1719, col: 5, offset: 40376},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12274,32 +12274,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1721, col: 1, offset: 40406},
+			pos:  position{line: 1721, col: 1, offset: 40402},
 			expr: &choiceExpr{
-				pos: position{line: 1722, col: 5, offset: 40424},
+				pos: position{line: 1722, col: 5, offset: 40420},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1722, col: 5, offset: 40424},
+						pos: position{line: 1722, col: 5, offset: 40420},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1722, col: 5, offset: 40424},
+							pos:        position{line: 1722, col: 5, offset: 40420},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1723, col: 5, offset: 40452},
+						pos: position{line: 1723, col: 5, offset: 40448},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1723, col: 5, offset: 40452},
+							pos:        position{line: 1723, col: 5, offset: 40448},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1724, col: 5, offset: 40480},
+						pos:        position{line: 1724, col: 5, offset: 40476},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12312,42 +12312,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1726, col: 1, offset: 40486},
+			pos:  position{line: 1726, col: 1, offset: 40482},
 			expr: &choiceExpr{
-				pos: position{line: 1727, col: 5, offset: 40504},
+				pos: position{line: 1727, col: 5, offset: 40500},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1727, col: 5, offset: 40504},
+						pos: position{line: 1727, col: 5, offset: 40500},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1727, col: 5, offset: 40504},
+							pos: position{line: 1727, col: 5, offset: 40500},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1727, col: 5, offset: 40504},
+									pos:        position{line: 1727, col: 5, offset: 40500},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1727, col: 9, offset: 40508},
+									pos:   position{line: 1727, col: 9, offset: 40504},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1727, col: 16, offset: 40515},
+										pos: position{line: 1727, col: 16, offset: 40511},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1727, col: 16, offset: 40515},
+												pos:  position{line: 1727, col: 16, offset: 40511},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1727, col: 25, offset: 40524},
+												pos:  position{line: 1727, col: 25, offset: 40520},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1727, col: 34, offset: 40533},
+												pos:  position{line: 1727, col: 34, offset: 40529},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1727, col: 43, offset: 40542},
+												pos:  position{line: 1727, col: 43, offset: 40538},
 												name: "HexDigit",
 											},
 										},
@@ -12357,65 +12357,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1730, col: 5, offset: 40605},
+						pos: position{line: 1730, col: 5, offset: 40601},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1730, col: 5, offset: 40605},
+							pos: position{line: 1730, col: 5, offset: 40601},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1730, col: 5, offset: 40605},
+									pos:        position{line: 1730, col: 5, offset: 40601},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1730, col: 9, offset: 40609},
+									pos:        position{line: 1730, col: 9, offset: 40605},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1730, col: 13, offset: 40613},
+									pos:   position{line: 1730, col: 13, offset: 40609},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1730, col: 20, offset: 40620},
+										pos: position{line: 1730, col: 20, offset: 40616},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1730, col: 20, offset: 40620},
+												pos:  position{line: 1730, col: 20, offset: 40616},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 29, offset: 40629},
+												pos: position{line: 1730, col: 29, offset: 40625},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 29, offset: 40629},
+													pos:  position{line: 1730, col: 29, offset: 40625},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 39, offset: 40639},
+												pos: position{line: 1730, col: 39, offset: 40635},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 39, offset: 40639},
+													pos:  position{line: 1730, col: 39, offset: 40635},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 49, offset: 40649},
+												pos: position{line: 1730, col: 49, offset: 40645},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 49, offset: 40649},
+													pos:  position{line: 1730, col: 49, offset: 40645},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 59, offset: 40659},
+												pos: position{line: 1730, col: 59, offset: 40655},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 59, offset: 40659},
+													pos:  position{line: 1730, col: 59, offset: 40655},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 69, offset: 40669},
+												pos: position{line: 1730, col: 69, offset: 40665},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 69, offset: 40669},
+													pos:  position{line: 1730, col: 69, offset: 40665},
 													name: "HexDigit",
 												},
 											},
@@ -12423,7 +12423,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1730, col: 80, offset: 40680},
+									pos:        position{line: 1730, col: 80, offset: 40676},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12438,9 +12438,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1735, col: 1, offset: 40735},
+			pos:  position{line: 1735, col: 1, offset: 40731},
 			expr: &charClassMatcher{
-				pos:        position{line: 1736, col: 5, offset: 40751},
+				pos:        position{line: 1736, col: 5, offset: 40747},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12452,11 +12452,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1738, col: 1, offset: 40766},
+			pos:  position{line: 1738, col: 1, offset: 40762},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1738, col: 5, offset: 40770},
+				pos: position{line: 1738, col: 5, offset: 40766},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1738, col: 5, offset: 40770},
+					pos:  position{line: 1738, col: 5, offset: 40766},
 					name: "AnySpace",
 				},
 			},
@@ -12465,11 +12465,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1740, col: 1, offset: 40781},
+			pos:  position{line: 1740, col: 1, offset: 40777},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1740, col: 6, offset: 40786},
+				pos: position{line: 1740, col: 6, offset: 40782},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1740, col: 6, offset: 40786},
+					pos:  position{line: 1740, col: 6, offset: 40782},
 					name: "AnySpace",
 				},
 			},
@@ -12478,20 +12478,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1742, col: 1, offset: 40797},
+			pos:  position{line: 1742, col: 1, offset: 40793},
 			expr: &choiceExpr{
-				pos: position{line: 1743, col: 5, offset: 40810},
+				pos: position{line: 1743, col: 5, offset: 40806},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1743, col: 5, offset: 40810},
+						pos:  position{line: 1743, col: 5, offset: 40806},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 5, offset: 40825},
+						pos:  position{line: 1744, col: 5, offset: 40821},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1745, col: 5, offset: 40844},
+						pos:  position{line: 1745, col: 5, offset: 40840},
 						name: "Comment",
 					},
 				},
@@ -12501,32 +12501,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1747, col: 1, offset: 40853},
+			pos:  position{line: 1747, col: 1, offset: 40849},
 			expr: &choiceExpr{
-				pos: position{line: 1748, col: 5, offset: 40871},
+				pos: position{line: 1748, col: 5, offset: 40867},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1748, col: 5, offset: 40871},
+						pos:  position{line: 1748, col: 5, offset: 40867},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1749, col: 5, offset: 40878},
+						pos:  position{line: 1749, col: 5, offset: 40874},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1750, col: 5, offset: 40885},
+						pos:  position{line: 1750, col: 5, offset: 40881},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1751, col: 5, offset: 40892},
+						pos:  position{line: 1751, col: 5, offset: 40888},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1752, col: 5, offset: 40899},
+						pos:  position{line: 1752, col: 5, offset: 40895},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1753, col: 5, offset: 40906},
+						pos:  position{line: 1753, col: 5, offset: 40902},
 						name: "Nl",
 					},
 				},
@@ -12536,16 +12536,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1755, col: 1, offset: 40910},
+			pos:  position{line: 1755, col: 1, offset: 40906},
 			expr: &choiceExpr{
-				pos: position{line: 1756, col: 5, offset: 40935},
+				pos: position{line: 1756, col: 5, offset: 40931},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1756, col: 5, offset: 40935},
+						pos:  position{line: 1756, col: 5, offset: 40931},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1757, col: 5, offset: 40942},
+						pos:  position{line: 1757, col: 5, offset: 40938},
 						name: "Mc",
 					},
 				},
@@ -12555,9 +12555,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1759, col: 1, offset: 40946},
+			pos:  position{line: 1759, col: 1, offset: 40942},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1760, col: 5, offset: 40963},
+				pos:  position{line: 1760, col: 5, offset: 40959},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12565,9 +12565,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1762, col: 1, offset: 40967},
+			pos:  position{line: 1762, col: 1, offset: 40963},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1763, col: 5, offset: 40999},
+				pos:  position{line: 1763, col: 5, offset: 40995},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12575,9 +12575,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1769, col: 1, offset: 41180},
+			pos:  position{line: 1769, col: 1, offset: 41176},
 			expr: &charClassMatcher{
-				pos:        position{line: 1769, col: 6, offset: 41185},
+				pos:        position{line: 1769, col: 6, offset: 41181},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12589,9 +12589,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1772, col: 1, offset: 45337},
+			pos:  position{line: 1772, col: 1, offset: 45333},
 			expr: &charClassMatcher{
-				pos:        position{line: 1772, col: 6, offset: 45342},
+				pos:        position{line: 1772, col: 6, offset: 45338},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12603,9 +12603,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1775, col: 1, offset: 45827},
+			pos:  position{line: 1775, col: 1, offset: 45823},
 			expr: &charClassMatcher{
-				pos:        position{line: 1775, col: 6, offset: 45832},
+				pos:        position{line: 1775, col: 6, offset: 45828},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12617,9 +12617,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1778, col: 1, offset: 49279},
+			pos:  position{line: 1778, col: 1, offset: 49275},
 			expr: &charClassMatcher{
-				pos:        position{line: 1778, col: 6, offset: 49284},
+				pos:        position{line: 1778, col: 6, offset: 49280},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12631,9 +12631,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1781, col: 1, offset: 49390},
+			pos:  position{line: 1781, col: 1, offset: 49386},
 			expr: &charClassMatcher{
-				pos:        position{line: 1781, col: 6, offset: 49395},
+				pos:        position{line: 1781, col: 6, offset: 49391},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12645,9 +12645,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1784, col: 1, offset: 53396},
+			pos:  position{line: 1784, col: 1, offset: 53392},
 			expr: &charClassMatcher{
-				pos:        position{line: 1784, col: 6, offset: 53401},
+				pos:        position{line: 1784, col: 6, offset: 53397},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12659,9 +12659,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1787, col: 1, offset: 54589},
+			pos:  position{line: 1787, col: 1, offset: 54585},
 			expr: &charClassMatcher{
-				pos:        position{line: 1787, col: 6, offset: 54594},
+				pos:        position{line: 1787, col: 6, offset: 54590},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12673,9 +12673,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1790, col: 1, offset: 56774},
+			pos:  position{line: 1790, col: 1, offset: 56770},
 			expr: &charClassMatcher{
-				pos:        position{line: 1790, col: 6, offset: 56779},
+				pos:        position{line: 1790, col: 6, offset: 56775},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12686,9 +12686,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1793, col: 1, offset: 57282},
+			pos:  position{line: 1793, col: 1, offset: 57278},
 			expr: &charClassMatcher{
-				pos:        position{line: 1793, col: 6, offset: 57287},
+				pos:        position{line: 1793, col: 6, offset: 57283},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12700,9 +12700,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1796, col: 1, offset: 57401},
+			pos:  position{line: 1796, col: 1, offset: 57397},
 			expr: &charClassMatcher{
-				pos:        position{line: 1796, col: 6, offset: 57406},
+				pos:        position{line: 1796, col: 6, offset: 57402},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12714,9 +12714,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1799, col: 1, offset: 57487},
+			pos:  position{line: 1799, col: 1, offset: 57483},
 			expr: &charClassMatcher{
-				pos:        position{line: 1799, col: 6, offset: 57492},
+				pos:        position{line: 1799, col: 6, offset: 57488},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12728,9 +12728,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1801, col: 1, offset: 57545},
+			pos:  position{line: 1801, col: 1, offset: 57541},
 			expr: &anyMatcher{
-				line: 1802, col: 5, offset: 57565,
+				line: 1802, col: 5, offset: 57561,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12738,48 +12738,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1804, col: 1, offset: 57568},
+			pos:         position{line: 1804, col: 1, offset: 57564},
 			expr: &choiceExpr{
-				pos: position{line: 1805, col: 5, offset: 57596},
+				pos: position{line: 1805, col: 5, offset: 57592},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1805, col: 5, offset: 57596},
+						pos:        position{line: 1805, col: 5, offset: 57592},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1806, col: 5, offset: 57605},
+						pos:        position{line: 1806, col: 5, offset: 57601},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1807, col: 5, offset: 57614},
+						pos:        position{line: 1807, col: 5, offset: 57610},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1808, col: 5, offset: 57623},
+						pos:        position{line: 1808, col: 5, offset: 57619},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1809, col: 5, offset: 57631},
+						pos:        position{line: 1809, col: 5, offset: 57627},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1810, col: 5, offset: 57644},
+						pos:        position{line: 1810, col: 5, offset: 57640},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1811, col: 5, offset: 57657},
+						pos:  position{line: 1811, col: 5, offset: 57653},
 						name: "Zs",
 					},
 				},
@@ -12789,9 +12789,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1813, col: 1, offset: 57661},
+			pos:  position{line: 1813, col: 1, offset: 57657},
 			expr: &charClassMatcher{
-				pos:        position{line: 1814, col: 5, offset: 57680},
+				pos:        position{line: 1814, col: 5, offset: 57676},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12803,16 +12803,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1816, col: 1, offset: 57700},
+			pos:         position{line: 1816, col: 1, offset: 57696},
 			expr: &choiceExpr{
-				pos: position{line: 1817, col: 5, offset: 57722},
+				pos: position{line: 1817, col: 5, offset: 57718},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1817, col: 5, offset: 57722},
+						pos:  position{line: 1817, col: 5, offset: 57718},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1818, col: 5, offset: 57743},
+						pos:  position{line: 1818, col: 5, offset: 57739},
 						name: "SingleLineComment",
 					},
 				},
@@ -12822,39 +12822,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1820, col: 1, offset: 57762},
+			pos:  position{line: 1820, col: 1, offset: 57758},
 			expr: &seqExpr{
-				pos: position{line: 1821, col: 5, offset: 57783},
+				pos: position{line: 1821, col: 5, offset: 57779},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1821, col: 5, offset: 57783},
+						pos:        position{line: 1821, col: 5, offset: 57779},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1821, col: 10, offset: 57788},
+						pos: position{line: 1821, col: 10, offset: 57784},
 						expr: &seqExpr{
-							pos: position{line: 1821, col: 11, offset: 57789},
+							pos: position{line: 1821, col: 11, offset: 57785},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1821, col: 11, offset: 57789},
+									pos: position{line: 1821, col: 11, offset: 57785},
 									expr: &litMatcher{
-										pos:        position{line: 1821, col: 12, offset: 57790},
+										pos:        position{line: 1821, col: 12, offset: 57786},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1821, col: 17, offset: 57795},
+									pos:  position{line: 1821, col: 17, offset: 57791},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1821, col: 35, offset: 57813},
+						pos:        position{line: 1821, col: 35, offset: 57809},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12866,30 +12866,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1823, col: 1, offset: 57819},
+			pos:  position{line: 1823, col: 1, offset: 57815},
 			expr: &seqExpr{
-				pos: position{line: 1824, col: 5, offset: 57841},
+				pos: position{line: 1824, col: 5, offset: 57837},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1824, col: 5, offset: 57841},
+						pos:        position{line: 1824, col: 5, offset: 57837},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1824, col: 10, offset: 57846},
+						pos: position{line: 1824, col: 10, offset: 57842},
 						expr: &seqExpr{
-							pos: position{line: 1824, col: 11, offset: 57847},
+							pos: position{line: 1824, col: 11, offset: 57843},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1824, col: 11, offset: 57847},
+									pos: position{line: 1824, col: 11, offset: 57843},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1824, col: 12, offset: 57848},
+										pos:  position{line: 1824, col: 12, offset: 57844},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1824, col: 27, offset: 57863},
+									pos:  position{line: 1824, col: 27, offset: 57859},
 									name: "SourceCharacter",
 								},
 							},
@@ -12902,19 +12902,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1826, col: 1, offset: 57882},
+			pos:  position{line: 1826, col: 1, offset: 57878},
 			expr: &seqExpr{
-				pos: position{line: 1826, col: 7, offset: 57888},
+				pos: position{line: 1826, col: 7, offset: 57884},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1826, col: 7, offset: 57888},
+						pos: position{line: 1826, col: 7, offset: 57884},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1826, col: 7, offset: 57888},
+							pos:  position{line: 1826, col: 7, offset: 57884},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1826, col: 19, offset: 57900},
+						pos:  position{line: 1826, col: 19, offset: 57896},
 						name: "LineTerminator",
 					},
 				},
@@ -12924,16 +12924,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1828, col: 1, offset: 57916},
+			pos:  position{line: 1828, col: 1, offset: 57912},
 			expr: &choiceExpr{
-				pos: position{line: 1828, col: 7, offset: 57922},
+				pos: position{line: 1828, col: 7, offset: 57918},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1828, col: 7, offset: 57922},
+						pos:  position{line: 1828, col: 7, offset: 57918},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1828, col: 11, offset: 57926},
+						pos:  position{line: 1828, col: 11, offset: 57922},
 						name: "EOF",
 					},
 				},
@@ -12943,11 +12943,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1830, col: 1, offset: 57931},
+			pos:  position{line: 1830, col: 1, offset: 57927},
 			expr: &notExpr{
-				pos: position{line: 1830, col: 7, offset: 57937},
+				pos: position{line: 1830, col: 7, offset: 57933},
 				expr: &anyMatcher{
-					line: 1830, col: 8, offset: 57938,
+					line: 1830, col: 8, offset: 57934,
 				},
 			},
 			leader:        false,
@@ -12955,11 +12955,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1832, col: 1, offset: 57941},
+			pos:  position{line: 1832, col: 1, offset: 57937},
 			expr: &notExpr{
-				pos: position{line: 1832, col: 8, offset: 57948},
+				pos: position{line: 1832, col: 8, offset: 57944},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1832, col: 9, offset: 57949},
+					pos:  position{line: 1832, col: 9, offset: 57945},
 					name: "KeyWordChars",
 				},
 			},
@@ -12968,15 +12968,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1836, col: 1, offset: 57985},
+			pos:  position{line: 1836, col: 1, offset: 57981},
 			expr: &actionExpr{
-				pos: position{line: 1837, col: 5, offset: 57997},
+				pos: position{line: 1837, col: 5, offset: 57993},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1837, col: 5, offset: 57997},
+					pos:   position{line: 1837, col: 5, offset: 57993},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1837, col: 7, offset: 57999},
+						pos:  position{line: 1837, col: 7, offset: 57995},
 						name: "Seq",
 					},
 				},
@@ -12986,9 +12986,9 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1845, col: 1, offset: 58145},
+			pos:  position{line: 1845, col: 1, offset: 58141},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1845, col: 12, offset: 58156},
+				pos:  position{line: 1845, col: 12, offset: 58152},
 				name: "SelectExpr",
 			},
 			leader:        false,
@@ -12996,73 +12996,73 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1847, col: 1, offset: 58168},
+			pos:  position{line: 1847, col: 1, offset: 58164},
 			expr: &actionExpr{
-				pos: position{line: 1848, col: 5, offset: 58183},
+				pos: position{line: 1848, col: 5, offset: 58179},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1848, col: 5, offset: 58183},
+					pos: position{line: 1848, col: 5, offset: 58179},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1848, col: 5, offset: 58183},
+							pos:   position{line: 1848, col: 5, offset: 58179},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1848, col: 10, offset: 58188},
+								pos:  position{line: 1848, col: 10, offset: 58184},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1849, col: 5, offset: 58206},
+							pos:   position{line: 1849, col: 5, offset: 58202},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1850, col: 9, offset: 58221},
+								pos: position{line: 1850, col: 9, offset: 58217},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1850, col: 9, offset: 58221},
+										pos:  position{line: 1850, col: 9, offset: 58217},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1851, col: 9, offset: 58242},
+										pos:  position{line: 1851, col: 9, offset: 58238},
 										name: "Select",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1852, col: 9, offset: 58257},
+										pos:  position{line: 1852, col: 9, offset: 58253},
 										name: "FromSelect",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1853, col: 9, offset: 58276},
+										pos:  position{line: 1853, col: 9, offset: 58272},
 										name: "SQLValues",
 									},
 									&actionExpr{
-										pos: position{line: 1854, col: 9, offset: 58294},
+										pos: position{line: 1854, col: 9, offset: 58290},
 										run: (*parser).callonSelectExpr11,
 										expr: &seqExpr{
-											pos: position{line: 1854, col: 9, offset: 58294},
+											pos: position{line: 1854, col: 9, offset: 58290},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1854, col: 9, offset: 58294},
+													pos:        position{line: 1854, col: 9, offset: 58290},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1854, col: 13, offset: 58298},
+													pos:  position{line: 1854, col: 13, offset: 58294},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1854, col: 16, offset: 58301},
+													pos:   position{line: 1854, col: 16, offset: 58297},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1854, col: 18, offset: 58303},
+														pos:  position{line: 1854, col: 18, offset: 58299},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1854, col: 26, offset: 58311},
+													pos:  position{line: 1854, col: 26, offset: 58307},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1854, col: 28, offset: 58313},
+													pos:        position{line: 1854, col: 28, offset: 58309},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13074,97 +13074,97 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1856, col: 5, offset: 58350},
+							pos:   position{line: 1856, col: 5, offset: 58346},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1856, col: 13, offset: 58358},
+								pos:  position{line: 1856, col: 13, offset: 58354},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1857, col: 5, offset: 58379},
+							pos:   position{line: 1857, col: 5, offset: 58375},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1857, col: 10, offset: 58384},
+								pos:  position{line: 1857, col: 10, offset: 58380},
 								name: "OptSQLLimitOffset",
 							},
 						},
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1877, col: 1, offset: 58785},
+			pos:  position{line: 1877, col: 1, offset: 58781},
 			expr: &actionExpr{
-				pos: position{line: 1878, col: 5, offset: 58796},
+				pos: position{line: 1878, col: 5, offset: 58792},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1878, col: 5, offset: 58796},
+					pos: position{line: 1878, col: 5, offset: 58792},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1878, col: 5, offset: 58796},
+							pos:  position{line: 1878, col: 5, offset: 58792},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1879, col: 5, offset: 58807},
+							pos:   position{line: 1879, col: 5, offset: 58803},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1879, col: 14, offset: 58816},
+								pos:  position{line: 1879, col: 14, offset: 58812},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1880, col: 5, offset: 58832},
+							pos:   position{line: 1880, col: 5, offset: 58828},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1880, col: 11, offset: 58838},
+								pos:  position{line: 1880, col: 11, offset: 58834},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1883, col: 5, offset: 58977},
+							pos:  position{line: 1883, col: 5, offset: 58973},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1883, col: 7, offset: 58979},
+							pos:   position{line: 1883, col: 7, offset: 58975},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1883, col: 17, offset: 58989},
+								pos:  position{line: 1883, col: 17, offset: 58985},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1884, col: 5, offset: 59003},
+							pos:   position{line: 1884, col: 5, offset: 58999},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1884, col: 10, offset: 59008},
+								pos:  position{line: 1884, col: 10, offset: 59004},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1885, col: 5, offset: 59026},
+							pos:   position{line: 1885, col: 5, offset: 59022},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1885, col: 11, offset: 59032},
+								pos:  position{line: 1885, col: 11, offset: 59028},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1886, col: 5, offset: 59051},
+							pos:   position{line: 1886, col: 5, offset: 59047},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1886, col: 11, offset: 59057},
+								pos:  position{line: 1886, col: 11, offset: 59053},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 5, offset: 59076},
+							pos:   position{line: 1887, col: 5, offset: 59072},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1887, col: 12, offset: 59083},
+								pos:  position{line: 1887, col: 12, offset: 59079},
 								name: "OptHavingClause",
 							},
 						},
@@ -13176,78 +13176,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1913, col: 1, offset: 59698},
+			pos:  position{line: 1913, col: 1, offset: 59694},
 			expr: &actionExpr{
-				pos: position{line: 1914, col: 5, offset: 59713},
+				pos: position{line: 1914, col: 5, offset: 59709},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1914, col: 5, offset: 59713},
+					pos: position{line: 1914, col: 5, offset: 59709},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1914, col: 5, offset: 59713},
+							pos:   position{line: 1914, col: 5, offset: 59709},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1914, col: 10, offset: 59718},
+								pos:  position{line: 1914, col: 10, offset: 59714},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1914, col: 17, offset: 59725},
+							pos:  position{line: 1914, col: 17, offset: 59721},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1914, col: 19, offset: 59727},
+							pos:  position{line: 1914, col: 19, offset: 59723},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1915, col: 5, offset: 59738},
+							pos:   position{line: 1915, col: 5, offset: 59734},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1915, col: 14, offset: 59747},
+								pos:  position{line: 1915, col: 14, offset: 59743},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1916, col: 5, offset: 59763},
+							pos:   position{line: 1916, col: 5, offset: 59759},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1916, col: 11, offset: 59769},
+								pos:  position{line: 1916, col: 11, offset: 59765},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1919, col: 5, offset: 59908},
+							pos:  position{line: 1919, col: 5, offset: 59904},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1919, col: 7, offset: 59910},
+							pos:   position{line: 1919, col: 7, offset: 59906},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1919, col: 17, offset: 59920},
+								pos:  position{line: 1919, col: 17, offset: 59916},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1920, col: 5, offset: 59934},
+							pos:   position{line: 1920, col: 5, offset: 59930},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1920, col: 11, offset: 59940},
+								pos:  position{line: 1920, col: 11, offset: 59936},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1921, col: 5, offset: 59959},
+							pos:   position{line: 1921, col: 5, offset: 59955},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1921, col: 11, offset: 59965},
+								pos:  position{line: 1921, col: 11, offset: 59961},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1922, col: 5, offset: 59984},
+							pos:   position{line: 1922, col: 5, offset: 59980},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1922, col: 12, offset: 59991},
+								pos:  position{line: 1922, col: 12, offset: 59987},
 								name: "OptHavingClause",
 							},
 						},
@@ -13259,26 +13259,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 1946, col: 1, offset: 60573},
+			pos:  position{line: 1946, col: 1, offset: 60569},
 			expr: &actionExpr{
-				pos: position{line: 1947, col: 5, offset: 60587},
+				pos: position{line: 1947, col: 5, offset: 60583},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 1947, col: 5, offset: 60587},
+					pos: position{line: 1947, col: 5, offset: 60583},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 5, offset: 60587},
+							pos:  position{line: 1947, col: 5, offset: 60583},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 12, offset: 60594},
+							pos:  position{line: 1947, col: 12, offset: 60590},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1947, col: 15, offset: 60597},
+							pos:   position{line: 1947, col: 15, offset: 60593},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 22, offset: 60604},
+								pos:  position{line: 1947, col: 22, offset: 60600},
 								name: "SQLTuples",
 							},
 						},
@@ -13290,26 +13290,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 1955, col: 1, offset: 60761},
+			pos:  position{line: 1955, col: 1, offset: 60757},
 			expr: &actionExpr{
-				pos: position{line: 1956, col: 5, offset: 60774},
+				pos: position{line: 1956, col: 5, offset: 60770},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 1956, col: 5, offset: 60774},
+					pos: position{line: 1956, col: 5, offset: 60770},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1956, col: 5, offset: 60774},
+							pos:  position{line: 1956, col: 5, offset: 60770},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1956, col: 12, offset: 60781},
+							pos:  position{line: 1956, col: 12, offset: 60777},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1956, col: 14, offset: 60783},
+							pos:   position{line: 1956, col: 14, offset: 60779},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1956, col: 20, offset: 60789},
+								pos:  position{line: 1956, col: 20, offset: 60785},
 								name: "Exprs",
 							},
 						},
@@ -13321,51 +13321,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 1965, col: 1, offset: 60936},
+			pos:  position{line: 1965, col: 1, offset: 60932},
 			expr: &actionExpr{
-				pos: position{line: 1966, col: 5, offset: 60950},
+				pos: position{line: 1966, col: 5, offset: 60946},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 1966, col: 5, offset: 60950},
+					pos: position{line: 1966, col: 5, offset: 60946},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1966, col: 5, offset: 60950},
+							pos:   position{line: 1966, col: 5, offset: 60946},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1966, col: 11, offset: 60956},
+								pos:  position{line: 1966, col: 11, offset: 60952},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1966, col: 20, offset: 60965},
+							pos:   position{line: 1966, col: 20, offset: 60961},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1966, col: 25, offset: 60970},
+								pos: position{line: 1966, col: 25, offset: 60966},
 								expr: &actionExpr{
-									pos: position{line: 1966, col: 26, offset: 60971},
+									pos: position{line: 1966, col: 26, offset: 60967},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 1966, col: 26, offset: 60971},
+										pos: position{line: 1966, col: 26, offset: 60967},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1966, col: 26, offset: 60971},
+												pos:  position{line: 1966, col: 26, offset: 60967},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1966, col: 29, offset: 60974},
+												pos:        position{line: 1966, col: 29, offset: 60970},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1966, col: 33, offset: 60978},
+												pos:  position{line: 1966, col: 33, offset: 60974},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1966, col: 36, offset: 60981},
+												pos:   position{line: 1966, col: 36, offset: 60977},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1966, col: 38, offset: 60983},
+													pos:  position{line: 1966, col: 38, offset: 60979},
 													name: "SQLTuple",
 												},
 											},
@@ -13382,37 +13382,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 1970, col: 1, offset: 61060},
+			pos:  position{line: 1970, col: 1, offset: 61056},
 			expr: &actionExpr{
-				pos: position{line: 1971, col: 5, offset: 61073},
+				pos: position{line: 1971, col: 5, offset: 61069},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1971, col: 5, offset: 61073},
+					pos: position{line: 1971, col: 5, offset: 61069},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1971, col: 5, offset: 61073},
+							pos:        position{line: 1971, col: 5, offset: 61069},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1971, col: 9, offset: 61077},
+							pos:  position{line: 1971, col: 9, offset: 61073},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1971, col: 12, offset: 61080},
+							pos:   position{line: 1971, col: 12, offset: 61076},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 18, offset: 61086},
+								pos:  position{line: 1971, col: 18, offset: 61082},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1971, col: 24, offset: 61092},
+							pos:  position{line: 1971, col: 24, offset: 61088},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1971, col: 27, offset: 61095},
+							pos:        position{line: 1971, col: 27, offset: 61091},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13425,49 +13425,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 1979, col: 1, offset: 61239},
+			pos:  position{line: 1979, col: 1, offset: 61235},
 			expr: &choiceExpr{
-				pos: position{line: 1980, col: 5, offset: 61255},
+				pos: position{line: 1980, col: 5, offset: 61251},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1980, col: 5, offset: 61255},
+						pos: position{line: 1980, col: 5, offset: 61251},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 1980, col: 5, offset: 61255},
+							pos: position{line: 1980, col: 5, offset: 61251},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1980, col: 5, offset: 61255},
+									pos:  position{line: 1980, col: 5, offset: 61251},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1980, col: 7, offset: 61257},
+									pos:  position{line: 1980, col: 7, offset: 61253},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1981, col: 5, offset: 61294},
+						pos: position{line: 1981, col: 5, offset: 61290},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 1981, col: 5, offset: 61294},
+							pos: position{line: 1981, col: 5, offset: 61290},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1981, col: 5, offset: 61294},
+									pos:  position{line: 1981, col: 5, offset: 61290},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1981, col: 7, offset: 61296},
+									pos:  position{line: 1981, col: 7, offset: 61292},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1982, col: 5, offset: 61332},
+						pos: position{line: 1982, col: 5, offset: 61328},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 1982, col: 5, offset: 61332},
+							pos:        position{line: 1982, col: 5, offset: 61328},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13480,57 +13480,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 1984, col: 1, offset: 61371},
+			pos:  position{line: 1984, col: 1, offset: 61367},
 			expr: &choiceExpr{
-				pos: position{line: 1985, col: 5, offset: 61390},
+				pos: position{line: 1985, col: 5, offset: 61386},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1985, col: 5, offset: 61390},
+						pos: position{line: 1985, col: 5, offset: 61386},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 1985, col: 5, offset: 61390},
+							pos: position{line: 1985, col: 5, offset: 61386},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1985, col: 5, offset: 61390},
+									pos:  position{line: 1985, col: 5, offset: 61386},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1985, col: 7, offset: 61392},
+									pos:  position{line: 1985, col: 7, offset: 61388},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1985, col: 10, offset: 61395},
+									pos:  position{line: 1985, col: 10, offset: 61391},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1985, col: 12, offset: 61397},
+									pos:  position{line: 1985, col: 12, offset: 61393},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1986, col: 5, offset: 61429},
+						pos: position{line: 1986, col: 5, offset: 61425},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 1986, col: 5, offset: 61429},
+							pos: position{line: 1986, col: 5, offset: 61425},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1986, col: 5, offset: 61429},
+									pos:  position{line: 1986, col: 5, offset: 61425},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1986, col: 7, offset: 61431},
+									pos:  position{line: 1986, col: 7, offset: 61427},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1987, col: 5, offset: 61502},
+						pos: position{line: 1987, col: 5, offset: 61498},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 1987, col: 5, offset: 61502},
+							pos:        position{line: 1987, col: 5, offset: 61498},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13543,19 +13543,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 1989, col: 1, offset: 61545},
+			pos:  position{line: 1989, col: 1, offset: 61541},
 			expr: &choiceExpr{
-				pos: position{line: 1990, col: 5, offset: 61563},
+				pos: position{line: 1990, col: 5, offset: 61559},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1990, col: 5, offset: 61563},
+						pos:  position{line: 1990, col: 5, offset: 61559},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 1991, col: 5, offset: 61578},
+						pos: position{line: 1991, col: 5, offset: 61574},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 1991, col: 5, offset: 61578},
+							pos:        position{line: 1991, col: 5, offset: 61574},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13568,39 +13568,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 1993, col: 1, offset: 61611},
+			pos:  position{line: 1993, col: 1, offset: 61607},
 			expr: &actionExpr{
-				pos: position{line: 1994, col: 5, offset: 61626},
+				pos: position{line: 1994, col: 5, offset: 61622},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 1994, col: 5, offset: 61626},
+					pos: position{line: 1994, col: 5, offset: 61622},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 5, offset: 61626},
+							pos:  position{line: 1994, col: 5, offset: 61622},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 1994, col: 10, offset: 61631},
+							pos:   position{line: 1994, col: 10, offset: 61627},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1994, col: 12, offset: 61633},
+								pos:  position{line: 1994, col: 12, offset: 61629},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 25, offset: 61646},
+							pos:  position{line: 1994, col: 25, offset: 61642},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1994, col: 27, offset: 61648},
+							pos:   position{line: 1994, col: 27, offset: 61644},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1994, col: 32, offset: 61653},
+								pos:  position{line: 1994, col: 32, offset: 61649},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 40, offset: 61661},
+							pos:  position{line: 1994, col: 40, offset: 61657},
 							name: "__",
 						},
 					},
@@ -13611,32 +13611,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2003, col: 1, offset: 61849},
+			pos:  position{line: 2003, col: 1, offset: 61845},
 			expr: &choiceExpr{
-				pos: position{line: 2004, col: 5, offset: 61866},
+				pos: position{line: 2004, col: 5, offset: 61862},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2004, col: 5, offset: 61866},
+						pos: position{line: 2004, col: 5, offset: 61862},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2004, col: 5, offset: 61866},
+							pos: position{line: 2004, col: 5, offset: 61862},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2004, col: 5, offset: 61866},
+									pos:  position{line: 2004, col: 5, offset: 61862},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2004, col: 7, offset: 61868},
+									pos:  position{line: 2004, col: 7, offset: 61864},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2005, col: 5, offset: 61904},
+						pos: position{line: 2005, col: 5, offset: 61900},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2005, col: 5, offset: 61904},
+							pos:        position{line: 2005, col: 5, offset: 61900},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13649,51 +13649,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2007, col: 1, offset: 61943},
+			pos:  position{line: 2007, col: 1, offset: 61939},
 			expr: &actionExpr{
-				pos: position{line: 2007, col: 11, offset: 61953},
+				pos: position{line: 2007, col: 11, offset: 61949},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2007, col: 11, offset: 61953},
+					pos: position{line: 2007, col: 11, offset: 61949},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2007, col: 11, offset: 61953},
+							pos:   position{line: 2007, col: 11, offset: 61949},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2007, col: 17, offset: 61959},
+								pos:  position{line: 2007, col: 17, offset: 61955},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2007, col: 21, offset: 61963},
+							pos:   position{line: 2007, col: 21, offset: 61959},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2007, col: 26, offset: 61968},
+								pos: position{line: 2007, col: 26, offset: 61964},
 								expr: &actionExpr{
-									pos: position{line: 2007, col: 28, offset: 61970},
+									pos: position{line: 2007, col: 28, offset: 61966},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2007, col: 28, offset: 61970},
+										pos: position{line: 2007, col: 28, offset: 61966},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2007, col: 28, offset: 61970},
+												pos:  position{line: 2007, col: 28, offset: 61966},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2007, col: 31, offset: 61973},
+												pos:        position{line: 2007, col: 31, offset: 61969},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2007, col: 35, offset: 61977},
+												pos:  position{line: 2007, col: 35, offset: 61973},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2007, col: 38, offset: 61980},
+												pos:   position{line: 2007, col: 38, offset: 61976},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2007, col: 42, offset: 61984},
+													pos:  position{line: 2007, col: 42, offset: 61980},
 													name: "Cte",
 												},
 											},
@@ -13710,65 +13710,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2011, col: 1, offset: 62052},
+			pos:  position{line: 2011, col: 1, offset: 62048},
 			expr: &actionExpr{
-				pos: position{line: 2012, col: 5, offset: 62060},
+				pos: position{line: 2012, col: 5, offset: 62056},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2012, col: 5, offset: 62060},
+					pos: position{line: 2012, col: 5, offset: 62056},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2012, col: 5, offset: 62060},
+							pos:   position{line: 2012, col: 5, offset: 62056},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2012, col: 10, offset: 62065},
+								pos:  position{line: 2012, col: 10, offset: 62061},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 24, offset: 62079},
+							pos:  position{line: 2012, col: 24, offset: 62075},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 26, offset: 62081},
+							pos:  position{line: 2012, col: 26, offset: 62077},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2012, col: 29, offset: 62084},
+							pos:   position{line: 2012, col: 29, offset: 62080},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2012, col: 31, offset: 62086},
+								pos:  position{line: 2012, col: 31, offset: 62082},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 47, offset: 62102},
+							pos:  position{line: 2012, col: 47, offset: 62098},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2012, col: 50, offset: 62105},
+							pos:        position{line: 2012, col: 50, offset: 62101},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 54, offset: 62109},
+							pos:  position{line: 2012, col: 54, offset: 62105},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2012, col: 57, offset: 62112},
+							pos:   position{line: 2012, col: 57, offset: 62108},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2012, col: 59, offset: 62114},
+								pos:  position{line: 2012, col: 59, offset: 62110},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 67, offset: 62122},
+							pos:  position{line: 2012, col: 67, offset: 62118},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2012, col: 70, offset: 62125},
+							pos:        position{line: 2012, col: 70, offset: 62121},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13781,65 +13781,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2021, col: 1, offset: 62311},
+			pos:  position{line: 2021, col: 1, offset: 62307},
 			expr: &choiceExpr{
-				pos: position{line: 2022, col: 5, offset: 62331},
+				pos: position{line: 2022, col: 5, offset: 62327},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2022, col: 5, offset: 62331},
+						pos: position{line: 2022, col: 5, offset: 62327},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2022, col: 5, offset: 62331},
+							pos: position{line: 2022, col: 5, offset: 62327},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2022, col: 5, offset: 62331},
+									pos:  position{line: 2022, col: 5, offset: 62327},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2022, col: 7, offset: 62333},
+									pos:  position{line: 2022, col: 7, offset: 62329},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2022, col: 20, offset: 62346},
+									pos:  position{line: 2022, col: 20, offset: 62342},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2023, col: 5, offset: 62385},
+						pos: position{line: 2023, col: 5, offset: 62381},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2023, col: 5, offset: 62385},
+							pos: position{line: 2023, col: 5, offset: 62381},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 5, offset: 62385},
+									pos:  position{line: 2023, col: 5, offset: 62381},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 7, offset: 62387},
+									pos:  position{line: 2023, col: 7, offset: 62383},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 11, offset: 62391},
+									pos:  position{line: 2023, col: 11, offset: 62387},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 13, offset: 62393},
+									pos:  position{line: 2023, col: 13, offset: 62389},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 26, offset: 62406},
+									pos:  position{line: 2023, col: 26, offset: 62402},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2024, col: 5, offset: 62437},
+						pos: position{line: 2024, col: 5, offset: 62433},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2024, col: 5, offset: 62437},
+							pos:        position{line: 2024, col: 5, offset: 62433},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13852,25 +13852,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2026, col: 1, offset: 62492},
+			pos:  position{line: 2026, col: 1, offset: 62488},
 			expr: &choiceExpr{
-				pos: position{line: 2027, col: 5, offset: 62509},
+				pos: position{line: 2027, col: 5, offset: 62505},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2027, col: 5, offset: 62509},
+						pos: position{line: 2027, col: 5, offset: 62505},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2027, col: 5, offset: 62509},
+								pos:  position{line: 2027, col: 5, offset: 62505},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2027, col: 7, offset: 62511},
+								pos:  position{line: 2027, col: 7, offset: 62507},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2028, col: 5, offset: 62519},
+						pos:        position{line: 2028, col: 5, offset: 62515},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -13882,25 +13882,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2030, col: 1, offset: 62523},
+			pos:  position{line: 2030, col: 1, offset: 62519},
 			expr: &choiceExpr{
-				pos: position{line: 2031, col: 5, offset: 62541},
+				pos: position{line: 2031, col: 5, offset: 62537},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2031, col: 5, offset: 62541},
+						pos: position{line: 2031, col: 5, offset: 62537},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2031, col: 5, offset: 62541},
+							pos: position{line: 2031, col: 5, offset: 62537},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 5, offset: 62541},
+									pos:  position{line: 2031, col: 5, offset: 62537},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2031, col: 7, offset: 62543},
+									pos:   position{line: 2031, col: 7, offset: 62539},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2031, col: 12, offset: 62548},
+										pos:  position{line: 2031, col: 12, offset: 62544},
 										name: "FromOp",
 									},
 								},
@@ -13908,10 +13908,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2034, col: 5, offset: 62590},
+						pos: position{line: 2034, col: 5, offset: 62586},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2034, col: 5, offset: 62590},
+							pos:        position{line: 2034, col: 5, offset: 62586},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13924,27 +13924,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2036, col: 1, offset: 62631},
+			pos:  position{line: 2036, col: 1, offset: 62627},
 			expr: &choiceExpr{
-				pos: position{line: 2037, col: 5, offset: 62650},
+				pos: position{line: 2037, col: 5, offset: 62646},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2037, col: 5, offset: 62650},
+						pos: position{line: 2037, col: 5, offset: 62646},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2037, col: 5, offset: 62650},
+							pos:   position{line: 2037, col: 5, offset: 62646},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2037, col: 11, offset: 62656},
+								pos:  position{line: 2037, col: 11, offset: 62652},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2038, col: 5, offset: 62698},
+						pos: position{line: 2038, col: 5, offset: 62694},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2038, col: 5, offset: 62698},
+							pos:        position{line: 2038, col: 5, offset: 62694},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13957,25 +13957,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2040, col: 1, offset: 62743},
+			pos:  position{line: 2040, col: 1, offset: 62739},
 			expr: &choiceExpr{
-				pos: position{line: 2041, col: 5, offset: 62762},
+				pos: position{line: 2041, col: 5, offset: 62758},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2041, col: 5, offset: 62762},
+						pos: position{line: 2041, col: 5, offset: 62758},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2041, col: 5, offset: 62762},
+							pos: position{line: 2041, col: 5, offset: 62758},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2041, col: 5, offset: 62762},
+									pos:  position{line: 2041, col: 5, offset: 62758},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2041, col: 7, offset: 62764},
+									pos:   position{line: 2041, col: 7, offset: 62760},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2041, col: 13, offset: 62770},
+										pos:  position{line: 2041, col: 13, offset: 62766},
 										name: "GroupClause",
 									},
 								},
@@ -13983,10 +13983,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2042, col: 5, offset: 62808},
+						pos: position{line: 2042, col: 5, offset: 62804},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2042, col: 5, offset: 62808},
+							pos:        position{line: 2042, col: 5, offset: 62804},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13999,34 +13999,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2044, col: 1, offset: 62849},
+			pos:  position{line: 2044, col: 1, offset: 62845},
 			expr: &actionExpr{
-				pos: position{line: 2045, col: 5, offset: 62865},
+				pos: position{line: 2045, col: 5, offset: 62861},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2045, col: 5, offset: 62865},
+					pos: position{line: 2045, col: 5, offset: 62861},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 5, offset: 62865},
+							pos:  position{line: 2045, col: 5, offset: 62861},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 11, offset: 62871},
+							pos:  position{line: 2045, col: 11, offset: 62867},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 13, offset: 62873},
+							pos:  position{line: 2045, col: 13, offset: 62869},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 16, offset: 62876},
+							pos:  position{line: 2045, col: 16, offset: 62872},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2045, col: 18, offset: 62878},
+							pos:   position{line: 2045, col: 18, offset: 62874},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2045, col: 23, offset: 62883},
+								pos:  position{line: 2045, col: 23, offset: 62879},
 								name: "GroupByList",
 							},
 						},
@@ -14038,51 +14038,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2047, col: 1, offset: 62917},
+			pos:  position{line: 2047, col: 1, offset: 62913},
 			expr: &actionExpr{
-				pos: position{line: 2048, col: 5, offset: 62933},
+				pos: position{line: 2048, col: 5, offset: 62929},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2048, col: 5, offset: 62933},
+					pos: position{line: 2048, col: 5, offset: 62929},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2048, col: 5, offset: 62933},
+							pos:   position{line: 2048, col: 5, offset: 62929},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2048, col: 11, offset: 62939},
+								pos:  position{line: 2048, col: 11, offset: 62935},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2048, col: 23, offset: 62951},
+							pos:   position{line: 2048, col: 23, offset: 62947},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2048, col: 28, offset: 62956},
+								pos: position{line: 2048, col: 28, offset: 62952},
 								expr: &actionExpr{
-									pos: position{line: 2048, col: 30, offset: 62958},
+									pos: position{line: 2048, col: 30, offset: 62954},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2048, col: 30, offset: 62958},
+										pos: position{line: 2048, col: 30, offset: 62954},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2048, col: 30, offset: 62958},
+												pos:  position{line: 2048, col: 30, offset: 62954},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2048, col: 33, offset: 62961},
+												pos:        position{line: 2048, col: 33, offset: 62957},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2048, col: 37, offset: 62965},
+												pos:  position{line: 2048, col: 37, offset: 62961},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2048, col: 40, offset: 62968},
+												pos:   position{line: 2048, col: 40, offset: 62964},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2048, col: 42, offset: 62970},
+													pos:  position{line: 2048, col: 42, offset: 62966},
 													name: "GroupByItem",
 												},
 											},
@@ -14099,9 +14099,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2052, col: 1, offset: 63051},
+			pos:  position{line: 2052, col: 1, offset: 63047},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2052, col: 15, offset: 63065},
+				pos:  position{line: 2052, col: 15, offset: 63061},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14109,25 +14109,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2054, col: 1, offset: 63071},
+			pos:  position{line: 2054, col: 1, offset: 63067},
 			expr: &choiceExpr{
-				pos: position{line: 2055, col: 5, offset: 63091},
+				pos: position{line: 2055, col: 5, offset: 63087},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2055, col: 5, offset: 63091},
+						pos: position{line: 2055, col: 5, offset: 63087},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2055, col: 5, offset: 63091},
+							pos: position{line: 2055, col: 5, offset: 63087},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2055, col: 5, offset: 63091},
+									pos:  position{line: 2055, col: 5, offset: 63087},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2055, col: 7, offset: 63093},
+									pos:   position{line: 2055, col: 7, offset: 63089},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2055, col: 9, offset: 63095},
+										pos:  position{line: 2055, col: 9, offset: 63091},
 										name: "HavingClause",
 									},
 								},
@@ -14135,10 +14135,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2056, col: 5, offset: 63130},
+						pos: position{line: 2056, col: 5, offset: 63126},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2056, col: 5, offset: 63130},
+							pos:        position{line: 2056, col: 5, offset: 63126},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14151,26 +14151,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2058, col: 1, offset: 63154},
+			pos:  position{line: 2058, col: 1, offset: 63150},
 			expr: &actionExpr{
-				pos: position{line: 2059, col: 5, offset: 63171},
+				pos: position{line: 2059, col: 5, offset: 63167},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2059, col: 5, offset: 63171},
+					pos: position{line: 2059, col: 5, offset: 63167},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2059, col: 5, offset: 63171},
+							pos:  position{line: 2059, col: 5, offset: 63167},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2059, col: 12, offset: 63178},
+							pos:  position{line: 2059, col: 12, offset: 63174},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2059, col: 14, offset: 63180},
+							pos:   position{line: 2059, col: 14, offset: 63176},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2059, col: 16, offset: 63182},
+								pos:  position{line: 2059, col: 16, offset: 63178},
 								name: "Expr",
 							},
 						},
@@ -14182,49 +14182,49 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2061, col: 1, offset: 63206},
+			pos:  position{line: 2061, col: 1, offset: 63202},
 			expr: &choiceExpr{
-				pos: position{line: 2062, col: 5, offset: 63224},
+				pos: position{line: 2062, col: 5, offset: 63220},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2062, col: 5, offset: 63224},
+						pos:  position{line: 2062, col: 5, offset: 63220},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2063, col: 5, offset: 63238},
+						pos:  position{line: 2063, col: 5, offset: 63234},
 						name: "ConditionJoin",
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2065, col: 1, offset: 63253},
+			pos:  position{line: 2065, col: 1, offset: 63249},
 			expr: &actionExpr{
-				pos: position{line: 2066, col: 5, offset: 63267},
+				pos: position{line: 2066, col: 5, offset: 63263},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2066, col: 5, offset: 63267},
+					pos: position{line: 2066, col: 5, offset: 63263},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2066, col: 5, offset: 63267},
+							pos:   position{line: 2066, col: 5, offset: 63263},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2066, col: 10, offset: 63272},
+								pos:  position{line: 2066, col: 10, offset: 63268},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2066, col: 19, offset: 63281},
+							pos:  position{line: 2066, col: 19, offset: 63277},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2066, col: 31, offset: 63293},
+							pos:   position{line: 2066, col: 31, offset: 63289},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2066, col: 37, offset: 63299},
+								pos:  position{line: 2066, col: 37, offset: 63295},
 								name: "FromElem",
 							},
 						},
@@ -14236,50 +14236,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2075, col: 1, offset: 63507},
+			pos:  position{line: 2075, col: 1, offset: 63503},
 			expr: &choiceExpr{
-				pos: position{line: 2076, col: 5, offset: 63523},
+				pos: position{line: 2076, col: 5, offset: 63519},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2076, col: 5, offset: 63523},
+						pos: position{line: 2076, col: 5, offset: 63519},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2076, col: 5, offset: 63523},
+								pos:  position{line: 2076, col: 5, offset: 63519},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2076, col: 8, offset: 63526},
+								pos:        position{line: 2076, col: 8, offset: 63522},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2076, col: 12, offset: 63530},
+								pos:  position{line: 2076, col: 12, offset: 63526},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2077, col: 5, offset: 63537},
+						pos: position{line: 2077, col: 5, offset: 63533},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 5, offset: 63537},
+								pos:  position{line: 2077, col: 5, offset: 63533},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 7, offset: 63539},
+								pos:  position{line: 2077, col: 7, offset: 63535},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 13, offset: 63545},
+								pos:  position{line: 2077, col: 13, offset: 63541},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 15, offset: 63547},
+								pos:  position{line: 2077, col: 15, offset: 63543},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 20, offset: 63552},
+								pos:  position{line: 2077, col: 20, offset: 63548},
 								name: "_",
 							},
 						},
@@ -14291,50 +14291,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2079, col: 1, offset: 63555},
+			pos:  position{line: 2079, col: 1, offset: 63551},
 			expr: &actionExpr{
-				pos: position{line: 2080, col: 5, offset: 63573},
+				pos: position{line: 2080, col: 5, offset: 63569},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2080, col: 5, offset: 63573},
+					pos: position{line: 2080, col: 5, offset: 63569},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2080, col: 5, offset: 63573},
+							pos:   position{line: 2080, col: 5, offset: 63569},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 10, offset: 63578},
+								pos:  position{line: 2080, col: 10, offset: 63574},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2080, col: 19, offset: 63587},
+							pos:   position{line: 2080, col: 19, offset: 63583},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 25, offset: 63593},
+								pos:  position{line: 2080, col: 25, offset: 63589},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2080, col: 38, offset: 63606},
+							pos:  position{line: 2080, col: 38, offset: 63602},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2080, col: 40, offset: 63608},
+							pos:   position{line: 2080, col: 40, offset: 63604},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 46, offset: 63614},
+								pos:  position{line: 2080, col: 46, offset: 63610},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2080, col: 55, offset: 63623},
+							pos:  position{line: 2080, col: 55, offset: 63619},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2080, col: 57, offset: 63625},
+							pos:   position{line: 2080, col: 57, offset: 63621},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 59, offset: 63627},
+								pos:  position{line: 2080, col: 59, offset: 63623},
 								name: "JoinCond",
 							},
 						},
@@ -14346,161 +14346,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2091, col: 1, offset: 63896},
+			pos:  position{line: 2091, col: 1, offset: 63892},
 			expr: &choiceExpr{
-				pos: position{line: 2092, col: 5, offset: 63913},
+				pos: position{line: 2092, col: 5, offset: 63909},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2092, col: 5, offset: 63913},
+						pos: position{line: 2092, col: 5, offset: 63909},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2092, col: 5, offset: 63913},
+							pos: position{line: 2092, col: 5, offset: 63909},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2092, col: 5, offset: 63913},
+									pos: position{line: 2092, col: 5, offset: 63909},
 									expr: &seqExpr{
-										pos: position{line: 2092, col: 6, offset: 63914},
+										pos: position{line: 2092, col: 6, offset: 63910},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2092, col: 6, offset: 63914},
+												pos:  position{line: 2092, col: 6, offset: 63910},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2092, col: 8, offset: 63916},
+												pos:  position{line: 2092, col: 8, offset: 63912},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2092, col: 16, offset: 63924},
+									pos:  position{line: 2092, col: 16, offset: 63920},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2092, col: 18, offset: 63926},
+									pos:  position{line: 2092, col: 18, offset: 63922},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2093, col: 5, offset: 63971},
+						pos: position{line: 2093, col: 5, offset: 63967},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2093, col: 5, offset: 63971},
+							pos: position{line: 2093, col: 5, offset: 63967},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2093, col: 5, offset: 63971},
+									pos:  position{line: 2093, col: 5, offset: 63967},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2093, col: 7, offset: 63973},
+									pos:  position{line: 2093, col: 7, offset: 63969},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2093, col: 12, offset: 63978},
+									pos: position{line: 2093, col: 12, offset: 63974},
 									expr: &seqExpr{
-										pos: position{line: 2093, col: 13, offset: 63979},
+										pos: position{line: 2093, col: 13, offset: 63975},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2093, col: 13, offset: 63979},
+												pos:  position{line: 2093, col: 13, offset: 63975},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2093, col: 15, offset: 63981},
+												pos:  position{line: 2093, col: 15, offset: 63977},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2093, col: 23, offset: 63989},
+									pos:  position{line: 2093, col: 23, offset: 63985},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2093, col: 25, offset: 63991},
+									pos:  position{line: 2093, col: 25, offset: 63987},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2094, col: 5, offset: 64025},
+						pos: position{line: 2094, col: 5, offset: 64021},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2094, col: 5, offset: 64025},
+							pos: position{line: 2094, col: 5, offset: 64021},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 5, offset: 64025},
+									pos:  position{line: 2094, col: 5, offset: 64021},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 7, offset: 64027},
+									pos:  position{line: 2094, col: 7, offset: 64023},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2094, col: 12, offset: 64032},
+									pos: position{line: 2094, col: 12, offset: 64028},
 									expr: &seqExpr{
-										pos: position{line: 2094, col: 13, offset: 64033},
+										pos: position{line: 2094, col: 13, offset: 64029},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2094, col: 13, offset: 64033},
+												pos:  position{line: 2094, col: 13, offset: 64029},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2094, col: 15, offset: 64035},
+												pos:  position{line: 2094, col: 15, offset: 64031},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 23, offset: 64043},
+									pos:  position{line: 2094, col: 23, offset: 64039},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 25, offset: 64045},
+									pos:  position{line: 2094, col: 25, offset: 64041},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2095, col: 5, offset: 64079},
+						pos: position{line: 2095, col: 5, offset: 64075},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2095, col: 5, offset: 64079},
+							pos: position{line: 2095, col: 5, offset: 64075},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2095, col: 5, offset: 64079},
+									pos:  position{line: 2095, col: 5, offset: 64075},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2095, col: 7, offset: 64081},
+									pos:  position{line: 2095, col: 7, offset: 64077},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2095, col: 13, offset: 64087},
+									pos: position{line: 2095, col: 13, offset: 64083},
 									expr: &seqExpr{
-										pos: position{line: 2095, col: 14, offset: 64088},
+										pos: position{line: 2095, col: 14, offset: 64084},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2095, col: 14, offset: 64088},
+												pos:  position{line: 2095, col: 14, offset: 64084},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2095, col: 16, offset: 64090},
+												pos:  position{line: 2095, col: 16, offset: 64086},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2095, col: 24, offset: 64098},
+									pos:  position{line: 2095, col: 24, offset: 64094},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2095, col: 26, offset: 64100},
+									pos:  position{line: 2095, col: 26, offset: 64096},
 									name: "JOIN",
 								},
 							},
@@ -14513,29 +14513,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2097, col: 1, offset: 64132},
+			pos:  position{line: 2097, col: 1, offset: 64128},
 			expr: &choiceExpr{
-				pos: position{line: 2098, col: 5, offset: 64145},
+				pos: position{line: 2098, col: 5, offset: 64141},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2098, col: 5, offset: 64145},
+						pos: position{line: 2098, col: 5, offset: 64141},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2098, col: 5, offset: 64145},
+							pos: position{line: 2098, col: 5, offset: 64141},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 5, offset: 64145},
+									pos:  position{line: 2098, col: 5, offset: 64141},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 8, offset: 64148},
+									pos:  position{line: 2098, col: 8, offset: 64144},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2098, col: 10, offset: 64150},
+									pos:   position{line: 2098, col: 10, offset: 64146},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2098, col: 12, offset: 64152},
+										pos:  position{line: 2098, col: 12, offset: 64148},
 										name: "Expr",
 									},
 								},
@@ -14543,43 +14543,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2105, col: 5, offset: 64305},
+						pos: position{line: 2105, col: 5, offset: 64301},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2105, col: 5, offset: 64305},
+							pos: position{line: 2105, col: 5, offset: 64301},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 5, offset: 64305},
+									pos:  position{line: 2105, col: 5, offset: 64301},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 11, offset: 64311},
+									pos:  position{line: 2105, col: 11, offset: 64307},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2105, col: 14, offset: 64314},
+									pos:        position{line: 2105, col: 14, offset: 64310},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 18, offset: 64318},
+									pos:  position{line: 2105, col: 18, offset: 64314},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2105, col: 21, offset: 64321},
+									pos:   position{line: 2105, col: 21, offset: 64317},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2105, col: 28, offset: 64328},
+										pos:  position{line: 2105, col: 28, offset: 64324},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 34, offset: 64334},
+									pos:  position{line: 2105, col: 34, offset: 64330},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2105, col: 37, offset: 64337},
+									pos:        position{line: 2105, col: 37, offset: 64333},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14594,40 +14594,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2113, col: 1, offset: 64507},
+			pos:  position{line: 2113, col: 1, offset: 64503},
 			expr: &choiceExpr{
-				pos: position{line: 2114, col: 5, offset: 64525},
+				pos: position{line: 2114, col: 5, offset: 64521},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2114, col: 5, offset: 64525},
+						pos: position{line: 2114, col: 5, offset: 64521},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2114, col: 5, offset: 64525},
+							pos: position{line: 2114, col: 5, offset: 64521},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 5, offset: 64525},
+									pos:  position{line: 2114, col: 5, offset: 64521},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 7, offset: 64527},
+									pos:  position{line: 2114, col: 7, offset: 64523},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 12, offset: 64532},
+									pos:  position{line: 2114, col: 12, offset: 64528},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 14, offset: 64534},
+									pos:  position{line: 2114, col: 14, offset: 64530},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2120, col: 5, offset: 64663},
+						pos: position{line: 2120, col: 5, offset: 64659},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2120, col: 5, offset: 64663},
+							pos:        position{line: 2120, col: 5, offset: 64659},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14640,25 +14640,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2122, col: 1, offset: 64712},
+			pos:  position{line: 2122, col: 1, offset: 64708},
 			expr: &choiceExpr{
-				pos: position{line: 2123, col: 5, offset: 64725},
+				pos: position{line: 2123, col: 5, offset: 64721},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2123, col: 5, offset: 64725},
+						pos: position{line: 2123, col: 5, offset: 64721},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2123, col: 5, offset: 64725},
+							pos: position{line: 2123, col: 5, offset: 64721},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2123, col: 5, offset: 64725},
+									pos:  position{line: 2123, col: 5, offset: 64721},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2123, col: 7, offset: 64727},
+									pos:   position{line: 2123, col: 7, offset: 64723},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2123, col: 9, offset: 64729},
+										pos:  position{line: 2123, col: 9, offset: 64725},
 										name: "AliasClause",
 									},
 								},
@@ -14666,10 +14666,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2124, col: 5, offset: 64763},
+						pos: position{line: 2124, col: 5, offset: 64759},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2124, col: 5, offset: 64763},
+							pos:        position{line: 2124, col: 5, offset: 64759},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14682,51 +14682,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2126, col: 1, offset: 64800},
+			pos:  position{line: 2126, col: 1, offset: 64796},
 			expr: &actionExpr{
-				pos: position{line: 2127, col: 4, offset: 64815},
+				pos: position{line: 2127, col: 4, offset: 64811},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2127, col: 4, offset: 64815},
+					pos: position{line: 2127, col: 4, offset: 64811},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2127, col: 4, offset: 64815},
+							pos: position{line: 2127, col: 4, offset: 64811},
 							expr: &seqExpr{
-								pos: position{line: 2127, col: 5, offset: 64816},
+								pos: position{line: 2127, col: 5, offset: 64812},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2127, col: 5, offset: 64816},
+										pos:  position{line: 2127, col: 5, offset: 64812},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2127, col: 8, offset: 64819},
+										pos:  position{line: 2127, col: 8, offset: 64815},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2127, col: 12, offset: 64823},
+							pos: position{line: 2127, col: 12, offset: 64819},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2127, col: 13, offset: 64824},
+								pos:  position{line: 2127, col: 13, offset: 64820},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2127, col: 22, offset: 64833},
+							pos:   position{line: 2127, col: 22, offset: 64829},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2127, col: 27, offset: 64838},
+								pos:  position{line: 2127, col: 27, offset: 64834},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2127, col: 42, offset: 64853},
+							pos:   position{line: 2127, col: 42, offset: 64849},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2127, col: 47, offset: 64858},
+								pos: position{line: 2127, col: 47, offset: 64854},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2127, col: 47, offset: 64858},
+									pos:  position{line: 2127, col: 47, offset: 64854},
 									name: "Columns",
 								},
 							},
@@ -14739,65 +14739,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2135, col: 1, offset: 65057},
+			pos:  position{line: 2135, col: 1, offset: 65053},
 			expr: &actionExpr{
-				pos: position{line: 2136, col: 5, offset: 65069},
+				pos: position{line: 2136, col: 5, offset: 65065},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2136, col: 5, offset: 65069},
+					pos: position{line: 2136, col: 5, offset: 65065},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2136, col: 5, offset: 65069},
+							pos:  position{line: 2136, col: 5, offset: 65065},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2136, col: 8, offset: 65072},
+							pos:        position{line: 2136, col: 8, offset: 65068},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2136, col: 12, offset: 65076},
+							pos:  position{line: 2136, col: 12, offset: 65072},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2136, col: 15, offset: 65079},
+							pos:   position{line: 2136, col: 15, offset: 65075},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2136, col: 21, offset: 65085},
+								pos:  position{line: 2136, col: 21, offset: 65081},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2136, col: 35, offset: 65099},
+							pos:   position{line: 2136, col: 35, offset: 65095},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2136, col: 40, offset: 65104},
+								pos: position{line: 2136, col: 40, offset: 65100},
 								expr: &actionExpr{
-									pos: position{line: 2136, col: 42, offset: 65106},
+									pos: position{line: 2136, col: 42, offset: 65102},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2136, col: 42, offset: 65106},
+										pos: position{line: 2136, col: 42, offset: 65102},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2136, col: 42, offset: 65106},
+												pos:  position{line: 2136, col: 42, offset: 65102},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2136, col: 45, offset: 65109},
+												pos:        position{line: 2136, col: 45, offset: 65105},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2136, col: 49, offset: 65113},
+												pos:  position{line: 2136, col: 49, offset: 65109},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2136, col: 52, offset: 65116},
+												pos:   position{line: 2136, col: 52, offset: 65112},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2136, col: 54, offset: 65118},
+													pos:  position{line: 2136, col: 54, offset: 65114},
 													name: "SQLIdentifier",
 												},
 											},
@@ -14807,11 +14807,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2136, col: 87, offset: 65151},
+							pos:  position{line: 2136, col: 87, offset: 65147},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2136, col: 90, offset: 65154},
+							pos:        position{line: 2136, col: 90, offset: 65150},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14824,51 +14824,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2140, col: 1, offset: 65225},
+			pos:  position{line: 2140, col: 1, offset: 65221},
 			expr: &actionExpr{
-				pos: position{line: 2141, col: 5, offset: 65239},
+				pos: position{line: 2141, col: 5, offset: 65235},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2141, col: 5, offset: 65239},
+					pos: position{line: 2141, col: 5, offset: 65235},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2141, col: 5, offset: 65239},
+							pos:   position{line: 2141, col: 5, offset: 65235},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2141, col: 11, offset: 65245},
+								pos:  position{line: 2141, col: 11, offset: 65241},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2141, col: 22, offset: 65256},
+							pos:   position{line: 2141, col: 22, offset: 65252},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2141, col: 27, offset: 65261},
+								pos: position{line: 2141, col: 27, offset: 65257},
 								expr: &actionExpr{
-									pos: position{line: 2141, col: 29, offset: 65263},
+									pos: position{line: 2141, col: 29, offset: 65259},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2141, col: 29, offset: 65263},
+										pos: position{line: 2141, col: 29, offset: 65259},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2141, col: 29, offset: 65263},
+												pos:  position{line: 2141, col: 29, offset: 65259},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2141, col: 32, offset: 65266},
+												pos:        position{line: 2141, col: 32, offset: 65262},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2141, col: 36, offset: 65270},
+												pos:  position{line: 2141, col: 36, offset: 65266},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2141, col: 39, offset: 65273},
+												pos:   position{line: 2141, col: 39, offset: 65269},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2141, col: 41, offset: 65275},
+													pos:  position{line: 2141, col: 41, offset: 65271},
 													name: "SelectElem",
 												},
 											},
@@ -14885,38 +14885,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2150, col: 1, offset: 65510},
+			pos:  position{line: 2150, col: 1, offset: 65506},
 			expr: &choiceExpr{
-				pos: position{line: 2151, col: 5, offset: 65525},
+				pos: position{line: 2151, col: 5, offset: 65521},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2151, col: 5, offset: 65525},
+						pos: position{line: 2151, col: 5, offset: 65521},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2151, col: 5, offset: 65525},
+							pos: position{line: 2151, col: 5, offset: 65521},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2151, col: 5, offset: 65525},
+									pos:   position{line: 2151, col: 5, offset: 65521},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2151, col: 11, offset: 65531},
+										pos: position{line: 2151, col: 11, offset: 65527},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2151, col: 11, offset: 65531},
+												pos:  position{line: 2151, col: 11, offset: 65527},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2151, col: 25, offset: 65545},
+												pos:  position{line: 2151, col: 25, offset: 65541},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2151, col: 31, offset: 65551},
+									pos:   position{line: 2151, col: 31, offset: 65547},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2151, col: 34, offset: 65554},
+										pos:  position{line: 2151, col: 34, offset: 65550},
 										name: "OptAsClause",
 									},
 								},
@@ -14924,10 +14924,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2162, col: 5, offset: 65782},
+						pos: position{line: 2162, col: 5, offset: 65778},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2162, col: 5, offset: 65782},
+							pos:        position{line: 2162, col: 5, offset: 65778},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -14940,33 +14940,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2167, col: 1, offset: 65887},
+			pos:  position{line: 2167, col: 1, offset: 65883},
 			expr: &choiceExpr{
-				pos: position{line: 2168, col: 5, offset: 65903},
+				pos: position{line: 2168, col: 5, offset: 65899},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2168, col: 5, offset: 65903},
+						pos: position{line: 2168, col: 5, offset: 65899},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2168, col: 5, offset: 65903},
+							pos: position{line: 2168, col: 5, offset: 65899},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2168, col: 5, offset: 65903},
+									pos:  position{line: 2168, col: 5, offset: 65899},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2168, col: 7, offset: 65905},
+									pos:  position{line: 2168, col: 7, offset: 65901},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2168, col: 10, offset: 65908},
+									pos:  position{line: 2168, col: 10, offset: 65904},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2168, col: 12, offset: 65910},
+									pos:   position{line: 2168, col: 12, offset: 65906},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2168, col: 15, offset: 65913},
+										pos:  position{line: 2168, col: 15, offset: 65909},
 										name: "SQLIdentifier",
 									},
 								},
@@ -14974,27 +14974,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2169, col: 5, offset: 65950},
+						pos: position{line: 2169, col: 5, offset: 65946},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2169, col: 5, offset: 65950},
+							pos: position{line: 2169, col: 5, offset: 65946},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2169, col: 5, offset: 65950},
+									pos:  position{line: 2169, col: 5, offset: 65946},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2169, col: 7, offset: 65952},
+									pos: position{line: 2169, col: 7, offset: 65948},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2169, col: 8, offset: 65953},
+										pos:  position{line: 2169, col: 8, offset: 65949},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2169, col: 17, offset: 65962},
+									pos:   position{line: 2169, col: 17, offset: 65958},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2169, col: 20, offset: 65965},
+										pos:  position{line: 2169, col: 20, offset: 65961},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15002,10 +15002,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2170, col: 5, offset: 66002},
+						pos: position{line: 2170, col: 5, offset: 65998},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2170, col: 5, offset: 66002},
+							pos:        position{line: 2170, col: 5, offset: 65998},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15018,41 +15018,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2172, col: 1, offset: 66027},
+			pos:  position{line: 2172, col: 1, offset: 66023},
 			expr: &choiceExpr{
-				pos: position{line: 2173, col: 5, offset: 66048},
+				pos: position{line: 2173, col: 5, offset: 66044},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2173, col: 5, offset: 66048},
+						pos: position{line: 2173, col: 5, offset: 66044},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2173, col: 5, offset: 66048},
+							pos: position{line: 2173, col: 5, offset: 66044},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 5, offset: 66048},
+									pos:  position{line: 2173, col: 5, offset: 66044},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 7, offset: 66050},
+									pos:  position{line: 2173, col: 7, offset: 66046},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 13, offset: 66056},
+									pos:  position{line: 2173, col: 13, offset: 66052},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 15, offset: 66058},
+									pos:  position{line: 2173, col: 15, offset: 66054},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 18, offset: 66061},
+									pos:  position{line: 2173, col: 18, offset: 66057},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2173, col: 20, offset: 66063},
+									pos:   position{line: 2173, col: 20, offset: 66059},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2173, col: 25, offset: 66068},
+										pos:  position{line: 2173, col: 25, offset: 66064},
 										name: "OrderByList",
 									},
 								},
@@ -15060,10 +15060,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2180, col: 5, offset: 66232},
+						pos: position{line: 2180, col: 5, offset: 66228},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2180, col: 5, offset: 66232},
+							pos:        position{line: 2180, col: 5, offset: 66228},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15076,51 +15076,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2182, col: 1, offset: 66265},
+			pos:  position{line: 2182, col: 1, offset: 66261},
 			expr: &actionExpr{
-				pos: position{line: 2183, col: 5, offset: 66281},
+				pos: position{line: 2183, col: 5, offset: 66277},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2183, col: 5, offset: 66281},
+					pos: position{line: 2183, col: 5, offset: 66277},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2183, col: 5, offset: 66281},
+							pos:   position{line: 2183, col: 5, offset: 66277},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2183, col: 11, offset: 66287},
+								pos:  position{line: 2183, col: 11, offset: 66283},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2183, col: 23, offset: 66299},
+							pos:   position{line: 2183, col: 23, offset: 66295},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2183, col: 28, offset: 66304},
+								pos: position{line: 2183, col: 28, offset: 66300},
 								expr: &actionExpr{
-									pos: position{line: 2183, col: 30, offset: 66306},
+									pos: position{line: 2183, col: 30, offset: 66302},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2183, col: 30, offset: 66306},
+										pos: position{line: 2183, col: 30, offset: 66302},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2183, col: 30, offset: 66306},
+												pos:  position{line: 2183, col: 30, offset: 66302},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2183, col: 33, offset: 66309},
+												pos:        position{line: 2183, col: 33, offset: 66305},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2183, col: 37, offset: 66313},
+												pos:  position{line: 2183, col: 37, offset: 66309},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2183, col: 40, offset: 66316},
+												pos:   position{line: 2183, col: 40, offset: 66312},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2183, col: 42, offset: 66318},
+													pos:  position{line: 2183, col: 42, offset: 66314},
 													name: "OrderByItem",
 												},
 											},
@@ -15137,34 +15137,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2187, col: 1, offset: 66419},
+			pos:  position{line: 2187, col: 1, offset: 66415},
 			expr: &actionExpr{
-				pos: position{line: 2188, col: 5, offset: 66435},
+				pos: position{line: 2188, col: 5, offset: 66431},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2188, col: 5, offset: 66435},
+					pos: position{line: 2188, col: 5, offset: 66431},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2188, col: 5, offset: 66435},
+							pos:   position{line: 2188, col: 5, offset: 66431},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2188, col: 7, offset: 66437},
+								pos:  position{line: 2188, col: 7, offset: 66433},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2188, col: 12, offset: 66442},
+							pos:   position{line: 2188, col: 12, offset: 66438},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2188, col: 18, offset: 66448},
+								pos:  position{line: 2188, col: 18, offset: 66444},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2188, col: 29, offset: 66459},
+							pos:   position{line: 2188, col: 29, offset: 66455},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2188, col: 35, offset: 66465},
+								pos:  position{line: 2188, col: 35, offset: 66461},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15176,49 +15176,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2199, col: 1, offset: 66715},
+			pos:  position{line: 2199, col: 1, offset: 66711},
 			expr: &choiceExpr{
-				pos: position{line: 2200, col: 5, offset: 66730},
+				pos: position{line: 2200, col: 5, offset: 66726},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2200, col: 5, offset: 66730},
+						pos: position{line: 2200, col: 5, offset: 66726},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2200, col: 5, offset: 66730},
+							pos: position{line: 2200, col: 5, offset: 66726},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2200, col: 5, offset: 66730},
+									pos:  position{line: 2200, col: 5, offset: 66726},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2200, col: 7, offset: 66732},
+									pos:  position{line: 2200, col: 7, offset: 66728},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2201, col: 5, offset: 66804},
+						pos: position{line: 2201, col: 5, offset: 66800},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2201, col: 5, offset: 66804},
+							pos: position{line: 2201, col: 5, offset: 66800},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2201, col: 5, offset: 66804},
+									pos:  position{line: 2201, col: 5, offset: 66800},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2201, col: 7, offset: 66806},
+									pos:  position{line: 2201, col: 7, offset: 66802},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2202, col: 5, offset: 66878},
+						pos: position{line: 2202, col: 5, offset: 66874},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2202, col: 5, offset: 66878},
+							pos:        position{line: 2202, col: 5, offset: 66874},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15231,65 +15231,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2204, col: 1, offset: 66910},
+			pos:  position{line: 2204, col: 1, offset: 66906},
 			expr: &choiceExpr{
-				pos: position{line: 2205, col: 5, offset: 66928},
+				pos: position{line: 2205, col: 5, offset: 66924},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2205, col: 5, offset: 66928},
+						pos: position{line: 2205, col: 5, offset: 66924},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2205, col: 5, offset: 66928},
+							pos: position{line: 2205, col: 5, offset: 66924},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 5, offset: 66928},
+									pos:  position{line: 2205, col: 5, offset: 66924},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 7, offset: 66930},
+									pos:  position{line: 2205, col: 7, offset: 66926},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 13, offset: 66936},
+									pos:  position{line: 2205, col: 13, offset: 66932},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 15, offset: 66938},
+									pos:  position{line: 2205, col: 15, offset: 66934},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2206, col: 5, offset: 67014},
+						pos: position{line: 2206, col: 5, offset: 67010},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2206, col: 5, offset: 67014},
+							pos: position{line: 2206, col: 5, offset: 67010},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 5, offset: 67014},
+									pos:  position{line: 2206, col: 5, offset: 67010},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 7, offset: 67016},
+									pos:  position{line: 2206, col: 7, offset: 67012},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 13, offset: 67022},
+									pos:  position{line: 2206, col: 13, offset: 67018},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 15, offset: 67024},
+									pos:  position{line: 2206, col: 15, offset: 67020},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2207, col: 5, offset: 67099},
+						pos: position{line: 2207, col: 5, offset: 67095},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2207, col: 5, offset: 67099},
+							pos:        position{line: 2207, col: 5, offset: 67095},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15302,25 +15302,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2209, col: 1, offset: 67144},
+			pos:  position{line: 2209, col: 1, offset: 67140},
 			expr: &choiceExpr{
-				pos: position{line: 2210, col: 5, offset: 67166},
+				pos: position{line: 2210, col: 5, offset: 67162},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2210, col: 5, offset: 67166},
+						pos: position{line: 2210, col: 5, offset: 67162},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2210, col: 5, offset: 67166},
+							pos: position{line: 2210, col: 5, offset: 67162},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2210, col: 5, offset: 67166},
+									pos:  position{line: 2210, col: 5, offset: 67162},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2210, col: 7, offset: 67168},
+									pos:   position{line: 2210, col: 7, offset: 67164},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2210, col: 10, offset: 67171},
+										pos:  position{line: 2210, col: 10, offset: 67167},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15328,10 +15328,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2211, col: 5, offset: 67209},
+						pos: position{line: 2211, col: 5, offset: 67205},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2211, col: 5, offset: 67209},
+							pos:        position{line: 2211, col: 5, offset: 67205},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15344,29 +15344,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2213, col: 1, offset: 67250},
+			pos:  position{line: 2213, col: 1, offset: 67246},
 			expr: &choiceExpr{
-				pos: position{line: 2214, col: 5, offset: 67269},
+				pos: position{line: 2214, col: 5, offset: 67265},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2214, col: 5, offset: 67269},
+						pos: position{line: 2214, col: 5, offset: 67265},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2214, col: 5, offset: 67269},
+							pos: position{line: 2214, col: 5, offset: 67265},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2214, col: 5, offset: 67269},
+									pos:   position{line: 2214, col: 5, offset: 67265},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2214, col: 7, offset: 67271},
+										pos:  position{line: 2214, col: 7, offset: 67267},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2214, col: 19, offset: 67283},
+									pos:   position{line: 2214, col: 19, offset: 67279},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2214, col: 21, offset: 67285},
+										pos:  position{line: 2214, col: 21, offset: 67281},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15374,24 +15374,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2227, col: 5, offset: 67549},
+						pos: position{line: 2227, col: 5, offset: 67545},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2227, col: 5, offset: 67549},
+							pos: position{line: 2227, col: 5, offset: 67545},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2227, col: 5, offset: 67549},
+									pos:   position{line: 2227, col: 5, offset: 67545},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2227, col: 7, offset: 67551},
+										pos:  position{line: 2227, col: 7, offset: 67547},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2227, col: 20, offset: 67564},
+									pos:   position{line: 2227, col: 20, offset: 67560},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2227, col: 22, offset: 67566},
+										pos:  position{line: 2227, col: 22, offset: 67562},
 										name: "OptLimitClause",
 									},
 								},
@@ -15405,25 +15405,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2239, col: 1, offset: 67795},
+			pos:  position{line: 2239, col: 1, offset: 67791},
 			expr: &choiceExpr{
-				pos: position{line: 2240, col: 5, offset: 67814},
+				pos: position{line: 2240, col: 5, offset: 67810},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2240, col: 5, offset: 67814},
+						pos: position{line: 2240, col: 5, offset: 67810},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2240, col: 5, offset: 67814},
+							pos: position{line: 2240, col: 5, offset: 67810},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 5, offset: 67814},
+									pos:  position{line: 2240, col: 5, offset: 67810},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2240, col: 7, offset: 67816},
+									pos:   position{line: 2240, col: 7, offset: 67812},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2240, col: 9, offset: 67818},
+										pos:  position{line: 2240, col: 9, offset: 67814},
 										name: "LimitClause",
 									},
 								},
@@ -15431,10 +15431,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2241, col: 5, offset: 67852},
+						pos: position{line: 2241, col: 5, offset: 67848},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2241, col: 5, offset: 67852},
+							pos:        position{line: 2241, col: 5, offset: 67848},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15447,50 +15447,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2243, col: 1, offset: 67889},
+			pos:  position{line: 2243, col: 1, offset: 67885},
 			expr: &choiceExpr{
-				pos: position{line: 2244, col: 5, offset: 67905},
+				pos: position{line: 2244, col: 5, offset: 67901},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2244, col: 5, offset: 67905},
+						pos: position{line: 2244, col: 5, offset: 67901},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2244, col: 5, offset: 67905},
+							pos: position{line: 2244, col: 5, offset: 67901},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 5, offset: 67905},
+									pos:  position{line: 2244, col: 5, offset: 67901},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 11, offset: 67911},
+									pos:  position{line: 2244, col: 11, offset: 67907},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 13, offset: 67913},
+									pos:  position{line: 2244, col: 13, offset: 67909},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2245, col: 5, offset: 67941},
+						pos: position{line: 2245, col: 5, offset: 67937},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2245, col: 5, offset: 67941},
+							pos: position{line: 2245, col: 5, offset: 67937},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2245, col: 5, offset: 67941},
+									pos:  position{line: 2245, col: 5, offset: 67937},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2245, col: 11, offset: 67947},
+									pos:  position{line: 2245, col: 11, offset: 67943},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2245, col: 13, offset: 67949},
+									pos:   position{line: 2245, col: 13, offset: 67945},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2245, col: 15, offset: 67951},
+										pos:  position{line: 2245, col: 15, offset: 67947},
 										name: "Expr",
 									},
 								},
@@ -15504,25 +15504,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2247, col: 1, offset: 67975},
+			pos:  position{line: 2247, col: 1, offset: 67971},
 			expr: &choiceExpr{
-				pos: position{line: 2248, col: 5, offset: 67995},
+				pos: position{line: 2248, col: 5, offset: 67991},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2248, col: 5, offset: 67995},
+						pos: position{line: 2248, col: 5, offset: 67991},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2248, col: 5, offset: 67995},
+							pos: position{line: 2248, col: 5, offset: 67991},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2248, col: 5, offset: 67995},
+									pos:  position{line: 2248, col: 5, offset: 67991},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2248, col: 7, offset: 67997},
+									pos:   position{line: 2248, col: 7, offset: 67993},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2248, col: 9, offset: 67999},
+										pos:  position{line: 2248, col: 9, offset: 67995},
 										name: "OffsetClause",
 									},
 								},
@@ -15530,10 +15530,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2249, col: 5, offset: 68035},
+						pos: position{line: 2249, col: 5, offset: 68031},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2249, col: 5, offset: 68035},
+							pos:        position{line: 2249, col: 5, offset: 68031},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15546,26 +15546,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2251, col: 1, offset: 68060},
+			pos:  position{line: 2251, col: 1, offset: 68056},
 			expr: &actionExpr{
-				pos: position{line: 2252, col: 5, offset: 68077},
+				pos: position{line: 2252, col: 5, offset: 68073},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2252, col: 5, offset: 68077},
+					pos: position{line: 2252, col: 5, offset: 68073},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2252, col: 5, offset: 68077},
+							pos:  position{line: 2252, col: 5, offset: 68073},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2252, col: 12, offset: 68084},
+							pos:  position{line: 2252, col: 12, offset: 68080},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2252, col: 14, offset: 68086},
+							pos:   position{line: 2252, col: 14, offset: 68082},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2252, col: 16, offset: 68088},
+								pos:  position{line: 2252, col: 16, offset: 68084},
 								name: "Expr",
 							},
 						},
@@ -15577,103 +15577,103 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2254, col: 1, offset: 68113},
+			pos:  position{line: 2254, col: 1, offset: 68109},
 			expr: &actionExpr{
-				pos: position{line: 2255, col: 5, offset: 68130},
+				pos: position{line: 2255, col: 5, offset: 68126},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2255, col: 5, offset: 68130},
+					pos: position{line: 2255, col: 5, offset: 68126},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2255, col: 5, offset: 68130},
+							pos:   position{line: 2255, col: 5, offset: 68126},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 10, offset: 68135},
+								pos:  position{line: 2255, col: 10, offset: 68131},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2255, col: 21, offset: 68146},
+							pos:   position{line: 2255, col: 21, offset: 68142},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 30, offset: 68155},
+								pos:  position{line: 2255, col: 30, offset: 68151},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2255, col: 36, offset: 68161},
+							pos:  position{line: 2255, col: 36, offset: 68157},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2255, col: 38, offset: 68163},
+							pos:   position{line: 2255, col: 38, offset: 68159},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 44, offset: 68169},
+								pos:  position{line: 2255, col: 44, offset: 68165},
 								name: "SelectExpr",
 							},
 						},
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2265, col: 1, offset: 68396},
+			pos:  position{line: 2265, col: 1, offset: 68392},
 			expr: &choiceExpr{
-				pos: position{line: 2266, col: 5, offset: 68406},
+				pos: position{line: 2266, col: 5, offset: 68402},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2266, col: 5, offset: 68406},
+						pos: position{line: 2266, col: 5, offset: 68402},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2266, col: 5, offset: 68406},
+							pos: position{line: 2266, col: 5, offset: 68402},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 5, offset: 68406},
+									pos:  position{line: 2266, col: 5, offset: 68402},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 7, offset: 68408},
+									pos:  position{line: 2266, col: 7, offset: 68404},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 13, offset: 68414},
+									pos:  position{line: 2266, col: 13, offset: 68410},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 15, offset: 68416},
+									pos:  position{line: 2266, col: 15, offset: 68412},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2267, col: 5, offset: 68452},
+						pos: position{line: 2267, col: 5, offset: 68448},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2267, col: 5, offset: 68452},
+							pos: position{line: 2267, col: 5, offset: 68448},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 5, offset: 68452},
+									pos:  position{line: 2267, col: 5, offset: 68448},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 7, offset: 68454},
+									pos:  position{line: 2267, col: 7, offset: 68450},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2267, col: 13, offset: 68460},
+									pos: position{line: 2267, col: 13, offset: 68456},
 									expr: &seqExpr{
-										pos: position{line: 2267, col: 14, offset: 68461},
+										pos: position{line: 2267, col: 14, offset: 68457},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2267, col: 14, offset: 68461},
+												pos:  position{line: 2267, col: 14, offset: 68457},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2267, col: 16, offset: 68463},
+												pos:  position{line: 2267, col: 16, offset: 68459},
 												name: "DISTINCT",
 											},
 										},
@@ -15689,84 +15689,84 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2270, col: 1, offset: 68515},
+			pos:  position{line: 2270, col: 1, offset: 68511},
 			expr: &choiceExpr{
-				pos: position{line: 2271, col: 5, offset: 68530},
+				pos: position{line: 2271, col: 5, offset: 68526},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 5, offset: 68530},
+						pos:  position{line: 2271, col: 5, offset: 68526},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 12, offset: 68537},
+						pos:  position{line: 2271, col: 12, offset: 68533},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 20, offset: 68545},
+						pos:  position{line: 2271, col: 20, offset: 68541},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 29, offset: 68554},
+						pos:  position{line: 2271, col: 29, offset: 68550},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 38, offset: 68563},
+						pos:  position{line: 2271, col: 38, offset: 68559},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 5, offset: 68577},
+						pos:  position{line: 2272, col: 5, offset: 68573},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 13, offset: 68585},
+						pos:  position{line: 2272, col: 13, offset: 68581},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 20, offset: 68592},
+						pos:  position{line: 2272, col: 20, offset: 68588},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 28, offset: 68600},
+						pos:  position{line: 2272, col: 28, offset: 68596},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 36, offset: 68608},
+						pos:  position{line: 2272, col: 36, offset: 68604},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 44, offset: 68616},
+						pos:  position{line: 2272, col: 44, offset: 68612},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2273, col: 5, offset: 68625},
+						pos:  position{line: 2273, col: 5, offset: 68621},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2274, col: 5, offset: 68635},
+						pos:  position{line: 2274, col: 5, offset: 68631},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2275, col: 5, offset: 68645},
+						pos:  position{line: 2275, col: 5, offset: 68641},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2276, col: 5, offset: 68656},
+						pos:  position{line: 2276, col: 5, offset: 68652},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2277, col: 5, offset: 68666},
+						pos:  position{line: 2277, col: 5, offset: 68662},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2278, col: 5, offset: 68676},
+						pos:  position{line: 2278, col: 5, offset: 68672},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2279, col: 5, offset: 68685},
+						pos:  position{line: 2279, col: 5, offset: 68681},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2280, col: 5, offset: 68695},
+						pos:  position{line: 2280, col: 5, offset: 68691},
 						name: "ON",
 					},
 				},
@@ -15776,20 +15776,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2282, col: 1, offset: 68699},
+			pos:  position{line: 2282, col: 1, offset: 68695},
 			expr: &seqExpr{
-				pos: position{line: 2282, col: 14, offset: 68712},
+				pos: position{line: 2282, col: 14, offset: 68708},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2282, col: 14, offset: 68712},
+						pos:        position{line: 2282, col: 14, offset: 68708},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2282, col: 33, offset: 68731},
+						pos: position{line: 2282, col: 33, offset: 68727},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2282, col: 34, offset: 68732},
+							pos:  position{line: 2282, col: 34, offset: 68728},
 							name: "IdentifierRest",
 						},
 					},
@@ -15800,20 +15800,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2283, col: 1, offset: 68747},
+			pos:  position{line: 2283, col: 1, offset: 68743},
 			expr: &seqExpr{
-				pos: position{line: 2283, col: 14, offset: 68760},
+				pos: position{line: 2283, col: 14, offset: 68756},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2283, col: 14, offset: 68760},
+						pos:        position{line: 2283, col: 14, offset: 68756},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2283, col: 33, offset: 68779},
+						pos: position{line: 2283, col: 33, offset: 68775},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2283, col: 34, offset: 68780},
+							pos:  position{line: 2283, col: 34, offset: 68776},
 							name: "IdentifierRest",
 						},
 					},
@@ -15824,23 +15824,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2284, col: 1, offset: 68795},
+			pos:  position{line: 2284, col: 1, offset: 68791},
 			expr: &actionExpr{
-				pos: position{line: 2284, col: 14, offset: 68808},
+				pos: position{line: 2284, col: 14, offset: 68804},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2284, col: 14, offset: 68808},
+					pos: position{line: 2284, col: 14, offset: 68804},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2284, col: 14, offset: 68808},
+							pos:        position{line: 2284, col: 14, offset: 68804},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2284, col: 33, offset: 68827},
+							pos: position{line: 2284, col: 33, offset: 68823},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2284, col: 34, offset: 68828},
+								pos:  position{line: 2284, col: 34, offset: 68824},
 								name: "IdentifierRest",
 							},
 						},
@@ -15852,20 +15852,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2285, col: 1, offset: 68865},
+			pos:  position{line: 2285, col: 1, offset: 68861},
 			expr: &seqExpr{
-				pos: position{line: 2285, col: 14, offset: 68878},
+				pos: position{line: 2285, col: 14, offset: 68874},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2285, col: 14, offset: 68878},
+						pos:        position{line: 2285, col: 14, offset: 68874},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2285, col: 33, offset: 68897},
+						pos: position{line: 2285, col: 33, offset: 68893},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2285, col: 34, offset: 68898},
+							pos:  position{line: 2285, col: 34, offset: 68894},
 							name: "IdentifierRest",
 						},
 					},
@@ -15876,20 +15876,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2286, col: 1, offset: 68913},
+			pos:  position{line: 2286, col: 1, offset: 68909},
 			expr: &seqExpr{
-				pos: position{line: 2286, col: 14, offset: 68926},
+				pos: position{line: 2286, col: 14, offset: 68922},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2286, col: 14, offset: 68926},
+						pos:        position{line: 2286, col: 14, offset: 68922},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2286, col: 33, offset: 68945},
+						pos: position{line: 2286, col: 33, offset: 68941},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2286, col: 34, offset: 68946},
+							pos:  position{line: 2286, col: 34, offset: 68942},
 							name: "IdentifierRest",
 						},
 					},
@@ -15900,23 +15900,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2287, col: 1, offset: 68961},
+			pos:  position{line: 2287, col: 1, offset: 68957},
 			expr: &actionExpr{
-				pos: position{line: 2287, col: 14, offset: 68974},
+				pos: position{line: 2287, col: 14, offset: 68970},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2287, col: 14, offset: 68974},
+					pos: position{line: 2287, col: 14, offset: 68970},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2287, col: 14, offset: 68974},
+							pos:        position{line: 2287, col: 14, offset: 68970},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2287, col: 33, offset: 68993},
+							pos: position{line: 2287, col: 33, offset: 68989},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2287, col: 34, offset: 68994},
+								pos:  position{line: 2287, col: 34, offset: 68990},
 								name: "IdentifierRest",
 							},
 						},
@@ -15928,20 +15928,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2288, col: 1, offset: 69031},
+			pos:  position{line: 2288, col: 1, offset: 69027},
 			expr: &seqExpr{
-				pos: position{line: 2288, col: 14, offset: 69044},
+				pos: position{line: 2288, col: 14, offset: 69040},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2288, col: 14, offset: 69044},
+						pos:        position{line: 2288, col: 14, offset: 69040},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2288, col: 33, offset: 69063},
+						pos: position{line: 2288, col: 33, offset: 69059},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2288, col: 34, offset: 69064},
+							pos:  position{line: 2288, col: 34, offset: 69060},
 							name: "IdentifierRest",
 						},
 					},
@@ -15952,20 +15952,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2289, col: 1, offset: 69079},
+			pos:  position{line: 2289, col: 1, offset: 69075},
 			expr: &seqExpr{
-				pos: position{line: 2289, col: 14, offset: 69092},
+				pos: position{line: 2289, col: 14, offset: 69088},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2289, col: 14, offset: 69092},
+						pos:        position{line: 2289, col: 14, offset: 69088},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2289, col: 33, offset: 69111},
+						pos: position{line: 2289, col: 33, offset: 69107},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2289, col: 34, offset: 69112},
+							pos:  position{line: 2289, col: 34, offset: 69108},
 							name: "IdentifierRest",
 						},
 					},
@@ -15976,20 +15976,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2290, col: 1, offset: 69127},
+			pos:  position{line: 2290, col: 1, offset: 69123},
 			expr: &seqExpr{
-				pos: position{line: 2290, col: 14, offset: 69140},
+				pos: position{line: 2290, col: 14, offset: 69136},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2290, col: 14, offset: 69140},
+						pos:        position{line: 2290, col: 14, offset: 69136},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2290, col: 33, offset: 69159},
+						pos: position{line: 2290, col: 33, offset: 69155},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2290, col: 34, offset: 69160},
+							pos:  position{line: 2290, col: 34, offset: 69156},
 							name: "IdentifierRest",
 						},
 					},
@@ -16000,20 +16000,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2291, col: 1, offset: 69175},
+			pos:  position{line: 2291, col: 1, offset: 69171},
 			expr: &seqExpr{
-				pos: position{line: 2291, col: 14, offset: 69188},
+				pos: position{line: 2291, col: 14, offset: 69184},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2291, col: 14, offset: 69188},
+						pos:        position{line: 2291, col: 14, offset: 69184},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2291, col: 33, offset: 69207},
+						pos: position{line: 2291, col: 33, offset: 69203},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2291, col: 34, offset: 69208},
+							pos:  position{line: 2291, col: 34, offset: 69204},
 							name: "IdentifierRest",
 						},
 					},
@@ -16024,20 +16024,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2292, col: 1, offset: 69223},
+			pos:  position{line: 2292, col: 1, offset: 69219},
 			expr: &seqExpr{
-				pos: position{line: 2292, col: 14, offset: 69236},
+				pos: position{line: 2292, col: 14, offset: 69232},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2292, col: 14, offset: 69236},
+						pos:        position{line: 2292, col: 14, offset: 69232},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2292, col: 33, offset: 69255},
+						pos: position{line: 2292, col: 33, offset: 69251},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2292, col: 34, offset: 69256},
+							pos:  position{line: 2292, col: 34, offset: 69252},
 							name: "IdentifierRest",
 						},
 					},
@@ -16048,20 +16048,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2293, col: 1, offset: 69271},
+			pos:  position{line: 2293, col: 1, offset: 69267},
 			expr: &seqExpr{
-				pos: position{line: 2293, col: 14, offset: 69284},
+				pos: position{line: 2293, col: 14, offset: 69280},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2293, col: 14, offset: 69284},
+						pos:        position{line: 2293, col: 14, offset: 69280},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2293, col: 33, offset: 69303},
+						pos: position{line: 2293, col: 33, offset: 69299},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2293, col: 34, offset: 69304},
+							pos:  position{line: 2293, col: 34, offset: 69300},
 							name: "IdentifierRest",
 						},
 					},
@@ -16072,20 +16072,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2294, col: 1, offset: 69319},
+			pos:  position{line: 2294, col: 1, offset: 69315},
 			expr: &seqExpr{
-				pos: position{line: 2294, col: 14, offset: 69332},
+				pos: position{line: 2294, col: 14, offset: 69328},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2294, col: 14, offset: 69332},
+						pos:        position{line: 2294, col: 14, offset: 69328},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2294, col: 33, offset: 69351},
+						pos: position{line: 2294, col: 33, offset: 69347},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2294, col: 34, offset: 69352},
+							pos:  position{line: 2294, col: 34, offset: 69348},
 							name: "IdentifierRest",
 						},
 					},
@@ -16096,20 +16096,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2295, col: 1, offset: 69367},
+			pos:  position{line: 2295, col: 1, offset: 69363},
 			expr: &seqExpr{
-				pos: position{line: 2295, col: 14, offset: 69380},
+				pos: position{line: 2295, col: 14, offset: 69376},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2295, col: 14, offset: 69380},
+						pos:        position{line: 2295, col: 14, offset: 69376},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2295, col: 33, offset: 69399},
+						pos: position{line: 2295, col: 33, offset: 69395},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2295, col: 34, offset: 69400},
+							pos:  position{line: 2295, col: 34, offset: 69396},
 							name: "IdentifierRest",
 						},
 					},
@@ -16120,20 +16120,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2296, col: 1, offset: 69415},
+			pos:  position{line: 2296, col: 1, offset: 69411},
 			expr: &seqExpr{
-				pos: position{line: 2296, col: 14, offset: 69428},
+				pos: position{line: 2296, col: 14, offset: 69424},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2296, col: 14, offset: 69428},
+						pos:        position{line: 2296, col: 14, offset: 69424},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2296, col: 33, offset: 69447},
+						pos: position{line: 2296, col: 33, offset: 69443},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2296, col: 34, offset: 69448},
+							pos:  position{line: 2296, col: 34, offset: 69444},
 							name: "IdentifierRest",
 						},
 					},
@@ -16144,20 +16144,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2297, col: 1, offset: 69463},
+			pos:  position{line: 2297, col: 1, offset: 69459},
 			expr: &seqExpr{
-				pos: position{line: 2297, col: 14, offset: 69476},
+				pos: position{line: 2297, col: 14, offset: 69472},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2297, col: 14, offset: 69476},
+						pos:        position{line: 2297, col: 14, offset: 69472},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2297, col: 33, offset: 69495},
+						pos: position{line: 2297, col: 33, offset: 69491},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2297, col: 34, offset: 69496},
+							pos:  position{line: 2297, col: 34, offset: 69492},
 							name: "IdentifierRest",
 						},
 					},
@@ -16168,23 +16168,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2298, col: 1, offset: 69511},
+			pos:  position{line: 2298, col: 1, offset: 69507},
 			expr: &actionExpr{
-				pos: position{line: 2298, col: 14, offset: 69524},
+				pos: position{line: 2298, col: 14, offset: 69520},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2298, col: 14, offset: 69524},
+					pos: position{line: 2298, col: 14, offset: 69520},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2298, col: 14, offset: 69524},
+							pos:        position{line: 2298, col: 14, offset: 69520},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2298, col: 33, offset: 69543},
+							pos: position{line: 2298, col: 33, offset: 69539},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2298, col: 34, offset: 69544},
+								pos:  position{line: 2298, col: 34, offset: 69540},
 								name: "IdentifierRest",
 							},
 						},
@@ -16196,20 +16196,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2299, col: 1, offset: 69582},
+			pos:  position{line: 2299, col: 1, offset: 69578},
 			expr: &seqExpr{
-				pos: position{line: 2299, col: 14, offset: 69595},
+				pos: position{line: 2299, col: 14, offset: 69591},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2299, col: 14, offset: 69595},
+						pos:        position{line: 2299, col: 14, offset: 69591},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2299, col: 33, offset: 69614},
+						pos: position{line: 2299, col: 33, offset: 69610},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2299, col: 34, offset: 69615},
+							pos:  position{line: 2299, col: 34, offset: 69611},
 							name: "IdentifierRest",
 						},
 					},
@@ -16220,20 +16220,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2300, col: 1, offset: 69630},
+			pos:  position{line: 2300, col: 1, offset: 69626},
 			expr: &seqExpr{
-				pos: position{line: 2300, col: 14, offset: 69643},
+				pos: position{line: 2300, col: 14, offset: 69639},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2300, col: 14, offset: 69643},
+						pos:        position{line: 2300, col: 14, offset: 69639},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2300, col: 33, offset: 69662},
+						pos: position{line: 2300, col: 33, offset: 69658},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2300, col: 34, offset: 69663},
+							pos:  position{line: 2300, col: 34, offset: 69659},
 							name: "IdentifierRest",
 						},
 					},
@@ -16244,23 +16244,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2301, col: 1, offset: 69678},
+			pos:  position{line: 2301, col: 1, offset: 69674},
 			expr: &actionExpr{
-				pos: position{line: 2301, col: 14, offset: 69691},
+				pos: position{line: 2301, col: 14, offset: 69687},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2301, col: 14, offset: 69691},
+					pos: position{line: 2301, col: 14, offset: 69687},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2301, col: 14, offset: 69691},
+							pos:        position{line: 2301, col: 14, offset: 69687},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2301, col: 33, offset: 69710},
+							pos: position{line: 2301, col: 33, offset: 69706},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2301, col: 34, offset: 69711},
+								pos:  position{line: 2301, col: 34, offset: 69707},
 								name: "IdentifierRest",
 							},
 						},
@@ -16272,20 +16272,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2302, col: 1, offset: 69749},
+			pos:  position{line: 2302, col: 1, offset: 69745},
 			expr: &seqExpr{
-				pos: position{line: 2302, col: 14, offset: 69762},
+				pos: position{line: 2302, col: 14, offset: 69758},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2302, col: 14, offset: 69762},
+						pos:        position{line: 2302, col: 14, offset: 69758},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2302, col: 33, offset: 69781},
+						pos: position{line: 2302, col: 33, offset: 69777},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2302, col: 34, offset: 69782},
+							pos:  position{line: 2302, col: 34, offset: 69778},
 							name: "IdentifierRest",
 						},
 					},
@@ -16296,20 +16296,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2303, col: 1, offset: 69797},
+			pos:  position{line: 2303, col: 1, offset: 69793},
 			expr: &seqExpr{
-				pos: position{line: 2303, col: 14, offset: 69810},
+				pos: position{line: 2303, col: 14, offset: 69806},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2303, col: 14, offset: 69810},
+						pos:        position{line: 2303, col: 14, offset: 69806},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2303, col: 33, offset: 69829},
+						pos: position{line: 2303, col: 33, offset: 69825},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2303, col: 34, offset: 69830},
+							pos:  position{line: 2303, col: 34, offset: 69826},
 							name: "IdentifierRest",
 						},
 					},
@@ -16320,20 +16320,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2304, col: 1, offset: 69845},
+			pos:  position{line: 2304, col: 1, offset: 69841},
 			expr: &seqExpr{
-				pos: position{line: 2304, col: 14, offset: 69858},
+				pos: position{line: 2304, col: 14, offset: 69854},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2304, col: 14, offset: 69858},
+						pos:        position{line: 2304, col: 14, offset: 69854},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2304, col: 33, offset: 69877},
+						pos: position{line: 2304, col: 33, offset: 69873},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2304, col: 34, offset: 69878},
+							pos:  position{line: 2304, col: 34, offset: 69874},
 							name: "IdentifierRest",
 						},
 					},
@@ -16344,20 +16344,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2305, col: 1, offset: 69893},
+			pos:  position{line: 2305, col: 1, offset: 69889},
 			expr: &seqExpr{
-				pos: position{line: 2305, col: 14, offset: 69906},
+				pos: position{line: 2305, col: 14, offset: 69902},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2305, col: 14, offset: 69906},
+						pos:        position{line: 2305, col: 14, offset: 69902},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2305, col: 33, offset: 69925},
+						pos: position{line: 2305, col: 33, offset: 69921},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2305, col: 34, offset: 69926},
+							pos:  position{line: 2305, col: 34, offset: 69922},
 							name: "IdentifierRest",
 						},
 					},
@@ -16368,20 +16368,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2306, col: 1, offset: 69941},
+			pos:  position{line: 2306, col: 1, offset: 69937},
 			expr: &seqExpr{
-				pos: position{line: 2306, col: 14, offset: 69954},
+				pos: position{line: 2306, col: 14, offset: 69950},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2306, col: 14, offset: 69954},
+						pos:        position{line: 2306, col: 14, offset: 69950},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2306, col: 33, offset: 69973},
+						pos: position{line: 2306, col: 33, offset: 69969},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2306, col: 34, offset: 69974},
+							pos:  position{line: 2306, col: 34, offset: 69970},
 							name: "IdentifierRest",
 						},
 					},
@@ -16392,20 +16392,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2307, col: 1, offset: 69989},
+			pos:  position{line: 2307, col: 1, offset: 69985},
 			expr: &seqExpr{
-				pos: position{line: 2307, col: 14, offset: 70002},
+				pos: position{line: 2307, col: 14, offset: 69998},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2307, col: 14, offset: 70002},
+						pos:        position{line: 2307, col: 14, offset: 69998},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2307, col: 33, offset: 70021},
+						pos: position{line: 2307, col: 33, offset: 70017},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2307, col: 34, offset: 70022},
+							pos:  position{line: 2307, col: 34, offset: 70018},
 							name: "IdentifierRest",
 						},
 					},
@@ -16416,20 +16416,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2308, col: 1, offset: 70037},
+			pos:  position{line: 2308, col: 1, offset: 70033},
 			expr: &seqExpr{
-				pos: position{line: 2308, col: 14, offset: 70050},
+				pos: position{line: 2308, col: 14, offset: 70046},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2308, col: 14, offset: 70050},
+						pos:        position{line: 2308, col: 14, offset: 70046},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2308, col: 33, offset: 70069},
+						pos: position{line: 2308, col: 33, offset: 70065},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2308, col: 34, offset: 70070},
+							pos:  position{line: 2308, col: 34, offset: 70066},
 							name: "IdentifierRest",
 						},
 					},
@@ -16440,20 +16440,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2309, col: 1, offset: 70085},
+			pos:  position{line: 2309, col: 1, offset: 70081},
 			expr: &seqExpr{
-				pos: position{line: 2309, col: 14, offset: 70098},
+				pos: position{line: 2309, col: 14, offset: 70094},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2309, col: 14, offset: 70098},
+						pos:        position{line: 2309, col: 14, offset: 70094},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2309, col: 33, offset: 70117},
+						pos: position{line: 2309, col: 33, offset: 70113},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2309, col: 34, offset: 70118},
+							pos:  position{line: 2309, col: 34, offset: 70114},
 							name: "IdentifierRest",
 						},
 					},
@@ -16464,20 +16464,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2310, col: 1, offset: 70133},
+			pos:  position{line: 2310, col: 1, offset: 70129},
 			expr: &seqExpr{
-				pos: position{line: 2310, col: 14, offset: 70146},
+				pos: position{line: 2310, col: 14, offset: 70142},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2310, col: 14, offset: 70146},
+						pos:        position{line: 2310, col: 14, offset: 70142},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2310, col: 33, offset: 70165},
+						pos: position{line: 2310, col: 33, offset: 70161},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2310, col: 34, offset: 70166},
+							pos:  position{line: 2310, col: 34, offset: 70162},
 							name: "IdentifierRest",
 						},
 					},
@@ -16488,20 +16488,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2311, col: 1, offset: 70181},
+			pos:  position{line: 2311, col: 1, offset: 70177},
 			expr: &seqExpr{
-				pos: position{line: 2311, col: 14, offset: 70194},
+				pos: position{line: 2311, col: 14, offset: 70190},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2311, col: 14, offset: 70194},
+						pos:        position{line: 2311, col: 14, offset: 70190},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2311, col: 33, offset: 70213},
+						pos: position{line: 2311, col: 33, offset: 70209},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2311, col: 34, offset: 70214},
+							pos:  position{line: 2311, col: 34, offset: 70210},
 							name: "IdentifierRest",
 						},
 					},
@@ -16512,20 +16512,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2312, col: 1, offset: 70229},
+			pos:  position{line: 2312, col: 1, offset: 70225},
 			expr: &seqExpr{
-				pos: position{line: 2312, col: 14, offset: 70242},
+				pos: position{line: 2312, col: 14, offset: 70238},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2312, col: 14, offset: 70242},
+						pos:        position{line: 2312, col: 14, offset: 70238},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2312, col: 33, offset: 70261},
+						pos: position{line: 2312, col: 33, offset: 70257},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2312, col: 34, offset: 70262},
+							pos:  position{line: 2312, col: 34, offset: 70258},
 							name: "IdentifierRest",
 						},
 					},
@@ -16536,20 +16536,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2313, col: 1, offset: 70277},
+			pos:  position{line: 2313, col: 1, offset: 70273},
 			expr: &seqExpr{
-				pos: position{line: 2313, col: 14, offset: 70290},
+				pos: position{line: 2313, col: 14, offset: 70286},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2313, col: 14, offset: 70290},
+						pos:        position{line: 2313, col: 14, offset: 70286},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2313, col: 33, offset: 70309},
+						pos: position{line: 2313, col: 33, offset: 70305},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2313, col: 34, offset: 70310},
+							pos:  position{line: 2313, col: 34, offset: 70306},
 							name: "IdentifierRest",
 						},
 					},
@@ -16560,20 +16560,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2314, col: 1, offset: 70325},
+			pos:  position{line: 2314, col: 1, offset: 70321},
 			expr: &seqExpr{
-				pos: position{line: 2314, col: 14, offset: 70338},
+				pos: position{line: 2314, col: 14, offset: 70334},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2314, col: 14, offset: 70338},
+						pos:        position{line: 2314, col: 14, offset: 70334},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2314, col: 33, offset: 70357},
+						pos: position{line: 2314, col: 33, offset: 70353},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2314, col: 34, offset: 70358},
+							pos:  position{line: 2314, col: 34, offset: 70354},
 							name: "IdentifierRest",
 						},
 					},
@@ -16584,20 +16584,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2315, col: 1, offset: 70373},
+			pos:  position{line: 2315, col: 1, offset: 70369},
 			expr: &seqExpr{
-				pos: position{line: 2315, col: 14, offset: 70386},
+				pos: position{line: 2315, col: 14, offset: 70382},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2315, col: 14, offset: 70386},
+						pos:        position{line: 2315, col: 14, offset: 70382},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2315, col: 33, offset: 70405},
+						pos: position{line: 2315, col: 33, offset: 70401},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2315, col: 34, offset: 70406},
+							pos:  position{line: 2315, col: 34, offset: 70402},
 							name: "IdentifierRest",
 						},
 					},
@@ -16608,20 +16608,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2316, col: 1, offset: 70421},
+			pos:  position{line: 2316, col: 1, offset: 70417},
 			expr: &seqExpr{
-				pos: position{line: 2316, col: 14, offset: 70434},
+				pos: position{line: 2316, col: 14, offset: 70430},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2316, col: 14, offset: 70434},
+						pos:        position{line: 2316, col: 14, offset: 70430},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2316, col: 33, offset: 70453},
+						pos: position{line: 2316, col: 33, offset: 70449},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2316, col: 34, offset: 70454},
+							pos:  position{line: 2316, col: 34, offset: 70450},
 							name: "IdentifierRest",
 						},
 					},
@@ -16632,20 +16632,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2317, col: 1, offset: 70469},
+			pos:  position{line: 2317, col: 1, offset: 70465},
 			expr: &seqExpr{
-				pos: position{line: 2317, col: 14, offset: 70482},
+				pos: position{line: 2317, col: 14, offset: 70478},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2317, col: 14, offset: 70482},
+						pos:        position{line: 2317, col: 14, offset: 70478},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2317, col: 33, offset: 70501},
+						pos: position{line: 2317, col: 33, offset: 70497},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2317, col: 34, offset: 70502},
+							pos:  position{line: 2317, col: 34, offset: 70498},
 							name: "IdentifierRest",
 						},
 					},
@@ -16656,20 +16656,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2318, col: 1, offset: 70517},
+			pos:  position{line: 2318, col: 1, offset: 70513},
 			expr: &seqExpr{
-				pos: position{line: 2318, col: 14, offset: 70530},
+				pos: position{line: 2318, col: 14, offset: 70526},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2318, col: 14, offset: 70530},
+						pos:        position{line: 2318, col: 14, offset: 70526},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2318, col: 33, offset: 70549},
+						pos: position{line: 2318, col: 33, offset: 70545},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2318, col: 34, offset: 70550},
+							pos:  position{line: 2318, col: 34, offset: 70546},
 							name: "IdentifierRest",
 						},
 					},
@@ -16680,20 +16680,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2319, col: 1, offset: 70565},
+			pos:  position{line: 2319, col: 1, offset: 70561},
 			expr: &seqExpr{
-				pos: position{line: 2319, col: 14, offset: 70578},
+				pos: position{line: 2319, col: 14, offset: 70574},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2319, col: 14, offset: 70578},
+						pos:        position{line: 2319, col: 14, offset: 70574},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2319, col: 33, offset: 70597},
+						pos: position{line: 2319, col: 33, offset: 70593},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2319, col: 34, offset: 70598},
+							pos:  position{line: 2319, col: 34, offset: 70594},
 							name: "IdentifierRest",
 						},
 					},
@@ -16704,20 +16704,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2320, col: 1, offset: 70613},
+			pos:  position{line: 2320, col: 1, offset: 70609},
 			expr: &seqExpr{
-				pos: position{line: 2320, col: 14, offset: 70626},
+				pos: position{line: 2320, col: 14, offset: 70622},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2320, col: 14, offset: 70626},
+						pos:        position{line: 2320, col: 14, offset: 70622},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2320, col: 33, offset: 70645},
+						pos: position{line: 2320, col: 33, offset: 70641},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2320, col: 34, offset: 70646},
+							pos:  position{line: 2320, col: 34, offset: 70642},
 							name: "IdentifierRest",
 						},
 					},
@@ -16728,20 +16728,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2321, col: 1, offset: 70661},
+			pos:  position{line: 2321, col: 1, offset: 70657},
 			expr: &seqExpr{
-				pos: position{line: 2321, col: 14, offset: 70674},
+				pos: position{line: 2321, col: 14, offset: 70670},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2321, col: 14, offset: 70674},
+						pos:        position{line: 2321, col: 14, offset: 70670},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2321, col: 33, offset: 70693},
+						pos: position{line: 2321, col: 33, offset: 70689},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2321, col: 34, offset: 70694},
+							pos:  position{line: 2321, col: 34, offset: 70690},
 							name: "IdentifierRest",
 						},
 					},
@@ -16752,20 +16752,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2322, col: 1, offset: 70709},
+			pos:  position{line: 2322, col: 1, offset: 70705},
 			expr: &seqExpr{
-				pos: position{line: 2322, col: 14, offset: 70722},
+				pos: position{line: 2322, col: 14, offset: 70718},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2322, col: 14, offset: 70722},
+						pos:        position{line: 2322, col: 14, offset: 70718},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2322, col: 33, offset: 70741},
+						pos: position{line: 2322, col: 33, offset: 70737},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2322, col: 34, offset: 70742},
+							pos:  position{line: 2322, col: 34, offset: 70738},
 							name: "IdentifierRest",
 						},
 					},
@@ -16776,20 +16776,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2323, col: 1, offset: 70757},
+			pos:  position{line: 2323, col: 1, offset: 70753},
 			expr: &seqExpr{
-				pos: position{line: 2323, col: 14, offset: 70770},
+				pos: position{line: 2323, col: 14, offset: 70766},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2323, col: 14, offset: 70770},
+						pos:        position{line: 2323, col: 14, offset: 70766},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2323, col: 33, offset: 70789},
+						pos: position{line: 2323, col: 33, offset: 70785},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2323, col: 34, offset: 70790},
+							pos:  position{line: 2323, col: 34, offset: 70786},
 							name: "IdentifierRest",
 						},
 					},
@@ -16800,20 +16800,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2324, col: 1, offset: 70805},
+			pos:  position{line: 2324, col: 1, offset: 70801},
 			expr: &seqExpr{
-				pos: position{line: 2324, col: 14, offset: 70818},
+				pos: position{line: 2324, col: 14, offset: 70814},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2324, col: 14, offset: 70818},
+						pos:        position{line: 2324, col: 14, offset: 70814},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2324, col: 33, offset: 70837},
+						pos: position{line: 2324, col: 33, offset: 70833},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2324, col: 34, offset: 70838},
+							pos:  position{line: 2324, col: 34, offset: 70834},
 							name: "IdentifierRest",
 						},
 					},
@@ -16824,20 +16824,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2325, col: 1, offset: 70853},
+			pos:  position{line: 2325, col: 1, offset: 70849},
 			expr: &seqExpr{
-				pos: position{line: 2325, col: 14, offset: 70866},
+				pos: position{line: 2325, col: 14, offset: 70862},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2325, col: 14, offset: 70866},
+						pos:        position{line: 2325, col: 14, offset: 70862},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2325, col: 33, offset: 70885},
+						pos: position{line: 2325, col: 33, offset: 70881},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2325, col: 34, offset: 70886},
+							pos:  position{line: 2325, col: 34, offset: 70882},
 							name: "IdentifierRest",
 						},
 					},
@@ -16848,20 +16848,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2326, col: 1, offset: 70901},
+			pos:  position{line: 2326, col: 1, offset: 70897},
 			expr: &seqExpr{
-				pos: position{line: 2326, col: 14, offset: 70914},
+				pos: position{line: 2326, col: 14, offset: 70910},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2326, col: 14, offset: 70914},
+						pos:        position{line: 2326, col: 14, offset: 70910},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2326, col: 33, offset: 70933},
+						pos: position{line: 2326, col: 33, offset: 70929},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2326, col: 34, offset: 70934},
+							pos:  position{line: 2326, col: 34, offset: 70930},
 							name: "IdentifierRest",
 						},
 					},
@@ -16872,20 +16872,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2327, col: 1, offset: 70949},
+			pos:  position{line: 2327, col: 1, offset: 70945},
 			expr: &seqExpr{
-				pos: position{line: 2327, col: 14, offset: 70962},
+				pos: position{line: 2327, col: 14, offset: 70958},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2327, col: 14, offset: 70962},
+						pos:        position{line: 2327, col: 14, offset: 70958},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2327, col: 33, offset: 70981},
+						pos: position{line: 2327, col: 33, offset: 70977},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2327, col: 34, offset: 70982},
+							pos:  position{line: 2327, col: 34, offset: 70978},
 							name: "IdentifierRest",
 						},
 					},
@@ -16896,20 +16896,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2328, col: 1, offset: 70997},
+			pos:  position{line: 2328, col: 1, offset: 70993},
 			expr: &seqExpr{
-				pos: position{line: 2328, col: 14, offset: 71010},
+				pos: position{line: 2328, col: 14, offset: 71006},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2328, col: 14, offset: 71010},
+						pos:        position{line: 2328, col: 14, offset: 71006},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2328, col: 33, offset: 71029},
+						pos: position{line: 2328, col: 33, offset: 71025},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2328, col: 34, offset: 71030},
+							pos:  position{line: 2328, col: 34, offset: 71026},
 							name: "IdentifierRest",
 						},
 					},
@@ -16920,20 +16920,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2329, col: 1, offset: 71045},
+			pos:  position{line: 2329, col: 1, offset: 71041},
 			expr: &seqExpr{
-				pos: position{line: 2329, col: 14, offset: 71058},
+				pos: position{line: 2329, col: 14, offset: 71054},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2329, col: 14, offset: 71058},
+						pos:        position{line: 2329, col: 14, offset: 71054},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2329, col: 33, offset: 71077},
+						pos: position{line: 2329, col: 33, offset: 71073},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2329, col: 34, offset: 71078},
+							pos:  position{line: 2329, col: 34, offset: 71074},
 							name: "IdentifierRest",
 						},
 					},
@@ -16944,20 +16944,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2330, col: 1, offset: 71093},
+			pos:  position{line: 2330, col: 1, offset: 71089},
 			expr: &seqExpr{
-				pos: position{line: 2330, col: 14, offset: 71106},
+				pos: position{line: 2330, col: 14, offset: 71102},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2330, col: 14, offset: 71106},
+						pos:        position{line: 2330, col: 14, offset: 71102},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2330, col: 33, offset: 71125},
+						pos: position{line: 2330, col: 33, offset: 71121},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2330, col: 34, offset: 71126},
+							pos:  position{line: 2330, col: 34, offset: 71122},
 							name: "IdentifierRest",
 						},
 					},
@@ -16968,20 +16968,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2331, col: 1, offset: 71141},
+			pos:  position{line: 2331, col: 1, offset: 71137},
 			expr: &seqExpr{
-				pos: position{line: 2331, col: 14, offset: 71154},
+				pos: position{line: 2331, col: 14, offset: 71150},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2331, col: 14, offset: 71154},
+						pos:        position{line: 2331, col: 14, offset: 71150},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2331, col: 33, offset: 71173},
+						pos: position{line: 2331, col: 33, offset: 71169},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2331, col: 34, offset: 71174},
+							pos:  position{line: 2331, col: 34, offset: 71170},
 							name: "IdentifierRest",
 						},
 					},
@@ -16992,20 +16992,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2332, col: 1, offset: 71189},
+			pos:  position{line: 2332, col: 1, offset: 71185},
 			expr: &seqExpr{
-				pos: position{line: 2332, col: 16, offset: 71204},
+				pos: position{line: 2332, col: 16, offset: 71200},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2332, col: 16, offset: 71204},
+						pos:        position{line: 2332, col: 16, offset: 71200},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2332, col: 33, offset: 71221},
+						pos: position{line: 2332, col: 33, offset: 71217},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2332, col: 34, offset: 71222},
+							pos:  position{line: 2332, col: 34, offset: 71218},
 							name: "IdentifierRest",
 						},
 					},
@@ -17016,20 +17016,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2333, col: 1, offset: 71237},
+			pos:  position{line: 2333, col: 1, offset: 71233},
 			expr: &seqExpr{
-				pos: position{line: 2333, col: 14, offset: 71250},
+				pos: position{line: 2333, col: 14, offset: 71246},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2333, col: 14, offset: 71250},
+						pos:        position{line: 2333, col: 14, offset: 71246},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2333, col: 33, offset: 71269},
+						pos: position{line: 2333, col: 33, offset: 71265},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2333, col: 34, offset: 71270},
+							pos:  position{line: 2333, col: 34, offset: 71266},
 							name: "IdentifierRest",
 						},
 					},
@@ -17040,20 +17040,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2334, col: 1, offset: 71285},
+			pos:  position{line: 2334, col: 1, offset: 71281},
 			expr: &seqExpr{
-				pos: position{line: 2334, col: 14, offset: 71298},
+				pos: position{line: 2334, col: 14, offset: 71294},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2334, col: 14, offset: 71298},
+						pos:        position{line: 2334, col: 14, offset: 71294},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2334, col: 33, offset: 71317},
+						pos: position{line: 2334, col: 33, offset: 71313},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2334, col: 34, offset: 71318},
+							pos:  position{line: 2334, col: 34, offset: 71314},
 							name: "IdentifierRest",
 						},
 					},
@@ -17064,20 +17064,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2335, col: 1, offset: 71333},
+			pos:  position{line: 2335, col: 1, offset: 71329},
 			expr: &seqExpr{
-				pos: position{line: 2335, col: 14, offset: 71346},
+				pos: position{line: 2335, col: 14, offset: 71342},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2335, col: 14, offset: 71346},
+						pos:        position{line: 2335, col: 14, offset: 71342},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2335, col: 33, offset: 71365},
+						pos: position{line: 2335, col: 33, offset: 71361},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2335, col: 34, offset: 71366},
+							pos:  position{line: 2335, col: 34, offset: 71362},
 							name: "IdentifierRest",
 						},
 					},
@@ -17088,20 +17088,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2336, col: 1, offset: 71381},
+			pos:  position{line: 2336, col: 1, offset: 71377},
 			expr: &seqExpr{
-				pos: position{line: 2336, col: 14, offset: 71394},
+				pos: position{line: 2336, col: 14, offset: 71390},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2336, col: 14, offset: 71394},
+						pos:        position{line: 2336, col: 14, offset: 71390},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2336, col: 33, offset: 71413},
+						pos: position{line: 2336, col: 33, offset: 71409},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2336, col: 34, offset: 71414},
+							pos:  position{line: 2336, col: 34, offset: 71410},
 							name: "IdentifierRest",
 						},
 					},
@@ -17112,20 +17112,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2337, col: 1, offset: 71429},
+			pos:  position{line: 2337, col: 1, offset: 71425},
 			expr: &seqExpr{
-				pos: position{line: 2337, col: 14, offset: 71442},
+				pos: position{line: 2337, col: 14, offset: 71438},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2337, col: 14, offset: 71442},
+						pos:        position{line: 2337, col: 14, offset: 71438},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2337, col: 33, offset: 71461},
+						pos: position{line: 2337, col: 33, offset: 71457},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2337, col: 34, offset: 71462},
+							pos:  position{line: 2337, col: 34, offset: 71458},
 							name: "IdentifierRest",
 						},
 					},
@@ -17136,20 +17136,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2338, col: 1, offset: 71477},
+			pos:  position{line: 2338, col: 1, offset: 71473},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 71490},
+				pos: position{line: 2338, col: 14, offset: 71486},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 71490},
+						pos:        position{line: 2338, col: 14, offset: 71486},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 71509},
+						pos: position{line: 2338, col: 33, offset: 71505},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 71510},
+							pos:  position{line: 2338, col: 34, offset: 71506},
 							name: "IdentifierRest",
 						},
 					},
@@ -17160,20 +17160,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2339, col: 1, offset: 71525},
+			pos:  position{line: 2339, col: 1, offset: 71521},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 71538},
+				pos: position{line: 2339, col: 14, offset: 71534},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 71538},
+						pos:        position{line: 2339, col: 14, offset: 71534},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 71557},
+						pos: position{line: 2339, col: 33, offset: 71553},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 71558},
+							pos:  position{line: 2339, col: 34, offset: 71554},
 							name: "IdentifierRest",
 						},
 					},
@@ -17184,23 +17184,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2340, col: 1, offset: 71573},
+			pos:  position{line: 2340, col: 1, offset: 71569},
 			expr: &actionExpr{
-				pos: position{line: 2340, col: 14, offset: 71586},
+				pos: position{line: 2340, col: 14, offset: 71582},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2340, col: 14, offset: 71586},
+					pos: position{line: 2340, col: 14, offset: 71582},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2340, col: 14, offset: 71586},
+							pos:        position{line: 2340, col: 14, offset: 71582},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2340, col: 33, offset: 71605},
+							pos: position{line: 2340, col: 33, offset: 71601},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2340, col: 34, offset: 71606},
+								pos:  position{line: 2340, col: 34, offset: 71602},
 								name: "IdentifierRest",
 							},
 						},
@@ -17212,20 +17212,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2341, col: 1, offset: 71642},
+			pos:  position{line: 2341, col: 1, offset: 71638},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 71655},
+				pos: position{line: 2341, col: 14, offset: 71651},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 71655},
+						pos:        position{line: 2341, col: 14, offset: 71651},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 71674},
+						pos: position{line: 2341, col: 33, offset: 71670},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 71675},
+							pos:  position{line: 2341, col: 34, offset: 71671},
 							name: "IdentifierRest",
 						},
 					},
@@ -17236,20 +17236,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2342, col: 1, offset: 71690},
+			pos:  position{line: 2342, col: 1, offset: 71686},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 71703},
+				pos: position{line: 2342, col: 14, offset: 71699},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 71703},
+						pos:        position{line: 2342, col: 14, offset: 71699},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 71722},
+						pos: position{line: 2342, col: 33, offset: 71718},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 71723},
+							pos:  position{line: 2342, col: 34, offset: 71719},
 							name: "IdentifierRest",
 						},
 					},
@@ -17260,20 +17260,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2343, col: 1, offset: 71738},
+			pos:  position{line: 2343, col: 1, offset: 71734},
 			expr: &seqExpr{
-				pos: position{line: 2343, col: 14, offset: 71751},
+				pos: position{line: 2343, col: 14, offset: 71747},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2343, col: 14, offset: 71751},
+						pos:        position{line: 2343, col: 14, offset: 71747},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2343, col: 33, offset: 71770},
+						pos: position{line: 2343, col: 33, offset: 71766},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2343, col: 34, offset: 71771},
+							pos:  position{line: 2343, col: 34, offset: 71767},
 							name: "IdentifierRest",
 						},
 					},
@@ -17284,20 +17284,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2344, col: 1, offset: 71786},
+			pos:  position{line: 2344, col: 1, offset: 71782},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 71799},
+				pos: position{line: 2344, col: 14, offset: 71795},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 71799},
+						pos:        position{line: 2344, col: 14, offset: 71795},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 71818},
+						pos: position{line: 2344, col: 33, offset: 71814},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 71819},
+							pos:  position{line: 2344, col: 34, offset: 71815},
 							name: "IdentifierRest",
 						},
 					},
@@ -17308,20 +17308,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2345, col: 1, offset: 71834},
+			pos:  position{line: 2345, col: 1, offset: 71830},
 			expr: &seqExpr{
-				pos: position{line: 2345, col: 14, offset: 71847},
+				pos: position{line: 2345, col: 14, offset: 71843},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2345, col: 14, offset: 71847},
+						pos:        position{line: 2345, col: 14, offset: 71843},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2345, col: 33, offset: 71866},
+						pos: position{line: 2345, col: 33, offset: 71862},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2345, col: 34, offset: 71867},
+							pos:  position{line: 2345, col: 34, offset: 71863},
 							name: "IdentifierRest",
 						},
 					},
@@ -17332,20 +17332,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2346, col: 1, offset: 71882},
+			pos:  position{line: 2346, col: 1, offset: 71878},
 			expr: &seqExpr{
-				pos: position{line: 2346, col: 14, offset: 71895},
+				pos: position{line: 2346, col: 14, offset: 71891},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2346, col: 14, offset: 71895},
+						pos:        position{line: 2346, col: 14, offset: 71891},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2346, col: 33, offset: 71914},
+						pos: position{line: 2346, col: 33, offset: 71910},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2346, col: 34, offset: 71915},
+							pos:  position{line: 2346, col: 34, offset: 71911},
 							name: "IdentifierRest",
 						},
 					},
@@ -17356,20 +17356,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2347, col: 1, offset: 71930},
+			pos:  position{line: 2347, col: 1, offset: 71926},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 71943},
+				pos: position{line: 2347, col: 14, offset: 71939},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 71943},
+						pos:        position{line: 2347, col: 14, offset: 71939},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 71962},
+						pos: position{line: 2347, col: 33, offset: 71958},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 71963},
+							pos:  position{line: 2347, col: 34, offset: 71959},
 							name: "IdentifierRest",
 						},
 					},
@@ -17380,20 +17380,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2348, col: 1, offset: 71978},
+			pos:  position{line: 2348, col: 1, offset: 71974},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 71991},
+				pos: position{line: 2348, col: 14, offset: 71987},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 71991},
+						pos:        position{line: 2348, col: 14, offset: 71987},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 72010},
+						pos: position{line: 2348, col: 33, offset: 72006},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 72011},
+							pos:  position{line: 2348, col: 34, offset: 72007},
 							name: "IdentifierRest",
 						},
 					},
@@ -17404,20 +17404,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2349, col: 1, offset: 72026},
+			pos:  position{line: 2349, col: 1, offset: 72022},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 72039},
+				pos: position{line: 2349, col: 14, offset: 72035},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 72039},
+						pos:        position{line: 2349, col: 14, offset: 72035},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 72058},
+						pos: position{line: 2349, col: 33, offset: 72054},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 72059},
+							pos:  position{line: 2349, col: 34, offset: 72055},
 							name: "IdentifierRest",
 						},
 					},
@@ -17428,20 +17428,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2350, col: 1, offset: 72074},
+			pos:  position{line: 2350, col: 1, offset: 72070},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 72087},
+				pos: position{line: 2350, col: 14, offset: 72083},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 72087},
+						pos:        position{line: 2350, col: 14, offset: 72083},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 72106},
+						pos: position{line: 2350, col: 33, offset: 72102},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 72107},
+							pos:  position{line: 2350, col: 34, offset: 72103},
 							name: "IdentifierRest",
 						},
 					},
@@ -17452,20 +17452,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2351, col: 1, offset: 72122},
+			pos:  position{line: 2351, col: 1, offset: 72118},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 72135},
+				pos: position{line: 2351, col: 14, offset: 72131},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 72135},
+						pos:        position{line: 2351, col: 14, offset: 72131},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 72154},
+						pos: position{line: 2351, col: 33, offset: 72150},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 72155},
+							pos:  position{line: 2351, col: 34, offset: 72151},
 							name: "IdentifierRest",
 						},
 					},
@@ -17476,20 +17476,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2352, col: 1, offset: 72170},
+			pos:  position{line: 2352, col: 1, offset: 72166},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 72183},
+				pos: position{line: 2352, col: 14, offset: 72179},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 72183},
+						pos:        position{line: 2352, col: 14, offset: 72179},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 72202},
+						pos: position{line: 2352, col: 33, offset: 72198},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 72203},
+							pos:  position{line: 2352, col: 34, offset: 72199},
 							name: "IdentifierRest",
 						},
 					},
@@ -17500,20 +17500,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2353, col: 1, offset: 72218},
+			pos:  position{line: 2353, col: 1, offset: 72214},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 72231},
+				pos: position{line: 2353, col: 14, offset: 72227},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 72231},
+						pos:        position{line: 2353, col: 14, offset: 72227},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 72250},
+						pos: position{line: 2353, col: 33, offset: 72246},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 72251},
+							pos:  position{line: 2353, col: 34, offset: 72247},
 							name: "IdentifierRest",
 						},
 					},
@@ -17524,20 +17524,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2354, col: 1, offset: 72266},
+			pos:  position{line: 2354, col: 1, offset: 72262},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 72279},
+				pos: position{line: 2354, col: 14, offset: 72275},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 72279},
+						pos:        position{line: 2354, col: 14, offset: 72275},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 72298},
+						pos: position{line: 2354, col: 33, offset: 72294},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 72299},
+							pos:  position{line: 2354, col: 34, offset: 72295},
 							name: "IdentifierRest",
 						},
 					},
@@ -17548,20 +17548,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2355, col: 1, offset: 72314},
+			pos:  position{line: 2355, col: 1, offset: 72310},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 72327},
+				pos: position{line: 2355, col: 14, offset: 72323},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 72327},
+						pos:        position{line: 2355, col: 14, offset: 72323},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 72346},
+						pos: position{line: 2355, col: 33, offset: 72342},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 72347},
+							pos:  position{line: 2355, col: 34, offset: 72343},
 							name: "IdentifierRest",
 						},
 					},
@@ -17572,20 +17572,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2356, col: 1, offset: 72362},
+			pos:  position{line: 2356, col: 1, offset: 72358},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 72375},
+				pos: position{line: 2356, col: 14, offset: 72371},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 72375},
+						pos:        position{line: 2356, col: 14, offset: 72371},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 72394},
+						pos: position{line: 2356, col: 33, offset: 72390},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 72395},
+							pos:  position{line: 2356, col: 34, offset: 72391},
 							name: "IdentifierRest",
 						},
 					},
@@ -17596,20 +17596,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2357, col: 1, offset: 72410},
+			pos:  position{line: 2357, col: 1, offset: 72406},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 72423},
+				pos: position{line: 2357, col: 14, offset: 72419},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 72423},
+						pos:        position{line: 2357, col: 14, offset: 72419},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 72442},
+						pos: position{line: 2357, col: 33, offset: 72438},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 72443},
+							pos:  position{line: 2357, col: 34, offset: 72439},
 							name: "IdentifierRest",
 						},
 					},
@@ -17620,20 +17620,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2358, col: 1, offset: 72458},
+			pos:  position{line: 2358, col: 1, offset: 72454},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 72471},
+				pos: position{line: 2358, col: 14, offset: 72467},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 72471},
+						pos:        position{line: 2358, col: 14, offset: 72467},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 72490},
+						pos: position{line: 2358, col: 33, offset: 72486},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 72491},
+							pos:  position{line: 2358, col: 34, offset: 72487},
 							name: "IdentifierRest",
 						},
 					},
@@ -17644,20 +17644,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2359, col: 1, offset: 72506},
+			pos:  position{line: 2359, col: 1, offset: 72502},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 72519},
+				pos: position{line: 2359, col: 14, offset: 72515},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 72519},
+						pos:        position{line: 2359, col: 14, offset: 72515},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 72538},
+						pos: position{line: 2359, col: 33, offset: 72534},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 72539},
+							pos:  position{line: 2359, col: 34, offset: 72535},
 							name: "IdentifierRest",
 						},
 					},
@@ -17668,20 +17668,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2360, col: 1, offset: 72554},
+			pos:  position{line: 2360, col: 1, offset: 72550},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 72567},
+				pos: position{line: 2360, col: 14, offset: 72563},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 72567},
+						pos:        position{line: 2360, col: 14, offset: 72563},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 72586},
+						pos: position{line: 2360, col: 33, offset: 72582},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 72587},
+							pos:  position{line: 2360, col: 34, offset: 72583},
 							name: "IdentifierRest",
 						},
 					},
@@ -17692,23 +17692,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2361, col: 1, offset: 72602},
+			pos:  position{line: 2361, col: 1, offset: 72598},
 			expr: &actionExpr{
-				pos: position{line: 2361, col: 14, offset: 72615},
+				pos: position{line: 2361, col: 14, offset: 72611},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2361, col: 14, offset: 72615},
+					pos: position{line: 2361, col: 14, offset: 72611},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2361, col: 14, offset: 72615},
+							pos:        position{line: 2361, col: 14, offset: 72611},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2361, col: 33, offset: 72634},
+							pos: position{line: 2361, col: 33, offset: 72630},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2361, col: 34, offset: 72635},
+								pos:  position{line: 2361, col: 34, offset: 72631},
 								name: "IdentifierRest",
 							},
 						},
@@ -17720,20 +17720,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2362, col: 1, offset: 72678},
+			pos:  position{line: 2362, col: 1, offset: 72674},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 72691},
+				pos: position{line: 2362, col: 14, offset: 72687},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 72691},
+						pos:        position{line: 2362, col: 14, offset: 72687},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 72710},
+						pos: position{line: 2362, col: 33, offset: 72706},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 72711},
+							pos:  position{line: 2362, col: 34, offset: 72707},
 							name: "IdentifierRest",
 						},
 					},
@@ -17744,20 +17744,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2363, col: 1, offset: 72726},
+			pos:  position{line: 2363, col: 1, offset: 72722},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 72739},
+				pos: position{line: 2363, col: 14, offset: 72735},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 72739},
+						pos:        position{line: 2363, col: 14, offset: 72735},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 72758},
+						pos: position{line: 2363, col: 33, offset: 72754},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 72759},
+							pos:  position{line: 2363, col: 34, offset: 72755},
 							name: "IdentifierRest",
 						},
 					},
@@ -17768,20 +17768,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2364, col: 1, offset: 72774},
+			pos:  position{line: 2364, col: 1, offset: 72770},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 72787},
+				pos: position{line: 2364, col: 14, offset: 72783},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 72787},
+						pos:        position{line: 2364, col: 14, offset: 72783},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 72806},
+						pos: position{line: 2364, col: 33, offset: 72802},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 72807},
+							pos:  position{line: 2364, col: 34, offset: 72803},
 							name: "IdentifierRest",
 						},
 					},
@@ -17792,20 +17792,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2365, col: 1, offset: 72822},
+			pos:  position{line: 2365, col: 1, offset: 72818},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 72835},
+				pos: position{line: 2365, col: 14, offset: 72831},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 72835},
+						pos:        position{line: 2365, col: 14, offset: 72831},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 72854},
+						pos: position{line: 2365, col: 33, offset: 72850},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 72855},
+							pos:  position{line: 2365, col: 34, offset: 72851},
 							name: "IdentifierRest",
 						},
 					},
@@ -17816,20 +17816,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2366, col: 1, offset: 72870},
+			pos:  position{line: 2366, col: 1, offset: 72866},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 72883},
+				pos: position{line: 2366, col: 14, offset: 72879},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 72883},
+						pos:        position{line: 2366, col: 14, offset: 72879},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 72902},
+						pos: position{line: 2366, col: 33, offset: 72898},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 72903},
+							pos:  position{line: 2366, col: 34, offset: 72899},
 							name: "IdentifierRest",
 						},
 					},
@@ -17840,20 +17840,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2367, col: 1, offset: 72918},
+			pos:  position{line: 2367, col: 1, offset: 72914},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 72931},
+				pos: position{line: 2367, col: 14, offset: 72927},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 72931},
+						pos:        position{line: 2367, col: 14, offset: 72927},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 72950},
+						pos: position{line: 2367, col: 33, offset: 72946},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 72951},
+							pos:  position{line: 2367, col: 34, offset: 72947},
 							name: "IdentifierRest",
 						},
 					},
@@ -17864,20 +17864,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2368, col: 1, offset: 72966},
+			pos:  position{line: 2368, col: 1, offset: 72962},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 72979},
+				pos: position{line: 2368, col: 14, offset: 72975},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 72979},
+						pos:        position{line: 2368, col: 14, offset: 72975},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 72998},
+						pos: position{line: 2368, col: 33, offset: 72994},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 72999},
+							pos:  position{line: 2368, col: 34, offset: 72995},
 							name: "IdentifierRest",
 						},
 					},
@@ -17888,20 +17888,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2369, col: 1, offset: 73014},
+			pos:  position{line: 2369, col: 1, offset: 73010},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 73027},
+				pos: position{line: 2369, col: 14, offset: 73023},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 73027},
+						pos:        position{line: 2369, col: 14, offset: 73023},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 73046},
+						pos: position{line: 2369, col: 33, offset: 73042},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 73047},
+							pos:  position{line: 2369, col: 34, offset: 73043},
 							name: "IdentifierRest",
 						},
 					},
@@ -17912,20 +17912,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2370, col: 1, offset: 73062},
+			pos:  position{line: 2370, col: 1, offset: 73058},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 73075},
+				pos: position{line: 2370, col: 14, offset: 73071},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 73075},
+						pos:        position{line: 2370, col: 14, offset: 73071},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 73094},
+						pos: position{line: 2370, col: 33, offset: 73090},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 73095},
+							pos:  position{line: 2370, col: 34, offset: 73091},
 							name: "IdentifierRest",
 						},
 					},
@@ -17936,20 +17936,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2371, col: 1, offset: 73110},
+			pos:  position{line: 2371, col: 1, offset: 73106},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 73123},
+				pos: position{line: 2371, col: 14, offset: 73119},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 73123},
+						pos:        position{line: 2371, col: 14, offset: 73119},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 73142},
+						pos: position{line: 2371, col: 33, offset: 73138},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 73143},
+							pos:  position{line: 2371, col: 34, offset: 73139},
 							name: "IdentifierRest",
 						},
 					},
@@ -17960,20 +17960,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2372, col: 1, offset: 73158},
+			pos:  position{line: 2372, col: 1, offset: 73154},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 73171},
+				pos: position{line: 2372, col: 14, offset: 73167},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 73171},
+						pos:        position{line: 2372, col: 14, offset: 73167},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 73190},
+						pos: position{line: 2372, col: 33, offset: 73186},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 73191},
+							pos:  position{line: 2372, col: 34, offset: 73187},
 							name: "IdentifierRest",
 						},
 					},
@@ -17984,20 +17984,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2373, col: 1, offset: 73206},
+			pos:  position{line: 2373, col: 1, offset: 73202},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 73219},
+				pos: position{line: 2373, col: 14, offset: 73215},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 73219},
+						pos:        position{line: 2373, col: 14, offset: 73215},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 73238},
+						pos: position{line: 2373, col: 33, offset: 73234},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 73239},
+							pos:  position{line: 2373, col: 34, offset: 73235},
 							name: "IdentifierRest",
 						},
 					},
@@ -20364,19 +20364,19 @@ func (p *parser) callonWhen1() (any, error) {
 	return p.cur.onWhen1(stack["cond"], stack["then"])
 }
 
-func (c *current) onQueryExpr1(body any) (any, error) {
-	return &ast.QueryExpr{
-		Kind: "QueryExpr",
+func (c *current) onSubquery1(body any) (any, error) {
+	return &ast.Subquery{
+		Kind: "Subquery",
 		Body: sliceOf[ast.Op](body),
 		Loc:  loc(c),
 	}, nil
 
 }
 
-func (p *parser) callonQueryExpr1() (any, error) {
+func (p *parser) callonSubquery1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onQueryExpr1(stack["body"])
+	return p.cur.onSubquery1(stack["body"])
 }
 
 func (c *current) onRecord1(elems any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -1071,7 +1071,7 @@ Primary
   / Literal
   / Identifier
   / Tuple
-  / "(" __ &SubqueryOps expr:QueryExpr __ ")" { return expr, nil }
+  / "(" __ &SubqueryOps expr:Subquery __ ")" { return expr, nil }
   / "(" __ expr:Expr __ ")" { return expr, nil }
 
 SubqueryOps = UNNEST / FROM / VALUES / SelectOp
@@ -1124,10 +1124,10 @@ When
       }, nil
     }
 
-QueryExpr
+Subquery
   = body:Seq {
-      return &ast.QueryExpr{
-        Kind: "QueryExpr",
+      return &ast.Subquery{
+        Kind: "Subquery",
         Body: sliceOf[ast.Op](body),
         Loc: loc(c),
       }, nil

--- a/compiler/rungen/expr.go
+++ b/compiler/rungen/expr.go
@@ -76,8 +76,8 @@ func (b *Builder) compileExpr(e dag.Expr) (expr.Evaluator, error) {
 		return b.compileIsNullExpr(e)
 	case *dag.SliceExpr:
 		return b.compileSliceExpr(e)
-	case *dag.QueryExpr:
-		return b.compileQueryExpr(e)
+	case *dag.Subquery:
+		return b.compileSubquery(e)
 	case *dag.RegexpMatch:
 		return b.compileRegexpMatch(e)
 	case *dag.RegexpSearch:
@@ -411,15 +411,15 @@ func (b *Builder) compileIsNullExpr(e *dag.IsNullExpr) (expr.Evaluator, error) {
 	return expr.NewIsNullExpr(eval), nil
 }
 
-func (b *Builder) compileQueryExpr(query *dag.QueryExpr) (expr.Evaluator, error) {
+func (b *Builder) compileSubquery(query *dag.Subquery) (expr.Evaluator, error) {
 	if !query.Correlated {
 		exit, err := b.compileSeqAndCombine(query.Body, nil)
 		if err != nil {
 			return nil, err
 		}
-		return traverse.NewCachedQueryExpr(b.rctx, exit), nil
+		return traverse.NewCachedSubquery(b.rctx, exit), nil
 	}
-	subquery := traverse.NewQueryExpr(b.rctx)
+	subquery := traverse.NewSubquery(b.rctx)
 	exit, err := b.compileSeqAndCombine(query.Body, []zbuf.Puller{subquery})
 	if err != nil {
 		return nil, err

--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -48,8 +48,8 @@ func (b *Builder) compileVamExpr(e dag.Expr) (vamexpr.Evaluator, error) {
 		return b.compileVamConditional(*e)
 	case *dag.Call:
 		return b.compileVamCall(e)
-	case *dag.QueryExpr:
-		return b.compileVamQueryExpr(e)
+	case *dag.Subquery:
+		return b.compileVamSubquery(e)
 	case *dag.RegexpMatch:
 		return b.compileVamRegexpMatch(e)
 	case *dag.RegexpSearch:
@@ -295,8 +295,8 @@ func (b *Builder) compileVamRecordExpr(e *dag.RecordExpr) (vamexpr.Evaluator, er
 	return vamexpr.NewRecordExpr(b.sctx(), elems), nil
 }
 
-func (b *Builder) compileVamQueryExpr(query *dag.QueryExpr) (vamexpr.Evaluator, error) {
-	e, err := b.compileQueryExpr(query)
+func (b *Builder) compileVamSubquery(query *dag.Subquery) (vamexpr.Evaluator, error) {
+	e, err := b.compileSubquery(query)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/sam/op/traverse/eval.go
+++ b/runtime/sam/op/traverse/eval.go
@@ -1,66 +1,10 @@
 package traverse
 
 import (
-	"context"
-
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/zbuf"
 	"github.com/brimdata/super/zcode"
 )
-
-// Expr provides provides glue to run a traversal subquery in expression
-// context.  It implements zbuf.Puller so it can serve as the data source
-// to the subquery as well as expr.Evalulator so it can be called from an
-// expression.  Each time its Eval method is called, it propagates the value
-// to the batch channel to be pulled into the scope.  If there is
-// just one result, then the value is returned.  If there are multiple results
-// then they are returned in an array (with union elements if the type varies).
-type Expr struct {
-	ctx     context.Context
-	sctx    *super.Context
-	batchCh chan zbuf.Batch
-	eos     bool
-
-	exit *Exit
-	out  []zbuf.Batch
-}
-
-var _ expr.Evaluator = (*Expr)(nil)
-var _ zbuf.Puller = (*Expr)(nil)
-
-func NewExpr(ctx context.Context, sctx *super.Context) *Expr {
-	return &Expr{
-		ctx:     ctx,
-		sctx:    sctx,
-		batchCh: make(chan zbuf.Batch, 1),
-	}
-}
-
-func (e *Expr) SetExit(exit *Exit) {
-	e.exit = exit
-}
-
-func (e *Expr) Eval(this super.Value) super.Value {
-	b := zbuf.NewArray([]super.Value{this})
-	select {
-	case e.batchCh <- b:
-	case <-e.ctx.Done():
-		return e.sctx.NewError(e.ctx.Err())
-	}
-	out := e.out[:0]
-	for {
-		b, err := e.exit.Pull(false)
-		if err != nil {
-			panic(err)
-		}
-		if b == nil {
-			e.out = out
-			return combine(e.sctx, out)
-		}
-		out = append(out, b)
-	}
-}
 
 func combine(sctx *super.Context, batches []zbuf.Batch) super.Value {
 	switch len(batches) {
@@ -112,18 +56,4 @@ func makeUnionArray(sctx *super.Context, vals []super.Value) super.Value {
 		super.BuildUnion(&b, union.TagOf(val.Type()), val.Bytes())
 	}
 	return super.NewValue(sctx.LookupTypeArray(union), b.Bytes())
-}
-
-func (e *Expr) Pull(done bool) (zbuf.Batch, error) {
-	if e.eos {
-		e.eos = false
-		return nil, nil
-	}
-	e.eos = true
-	select {
-	case batch := <-e.batchCh:
-		return batch, nil
-	case <-e.ctx.Done():
-		return nil, e.ctx.Err()
-	}
 }

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -212,7 +212,7 @@ func (c *canon) expr(e ast.Expr, parent string) {
 			c.expr(e.Value, "")
 		}
 		c.write("}|")
-	case *ast.QueryExpr:
+	case *ast.Subquery:
 		c.open("(")
 		c.head = true
 		c.seq(e.Body)

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -109,7 +109,7 @@ func (c *canonDAG) expr(e dag.Expr, parent string) {
 	case *dag.IsNullExpr:
 		c.expr(e.Expr, "")
 		c.write(" IS NULL")
-	case *dag.QueryExpr:
+	case *dag.Subquery:
 		c.open("(")
 		c.head = true
 		c.seq(e.Body)


### PR DESCRIPTION
This is a simple rename and removes unused code and doesn't otherwise change anything.