### PR TITLE
run markdownlint on all Markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin/
 /dist/
 /zed-sample-data/
+node_modules/
 
 .idea
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ peg: compiler/parser/parser.go
 .PHONY: markdown-lint
 markdown-lint:
 	@npm install --no-save markdownlint-cli@0.35.0
-	@npx markdownlint docs
+	@npx markdownlint --ignore-path .gitignore .
 
 # CI performs these actions individually since that looks nicer in the UI;
 # this is a shortcut so that a local dev can easily run everything.

--- a/book/.gitignore
+++ b/book/.gitignore
@@ -1,7 +1,6 @@
 book
 theme
 
-node_modules
 package-lock.json
 src/super.wasm
 super-example.bundle.js


### PR DESCRIPTION
"make markdown-lint" runs markdownlint on the docs directory.  Run it on all markdown files in the repository instead.

Depends on #6187.