### PR TITLE
compiler: remove dag.Vectorize

### DIFF
--- a/compiler/dag/op.go
+++ b/compiler/dag/op.go
@@ -174,11 +174,6 @@ type (
 		Kind  string `json:"kind" unpack:""`
 		Exprs []Expr `json:"exprs"`
 	}
-	// Vectorize executes its body using the vector engine.
-	Vectorize struct {
-		Kind string `json:"kind" unpack:""`
-		Body Seq    `json:"body"`
-	}
 )
 
 // Input structure
@@ -350,7 +345,6 @@ func (*Shape) opNode()     {}
 func (*Explode) opNode()   {}
 func (*Unnest) opNode()    {}
 func (*Values) opNode()    {}
-func (*Vectorize) opNode() {}
 func (*Merge) opNode()     {}
 func (*Mirror) opNode()    {}
 func (*Combine) opNode()   {}

--- a/compiler/dag/unpack.go
+++ b/compiler/dag/unpack.go
@@ -75,7 +75,6 @@ var unpacker = unpack.New(
 	Uniq{},
 	Unnest{},
 	Values{},
-	Vectorize{},
 	VectorValue{},
 )
 

--- a/compiler/optimizer/demand.go
+++ b/compiler/optimizer/demand.go
@@ -56,8 +56,6 @@ func demandForOp(op dag.Op, downstreams []demand.Demand) []demand.Demand {
 			d = demand.Union(d, demand.Union(DemandForSeq(c.Path, downstreams[i])...))
 		}
 		return []demand.Demand{d}
-	case *dag.Vectorize:
-		return DemandForSeq(op.Body, downstreams...)
 	default:
 		return []demand.Demand{demandForSimpleOp(op, demand.Union(downstreams...))}
 	}

--- a/compiler/optimizer/vam.go
+++ b/compiler/optimizer/vam.go
@@ -1,63 +1,8 @@
 package optimizer
 
 import (
-	"context"
-
 	"github.com/brimdata/super/compiler/dag"
-	"github.com/brimdata/super/pkg/field"
 )
-
-func (o *Optimizer) Vectorize(seq dag.Seq) (dag.Seq, error) {
-	return walkEntries(seq, func(seq dag.Seq) (dag.Seq, error) {
-		if len(seq) < 2 {
-			return seq, nil
-		}
-		if ok, err := o.isScanWithVectors(seq[0]); !ok || err != nil {
-			return seq, err
-		}
-		if _, ok := IsCountByString(seq[1]); ok {
-			return vectorize(seq, 2), nil
-		}
-		if _, ok := IsSum(seq[1]); ok {
-			return vectorize(seq, 2), nil
-		}
-		return seq, nil
-	})
-}
-
-func (o *Optimizer) isScanWithVectors(op dag.Op) (bool, error) {
-	scan, ok := op.(*dag.SeqScan)
-	if !ok {
-		return false, nil
-	}
-	pool, err := o.lookupPool(scan.Pool)
-	if err != nil {
-		return false, err
-	}
-	snap, err := pool.Snapshot(context.TODO(), scan.Commit)
-	if err != nil {
-		return false, err
-	}
-	objects := snap.SelectAll()
-	if len(objects) == 0 {
-		return false, nil
-	}
-	for _, obj := range objects {
-		if !snap.HasVector(obj.ID) {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-func vectorize(seq dag.Seq, n int) dag.Seq {
-	return append(dag.Seq{
-		&dag.Vectorize{
-			Kind: "Vectorize",
-			Body: seq[:n],
-		},
-	}, seq[n:]...)
-}
 
 // IsCountByString returns whether o represents "count() by <top-level field>"
 // along with the field name.
@@ -65,18 +10,6 @@ func IsCountByString(o dag.Op) (string, bool) {
 	s, ok := o.(*dag.Aggregate)
 	if ok && len(s.Aggs) == 1 && len(s.Keys) == 1 && isCount(s.Aggs[0]) {
 		return isSingleField(s.Keys[0])
-	}
-	return "", false
-}
-
-// IsSum return whether o represents "sum(<top-level field>)" along with the
-// field name.
-func IsSum(o dag.Op) (string, bool) {
-	s, ok := o.(*dag.Aggregate)
-	if ok && len(s.Aggs) == 1 && len(s.Keys) == 0 {
-		if path, ok := isSum(s.Aggs[0]); ok && len(path) == 1 {
-			return path[0], true
-		}
 	}
 	return "", false
 }
@@ -90,18 +23,6 @@ func isCount(a dag.Assignment) bool {
 	return ok && agg.Name == "count" && agg.Expr == nil && agg.Where == nil
 }
 
-func isSum(a dag.Assignment) (field.Path, bool) {
-	this, ok := a.LHS.(*dag.This)
-	if !ok || len(this.Path) != 1 || this.Path[0] != "sum" {
-		return nil, false
-	}
-	agg, ok := a.RHS.(*dag.Agg)
-	if ok && agg.Name == "sum" && agg.Where == nil {
-		return isThis(agg.Expr)
-	}
-	return nil, false
-}
-
 func isSingleField(a dag.Assignment) (string, bool) {
 	lhs := fieldOf(a.LHS)
 	rhs := fieldOf(a.RHS)
@@ -109,11 +30,4 @@ func isSingleField(a dag.Assignment) (string, bool) {
 		return "", false
 	}
 	return lhs[0], true
-}
-
-func isThis(e dag.Expr) (field.Path, bool) {
-	if this, ok := e.(*dag.This); ok && len(this.Path) >= 1 {
-		return this.Path, true
-	}
-	return nil, false
 }

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -40,14 +40,7 @@ func Optimize(ctx context.Context, seq dag.Seq, env *exec.Environment, parallel 
 		// any parallelization right now though this could be potentially
 		// beneficial depending on where the bottleneck is for a given shaper.
 		// See issue #2641.
-		seq, err = o.Parallelize(seq, parallel)
-		if err != nil {
-			return nil, err
-		}
-		seq, err = o.Vectorize(seq)
-		if err != nil {
-			return nil, err
-		}
+		return o.Parallelize(seq, parallel)
 	}
 	return seq, nil
 }

--- a/compiler/sfmt/dag.go
+++ b/compiler/sfmt/dag.go
@@ -571,12 +571,6 @@ func (c *canonDAG) op(p dag.Op) {
 	case *dag.Pass:
 		c.next()
 		c.write("pass")
-	case *dag.Vectorize:
-		c.next()
-		c.open("vectorize =>")
-		c.head = true
-		c.seq(p.Body)
-		c.close()
 	case *dag.Output:
 		c.next()
 		c.write("output %s", p.Name)


### PR DESCRIPTION
dag.Vectorize exists to allow the optimizer to decide which parts of the DAG to execute with the vector runtime.  Remove it since we've moved that decision to rungen.