### PR TITLE
automatically promote a user-op in an expression to a subquery

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -629,13 +629,12 @@ func (a *analyzer) semCall(call *ast.Call) dag.Expr {
 		return badExpr()
 	}
 	if userOp := a.maybeConvertUserOp(call); userOp != nil {
-		// When a user op is encountered inside an expression, we turn it into
+		// When a user op is encountered inside an expression, we turn it into a
 		// subquery operating on a single-shot "this" value unless it's uncorrelated
 		// (i.e., starts with a from), in which case we put the uncorrelated body
 		// in the subquery without the values/collect logic.
-		var correlated bool
-		if isCorrelated(userOp) {
-			correlated = true
+		correlated := isCorrelated(userOp)
+		if correlated {
 			valuesOp := &dag.Values{
 				Kind:  "Values",
 				Exprs: []dag.Expr{dag.NewThis(nil)},

--- a/compiler/ztests/user-op-subquery-from.yaml
+++ b/compiler/ztests/user-op-subquery-from.yaml
@@ -1,0 +1,18 @@
+script: |
+  super -s -I query.spq
+
+inputs:
+  - name: query.spq
+    data: |
+      op slurp() : (from in.sup | count())
+      values {x:slurp()}
+  - name: in.sup
+    data: |
+      1
+      2
+      3
+
+outputs:
+  - name: stdout
+    data: |
+      {x:3::uint64}

--- a/compiler/ztests/user-op-subquery.yaml
+++ b/compiler/ztests/user-op-subquery.yaml
@@ -1,0 +1,7 @@
+spq: |
+  op F(a) : (unnest a | this+1)
+  values {a:[1,2]}
+  | values {x:F(a)}
+
+output: |
+  {x:[2,3]}


### PR DESCRIPTION
This commit changes the handling of user-ops referenced in expressions from an error to a subquery.  When the user-op begins with a from, then the subquery is spliced into the expression as an uncorrelated query. Otherwise, it is dependenent on its input and the user-op is expanded into the pattern (values this | userOp(params) | collect(this)).