### PR TITLE
compiler/sfmt: fix DAG output for this["@f"]

### DIFF
--- a/compiler/sfmt/zed.go
+++ b/compiler/sfmt/zed.go
@@ -36,7 +36,7 @@ func (c *canonZed) fieldpath(path []string) {
 			c.write(s)
 		} else {
 			if k == 0 {
-				c.write(".")
+				c.write("this")
 			}
 			c.write("[%q]", s)
 		}

--- a/compiler/sfmt/ztests/parallel.yaml
+++ b/compiler/sfmt/ztests/parallel.yaml
@@ -9,7 +9,7 @@ outputs:
       | fork
         (
           aggregate
-              count:=count() by x:=.["@foo"]
+              count:=count() by x:=this["@foo"]
         )
         (
           aggregate


### PR DESCRIPTION
It's currently formatted as `.["@f"]`.