### PR TITLE
compiler/optimizer: fix missing field bug in liftFilterOps, mergeValuesOps

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -525,11 +525,11 @@ func liftFilterOps(seq dag.Seq) dag.Seq {
 				}
 				e1, ok := fields[this.Path[0]]
 				if !ok {
-					if spread != nil {
-						// Copy spread so f and y don't share dag.Exprs.
-						return addPathToExpr(dag.CopyExpr(spread), this.Path)
+					if spread == nil {
+						return &dag.Literal{Kind: "Literal", Value: `error("missing")`}
 					}
-					return e
+					// Copy spread so f and y don't share dag.Exprs.
+					return addPathToExpr(dag.CopyExpr(spread), this.Path)
 				}
 				// Copy e1 so f and y don't share dag.Exprs.
 				return addPathToExpr(dag.CopyExpr(e1), this.Path[1:])
@@ -563,10 +563,10 @@ func mergeValuesOps(seq dag.Seq) dag.Seq {
 				}
 				v1Expr, ok := v1TopLevelFields[this.Path[0]]
 				if !ok {
-					if v1TopLevelSpread != nil {
-						return addPathToExpr(v1TopLevelSpread, this.Path)
+					if v1TopLevelSpread == nil {
+						return &dag.Literal{Kind: "Literal", Value: `error("missing")`}
 					}
-					return e
+					return addPathToExpr(v1TopLevelSpread, this.Path)
 				}
 				return addPathToExpr(v1Expr, this.Path[1:])
 			}

--- a/compiler/ztests/lift-filters.yaml
+++ b/compiler/ztests/lift-filters.yaml
@@ -1,5 +1,5 @@
 script: |
-  super compile -C -O 'values {a:b} | where a==1'
+  super compile -C -O 'values {a:b} | where a==1 and c==2'
   echo ===
   super compile -C -O 'values {...a} | where b==1'
   echo ===
@@ -9,7 +9,7 @@ outputs:
   - name: stdout
     data: |
       null
-      | where b==1
+      | where b==1 and error("missing")==2
       | values {a:b}
       | output main
       ===

--- a/compiler/ztests/merge-values.yaml
+++ b/compiler/ztests/merge-values.yaml
@@ -1,7 +1,7 @@
 script: |
-  super compile -C -O 'values {a:1} | values a, {b:a}'
+  super compile -C -O 'values {a:1} | values a, {b:a}, c'
   echo ===
-  super compile -C -O 'values {a,b} | aggregate count(a) by b'
+  super compile -C -O 'values {a,b} | aggregate count(a) by b, c'
   echo ===
   super compile -C -O 'values {...a} | values {...b.c} | values d, {e}'
   echo ===
@@ -17,12 +17,12 @@ outputs:
   - name: stdout
     data: |
       null
-      | values 1, {b:1}
+      | values 1, {b:1}, error("missing")
       | output main
       ===
       null
       | aggregate
-          count:=count(a) by b:=b
+          count:=count(a) by b:=b,c:=error("missing")
       | output main
       ===
       null


### PR DESCRIPTION
Both optimizations do the wrong thing when they encounter a field known to be missing.  For example, liftFilterOps rewrites `values {a} | where b==1` to `where b==1 | values {a}` instead of `where error("missing")==1 | values {a}`, and mergeValuesOps rewrites `values {a} | values b` to `values b` instead of `values error("missing")`.