### PR TITLE
remove unneeded consts from dag

### DIFF
--- a/compiler/dag/op.go
+++ b/compiler/dag/op.go
@@ -130,10 +130,9 @@ type (
 		Paths []Seq  `json:"paths"`
 	}
 	Scope struct {
-		Kind   string  `json:"kind" unpack:""`
-		Consts []Def   `json:"consts"`
-		Funcs  []*Func `json:"funcs"`
-		Body   Seq     `json:"seq"`
+		Kind  string  `json:"kind" unpack:""`
+		Funcs []*Func `json:"funcs"`
+		Body  Seq     `json:"seq"`
 	}
 	Shape struct {
 		Kind string `json:"kind" unpack:""`
@@ -323,10 +322,6 @@ type (
 	Case struct {
 		Expr Expr `json:"expr"`
 		Path Seq  `json:"seq"`
-	}
-	Def struct {
-		Name string `json:"name"`
-		Expr Expr   `json:"expr"`
 	}
 )
 

--- a/compiler/sfmt/dag.go
+++ b/compiler/sfmt/dag.go
@@ -616,14 +616,9 @@ func (c *canonDAG) scope(s *dag.Scope) {
 	first := c.first
 	if !first {
 		c.open("(")
-		c.ret()
-		c.flush()
-	}
-	for _, d := range s.Consts {
-		c.write("const %s = ", d.Name)
-		c.expr(d.Expr, "")
-		c.ret()
-		c.flush()
+		if len(s.Funcs) > 0 {
+			c.ret()
+		}
 	}
 	for _, f := range s.Funcs {
 		c.write("func %s(", f.Name)

--- a/compiler/sfmt/ztests/decls.yaml
+++ b/compiler/sfmt/ztests/decls.yaml
@@ -50,8 +50,6 @@ outputs:
       | call stamp "bob"
       ===
       (
-        const foo = "bar"
-        const bar = "baz"
         func fib(n): (
           (n<=1) ? n : fib(n-1)+fib(n-2)
         )

--- a/compiler/ztests/const-source.yaml
+++ b/compiler/ztests/const-source.yaml
@@ -15,22 +15,16 @@ outputs:
   - name: stdout
     data: |
       (
-        const POOL = "test"
-        
         pool XXX
         | output main
       )
       ===
       (
-        const FILE = "A.sup"
-        
         file A.sup format sup
         | output main
       )
       ===
       (
-        const URL = "http://brimdata.io"
-        
         get http://brimdata.io
         | output main
       )

--- a/compiler/ztests/head.yaml
+++ b/compiler/ztests/head.yaml
@@ -15,8 +15,6 @@ outputs:
       ===
       null
       | (
-        const x = 1
-        
         head 2
         | output main
       )

--- a/compiler/ztests/tail.yaml
+++ b/compiler/ztests/tail.yaml
@@ -15,8 +15,6 @@ outputs:
       ===
       null
       | (
-        const x = 1
-        
         tail 2
         | output main
       )


### PR DESCRIPTION
This commit removes const definitions from the DAG since all constant folding and replacement is handled in the semantic pass.