### PR TITLE
No numbered chapters in book docs

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -16,6 +16,7 @@ additional-js = ["super-example.bundle.js", "copy-button/copy-button.js", "theme
 # to work around a problem where cached files cause the sidebar not to reflect
 # changes to SUMMARY.md.  See https://github.com/rust-lang/mdBook/issues/2547
 hash-files = true
+no-section-label = true
 
 [output.html.playground]
 # Suppress mdBook's copy button since we add our own.


### PR DESCRIPTION
## What's Changing

This drops the automatically-generated chapter numbers in the left-hand nav in the rendered "book" docs.

### Before

<img width="287" height="370" alt="image" src="https://github.com/user-attachments/assets/bd386edc-97a9-48f0-a324-255795f5bff0" />

### With the changes on this branch

<img width="287" height="370" alt="image" src="https://github.com/user-attachments/assets/1fc90c44-37a0-40d9-914f-83853f86cfb9" />

## Why

After a brief survey within the team, there seems to be consensus that the chapter numbering is not needed.

## Details

Per [mdbook docs](https://rust-lang.github.io/mdBook/format/configuration/renderers.html?highlight=chapter#html-renderer-options), by default it adds these numeric section labels in the left hand nav, but it can be easily toggled off like I've done in this PR.

In terms of background with our own docs, neither of our prior sites https://zed.brimdata.io/docs nor https://superdb.org/docs happened to have numbered chapters like this and I don't recall anyone ever citing a desire to have them. Therefore mdbook providing them effectively seems like a coincidence.

In terms of what other mdbook sites happen to do, I see some that keep this default behavior such as the [The Rust Programming Language](https://doc.rust-lang.org/book/#the-rust-programming-language) book but also some that toggle the numbers off such as [Snort](https://docs.snort.org/) and [HackTricks](https://book.hacktricks.wiki/en/index.html).

Speaking just for myself, a tiebreaker in my mind is that we already have some docs with internal section numbering such as the [Formats docs](https://superdb.org/book/formats/intro.html) so to me dropping the default chapter numbering eliminates one area of possible confusion around "numbers within numbers".