### PR TITLE
Makefile targets to run sqllogic ztests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ $(SAMPLEDATA):
 
 sampledata: $(SAMPLEDATA)
 
+SQLLOGIC_ZTESTS:=sqllogic-ztests/README.md
+
+$(SQLLOGIC_ZTESTS):
+	git clone --depth=1 https://github.com/brimdata/sqllogic-ztests $(@D)
+
+sqllogic-ztests: $(SQLLOGIC_ZTESTS)
+
 bin/minio: Makefile
 	@curl -o $@ --compressed --create-dirs \
 		https://dl.min.io/server/minio/release/$$(go env GOOS)-$$(go env GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z
@@ -58,6 +65,9 @@ test-run: build bin/minio
 
 test-heavy: build
 	@PATH="$(CURDIR)/dist:$(PATH)" go test -tags=heavy ./mdtest
+
+test-sqllogic: build $(SQLLOGIC_ZTESTS)
+	make TEST=TestSPQ/sqllogic-ztests
 
 output-check: build $(SAMPLEDATA)
 	scripts/output-check.sh
@@ -92,5 +102,5 @@ test-ci: fmt tidy vet test-generate test-unit test-system test-heavy
 clean:
 	@rm -rf dist
 
-.PHONY: fmt tidy vet test-unit test-system test-heavy sampledata test-ci
+.PHONY: fmt tidy vet test-unit test-system test-heavy test-sqllogic sampledata test-ci
 .PHONY: build install clean generate test-generate


### PR DESCRIPTION
## What's Changing

This is a first attempt at running some of the successful sqllogictest queries as ztests to catch SuperDB regressions. I expect I'll need some help improving the Makefile. To run:

```
make test-sqllogic
```

## Why

While working on sqllogictests to find new problems I've bumped into some regressions such as #6223, so there's been recent interest within the Dev team in "locking in" the automated running of successful tests so such breakages can be caught early.

## Details

As this first step, I'm just trying to make it possible to run the tests and will leave it up to group consensus where this fits into the Dev workflow, e.g., if/when it runs in CI.

What I've got in this PR is basically following the existing "sampledata" pattern in the Makefile. I've noticed that once the `test-sqllogic/` directory exists, the logic that finds all the ztest YAML in the source tree seems to run these tests even in targets like `test-ci` that don't explicitly target these tests, so this is one area where I'll surely need help to improve.