### PR TITLE
remove primitive-type function-style casts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ FROM 'https://data.gharchive.org/2015-01-01-15.json.gz'
   LIMIT 5
 | FORK
   ( FROM eval(f'https://api.github.com/users/{user}')
-    SELECT VALUE {user:login,created_at:time(created_at)} )
+    SELECT VALUE {user:login,created_at:created_at::time} )
   ( PASS )
 | JOIN USING (user)
 | VALUES {...left,repos:right.repos}

--- a/book/src/super-sql/operators/switch.md
+++ b/book/src/super-sql/operators/switch.md
@@ -73,7 +73,7 @@ _Switch on `this` with a constant case_
 # spq
 switch this
   case 1 ( values "1!" )
-  default ( values string(this) )
+  default ( values this::string )
 | sort
 # input
 1

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -656,15 +656,6 @@ func (a *analyzer) semCall(call *ast.Call) dag.Expr {
 			Name: name,
 			Args: exprs,
 		}
-	case super.LookupPrimitive(name) != nil:
-		// Primitive function call, change this to a cast.
-		if err := function.CheckArgCount(nargs, 1, 1); err != nil {
-			a.error(call, err)
-			return badExpr()
-		}
-		exprs = append(exprs, &dag.Literal{Kind: "Literal", Value: "<" + name + ">"})
-		name = "cast"
-		nameLower = name
 	case expr.NewShaperTransform(nameLower) != 0:
 		if err := function.CheckArgCount(nargs, 1, 2); err != nil {
 			a.error(call, err)

--- a/compiler/ztests/const-redefined-error.yaml
+++ b/compiler/ztests/const-redefined-error.yaml
@@ -1,7 +1,7 @@
 spq: |
   type myport=int16 
   type myport=int32 
-  put b:=type(myport)
+  put b:=this::'myport'
 
 error: |
   symbol "myport" redefined at line 2, column 6:

--- a/compiler/ztests/f-string.yaml
+++ b/compiler/ztests/f-string.yaml
@@ -1,7 +1,7 @@
 spq: |
   values
     f"hello {this}",
-    f'hello {hex(bytes(this))}',
+    f'hello {hex(this::bytes)}',
     f"hello \{this}",
     f'hello \{hex(this)}',
     f'yo {f"dawg {this}"}',

--- a/compiler/ztests/scoped-this.yaml
+++ b/compiler/ztests/scoped-this.yaml
@@ -1,5 +1,5 @@
 spq: |
-  unnest this into (collect(string(this)))
+  unnest this into (collect(this::string))
 
 vector: true
 

--- a/compiler/ztests/sql/having-agg.yaml
+++ b/compiler/ztests/sql/having-agg.yaml
@@ -1,5 +1,5 @@
 script: |
-  super -s -c "select sum(a) as s, b, max(a+1) as m from t.json group by b having float64(max(a))/m > 0.7"
+  super -s -c "select sum(a) as s, b, max(a+1) as m from t.json group by b having max(a)::float64/m > 0.7"
 
 inputs:
   - name: t.json

--- a/compiler/ztests/sql/readme-query.yaml
+++ b/compiler/ztests/sql/readme-query.yaml
@@ -12,7 +12,7 @@ inputs:
       | FORK
         (
           FROM eval(f'{user}.sup')
-          SELECT VALUE {user:login,created_at:time(created_at)}
+          SELECT VALUE {user:login,created_at:created_at::time}
         )
         ( PASS )
       | JOIN USING (user)

--- a/docs/commands/super.md
+++ b/docs/commands/super.md
@@ -718,7 +718,7 @@ sum(val) by key | sort key
 _Read CSV input and [cast](../language/functions/cast.md) a to an integer from default float_
 ```mdtest-spq
 # spq
-a:=int64(a)
+a:=a::int64
 # input
 a,b
 1,foo
@@ -731,7 +731,7 @@ a,b
 _Read JSON input and cast to an integer from default float_
 ```mdtest-spq
 # spq
-a:=int64(a)
+a:=a::int64
 # input
 {"a":1,"b":"foo"}
 {"a":2,"b":"bar"}

--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -579,7 +579,7 @@ to the indicated type, then the cast's result is an error value.
 For example,
 ```mdtest-spq {data-layout="stacked"}
 # spq
-values int8(this)
+values this::int8
 # input
 1
 200
@@ -598,7 +598,7 @@ based on the [Go Date Parser library](https://github.com/araddon/dateparse).
 
 ```mdtest-spq
 # spq
-values time(this)
+values this::time
 # input
 "May 8, 2009 5:57:51 PM"
 "oct 7, 1970"

--- a/docs/language/functions/base64.md
+++ b/docs/language/functions/base64.md
@@ -40,7 +40,7 @@ values base64(this)
 Encode ASCII string into Base64-encoded string:
 ```mdtest-spq
 # spq
-values base64(bytes(this))
+values base64(this::bytes)
 # input
 "hello, world"
 # expected output
@@ -50,7 +50,7 @@ values base64(bytes(this))
 Decode a Base64 string and cast the decoded bytes to a string:
 ```mdtest-spq
 # spq
-values string(base64(this))
+values base64(this)::string
 # input
 "aGVsbG8gd29ybGQ="
 # expected output

--- a/docs/language/functions/bucket.md
+++ b/docs/language/functions/bucket.md
@@ -21,7 +21,7 @@ aligns with 0.
 Bucket a couple times to hour intervals:
 ```mdtest-spq
 # spq
-values bucket(time(this), 1h)
+values bucket(this::time, 1h)
 # input
 2020-05-26T15:27:47Z
 "5/26/2020 3:27pm"

--- a/docs/language/functions/hex.md
+++ b/docs/language/functions/hex.md
@@ -37,7 +37,7 @@ values hex(this)
 Encode the bytes of an ASCII string as a hexadecimal string:
 ```mdtest-spq
 # spq
-values hex(bytes(this))
+values hex(this::bytes)
 # input
 "hello, world"
 # expected output
@@ -47,7 +47,7 @@ values hex(bytes(this))
 Decode hex string representing ASCII into its string form:
 ```mdtest-spq
 # spq
-values string(hex(this))
+values hex(this)::string
 # input
 "68656c6c6f20776f726c64"
 # expected output

--- a/docs/language/functions/log.md
+++ b/docs/language/functions/log.md
@@ -34,7 +34,7 @@ error({message:"log: illegal argument",on:-1})
 The largest power of 10 smaller than the input:
 ```mdtest-spq
 # spq
-values int64(log(this)/log(10))
+values (log(this)/log(10))::int64
 # input
 9
 10

--- a/docs/language/functions/rune_len.md
+++ b/docs/language/functions/rune_len.md
@@ -31,7 +31,7 @@ values rune_len(this)
 The length in bytes of a smiley is 4:
 ```mdtest-spq
 # spq
-values len(bytes(this))
+values len(this::bytes)
 # input
 "hello"
 "😎"

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -186,7 +186,7 @@ super db -db example -s -c '
     ( pass )
     ( from coinflips@trial 
       | c:=count()
-      | values f"There were {int64(c)} flips" )
+      | values f"There were {c::int64} flips" )
   | sort this'
 ```
 =>

--- a/docs/language/operators/switch.md
+++ b/docs/language/operators/switch.md
@@ -70,7 +70,7 @@ _Switch on `this` with a constant case_
 # spq
 switch this
   case 1 ( values "1!" )
-  default ( values string(this) )
+  default ( values this::string )
 | sort
 # input
 1

--- a/docs/tutorials/super-for-jq.md
+++ b/docs/tutorials/super-for-jq.md
@@ -835,7 +835,7 @@ which produces this string:
 Since the super data model has a native `time` type and we might want to do native date comparisons
 on these time fields, we can easily translate the string to a time with a cast, e.g.,
 ```mdtest-command dir=docs/tutorials
-super -s -c 'unnest this | head 1 | values time(created_at)' prs.json
+super -s -c 'unnest this | head 1 | values created_at::time' prs.json
 ```
 produces the native time value:
 ```mdtest-output
@@ -843,7 +843,7 @@ produces the native time value:
 ```
 To be sure, you can check any value's type with the `typeof` function, e.g.,
 ```mdtest-command dir=docs/tutorials
-super -s -c 'unnest this | head 1 | values time(created_at) | typeof(this)' prs.json
+super -s -c 'unnest this | head 1 | values created_at::time | typeof(this)' prs.json
 ```
 produces the native time value:
 ```mdtest-output
@@ -926,10 +926,10 @@ To fix those strings, we simply transform the fields in place using the
 output as BSUP to the file `prs.bsup`:
 ```
 super -c '
-  closed_at:=time(closed_at),
-  merged_at:=time(merged_at),
-  created_at:=time(created_at),
-  updated_at:=time(updated_at)
+  closed_at:=closed_at::time,
+  merged_at:=merged_at::time,
+  created_at:=created_at::time,
+  updated_at:=updated_at::time
 ' prs2.bsup > prs.bsup
 ```
 We can check the result with our type analysis:
@@ -969,10 +969,10 @@ unnest this                      -- traverse the array of objects
 | len(this) != 0               -- skip empty objects
 | fuse                         -- fuse objects into records of a combined type
 | drop head,base,_links        -- drop fields that we don't need
-| closed_at:=time(closed_at),  -- transform string dates to type time
-  merged_at:=time(merged_at),
-  created_at:=time(created_at),
-  updated_at:=time(updated_at)
+| closed_at:=closed_at::time,  -- transform string dates to type time
+  merged_at:=merged_at::time,
+  created_at:=created_at::time,
+  updated_at:=updated_at::time
 ```
 
 {{% tip "Note" %}}

--- a/runtime/sam/expr/expr_test.go
+++ b/runtime/sam/expr/expr_test.go
@@ -383,12 +383,12 @@ func TestArithmetic(t *testing.T) {
 
 	// Test arithmetic with null values
 	testSuccessful(t, "null + 1", "", "null::int64")
-	testSuccessful(t, "uint64(1) + null", "", "null::uint64")
+	testSuccessful(t, "(1)::uint64 + null", "", "null::uint64")
 	testSuccessful(t, "null + 1.0", "", "null::float64")
 	testSuccessful(t, "1. - null", "", "null::float64")
-	testSuccessful(t, "uint64(1) * null", "", "null::uint64")
+	testSuccessful(t, "(1)::uint64 * null", "", "null::uint64")
 	testSuccessful(t, "null / 1.", "", "null::float64")
-	testSuccessful(t, "1 / uint64(null)", "", "null::int64")
+	testSuccessful(t, "1 / (null)::uint64", "", "null::int64")
 	testSuccessful(t, "null % 1", "", "null::int64")
 
 	// Difference of two times is a duration
@@ -506,97 +506,97 @@ func TestConditional(t *testing.T) {
 
 func TestCasts(t *testing.T) {
 	// Test casts to byte
-	testSuccessful(t, "uint8(10)", "", "10::uint8")
-	testSuccessful(t, "uint8(-1)", "", `error({message:"cannot cast to uint8",on:-1})`)
-	testSuccessful(t, "uint8(300)", "", `error({message:"cannot cast to uint8",on:300})`)
-	testSuccessful(t, `uint8("foo")`, "", `error({message:"cannot cast to uint8",on:"foo"})`)
-	testSuccessful(t, `uint8("-1")`, "", `error({message:"cannot cast to uint8",on:"-1"})`)
-	testSuccessful(t, "uint8(258.)", "", `error({message:"cannot cast to uint8",on:258.})`)
-	testSuccessful(t, `uint8("255")`, "", `255::uint8`)
+	testSuccessful(t, "(10)::uint8", "", "10::uint8")
+	testSuccessful(t, "(-1)::uint8", "", `error({message:"cannot cast to uint8",on:-1})`)
+	testSuccessful(t, "(300)::uint8", "", `error({message:"cannot cast to uint8",on:300})`)
+	testSuccessful(t, `("foo")::uint8`, "", `error({message:"cannot cast to uint8",on:"foo"})`)
+	testSuccessful(t, `("-1")::uint8`, "", `error({message:"cannot cast to uint8",on:"-1"})`)
+	testSuccessful(t, "(258.)::uint8", "", `error({message:"cannot cast to uint8",on:258.})`)
+	testSuccessful(t, `("255")::uint8`, "", `255::uint8`)
 
 	// Test casts to int16
-	testSuccessful(t, "int16(10)", "", "10::int16")
-	testSuccessful(t, "int16(-33000)", "", `error({message:"cannot cast to int16",on:-33000})`)
-	testSuccessful(t, "int16(33000)", "", `error({message:"cannot cast to int16",on:33000})`)
-	testSuccessful(t, `int16("foo")`, "", `error({message:"cannot cast to int16",on:"foo"})`)
+	testSuccessful(t, "(10)::int16", "", "10::int16")
+	testSuccessful(t, "(-33000)::int16", "", `error({message:"cannot cast to int16",on:-33000})`)
+	testSuccessful(t, "(33000)::int16", "", `error({message:"cannot cast to int16",on:33000})`)
+	testSuccessful(t, `("foo")::int16`, "", `error({message:"cannot cast to int16",on:"foo"})`)
 
 	// Test casts to uint16
-	testSuccessful(t, "uint16(10)", "", "10::uint16")
-	testSuccessful(t, "uint16(-1)", "", `error({message:"cannot cast to uint16",on:-1})`)
-	testSuccessful(t, "uint16(66000)", "", `error({message:"cannot cast to uint16",on:66000})`)
-	testSuccessful(t, `uint16("foo")`, "", `error({message:"cannot cast to uint16",on:"foo"})`)
+	testSuccessful(t, "(10)::uint16", "", "10::uint16")
+	testSuccessful(t, "(-1)::uint16", "", `error({message:"cannot cast to uint16",on:-1})`)
+	testSuccessful(t, "(66000)::uint16", "", `error({message:"cannot cast to uint16",on:66000})`)
+	testSuccessful(t, `("foo")::uint16`, "", `error({message:"cannot cast to uint16",on:"foo"})`)
 
 	// Test casts to int32
-	testSuccessful(t, "int32(10)", "", "10::int32")
-	testSuccessful(t, "int32(-2200000000)", "", `error({message:"cannot cast to int32",on:-2200000000})`)
-	testSuccessful(t, "int32(2200000000)", "", `error({message:"cannot cast to int32",on:2200000000})`)
-	testSuccessful(t, `int32("foo")`, "", `error({message:"cannot cast to int32",on:"foo"})`)
+	testSuccessful(t, "(10)::int32", "", "10::int32")
+	testSuccessful(t, "(-2200000000)::int32", "", `error({message:"cannot cast to int32",on:-2200000000})`)
+	testSuccessful(t, "(2200000000)::int32", "", `error({message:"cannot cast to int32",on:2200000000})`)
+	testSuccessful(t, `("foo")::int32`, "", `error({message:"cannot cast to int32",on:"foo"})`)
 
 	// Test casts to uint32
-	testSuccessful(t, "uint32(10)", "", "10::uint32")
-	testSuccessful(t, "uint32(-1)", "", `error({message:"cannot cast to uint32",on:-1})`)
-	testSuccessful(t, "uint32(4300000000)", "", `error({message:"cannot cast to uint32",on:4300000000})`)
-	testSuccessful(t, "uint32(-4.3e9)", "", `error({message:"cannot cast to uint32",on:-4300000000.})`)
-	testSuccessful(t, `uint32("foo")`, "", `error({message:"cannot cast to uint32",on:"foo"})`)
+	testSuccessful(t, "(10)::uint32", "", "10::uint32")
+	testSuccessful(t, "(-1)::uint32", "", `error({message:"cannot cast to uint32",on:-1})`)
+	testSuccessful(t, "(4300000000)::uint32", "", `error({message:"cannot cast to uint32",on:4300000000})`)
+	testSuccessful(t, "(-4.3e9)::uint32", "", `error({message:"cannot cast to uint32",on:-4300000000.})`)
+	testSuccessful(t, `("foo")::uint32`, "", `error({message:"cannot cast to uint32",on:"foo"})`)
 
 	// Test cast to int64
-	testSuccessful(t, "int64(this)", "10000000000000000000::uint64", `error({message:"cannot cast to int64",on:10000000000000000000::uint64})::error({message:string,on:uint64})`)
-	testSuccessful(t, "int64(this)", "1e+19", `error({message:"cannot cast to int64",on:1e+19})`)
-	testSuccessful(t, `int64("10000000000000000000")`, "", `error({message:"cannot cast to int64",on:"10000000000000000000"})`)
+	testSuccessful(t, "(this)::int64", "10000000000000000000::uint64", `error({message:"cannot cast to int64",on:10000000000000000000::uint64})::error({message:string,on:uint64})`)
+	testSuccessful(t, "(this)::int64", "1e+19", `error({message:"cannot cast to int64",on:1e+19})`)
+	testSuccessful(t, `("10000000000000000000")::int64`, "", `error({message:"cannot cast to int64",on:"10000000000000000000"})`)
 
 	// Test casts to uint64
-	testSuccessful(t, "uint64(10)", "", "10::uint64")
-	testSuccessful(t, "uint64(-1)", "", `error({message:"cannot cast to uint64",on:-1})`)
-	testSuccessful(t, `uint64("foo")`, "", `error({message:"cannot cast to uint64",on:"foo"})`)
-	testSuccessful(t, `uint64(+Inf)`, "", `error({message:"cannot cast to uint64",on:+Inf})`)
+	testSuccessful(t, "(10)::uint64", "", "10::uint64")
+	testSuccessful(t, "(-1)::uint64", "", `error({message:"cannot cast to uint64",on:-1})`)
+	testSuccessful(t, `("foo")::uint64`, "", `error({message:"cannot cast to uint64",on:"foo"})`)
+	testSuccessful(t, `(+Inf)::uint64`, "", `error({message:"cannot cast to uint64",on:+Inf})`)
 
 	// Test casts to float16
-	testSuccessful(t, "float16(10)", "", "10.::float16")
-	testSuccessful(t, `float16("foo")`, "", `error({message:"cannot cast to float16",on:"foo"})`)
+	testSuccessful(t, "(10)::float16", "", "10.::float16")
+	testSuccessful(t, `("foo")::float16`, "", `error({message:"cannot cast to float16",on:"foo"})`)
 
 	// Test casts to float32
-	testSuccessful(t, "float32(10)", "", "10.::float32")
-	testSuccessful(t, `float32("foo")`, "", `error({message:"cannot cast to float32",on:"foo"})`)
+	testSuccessful(t, "(10)::float32", "", "10.::float32")
+	testSuccessful(t, `("foo")::float32`, "", `error({message:"cannot cast to float32",on:"foo"})`)
 
 	// Test casts to float64
-	testSuccessful(t, "float64(10)", "", "10.")
-	testSuccessful(t, `float64("foo")`, "", `error({message:"cannot cast to float64",on:"foo"})`)
+	testSuccessful(t, "(10)::float64", "", "10.")
+	testSuccessful(t, `("foo")::float64`, "", `error({message:"cannot cast to float64",on:"foo"})`)
 
 	// Test casts to ip
-	testSuccessful(t, `ip("1.2.3.4")`, "", "1.2.3.4")
-	testSuccessful(t, "ip(1234)", "", `error({message:"cannot cast to ip",on:1234})`)
-	testSuccessful(t, `ip("not an address")`, "", `error({message:"cannot cast to ip",on:"not an address"})`)
+	testSuccessful(t, `("1.2.3.4")::ip`, "", "1.2.3.4")
+	testSuccessful(t, "(1234)::ip", "", `error({message:"cannot cast to ip",on:1234})`)
+	testSuccessful(t, `("not an address")::ip`, "", `error({message:"cannot cast to ip",on:"not an address"})`)
 
 	// Test casts to net
-	testSuccessful(t, `net("1.2.3.0/24")`, "", "1.2.3.0/24")
-	testSuccessful(t, "net(1234)", "", `error({message:"cannot cast to net",on:1234})`)
-	testSuccessful(t, `net("not an address")`, "", `error({message:"cannot cast to net",on:"not an address"})`)
-	testSuccessful(t, `net(1.2.3.4)`, "", `error({message:"cannot cast to net",on:1.2.3.4})`)
+	testSuccessful(t, `("1.2.3.0/24")::net`, "", "1.2.3.0/24")
+	testSuccessful(t, "(1234)::net", "", `error({message:"cannot cast to net",on:1234})`)
+	testSuccessful(t, `("not an address")::net`, "", `error({message:"cannot cast to net",on:"not an address"})`)
+	testSuccessful(t, `(1.2.3.4)::net`, "", `error({message:"cannot cast to net",on:1.2.3.4})`)
 
 	// Test casts to time
-	testSuccessful(t, "time(float16(65504))", "", "1970-01-01T00:00:00.000065504Z")
+	testSuccessful(t, "((65504)::float16)::time", "", "1970-01-01T00:00:00.000065504Z")
 	// float32 lacks sufficient precision to represent this time exactly.
-	testSuccessful(t, "time(float32(1589126400000000000))", "", "2020-05-10T15:59:14.647908352Z")
-	testSuccessful(t, "time(float64(1589126400000000000))", "", "2020-05-10T16:00:00Z")
-	testSuccessful(t, "time(1589126400000000000)", "", "2020-05-10T16:00:00Z")
-	testSuccessful(t, `time("1589126400000000000")`, "", "2020-05-10T16:00:00Z")
+	testSuccessful(t, "((1589126400000000000)::float32)::time", "", "2020-05-10T15:59:14.647908352Z")
+	testSuccessful(t, "((1589126400000000000)::float64)::time", "", "2020-05-10T16:00:00Z")
+	testSuccessful(t, "(1589126400000000000)::time", "", "2020-05-10T16:00:00Z")
+	testSuccessful(t, `("1589126400000000000")::time`, "", "2020-05-10T16:00:00Z")
 
-	testSuccessful(t, "string(1.2)", "", `"1.2"`)
-	testSuccessful(t, "string(5)", "", `"5"`)
-	testSuccessful(t, "string(this)", "5::uint8", `"5"`)
-	testSuccessful(t, "string(this)", "5.5::float16", `"5.5"`)
-	testSuccessful(t, "string(1.2.3.4)", "", `"1.2.3.4"`)
-	testSuccessful(t, `int64("1")`, "", "1")
-	testSuccessful(t, `int64("-1")`, "", "-1")
-	testSuccessful(t, `float16("5.5")`, "", "5.5::float16")
-	testSuccessful(t, `float32("5.5")`, "", "5.5::float32")
-	testSuccessful(t, `float64("5.5")`, "", "5.5")
-	testSuccessful(t, `ip("1.2.3.4")`, "", "1.2.3.4")
+	testSuccessful(t, "(1.2)::string", "", `"1.2"`)
+	testSuccessful(t, "(5)::string", "", `"5"`)
+	testSuccessful(t, "(this)::string", "5::uint8", `"5"`)
+	testSuccessful(t, "(this)::string", "5.5::float16", `"5.5"`)
+	testSuccessful(t, "(1.2.3.4)::string", "", `"1.2.3.4"`)
+	testSuccessful(t, `("1")::int64`, "", "1")
+	testSuccessful(t, `("-1")::int64`, "", "-1")
+	testSuccessful(t, `("5.5")::float16`, "", "5.5::float16")
+	testSuccessful(t, `("5.5")::float32`, "", "5.5::float32")
+	testSuccessful(t, `("5.5")::float64`, "", "5.5")
+	testSuccessful(t, `("1.2.3.4")::ip`, "", "1.2.3.4")
 
-	testSuccessful(t, "ip(1)", "", `error({message:"cannot cast to ip",on:1})`)
-	testSuccessful(t, `int64("abc")`, "", `error({message:"cannot cast to int64",on:"abc"})`)
-	testSuccessful(t, `float16("abc")`, "", `error({message:"cannot cast to float16",on:"abc"})`)
-	testSuccessful(t, `float32("abc")`, "", `error({message:"cannot cast to float32",on:"abc"})`)
-	testSuccessful(t, `float64("abc")`, "", `error({message:"cannot cast to float64",on:"abc"})`)
-	testSuccessful(t, `ip("abc")`, "", `error({message:"cannot cast to ip",on:"abc"})`)
+	testSuccessful(t, "(1)::ip", "", `error({message:"cannot cast to ip",on:1})`)
+	testSuccessful(t, `("abc")::int64`, "", `error({message:"cannot cast to int64",on:"abc"})`)
+	testSuccessful(t, `("abc")::float16`, "", `error({message:"cannot cast to float16",on:"abc"})`)
+	testSuccessful(t, `("abc")::float32`, "", `error({message:"cannot cast to float32",on:"abc"})`)
+	testSuccessful(t, `("abc")::float64`, "", `error({message:"cannot cast to float64",on:"abc"})`)
+	testSuccessful(t, `("abc")::ip`, "", `error({message:"cannot cast to ip",on:"abc"})`)
 }

--- a/runtime/sam/expr/ztests/agg-expr.yaml
+++ b/runtime/sam/expr/ztests/agg-expr.yaml
@@ -1,5 +1,5 @@
 spq: |
-  cut count := count() - uint64(1),
+  cut count := count() - 1::uint64,
       dcount := dcount(this),
       sum := sum(this), 
       min := min(this),

--- a/runtime/sam/expr/ztests/cast-bytes-string-err.yaml
+++ b/runtime/sam/expr/ztests/cast-bytes-string-err.yaml
@@ -1,4 +1,4 @@
-spq: 'put s:=string(b)'
+spq: 'put s:=b::string'
 
 input: |
   {b:0xc328}

--- a/runtime/sam/expr/ztests/map.yaml
+++ b/runtime/sam/expr/ztests/map.yaml
@@ -1,8 +1,8 @@
 script: |
   echo '{a:["foo","bar","baz"]}' | super -s -c 'a := map(a,upper)' -
   echo '{a:|["foo","bar","baz"]|}' | super -s -c 'a := map(a,upper)' -
-  echo '["1","2","3"]' | super -s -c 'values map(this,int64)' -
-  echo '[1,2,3]' |super - | super -s -I udf.zed -
+  echo '["1","2","3"]' | super -s -c 'func castInt(v) : (v::int64) values map(this, castInt)' -
+  echo '[1,2,3]' | super - | super -s -I udf.zed -
 
 inputs:
   - name: udf.zed

--- a/runtime/sam/op/robot/ztests/array.yaml
+++ b/runtime/sam/op/robot/ztests/array.yaml
@@ -1,5 +1,5 @@
 script: |
-  super -s -c 'from which.sup | select value s from eval(["a"+string(val)+".sup","a"+string(val+1)+".sup"])'
+  super -s -c 'from which.sup | select value s from eval(["a"+val::string+".sup","a"+(val+1)::string+".sup"])'
 
 inputs:
   - name: which.sup

--- a/runtime/ztests/expr/cast-time-to-number.yaml
+++ b/runtime/ztests/expr/cast-time-to-number.yaml
@@ -1,9 +1,9 @@
 spq: |
-  values duration(this),
-        duration(this+2h-this),
-        int64(this),
-        uint64(this),
-        float64(this)
+  values this::duration,
+        (this+2h-this)::duration,
+        this::int64,
+        this::uint64,
+        this::float64
 
 vector: true
 

--- a/runtime/ztests/expr/cast/bool.yaml
+++ b/runtime/ztests/expr/cast/bool.yaml
@@ -1,4 +1,4 @@
-spq: bool(this)
+spq: this::bool
 
 vector: true
 

--- a/runtime/ztests/expr/cast/bytes.yaml
+++ b/runtime/ztests/expr/cast/bytes.yaml
@@ -1,4 +1,4 @@
-spq: bytes(this)
+spq: this::bytes
 
 vector: true
 

--- a/runtime/ztests/expr/cast/duration.yaml
+++ b/runtime/ztests/expr/cast/duration.yaml
@@ -1,4 +1,4 @@
-spq: duration(this)
+spq: this::duration
 
 vector: true
 

--- a/runtime/ztests/expr/cast/float.yaml
+++ b/runtime/ztests/expr/cast/float.yaml
@@ -1,4 +1,4 @@
-spq: values float16(this), float32(this), float64(this)
+spq: values this::float16, this::float32, this::float64
 
 vector: true
 

--- a/runtime/ztests/expr/cast/int.yaml
+++ b/runtime/ztests/expr/cast/int.yaml
@@ -1,5 +1,5 @@
 spq: |
-  values int8(this), int16(this), int32(this), int64(this)
+  values this::int8, this::int16, this::int32, this::int64
 
 vector: true
 

--- a/runtime/ztests/expr/cast/ip.yaml
+++ b/runtime/ztests/expr/cast/ip.yaml
@@ -1,4 +1,4 @@
-spq: ip(this)
+spq: this::ip
 
 vector: true
 

--- a/runtime/ztests/expr/cast/net.yaml
+++ b/runtime/ztests/expr/cast/net.yaml
@@ -1,4 +1,4 @@
-spq: net(this)
+spq: this::net
 
 vector: true
 

--- a/runtime/ztests/expr/cast/nulls.yaml
+++ b/runtime/ztests/expr/cast/nulls.yaml
@@ -1,6 +1,6 @@
 spq: |
-  values uint64(this), int64(this), float64(this), bool(this), bytes(this),
-        string(this), ip(this), net(this), type(null)
+  values this::uint64, this::int64, this::float64, this::bool, this::bytes,
+        this::string, this::ip, this::net, null::type
 
 vector: true
 

--- a/runtime/ztests/expr/cast/string.yaml
+++ b/runtime/ztests/expr/cast/string.yaml
@@ -1,4 +1,4 @@
-spq: string(this)
+spq: this::string
 
 vector: true
 

--- a/runtime/ztests/expr/cast/time.yaml
+++ b/runtime/ztests/expr/cast/time.yaml
@@ -1,4 +1,4 @@
-spq: time(this)
+spq: this::time
 
 vector: true
 

--- a/runtime/ztests/expr/cast/type.yaml
+++ b/runtime/ztests/expr/cast/type.yaml
@@ -1,4 +1,4 @@
-spq: type(this)
+spq: this::type
 
 vector: true
 

--- a/runtime/ztests/expr/cast/uint-nulls-const.yaml
+++ b/runtime/ztests/expr/cast/uint-nulls-const.yaml
@@ -1,5 +1,5 @@
 # This test is to test that overflows with const nulls are properly handled.
-spq: values uint8(this), uint16(this), uint32(this), uint64(this)
+spq: values this::uint8, this::uint16, this::uint32, this::uint64
 
 vector: true
 

--- a/runtime/ztests/expr/enum.yaml
+++ b/runtime/ztests/expr/enum.yaml
@@ -1,4 +1,4 @@
-spq: "put s:=string(e), v:=e+1"
+spq: "put s:=e::string, v:=e+1"
 
 vector: true
 

--- a/runtime/ztests/expr/function/now.yaml
+++ b/runtime/ztests/expr/function/now.yaml
@@ -1,7 +1,7 @@
 spq: |
   const t1 = now()
   values t1, now()
-  | values string(this) ~ '[0-9TZ:\\-\\.]+'
+  | values this::string ~ '[0-9TZ:\\-\\.]+'
 
 vector: true
 

--- a/runtime/ztests/expr/record-spread-unnest.yaml
+++ b/runtime/ztests/expr/record-spread-unnest.yaml
@@ -1,6 +1,6 @@
 spq: |
-  unnest {outer:this,tweet_ids} into (
-    ids:=collect(string(tweet_ids)) by outer
+  unnest {outer:this,id:tweet_ids} into (
+    ids:=collect(id::string) by outer
     | values {...outer,tweet_ids:join(ids,',')}
   )
 

--- a/runtime/ztests/expr/unnest-expr-nested.yaml
+++ b/runtime/ztests/expr/unnest-expr-nested.yaml
@@ -1,4 +1,4 @@
-spq: values (unnest a | unnest this | collect(string(this)))
+spq: values (unnest a | unnest this | collect(this::string))
 
 vector: true
 

--- a/sio/jsonio/ztests/unicode-nfc.yaml
+++ b/sio/jsonio/ztests/unicode-nfc.yaml
@@ -1,4 +1,4 @@
-spq: values bytes(this)
+spq: values this::bytes
 
 input-flags: -i json
 

--- a/ztests/bytes.yaml
+++ b/ztests/bytes.yaml
@@ -1,4 +1,4 @@
-spq: c:=string(b),d:=base64(b) | e:=string(base64(d))
+spq: c:=b::string,d:=base64(b) | e:=base64(d)::string
 
 input: |
   {b:0x68692c20776f726c64}


### PR DESCRIPTION
This commit finishes the previous commit of removing function style casts.  We missed the primitive case because there was logic in the semantic pass that checked if a function name was a primitive type. We've removed that and updated all the tests and examples.