### PR TITLE
Simplify syntax for array-wrapped subquery

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -304,9 +304,10 @@ type TupleExpr struct {
 }
 
 type Subquery struct {
-	Kind string `json:"kind" unpack:""`
-	Body Seq    `json:"body"`
-	Loc  `json:"loc"`
+	Kind  string `json:"kind" unpack:""`
+	Body  Seq    `json:"body"`
+	Array bool   `json:"array"`
+	Loc   `json:"loc"`
 }
 
 type FString struct {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -7492,6 +7492,43 @@ var g = &grammar{
 							},
 						},
 					},
+					&actionExpr{
+						pos: position{line: 1134, col: 5, offset: 26988},
+						run: (*parser).callonPrimary27,
+						expr: &seqExpr{
+							pos: position{line: 1134, col: 5, offset: 26988},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 1134, col: 5, offset: 26988},
+									val:        "[",
+									ignoreCase: false,
+									want:       "\"[\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 1134, col: 9, offset: 26992},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 1134, col: 12, offset: 26995},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 1134, col: 17, offset: 27000},
+										name: "Subquery",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 1134, col: 26, offset: 27009},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 1134, col: 29, offset: 27012},
+									val:        "]",
+									ignoreCase: false,
+									want:       "\"]\"",
+								},
+							},
+						},
+					},
 				},
 			},
 			leader:        false,
@@ -7499,53 +7536,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1135, col: 1, offset: 26985},
+			pos:  position{line: 1139, col: 1, offset: 27090},
 			expr: &choiceExpr{
-				pos: position{line: 1136, col: 5, offset: 26998},
+				pos: position{line: 1140, col: 5, offset: 27103},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1136, col: 5, offset: 26998},
+						pos: position{line: 1140, col: 5, offset: 27103},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1136, col: 5, offset: 26998},
+							pos: position{line: 1140, col: 5, offset: 27103},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1136, col: 5, offset: 26998},
+									pos:  position{line: 1140, col: 5, offset: 27103},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1136, col: 10, offset: 27003},
+									pos:   position{line: 1140, col: 10, offset: 27108},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1136, col: 16, offset: 27009},
+										pos: position{line: 1140, col: 16, offset: 27114},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1136, col: 16, offset: 27009},
+											pos:  position{line: 1140, col: 16, offset: 27114},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1136, col: 22, offset: 27015},
+									pos:   position{line: 1140, col: 22, offset: 27120},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1136, col: 28, offset: 27021},
+										pos: position{line: 1140, col: 28, offset: 27126},
 										expr: &seqExpr{
-											pos: position{line: 1136, col: 29, offset: 27022},
+											pos: position{line: 1140, col: 29, offset: 27127},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1136, col: 29, offset: 27022},
+													pos:  position{line: 1140, col: 29, offset: 27127},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1136, col: 31, offset: 27024},
+													pos:  position{line: 1140, col: 31, offset: 27129},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1136, col: 36, offset: 27029},
+													pos:  position{line: 1140, col: 36, offset: 27134},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1136, col: 38, offset: 27031},
+													pos:  position{line: 1140, col: 38, offset: 27136},
 													name: "Expr",
 												},
 											},
@@ -7553,24 +7590,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1136, col: 45, offset: 27038},
+									pos:  position{line: 1140, col: 45, offset: 27143},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1136, col: 47, offset: 27040},
+									pos:  position{line: 1140, col: 47, offset: 27145},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1136, col: 51, offset: 27044},
+									pos: position{line: 1140, col: 51, offset: 27149},
 									expr: &seqExpr{
-										pos: position{line: 1136, col: 52, offset: 27045},
+										pos: position{line: 1140, col: 52, offset: 27150},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1136, col: 52, offset: 27045},
+												pos:  position{line: 1140, col: 52, offset: 27150},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1136, col: 54, offset: 27047},
+												pos:  position{line: 1140, col: 54, offset: 27152},
 												name: "CASE",
 											},
 										},
@@ -7580,60 +7617,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1160, col: 5, offset: 27696},
+						pos: position{line: 1164, col: 5, offset: 27801},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1160, col: 5, offset: 27696},
+							pos: position{line: 1164, col: 5, offset: 27801},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1160, col: 5, offset: 27696},
+									pos:  position{line: 1164, col: 5, offset: 27801},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1160, col: 10, offset: 27701},
+									pos:  position{line: 1164, col: 10, offset: 27806},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1160, col: 12, offset: 27703},
+									pos:   position{line: 1164, col: 12, offset: 27808},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1160, col: 17, offset: 27708},
+										pos:  position{line: 1164, col: 17, offset: 27813},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1160, col: 22, offset: 27713},
+									pos:   position{line: 1164, col: 22, offset: 27818},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1160, col: 28, offset: 27719},
+										pos: position{line: 1164, col: 28, offset: 27824},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1160, col: 28, offset: 27719},
+											pos:  position{line: 1164, col: 28, offset: 27824},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1160, col: 34, offset: 27725},
+									pos:   position{line: 1164, col: 34, offset: 27830},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1160, col: 40, offset: 27731},
+										pos: position{line: 1164, col: 40, offset: 27836},
 										expr: &seqExpr{
-											pos: position{line: 1160, col: 41, offset: 27732},
+											pos: position{line: 1164, col: 41, offset: 27837},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1160, col: 41, offset: 27732},
+													pos:  position{line: 1164, col: 41, offset: 27837},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1160, col: 43, offset: 27734},
+													pos:  position{line: 1164, col: 43, offset: 27839},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1160, col: 48, offset: 27739},
+													pos:  position{line: 1164, col: 48, offset: 27844},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1160, col: 50, offset: 27741},
+													pos:  position{line: 1164, col: 50, offset: 27846},
 													name: "Expr",
 												},
 											},
@@ -7641,24 +7678,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1160, col: 57, offset: 27748},
+									pos:  position{line: 1164, col: 57, offset: 27853},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1160, col: 59, offset: 27750},
+									pos:  position{line: 1164, col: 59, offset: 27855},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1160, col: 63, offset: 27754},
+									pos: position{line: 1164, col: 63, offset: 27859},
 									expr: &seqExpr{
-										pos: position{line: 1160, col: 64, offset: 27755},
+										pos: position{line: 1164, col: 64, offset: 27860},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1160, col: 64, offset: 27755},
+												pos:  position{line: 1164, col: 64, offset: 27860},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1160, col: 66, offset: 27757},
+												pos:  position{line: 1164, col: 66, offset: 27862},
 												name: "CASE",
 											},
 										},
@@ -7674,50 +7711,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1173, col: 1, offset: 28063},
+			pos:  position{line: 1177, col: 1, offset: 28168},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 5, offset: 28072},
+				pos: position{line: 1178, col: 5, offset: 28177},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1174, col: 5, offset: 28072},
+					pos: position{line: 1178, col: 5, offset: 28177},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 5, offset: 28072},
+							pos:  position{line: 1178, col: 5, offset: 28177},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 7, offset: 28074},
+							pos:  position{line: 1178, col: 7, offset: 28179},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 12, offset: 28079},
+							pos:  position{line: 1178, col: 12, offset: 28184},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1174, col: 14, offset: 28081},
+							pos:   position{line: 1178, col: 14, offset: 28186},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1174, col: 19, offset: 28086},
+								pos:  position{line: 1178, col: 19, offset: 28191},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 24, offset: 28091},
+							pos:  position{line: 1178, col: 24, offset: 28196},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 26, offset: 28093},
+							pos:  position{line: 1178, col: 26, offset: 28198},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 31, offset: 28098},
+							pos:  position{line: 1178, col: 31, offset: 28203},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1174, col: 33, offset: 28100},
+							pos:   position{line: 1178, col: 33, offset: 28205},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1174, col: 38, offset: 28105},
+								pos:  position{line: 1178, col: 38, offset: 28210},
 								name: "Expr",
 							},
 						},
@@ -7729,15 +7766,15 @@ var g = &grammar{
 		},
 		{
 			name: "Subquery",
-			pos:  position{line: 1183, col: 1, offset: 28260},
+			pos:  position{line: 1187, col: 1, offset: 28365},
 			expr: &actionExpr{
-				pos: position{line: 1184, col: 5, offset: 28273},
+				pos: position{line: 1188, col: 5, offset: 28378},
 				run: (*parser).callonSubquery1,
 				expr: &labeledExpr{
-					pos:   position{line: 1184, col: 5, offset: 28273},
+					pos:   position{line: 1188, col: 5, offset: 28378},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1184, col: 10, offset: 28278},
+						pos:  position{line: 1188, col: 10, offset: 28383},
 						name: "Seq",
 					},
 				},
@@ -7747,37 +7784,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1192, col: 1, offset: 28414},
+			pos:  position{line: 1196, col: 1, offset: 28519},
 			expr: &actionExpr{
-				pos: position{line: 1193, col: 5, offset: 28425},
+				pos: position{line: 1197, col: 5, offset: 28530},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1193, col: 5, offset: 28425},
+					pos: position{line: 1197, col: 5, offset: 28530},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1193, col: 5, offset: 28425},
+							pos:        position{line: 1197, col: 5, offset: 28530},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1193, col: 9, offset: 28429},
+							pos:  position{line: 1197, col: 9, offset: 28534},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1193, col: 12, offset: 28432},
+							pos:   position{line: 1197, col: 12, offset: 28537},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1193, col: 18, offset: 28438},
+								pos:  position{line: 1197, col: 18, offset: 28543},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1193, col: 30, offset: 28450},
+							pos:  position{line: 1197, col: 30, offset: 28555},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1193, col: 33, offset: 28453},
+							pos:        position{line: 1197, col: 33, offset: 28558},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7790,31 +7827,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1201, col: 1, offset: 28611},
+			pos:  position{line: 1205, col: 1, offset: 28716},
 			expr: &choiceExpr{
-				pos: position{line: 1202, col: 5, offset: 28627},
+				pos: position{line: 1206, col: 5, offset: 28732},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1202, col: 5, offset: 28627},
+						pos: position{line: 1206, col: 5, offset: 28732},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1202, col: 5, offset: 28627},
+							pos: position{line: 1206, col: 5, offset: 28732},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1202, col: 5, offset: 28627},
+									pos:   position{line: 1206, col: 5, offset: 28732},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1202, col: 11, offset: 28633},
+										pos:  position{line: 1206, col: 11, offset: 28738},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1202, col: 22, offset: 28644},
+									pos:   position{line: 1206, col: 22, offset: 28749},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1202, col: 27, offset: 28649},
+										pos: position{line: 1206, col: 27, offset: 28754},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1202, col: 27, offset: 28649},
+											pos:  position{line: 1206, col: 27, offset: 28754},
 											name: "RecordElemTail",
 										},
 									},
@@ -7823,10 +7860,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1205, col: 5, offset: 28712},
+						pos: position{line: 1209, col: 5, offset: 28817},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1205, col: 5, offset: 28712},
+							pos:  position{line: 1209, col: 5, offset: 28817},
 							name: "__",
 						},
 					},
@@ -7837,32 +7874,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1207, col: 1, offset: 28736},
+			pos:  position{line: 1211, col: 1, offset: 28841},
 			expr: &actionExpr{
-				pos: position{line: 1207, col: 18, offset: 28753},
+				pos: position{line: 1211, col: 18, offset: 28858},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1207, col: 18, offset: 28753},
+					pos: position{line: 1211, col: 18, offset: 28858},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1207, col: 18, offset: 28753},
+							pos:  position{line: 1211, col: 18, offset: 28858},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1207, col: 21, offset: 28756},
+							pos:        position{line: 1211, col: 21, offset: 28861},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1207, col: 25, offset: 28760},
+							pos:  position{line: 1211, col: 25, offset: 28865},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1207, col: 28, offset: 28763},
+							pos:   position{line: 1211, col: 28, offset: 28868},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1207, col: 33, offset: 28768},
+								pos:  position{line: 1211, col: 33, offset: 28873},
 								name: "RecordElem",
 							},
 						},
@@ -7874,20 +7911,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1209, col: 1, offset: 28801},
+			pos:  position{line: 1213, col: 1, offset: 28906},
 			expr: &choiceExpr{
-				pos: position{line: 1210, col: 5, offset: 28816},
+				pos: position{line: 1214, col: 5, offset: 28921},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1210, col: 5, offset: 28816},
+						pos:  position{line: 1214, col: 5, offset: 28921},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1211, col: 5, offset: 28827},
+						pos:  position{line: 1215, col: 5, offset: 28932},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1212, col: 5, offset: 28841},
+						pos:  position{line: 1216, col: 5, offset: 28946},
 						name: "Identifier",
 					},
 				},
@@ -7897,28 +7934,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1214, col: 1, offset: 28853},
+			pos:  position{line: 1218, col: 1, offset: 28958},
 			expr: &actionExpr{
-				pos: position{line: 1215, col: 5, offset: 28864},
+				pos: position{line: 1219, col: 5, offset: 28969},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1215, col: 5, offset: 28864},
+					pos: position{line: 1219, col: 5, offset: 28969},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1215, col: 5, offset: 28864},
+							pos:        position{line: 1219, col: 5, offset: 28969},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1215, col: 11, offset: 28870},
+							pos:  position{line: 1219, col: 11, offset: 28975},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1215, col: 14, offset: 28873},
+							pos:   position{line: 1219, col: 14, offset: 28978},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1215, col: 19, offset: 28878},
+								pos:  position{line: 1219, col: 19, offset: 28983},
 								name: "Expr",
 							},
 						},
@@ -7930,40 +7967,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1219, col: 1, offset: 28974},
+			pos:  position{line: 1223, col: 1, offset: 29079},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 5, offset: 28988},
+				pos: position{line: 1224, col: 5, offset: 29093},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 5, offset: 28988},
+					pos: position{line: 1224, col: 5, offset: 29093},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1220, col: 5, offset: 28988},
+							pos:   position{line: 1224, col: 5, offset: 29093},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 10, offset: 28993},
+								pos:  position{line: 1224, col: 10, offset: 29098},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 15, offset: 28998},
+							pos:  position{line: 1224, col: 15, offset: 29103},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1220, col: 18, offset: 29001},
+							pos:        position{line: 1224, col: 18, offset: 29106},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 22, offset: 29005},
+							pos:  position{line: 1224, col: 22, offset: 29110},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1220, col: 25, offset: 29008},
+							pos:   position{line: 1224, col: 25, offset: 29113},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 31, offset: 29014},
+								pos:  position{line: 1224, col: 31, offset: 29119},
 								name: "Expr",
 							},
 						},
@@ -7975,37 +8012,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1229, col: 1, offset: 29183},
+			pos:  position{line: 1233, col: 1, offset: 29288},
 			expr: &actionExpr{
-				pos: position{line: 1230, col: 5, offset: 29193},
+				pos: position{line: 1234, col: 5, offset: 29298},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1230, col: 5, offset: 29193},
+					pos: position{line: 1234, col: 5, offset: 29298},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1230, col: 5, offset: 29193},
+							pos:        position{line: 1234, col: 5, offset: 29298},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1230, col: 9, offset: 29197},
+							pos:  position{line: 1234, col: 9, offset: 29302},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1230, col: 12, offset: 29200},
+							pos:   position{line: 1234, col: 12, offset: 29305},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1230, col: 18, offset: 29206},
+								pos:  position{line: 1234, col: 18, offset: 29311},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1230, col: 30, offset: 29218},
+							pos:  position{line: 1234, col: 30, offset: 29323},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1230, col: 33, offset: 29221},
+							pos:        position{line: 1234, col: 33, offset: 29326},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8018,37 +8055,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1238, col: 1, offset: 29377},
+			pos:  position{line: 1242, col: 1, offset: 29482},
 			expr: &actionExpr{
-				pos: position{line: 1239, col: 5, offset: 29385},
+				pos: position{line: 1243, col: 5, offset: 29490},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1239, col: 5, offset: 29385},
+					pos: position{line: 1243, col: 5, offset: 29490},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1239, col: 5, offset: 29385},
+							pos:        position{line: 1243, col: 5, offset: 29490},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1239, col: 10, offset: 29390},
+							pos:  position{line: 1243, col: 10, offset: 29495},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1239, col: 13, offset: 29393},
+							pos:   position{line: 1243, col: 13, offset: 29498},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1239, col: 19, offset: 29399},
+								pos:  position{line: 1243, col: 19, offset: 29504},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1239, col: 31, offset: 29411},
+							pos:  position{line: 1243, col: 31, offset: 29516},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1239, col: 34, offset: 29414},
+							pos:        position{line: 1243, col: 34, offset: 29519},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8061,54 +8098,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1247, col: 1, offset: 29567},
+			pos:  position{line: 1251, col: 1, offset: 29672},
 			expr: &choiceExpr{
-				pos: position{line: 1248, col: 5, offset: 29583},
+				pos: position{line: 1252, col: 5, offset: 29688},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1248, col: 5, offset: 29583},
+						pos: position{line: 1252, col: 5, offset: 29688},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1248, col: 5, offset: 29583},
+							pos: position{line: 1252, col: 5, offset: 29688},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1248, col: 5, offset: 29583},
+									pos:   position{line: 1252, col: 5, offset: 29688},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1248, col: 11, offset: 29589},
+										pos:  position{line: 1252, col: 11, offset: 29694},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1248, col: 22, offset: 29600},
+									pos:   position{line: 1252, col: 22, offset: 29705},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1248, col: 27, offset: 29605},
+										pos: position{line: 1252, col: 27, offset: 29710},
 										expr: &actionExpr{
-											pos: position{line: 1248, col: 28, offset: 29606},
+											pos: position{line: 1252, col: 28, offset: 29711},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1248, col: 28, offset: 29606},
+												pos: position{line: 1252, col: 28, offset: 29711},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1248, col: 28, offset: 29606},
+														pos:  position{line: 1252, col: 28, offset: 29711},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1248, col: 31, offset: 29609},
+														pos:        position{line: 1252, col: 31, offset: 29714},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1248, col: 35, offset: 29613},
+														pos:  position{line: 1252, col: 35, offset: 29718},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1248, col: 38, offset: 29616},
+														pos:   position{line: 1252, col: 38, offset: 29721},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1248, col: 40, offset: 29618},
+															pos:  position{line: 1252, col: 40, offset: 29723},
 															name: "VectorElem",
 														},
 													},
@@ -8121,10 +8158,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1251, col: 5, offset: 29700},
+						pos: position{line: 1255, col: 5, offset: 29805},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1251, col: 5, offset: 29700},
+							pos:  position{line: 1255, col: 5, offset: 29805},
 							name: "__",
 						},
 					},
@@ -8135,22 +8172,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1253, col: 1, offset: 29724},
+			pos:  position{line: 1257, col: 1, offset: 29829},
 			expr: &choiceExpr{
-				pos: position{line: 1254, col: 5, offset: 29739},
+				pos: position{line: 1258, col: 5, offset: 29844},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1254, col: 5, offset: 29739},
+						pos:  position{line: 1258, col: 5, offset: 29844},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1255, col: 5, offset: 29750},
+						pos: position{line: 1259, col: 5, offset: 29855},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1255, col: 5, offset: 29750},
+							pos:   position{line: 1259, col: 5, offset: 29855},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1255, col: 7, offset: 29752},
+								pos:  position{line: 1259, col: 7, offset: 29857},
 								name: "Expr",
 							},
 						},
@@ -8162,37 +8199,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1257, col: 1, offset: 29843},
+			pos:  position{line: 1261, col: 1, offset: 29948},
 			expr: &actionExpr{
-				pos: position{line: 1258, col: 5, offset: 29851},
+				pos: position{line: 1262, col: 5, offset: 29956},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1258, col: 5, offset: 29851},
+					pos: position{line: 1262, col: 5, offset: 29956},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1258, col: 5, offset: 29851},
+							pos:        position{line: 1262, col: 5, offset: 29956},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1258, col: 10, offset: 29856},
+							pos:  position{line: 1262, col: 10, offset: 29961},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1258, col: 13, offset: 29859},
+							pos:   position{line: 1262, col: 13, offset: 29964},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1258, col: 19, offset: 29865},
+								pos:  position{line: 1262, col: 19, offset: 29970},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1258, col: 27, offset: 29873},
+							pos:  position{line: 1262, col: 27, offset: 29978},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1258, col: 30, offset: 29876},
+							pos:        position{line: 1262, col: 30, offset: 29981},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8205,31 +8242,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1266, col: 1, offset: 30030},
+			pos:  position{line: 1270, col: 1, offset: 30135},
 			expr: &choiceExpr{
-				pos: position{line: 1267, col: 5, offset: 30042},
+				pos: position{line: 1271, col: 5, offset: 30147},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 30042},
+						pos: position{line: 1271, col: 5, offset: 30147},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1267, col: 5, offset: 30042},
+							pos: position{line: 1271, col: 5, offset: 30147},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1267, col: 5, offset: 30042},
+									pos:   position{line: 1271, col: 5, offset: 30147},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1267, col: 11, offset: 30048},
+										pos:  position{line: 1271, col: 11, offset: 30153},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 17, offset: 30054},
+									pos:   position{line: 1271, col: 17, offset: 30159},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1267, col: 22, offset: 30059},
+										pos: position{line: 1271, col: 22, offset: 30164},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1267, col: 22, offset: 30059},
+											pos:  position{line: 1271, col: 22, offset: 30164},
 											name: "EntryTail",
 										},
 									},
@@ -8238,10 +8275,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1270, col: 5, offset: 30117},
+						pos: position{line: 1274, col: 5, offset: 30222},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1270, col: 5, offset: 30117},
+							pos:  position{line: 1274, col: 5, offset: 30222},
 							name: "__",
 						},
 					},
@@ -8252,32 +8289,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1273, col: 1, offset: 30142},
+			pos:  position{line: 1277, col: 1, offset: 30247},
 			expr: &actionExpr{
-				pos: position{line: 1273, col: 13, offset: 30154},
+				pos: position{line: 1277, col: 13, offset: 30259},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1273, col: 13, offset: 30154},
+					pos: position{line: 1277, col: 13, offset: 30259},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1273, col: 13, offset: 30154},
+							pos:  position{line: 1277, col: 13, offset: 30259},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1273, col: 16, offset: 30157},
+							pos:        position{line: 1277, col: 16, offset: 30262},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1273, col: 20, offset: 30161},
+							pos:  position{line: 1277, col: 20, offset: 30266},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1273, col: 23, offset: 30164},
+							pos:   position{line: 1277, col: 23, offset: 30269},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1273, col: 25, offset: 30166},
+								pos:  position{line: 1277, col: 25, offset: 30271},
 								name: "Entry",
 							},
 						},
@@ -8289,40 +8326,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1275, col: 1, offset: 30191},
+			pos:  position{line: 1279, col: 1, offset: 30296},
 			expr: &actionExpr{
-				pos: position{line: 1276, col: 5, offset: 30201},
+				pos: position{line: 1280, col: 5, offset: 30306},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1276, col: 5, offset: 30201},
+					pos: position{line: 1280, col: 5, offset: 30306},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1276, col: 5, offset: 30201},
+							pos:   position{line: 1280, col: 5, offset: 30306},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1276, col: 9, offset: 30205},
+								pos:  position{line: 1280, col: 9, offset: 30310},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1276, col: 14, offset: 30210},
+							pos:  position{line: 1280, col: 14, offset: 30315},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1276, col: 17, offset: 30213},
+							pos:        position{line: 1280, col: 17, offset: 30318},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1276, col: 21, offset: 30217},
+							pos:  position{line: 1280, col: 21, offset: 30322},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1276, col: 24, offset: 30220},
+							pos:   position{line: 1280, col: 24, offset: 30325},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1276, col: 30, offset: 30226},
+								pos:  position{line: 1280, col: 30, offset: 30331},
 								name: "Expr",
 							},
 						},
@@ -8334,61 +8371,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1280, col: 1, offset: 30329},
+			pos:  position{line: 1284, col: 1, offset: 30434},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 5, offset: 30339},
+				pos: position{line: 1285, col: 5, offset: 30444},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1281, col: 5, offset: 30339},
+					pos: position{line: 1285, col: 5, offset: 30444},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1281, col: 5, offset: 30339},
+							pos:        position{line: 1285, col: 5, offset: 30444},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1281, col: 9, offset: 30343},
+							pos:  position{line: 1285, col: 9, offset: 30448},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1281, col: 12, offset: 30346},
+							pos:   position{line: 1285, col: 12, offset: 30451},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1281, col: 18, offset: 30352},
+								pos:  position{line: 1285, col: 18, offset: 30457},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1281, col: 23, offset: 30357},
+							pos:   position{line: 1285, col: 23, offset: 30462},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1281, col: 28, offset: 30362},
+								pos: position{line: 1285, col: 28, offset: 30467},
 								expr: &actionExpr{
-									pos: position{line: 1281, col: 29, offset: 30363},
+									pos: position{line: 1285, col: 29, offset: 30468},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1281, col: 29, offset: 30363},
+										pos: position{line: 1285, col: 29, offset: 30468},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1281, col: 29, offset: 30363},
+												pos:  position{line: 1285, col: 29, offset: 30468},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1281, col: 32, offset: 30366},
+												pos:        position{line: 1285, col: 32, offset: 30471},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1281, col: 36, offset: 30370},
+												pos:  position{line: 1285, col: 36, offset: 30475},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1281, col: 39, offset: 30373},
+												pos:   position{line: 1285, col: 39, offset: 30478},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1281, col: 41, offset: 30375},
+													pos:  position{line: 1285, col: 41, offset: 30480},
 													name: "Expr",
 												},
 											},
@@ -8398,11 +8435,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1281, col: 66, offset: 30400},
+							pos:  position{line: 1285, col: 66, offset: 30505},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1281, col: 69, offset: 30403},
+							pos:        position{line: 1285, col: 69, offset: 30508},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8415,39 +8452,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1289, col: 1, offset: 30562},
+			pos:  position{line: 1293, col: 1, offset: 30667},
 			expr: &actionExpr{
-				pos: position{line: 1290, col: 5, offset: 30579},
+				pos: position{line: 1294, col: 5, offset: 30684},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1290, col: 5, offset: 30579},
+					pos: position{line: 1294, col: 5, offset: 30684},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1290, col: 5, offset: 30579},
+							pos:   position{line: 1294, col: 5, offset: 30684},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1290, col: 10, offset: 30584},
+								pos: position{line: 1294, col: 10, offset: 30689},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1290, col: 10, offset: 30584},
+										pos:  position{line: 1294, col: 10, offset: 30689},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1290, col: 17, offset: 30591},
+										pos:  position{line: 1294, col: 17, offset: 30696},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1290, col: 28, offset: 30602},
+							pos:  position{line: 1294, col: 28, offset: 30707},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1290, col: 30, offset: 30604},
+							pos:   position{line: 1294, col: 30, offset: 30709},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1290, col: 32, offset: 30606},
+								pos:  position{line: 1294, col: 32, offset: 30711},
 								name: "StringLiteral",
 							},
 						},
@@ -8459,56 +8496,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1301, col: 1, offset: 30823},
+			pos:  position{line: 1305, col: 1, offset: 30928},
 			expr: &choiceExpr{
-				pos: position{line: 1302, col: 5, offset: 30835},
+				pos: position{line: 1306, col: 5, offset: 30940},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1302, col: 5, offset: 30835},
+						pos:  position{line: 1306, col: 5, offset: 30940},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1303, col: 5, offset: 30851},
+						pos:  position{line: 1307, col: 5, offset: 30956},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1304, col: 5, offset: 30869},
+						pos:  position{line: 1308, col: 5, offset: 30974},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1305, col: 5, offset: 30881},
+						pos:  position{line: 1309, col: 5, offset: 30986},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1306, col: 5, offset: 30899},
+						pos:  position{line: 1310, col: 5, offset: 31004},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1307, col: 5, offset: 30918},
+						pos:  position{line: 1311, col: 5, offset: 31023},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1308, col: 5, offset: 30935},
+						pos:  position{line: 1312, col: 5, offset: 31040},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1309, col: 5, offset: 30948},
+						pos:  position{line: 1313, col: 5, offset: 31053},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1310, col: 5, offset: 30957},
+						pos:  position{line: 1314, col: 5, offset: 31062},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1311, col: 5, offset: 30974},
+						pos:  position{line: 1315, col: 5, offset: 31079},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 5, offset: 30993},
+						pos:  position{line: 1316, col: 5, offset: 31098},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1313, col: 5, offset: 31012},
+						pos:  position{line: 1317, col: 5, offset: 31117},
 						name: "NullLiteral",
 					},
 				},
@@ -8518,28 +8555,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1315, col: 1, offset: 31025},
+			pos:  position{line: 1319, col: 1, offset: 31130},
 			expr: &choiceExpr{
-				pos: position{line: 1316, col: 5, offset: 31043},
+				pos: position{line: 1320, col: 5, offset: 31148},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 31043},
+						pos: position{line: 1320, col: 5, offset: 31148},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 5, offset: 31043},
+							pos: position{line: 1320, col: 5, offset: 31148},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1316, col: 5, offset: 31043},
+									pos:   position{line: 1320, col: 5, offset: 31148},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1316, col: 7, offset: 31045},
+										pos:  position{line: 1320, col: 7, offset: 31150},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1316, col: 14, offset: 31052},
+									pos: position{line: 1320, col: 14, offset: 31157},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1316, col: 15, offset: 31053},
+										pos:  position{line: 1320, col: 15, offset: 31158},
 										name: "IdentifierRest",
 									},
 								},
@@ -8547,13 +8584,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1319, col: 5, offset: 31133},
+						pos: position{line: 1323, col: 5, offset: 31238},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1319, col: 5, offset: 31133},
+							pos:   position{line: 1323, col: 5, offset: 31238},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1319, col: 7, offset: 31135},
+								pos:  position{line: 1323, col: 7, offset: 31240},
 								name: "IP4Net",
 							},
 						},
@@ -8565,35 +8602,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1323, col: 1, offset: 31204},
+			pos:  position{line: 1327, col: 1, offset: 31309},
 			expr: &choiceExpr{
-				pos: position{line: 1324, col: 5, offset: 31223},
+				pos: position{line: 1328, col: 5, offset: 31328},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1324, col: 5, offset: 31223},
+						pos: position{line: 1328, col: 5, offset: 31328},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1324, col: 5, offset: 31223},
+							pos: position{line: 1328, col: 5, offset: 31328},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1324, col: 5, offset: 31223},
+									pos:   position{line: 1328, col: 5, offset: 31328},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1324, col: 7, offset: 31225},
+										pos:  position{line: 1328, col: 7, offset: 31330},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1324, col: 11, offset: 31229},
+									pos: position{line: 1328, col: 11, offset: 31334},
 									expr: &choiceExpr{
-										pos: position{line: 1324, col: 13, offset: 31231},
+										pos: position{line: 1328, col: 13, offset: 31336},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1324, col: 13, offset: 31231},
+												pos:  position{line: 1328, col: 13, offset: 31336},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1324, col: 30, offset: 31248},
+												pos:  position{line: 1328, col: 30, offset: 31353},
 												name: "TypeLiteral",
 											},
 										},
@@ -8603,13 +8640,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1327, col: 5, offset: 31325},
+						pos: position{line: 1331, col: 5, offset: 31430},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1327, col: 5, offset: 31325},
+							pos:   position{line: 1331, col: 5, offset: 31430},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1327, col: 7, offset: 31327},
+								pos:  position{line: 1331, col: 7, offset: 31432},
 								name: "IP",
 							},
 						},
@@ -8621,15 +8658,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1331, col: 1, offset: 31391},
+			pos:  position{line: 1335, col: 1, offset: 31496},
 			expr: &actionExpr{
-				pos: position{line: 1332, col: 5, offset: 31408},
+				pos: position{line: 1336, col: 5, offset: 31513},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1332, col: 5, offset: 31408},
+					pos:   position{line: 1336, col: 5, offset: 31513},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1332, col: 7, offset: 31410},
+						pos:  position{line: 1336, col: 7, offset: 31515},
 						name: "FloatString",
 					},
 				},
@@ -8639,15 +8676,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1336, col: 1, offset: 31488},
+			pos:  position{line: 1340, col: 1, offset: 31593},
 			expr: &actionExpr{
-				pos: position{line: 1337, col: 5, offset: 31507},
+				pos: position{line: 1341, col: 5, offset: 31612},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1337, col: 5, offset: 31507},
+					pos:   position{line: 1341, col: 5, offset: 31612},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1337, col: 7, offset: 31509},
+						pos:  position{line: 1341, col: 7, offset: 31614},
 						name: "IntString",
 					},
 				},
@@ -8657,23 +8694,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1341, col: 1, offset: 31583},
+			pos:  position{line: 1345, col: 1, offset: 31688},
 			expr: &choiceExpr{
-				pos: position{line: 1342, col: 5, offset: 31602},
+				pos: position{line: 1346, col: 5, offset: 31707},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 31602},
+						pos: position{line: 1346, col: 5, offset: 31707},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1342, col: 5, offset: 31602},
+							pos:  position{line: 1346, col: 5, offset: 31707},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1343, col: 5, offset: 31660},
+						pos: position{line: 1347, col: 5, offset: 31765},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1343, col: 5, offset: 31660},
+							pos:  position{line: 1347, col: 5, offset: 31765},
 							name: "FALSE",
 						},
 					},
@@ -8684,12 +8721,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1345, col: 1, offset: 31716},
+			pos:  position{line: 1349, col: 1, offset: 31821},
 			expr: &actionExpr{
-				pos: position{line: 1346, col: 5, offset: 31732},
+				pos: position{line: 1350, col: 5, offset: 31837},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1346, col: 5, offset: 31732},
+					pos:  position{line: 1350, col: 5, offset: 31837},
 					name: "NULL",
 				},
 			},
@@ -8698,23 +8735,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1348, col: 1, offset: 31782},
+			pos:  position{line: 1352, col: 1, offset: 31887},
 			expr: &actionExpr{
-				pos: position{line: 1349, col: 5, offset: 31799},
+				pos: position{line: 1353, col: 5, offset: 31904},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1349, col: 5, offset: 31799},
+					pos: position{line: 1353, col: 5, offset: 31904},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1349, col: 5, offset: 31799},
+							pos:        position{line: 1353, col: 5, offset: 31904},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1349, col: 10, offset: 31804},
+							pos: position{line: 1353, col: 10, offset: 31909},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1349, col: 10, offset: 31804},
+								pos:  position{line: 1353, col: 10, offset: 31909},
 								name: "HexDigit",
 							},
 						},
@@ -8726,29 +8763,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1353, col: 1, offset: 31878},
+			pos:  position{line: 1357, col: 1, offset: 31983},
 			expr: &actionExpr{
-				pos: position{line: 1354, col: 5, offset: 31894},
+				pos: position{line: 1358, col: 5, offset: 31999},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1354, col: 5, offset: 31894},
+					pos: position{line: 1358, col: 5, offset: 31999},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1354, col: 5, offset: 31894},
+							pos:        position{line: 1358, col: 5, offset: 31999},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1354, col: 9, offset: 31898},
+							pos:   position{line: 1358, col: 9, offset: 32003},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1354, col: 13, offset: 31902},
+								pos:  position{line: 1358, col: 13, offset: 32007},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1354, col: 18, offset: 31907},
+							pos:        position{line: 1358, col: 18, offset: 32012},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8761,27 +8798,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1362, col: 1, offset: 32040},
+			pos:  position{line: 1366, col: 1, offset: 32145},
 			expr: &choiceExpr{
-				pos: position{line: 1363, col: 5, offset: 32056},
+				pos: position{line: 1367, col: 5, offset: 32161},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1363, col: 5, offset: 32056},
+						pos: position{line: 1367, col: 5, offset: 32161},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1363, col: 5, offset: 32056},
+							pos: position{line: 1367, col: 5, offset: 32161},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1363, col: 5, offset: 32056},
+									pos:        position{line: 1367, col: 5, offset: 32161},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1363, col: 9, offset: 32060},
+									pos:   position{line: 1367, col: 9, offset: 32165},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1363, col: 14, offset: 32065},
+										pos:  position{line: 1367, col: 14, offset: 32170},
 										name: "Name",
 									},
 								},
@@ -8789,13 +8826,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1364, col: 5, offset: 32139},
+						pos: position{line: 1368, col: 5, offset: 32244},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1364, col: 5, offset: 32139},
+							pos:   position{line: 1368, col: 5, offset: 32244},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1364, col: 7, offset: 32141},
+								pos:  position{line: 1368, col: 7, offset: 32246},
 								name: "EasyType",
 							},
 						},
@@ -8807,16 +8844,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1372, col: 1, offset: 32277},
+			pos:  position{line: 1376, col: 1, offset: 32382},
 			expr: &choiceExpr{
-				pos: position{line: 1373, col: 5, offset: 32286},
+				pos: position{line: 1377, col: 5, offset: 32391},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1373, col: 5, offset: 32286},
+						pos:  position{line: 1377, col: 5, offset: 32391},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1374, col: 5, offset: 32300},
+						pos:  position{line: 1378, col: 5, offset: 32405},
 						name: "ComponentType",
 					},
 				},
@@ -8826,52 +8863,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1376, col: 1, offset: 32315},
+			pos:  position{line: 1380, col: 1, offset: 32420},
 			expr: &choiceExpr{
-				pos: position{line: 1377, col: 5, offset: 32333},
+				pos: position{line: 1381, col: 5, offset: 32438},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1377, col: 5, offset: 32333},
+						pos:  position{line: 1381, col: 5, offset: 32438},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1378, col: 5, offset: 32346},
+						pos: position{line: 1382, col: 5, offset: 32451},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1378, col: 5, offset: 32346},
+							pos: position{line: 1382, col: 5, offset: 32451},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1378, col: 5, offset: 32346},
+									pos:   position{line: 1382, col: 5, offset: 32451},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1378, col: 10, offset: 32351},
+										pos:  position{line: 1382, col: 10, offset: 32456},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1378, col: 15, offset: 32356},
+									pos:   position{line: 1382, col: 15, offset: 32461},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1378, col: 19, offset: 32360},
+										pos: position{line: 1382, col: 19, offset: 32465},
 										expr: &seqExpr{
-											pos: position{line: 1378, col: 20, offset: 32361},
+											pos: position{line: 1382, col: 20, offset: 32466},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1378, col: 20, offset: 32361},
+													pos:  position{line: 1382, col: 20, offset: 32466},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1378, col: 23, offset: 32364},
+													pos:        position{line: 1382, col: 23, offset: 32469},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1378, col: 27, offset: 32368},
+													pos:  position{line: 1382, col: 27, offset: 32473},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1378, col: 30, offset: 32371},
+													pos:  position{line: 1382, col: 30, offset: 32476},
 													name: "Type",
 												},
 											},
@@ -8888,40 +8925,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1390, col: 1, offset: 32693},
+			pos:  position{line: 1394, col: 1, offset: 32798},
 			expr: &choiceExpr{
-				pos: position{line: 1391, col: 5, offset: 32706},
+				pos: position{line: 1395, col: 5, offset: 32811},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1391, col: 5, offset: 32706},
+						pos: position{line: 1395, col: 5, offset: 32811},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1391, col: 5, offset: 32706},
+							pos: position{line: 1395, col: 5, offset: 32811},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1391, col: 5, offset: 32706},
+									pos:        position{line: 1395, col: 5, offset: 32811},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1391, col: 9, offset: 32710},
+									pos:  position{line: 1395, col: 9, offset: 32815},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1391, col: 12, offset: 32713},
+									pos:   position{line: 1395, col: 12, offset: 32818},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1391, col: 16, offset: 32717},
+										pos:  position{line: 1395, col: 16, offset: 32822},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1391, col: 21, offset: 32722},
+									pos:  position{line: 1395, col: 21, offset: 32827},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1391, col: 24, offset: 32725},
+									pos:        position{line: 1395, col: 24, offset: 32830},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8930,23 +8967,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1392, col: 5, offset: 32752},
+						pos: position{line: 1396, col: 5, offset: 32857},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1392, col: 5, offset: 32752},
+							pos: position{line: 1396, col: 5, offset: 32857},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1392, col: 5, offset: 32752},
+									pos:   position{line: 1396, col: 5, offset: 32857},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1392, col: 10, offset: 32757},
+										pos:  position{line: 1396, col: 10, offset: 32862},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1392, col: 24, offset: 32771},
+									pos: position{line: 1396, col: 24, offset: 32876},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1392, col: 25, offset: 32772},
+										pos:  position{line: 1396, col: 25, offset: 32877},
 										name: "IdentifierRest",
 									},
 								},
@@ -8954,43 +8991,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1393, col: 5, offset: 32812},
+						pos: position{line: 1397, col: 5, offset: 32917},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1393, col: 5, offset: 32812},
+							pos: position{line: 1397, col: 5, offset: 32917},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1393, col: 5, offset: 32812},
+									pos:  position{line: 1397, col: 5, offset: 32917},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1393, col: 11, offset: 32818},
+									pos:  position{line: 1397, col: 11, offset: 32923},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1393, col: 14, offset: 32821},
+									pos:        position{line: 1397, col: 14, offset: 32926},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1393, col: 18, offset: 32825},
+									pos:  position{line: 1397, col: 18, offset: 32930},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1393, col: 21, offset: 32828},
+									pos:   position{line: 1397, col: 21, offset: 32933},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1393, col: 23, offset: 32830},
+										pos:  position{line: 1397, col: 23, offset: 32935},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1393, col: 28, offset: 32835},
+									pos:  position{line: 1397, col: 28, offset: 32940},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1393, col: 31, offset: 32838},
+									pos:        position{line: 1397, col: 31, offset: 32943},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8999,43 +9036,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1400, col: 5, offset: 32978},
+						pos: position{line: 1404, col: 5, offset: 33083},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1400, col: 5, offset: 32978},
+							pos: position{line: 1404, col: 5, offset: 33083},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1400, col: 5, offset: 32978},
+									pos:  position{line: 1404, col: 5, offset: 33083},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1400, col: 10, offset: 32983},
+									pos:  position{line: 1404, col: 10, offset: 33088},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1400, col: 13, offset: 32986},
+									pos:        position{line: 1404, col: 13, offset: 33091},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1400, col: 17, offset: 32990},
+									pos:  position{line: 1404, col: 17, offset: 33095},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1400, col: 20, offset: 32993},
+									pos:   position{line: 1404, col: 20, offset: 33098},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1400, col: 26, offset: 32999},
+										pos:  position{line: 1404, col: 26, offset: 33104},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1400, col: 32, offset: 33005},
+									pos:  position{line: 1404, col: 32, offset: 33110},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1400, col: 35, offset: 33008},
+									pos:        position{line: 1404, col: 35, offset: 33113},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9044,35 +9081,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1407, col: 5, offset: 33162},
+						pos: position{line: 1411, col: 5, offset: 33267},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1407, col: 5, offset: 33162},
+							pos: position{line: 1411, col: 5, offset: 33267},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1407, col: 5, offset: 33162},
+									pos:        position{line: 1411, col: 5, offset: 33267},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1407, col: 9, offset: 33166},
+									pos:  position{line: 1411, col: 9, offset: 33271},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1407, col: 12, offset: 33169},
+									pos:   position{line: 1411, col: 12, offset: 33274},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1407, col: 19, offset: 33176},
+										pos:  position{line: 1411, col: 19, offset: 33281},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1407, col: 33, offset: 33190},
+									pos:  position{line: 1411, col: 33, offset: 33295},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1407, col: 36, offset: 33193},
+									pos:        position{line: 1411, col: 36, offset: 33298},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9081,35 +9118,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1414, col: 5, offset: 33355},
+						pos: position{line: 1418, col: 5, offset: 33460},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1414, col: 5, offset: 33355},
+							pos: position{line: 1418, col: 5, offset: 33460},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1414, col: 5, offset: 33355},
+									pos:        position{line: 1418, col: 5, offset: 33460},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1414, col: 9, offset: 33359},
+									pos:  position{line: 1418, col: 9, offset: 33464},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1414, col: 12, offset: 33362},
+									pos:   position{line: 1418, col: 12, offset: 33467},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1414, col: 16, offset: 33366},
+										pos:  position{line: 1418, col: 16, offset: 33471},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1414, col: 21, offset: 33371},
+									pos:  position{line: 1418, col: 21, offset: 33476},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1414, col: 24, offset: 33374},
+									pos:        position{line: 1418, col: 24, offset: 33479},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9118,35 +9155,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1421, col: 5, offset: 33516},
+						pos: position{line: 1425, col: 5, offset: 33621},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1421, col: 5, offset: 33516},
+							pos: position{line: 1425, col: 5, offset: 33621},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1421, col: 5, offset: 33516},
+									pos:        position{line: 1425, col: 5, offset: 33621},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1421, col: 10, offset: 33521},
+									pos:  position{line: 1425, col: 10, offset: 33626},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1421, col: 13, offset: 33524},
+									pos:   position{line: 1425, col: 13, offset: 33629},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1421, col: 17, offset: 33528},
+										pos:  position{line: 1425, col: 17, offset: 33633},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1421, col: 22, offset: 33533},
+									pos:  position{line: 1425, col: 22, offset: 33638},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1421, col: 25, offset: 33536},
+									pos:        position{line: 1425, col: 25, offset: 33641},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9155,57 +9192,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1428, col: 5, offset: 33675},
+						pos: position{line: 1432, col: 5, offset: 33780},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1428, col: 5, offset: 33675},
+							pos: position{line: 1432, col: 5, offset: 33780},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1428, col: 5, offset: 33675},
+									pos:        position{line: 1432, col: 5, offset: 33780},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1428, col: 10, offset: 33680},
+									pos:  position{line: 1432, col: 10, offset: 33785},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1428, col: 13, offset: 33683},
+									pos:   position{line: 1432, col: 13, offset: 33788},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1428, col: 21, offset: 33691},
+										pos:  position{line: 1432, col: 21, offset: 33796},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1428, col: 26, offset: 33696},
+									pos:  position{line: 1432, col: 26, offset: 33801},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1428, col: 29, offset: 33699},
+									pos:        position{line: 1432, col: 29, offset: 33804},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1428, col: 33, offset: 33703},
+									pos:  position{line: 1432, col: 33, offset: 33808},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1428, col: 36, offset: 33706},
+									pos:   position{line: 1432, col: 36, offset: 33811},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1428, col: 44, offset: 33714},
+										pos:  position{line: 1432, col: 44, offset: 33819},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1428, col: 49, offset: 33719},
+									pos:  position{line: 1432, col: 49, offset: 33824},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1428, col: 52, offset: 33722},
+									pos:        position{line: 1432, col: 52, offset: 33827},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9220,15 +9257,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1437, col: 1, offset: 33896},
+			pos:  position{line: 1441, col: 1, offset: 34001},
 			expr: &actionExpr{
-				pos: position{line: 1438, col: 5, offset: 33910},
+				pos: position{line: 1442, col: 5, offset: 34015},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1438, col: 5, offset: 33910},
+					pos:   position{line: 1442, col: 5, offset: 34015},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1438, col: 11, offset: 33916},
+						pos:  position{line: 1442, col: 11, offset: 34021},
 						name: "TypeList",
 					},
 				},
@@ -9238,28 +9275,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1446, col: 1, offset: 34053},
+			pos:  position{line: 1450, col: 1, offset: 34158},
 			expr: &actionExpr{
-				pos: position{line: 1447, col: 5, offset: 34066},
+				pos: position{line: 1451, col: 5, offset: 34171},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1447, col: 5, offset: 34066},
+					pos: position{line: 1451, col: 5, offset: 34171},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1447, col: 5, offset: 34066},
+							pos:   position{line: 1451, col: 5, offset: 34171},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1447, col: 11, offset: 34072},
+								pos:  position{line: 1451, col: 11, offset: 34177},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1447, col: 25, offset: 34086},
+							pos:   position{line: 1451, col: 25, offset: 34191},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1447, col: 30, offset: 34091},
+								pos: position{line: 1451, col: 30, offset: 34196},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1447, col: 30, offset: 34091},
+									pos:  position{line: 1451, col: 30, offset: 34196},
 									name: "TypeListTail",
 								},
 							},
@@ -9272,32 +9309,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1451, col: 1, offset: 34149},
+			pos:  position{line: 1455, col: 1, offset: 34254},
 			expr: &actionExpr{
-				pos: position{line: 1451, col: 16, offset: 34164},
+				pos: position{line: 1455, col: 16, offset: 34269},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1451, col: 16, offset: 34164},
+					pos: position{line: 1455, col: 16, offset: 34269},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1451, col: 16, offset: 34164},
+							pos:  position{line: 1455, col: 16, offset: 34269},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1451, col: 19, offset: 34167},
+							pos:        position{line: 1455, col: 19, offset: 34272},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1451, col: 23, offset: 34171},
+							pos:  position{line: 1455, col: 23, offset: 34276},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1451, col: 26, offset: 34174},
+							pos:   position{line: 1455, col: 26, offset: 34279},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1451, col: 30, offset: 34178},
+								pos:  position{line: 1455, col: 30, offset: 34283},
 								name: "ComponentType",
 							},
 						},
@@ -9309,42 +9346,42 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1453, col: 1, offset: 34213},
+			pos:  position{line: 1457, col: 1, offset: 34318},
 			expr: &choiceExpr{
-				pos: position{line: 1454, col: 5, offset: 34231},
+				pos: position{line: 1458, col: 5, offset: 34336},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1454, col: 5, offset: 34231},
+						pos: position{line: 1458, col: 5, offset: 34336},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1454, col: 5, offset: 34231},
+							pos:   position{line: 1458, col: 5, offset: 34336},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1454, col: 7, offset: 34233},
+								pos:  position{line: 1458, col: 7, offset: 34338},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1455, col: 5, offset: 34340},
+						pos: position{line: 1459, col: 5, offset: 34445},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1455, col: 5, offset: 34340},
+							pos:   position{line: 1459, col: 5, offset: 34445},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1455, col: 7, offset: 34342},
+								pos:  position{line: 1459, col: 7, offset: 34447},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1456, col: 5, offset: 34419},
+						pos: position{line: 1460, col: 5, offset: 34524},
 						run: (*parser).callonStringLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1456, col: 5, offset: 34419},
+							pos:   position{line: 1460, col: 5, offset: 34524},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1456, col: 7, offset: 34421},
+								pos:  position{line: 1460, col: 7, offset: 34526},
 								name: "RString",
 							},
 						},
@@ -9356,35 +9393,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1458, col: 1, offset: 34484},
+			pos:  position{line: 1462, col: 1, offset: 34589},
 			expr: &choiceExpr{
-				pos: position{line: 1459, col: 5, offset: 34496},
+				pos: position{line: 1463, col: 5, offset: 34601},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1459, col: 5, offset: 34496},
+						pos: position{line: 1463, col: 5, offset: 34601},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1459, col: 5, offset: 34496},
+							pos: position{line: 1463, col: 5, offset: 34601},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1459, col: 5, offset: 34496},
+									pos:        position{line: 1463, col: 5, offset: 34601},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1459, col: 11, offset: 34502},
+									pos:   position{line: 1463, col: 11, offset: 34607},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1459, col: 13, offset: 34504},
+										pos: position{line: 1463, col: 13, offset: 34609},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1459, col: 13, offset: 34504},
+											pos:  position{line: 1463, col: 13, offset: 34609},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1459, col: 38, offset: 34529},
+									pos:        position{line: 1463, col: 38, offset: 34634},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9393,30 +9430,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1466, col: 5, offset: 34675},
+						pos: position{line: 1470, col: 5, offset: 34780},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1466, col: 5, offset: 34675},
+							pos: position{line: 1470, col: 5, offset: 34780},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1466, col: 5, offset: 34675},
+									pos:        position{line: 1470, col: 5, offset: 34780},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1466, col: 10, offset: 34680},
+									pos:   position{line: 1470, col: 10, offset: 34785},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1466, col: 12, offset: 34682},
+										pos: position{line: 1470, col: 12, offset: 34787},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1466, col: 12, offset: 34682},
+											pos:  position{line: 1470, col: 12, offset: 34787},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1466, col: 37, offset: 34707},
+									pos:        position{line: 1470, col: 37, offset: 34812},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9431,24 +9468,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1474, col: 1, offset: 34850},
+			pos:  position{line: 1478, col: 1, offset: 34955},
 			expr: &choiceExpr{
-				pos: position{line: 1475, col: 5, offset: 34878},
+				pos: position{line: 1479, col: 5, offset: 34983},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1475, col: 5, offset: 34878},
+						pos:  position{line: 1479, col: 5, offset: 34983},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1476, col: 5, offset: 34894},
+						pos: position{line: 1480, col: 5, offset: 34999},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1476, col: 5, offset: 34894},
+							pos:   position{line: 1480, col: 5, offset: 34999},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1476, col: 7, offset: 34896},
+								pos: position{line: 1480, col: 7, offset: 35001},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1476, col: 7, offset: 34896},
+									pos:  position{line: 1480, col: 7, offset: 35001},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9461,27 +9498,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1480, col: 1, offset: 35019},
+			pos:  position{line: 1484, col: 1, offset: 35124},
 			expr: &choiceExpr{
-				pos: position{line: 1481, col: 5, offset: 35047},
+				pos: position{line: 1485, col: 5, offset: 35152},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1481, col: 5, offset: 35047},
+						pos: position{line: 1485, col: 5, offset: 35152},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1481, col: 5, offset: 35047},
+							pos: position{line: 1485, col: 5, offset: 35152},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1481, col: 5, offset: 35047},
+									pos:        position{line: 1485, col: 5, offset: 35152},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1481, col: 10, offset: 35052},
+									pos:   position{line: 1485, col: 10, offset: 35157},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1481, col: 12, offset: 35054},
+										pos:        position{line: 1485, col: 12, offset: 35159},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9491,25 +9528,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1482, col: 5, offset: 35080},
+						pos: position{line: 1486, col: 5, offset: 35185},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1482, col: 5, offset: 35080},
+							pos: position{line: 1486, col: 5, offset: 35185},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1482, col: 5, offset: 35080},
+									pos: position{line: 1486, col: 5, offset: 35185},
 									expr: &litMatcher{
-										pos:        position{line: 1482, col: 7, offset: 35082},
+										pos:        position{line: 1486, col: 7, offset: 35187},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1482, col: 12, offset: 35087},
+									pos:   position{line: 1486, col: 12, offset: 35192},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1482, col: 14, offset: 35089},
+										pos:  position{line: 1486, col: 14, offset: 35194},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9523,24 +9560,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1484, col: 1, offset: 35125},
+			pos:  position{line: 1488, col: 1, offset: 35230},
 			expr: &choiceExpr{
-				pos: position{line: 1485, col: 5, offset: 35153},
+				pos: position{line: 1489, col: 5, offset: 35258},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1485, col: 5, offset: 35153},
+						pos:  position{line: 1489, col: 5, offset: 35258},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1486, col: 5, offset: 35169},
+						pos: position{line: 1490, col: 5, offset: 35274},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1486, col: 5, offset: 35169},
+							pos:   position{line: 1490, col: 5, offset: 35274},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1486, col: 7, offset: 35171},
+								pos: position{line: 1490, col: 7, offset: 35276},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1486, col: 7, offset: 35171},
+									pos:  position{line: 1490, col: 7, offset: 35276},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9553,27 +9590,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1490, col: 1, offset: 35294},
+			pos:  position{line: 1494, col: 1, offset: 35399},
 			expr: &choiceExpr{
-				pos: position{line: 1491, col: 5, offset: 35322},
+				pos: position{line: 1495, col: 5, offset: 35427},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1491, col: 5, offset: 35322},
+						pos: position{line: 1495, col: 5, offset: 35427},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1491, col: 5, offset: 35322},
+							pos: position{line: 1495, col: 5, offset: 35427},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1491, col: 5, offset: 35322},
+									pos:        position{line: 1495, col: 5, offset: 35427},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1491, col: 10, offset: 35327},
+									pos:   position{line: 1495, col: 10, offset: 35432},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1491, col: 12, offset: 35329},
+										pos:        position{line: 1495, col: 12, offset: 35434},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9583,25 +9620,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1492, col: 5, offset: 35355},
+						pos: position{line: 1496, col: 5, offset: 35460},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1492, col: 5, offset: 35355},
+							pos: position{line: 1496, col: 5, offset: 35460},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1492, col: 5, offset: 35355},
+									pos: position{line: 1496, col: 5, offset: 35460},
 									expr: &litMatcher{
-										pos:        position{line: 1492, col: 7, offset: 35357},
+										pos:        position{line: 1496, col: 7, offset: 35462},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1492, col: 12, offset: 35362},
+									pos:   position{line: 1496, col: 12, offset: 35467},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1492, col: 14, offset: 35364},
+										pos:  position{line: 1496, col: 14, offset: 35469},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9615,37 +9652,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1494, col: 1, offset: 35400},
+			pos:  position{line: 1498, col: 1, offset: 35505},
 			expr: &actionExpr{
-				pos: position{line: 1495, col: 5, offset: 35416},
+				pos: position{line: 1499, col: 5, offset: 35521},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1495, col: 5, offset: 35416},
+					pos: position{line: 1499, col: 5, offset: 35521},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1495, col: 5, offset: 35416},
+							pos:        position{line: 1499, col: 5, offset: 35521},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1495, col: 9, offset: 35420},
+							pos:  position{line: 1499, col: 9, offset: 35525},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1495, col: 12, offset: 35423},
+							pos:   position{line: 1499, col: 12, offset: 35528},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1495, col: 14, offset: 35425},
+								pos:  position{line: 1499, col: 14, offset: 35530},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1495, col: 19, offset: 35430},
+							pos:  position{line: 1499, col: 19, offset: 35535},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1495, col: 22, offset: 35433},
+							pos:        position{line: 1499, col: 22, offset: 35538},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9658,129 +9695,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1503, col: 1, offset: 35568},
+			pos:  position{line: 1507, col: 1, offset: 35673},
 			expr: &actionExpr{
-				pos: position{line: 1504, col: 5, offset: 35586},
+				pos: position{line: 1508, col: 5, offset: 35691},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1504, col: 9, offset: 35590},
+					pos: position{line: 1508, col: 9, offset: 35695},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1504, col: 9, offset: 35590},
+							pos:        position{line: 1508, col: 9, offset: 35695},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1504, col: 19, offset: 35600},
+							pos:        position{line: 1508, col: 19, offset: 35705},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1504, col: 30, offset: 35611},
+							pos:        position{line: 1508, col: 30, offset: 35716},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1504, col: 41, offset: 35622},
+							pos:        position{line: 1508, col: 41, offset: 35727},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1505, col: 9, offset: 35639},
+							pos:        position{line: 1509, col: 9, offset: 35744},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1505, col: 18, offset: 35648},
+							pos:        position{line: 1509, col: 18, offset: 35753},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1505, col: 28, offset: 35658},
+							pos:        position{line: 1509, col: 28, offset: 35763},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1505, col: 38, offset: 35668},
+							pos:        position{line: 1509, col: 38, offset: 35773},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1506, col: 9, offset: 35684},
+							pos:        position{line: 1510, col: 9, offset: 35789},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1506, col: 21, offset: 35696},
+							pos:        position{line: 1510, col: 21, offset: 35801},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1506, col: 33, offset: 35708},
+							pos:        position{line: 1510, col: 33, offset: 35813},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1507, col: 9, offset: 35726},
+							pos:        position{line: 1511, col: 9, offset: 35831},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1507, col: 18, offset: 35735},
+							pos:        position{line: 1511, col: 18, offset: 35840},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1508, col: 9, offset: 35752},
+							pos:        position{line: 1512, col: 9, offset: 35857},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1508, col: 22, offset: 35765},
+							pos:        position{line: 1512, col: 22, offset: 35870},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1509, col: 9, offset: 35780},
+							pos:        position{line: 1513, col: 9, offset: 35885},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1510, col: 9, offset: 35796},
+							pos:        position{line: 1514, col: 9, offset: 35901},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1510, col: 16, offset: 35803},
+							pos:        position{line: 1514, col: 16, offset: 35908},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 9, offset: 35817},
+							pos:        position{line: 1515, col: 9, offset: 35922},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 18, offset: 35826},
+							pos:        position{line: 1515, col: 18, offset: 35931},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9793,31 +9830,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1519, col: 1, offset: 36011},
+			pos:  position{line: 1523, col: 1, offset: 36116},
 			expr: &choiceExpr{
-				pos: position{line: 1520, col: 5, offset: 36029},
+				pos: position{line: 1524, col: 5, offset: 36134},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1520, col: 5, offset: 36029},
+						pos: position{line: 1524, col: 5, offset: 36134},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1520, col: 5, offset: 36029},
+							pos: position{line: 1524, col: 5, offset: 36134},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1520, col: 5, offset: 36029},
+									pos:   position{line: 1524, col: 5, offset: 36134},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1520, col: 11, offset: 36035},
+										pos:  position{line: 1524, col: 11, offset: 36140},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1520, col: 21, offset: 36045},
+									pos:   position{line: 1524, col: 21, offset: 36150},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1520, col: 26, offset: 36050},
+										pos: position{line: 1524, col: 26, offset: 36155},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1520, col: 26, offset: 36050},
+											pos:  position{line: 1524, col: 26, offset: 36155},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9826,10 +9863,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1523, col: 5, offset: 36116},
+						pos: position{line: 1527, col: 5, offset: 36221},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1523, col: 5, offset: 36116},
+							pos:        position{line: 1527, col: 5, offset: 36221},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9842,32 +9879,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1525, col: 1, offset: 36140},
+			pos:  position{line: 1529, col: 1, offset: 36245},
 			expr: &actionExpr{
-				pos: position{line: 1525, col: 21, offset: 36160},
+				pos: position{line: 1529, col: 21, offset: 36265},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1525, col: 21, offset: 36160},
+					pos: position{line: 1529, col: 21, offset: 36265},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1525, col: 21, offset: 36160},
+							pos:  position{line: 1529, col: 21, offset: 36265},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1525, col: 24, offset: 36163},
+							pos:        position{line: 1529, col: 24, offset: 36268},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1525, col: 28, offset: 36167},
+							pos:  position{line: 1529, col: 28, offset: 36272},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1525, col: 31, offset: 36170},
+							pos:   position{line: 1529, col: 31, offset: 36275},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1525, col: 35, offset: 36174},
+								pos:  position{line: 1529, col: 35, offset: 36279},
 								name: "TypeField",
 							},
 						},
@@ -9879,40 +9916,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1527, col: 1, offset: 36205},
+			pos:  position{line: 1531, col: 1, offset: 36310},
 			expr: &actionExpr{
-				pos: position{line: 1528, col: 5, offset: 36219},
+				pos: position{line: 1532, col: 5, offset: 36324},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1528, col: 5, offset: 36219},
+					pos: position{line: 1532, col: 5, offset: 36324},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1528, col: 5, offset: 36219},
+							pos:   position{line: 1532, col: 5, offset: 36324},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1528, col: 10, offset: 36224},
+								pos:  position{line: 1532, col: 10, offset: 36329},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1528, col: 15, offset: 36229},
+							pos:  position{line: 1532, col: 15, offset: 36334},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1528, col: 18, offset: 36232},
+							pos:        position{line: 1532, col: 18, offset: 36337},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1528, col: 22, offset: 36236},
+							pos:  position{line: 1532, col: 22, offset: 36341},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1528, col: 25, offset: 36239},
+							pos:   position{line: 1532, col: 25, offset: 36344},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1528, col: 29, offset: 36243},
+								pos:  position{line: 1532, col: 29, offset: 36348},
 								name: "Type",
 							},
 						},
@@ -9924,26 +9961,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1536, col: 1, offset: 36392},
+			pos:  position{line: 1540, col: 1, offset: 36497},
 			expr: &actionExpr{
-				pos: position{line: 1537, col: 4, offset: 36400},
+				pos: position{line: 1541, col: 4, offset: 36505},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1537, col: 4, offset: 36400},
+					pos:   position{line: 1541, col: 4, offset: 36505},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1537, col: 7, offset: 36403},
+						pos: position{line: 1541, col: 7, offset: 36508},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1537, col: 7, offset: 36403},
+								pos:  position{line: 1541, col: 7, offset: 36508},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1537, col: 24, offset: 36420},
+								pos:  position{line: 1541, col: 24, offset: 36525},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1537, col: 45, offset: 36441},
+								pos:  position{line: 1541, col: 45, offset: 36546},
 								name: "SingleQuotedString",
 							},
 						},
@@ -9955,51 +9992,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1541, col: 1, offset: 36541},
+			pos:  position{line: 1545, col: 1, offset: 36646},
 			expr: &actionExpr{
-				pos: position{line: 1542, col: 5, offset: 36551},
+				pos: position{line: 1546, col: 5, offset: 36656},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1542, col: 5, offset: 36551},
+					pos: position{line: 1546, col: 5, offset: 36656},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1542, col: 5, offset: 36551},
+							pos:   position{line: 1546, col: 5, offset: 36656},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1542, col: 11, offset: 36557},
+								pos:  position{line: 1546, col: 11, offset: 36662},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1542, col: 16, offset: 36562},
+							pos:   position{line: 1546, col: 16, offset: 36667},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1542, col: 21, offset: 36567},
+								pos: position{line: 1546, col: 21, offset: 36672},
 								expr: &actionExpr{
-									pos: position{line: 1542, col: 22, offset: 36568},
+									pos: position{line: 1546, col: 22, offset: 36673},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1542, col: 22, offset: 36568},
+										pos: position{line: 1546, col: 22, offset: 36673},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1542, col: 22, offset: 36568},
+												pos:  position{line: 1546, col: 22, offset: 36673},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1542, col: 25, offset: 36571},
+												pos:        position{line: 1546, col: 25, offset: 36676},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1542, col: 29, offset: 36575},
+												pos:  position{line: 1546, col: 29, offset: 36680},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1542, col: 32, offset: 36578},
+												pos:   position{line: 1546, col: 32, offset: 36683},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1542, col: 37, offset: 36583},
+													pos:  position{line: 1546, col: 37, offset: 36688},
 													name: "Name",
 												},
 											},
@@ -10016,15 +10053,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1546, col: 1, offset: 36655},
+			pos:  position{line: 1550, col: 1, offset: 36760},
 			expr: &actionExpr{
-				pos: position{line: 1547, col: 5, offset: 36670},
+				pos: position{line: 1551, col: 5, offset: 36775},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1547, col: 5, offset: 36670},
+					pos:   position{line: 1551, col: 5, offset: 36775},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1547, col: 8, offset: 36673},
+						pos:  position{line: 1551, col: 8, offset: 36778},
 						name: "IdentifierName",
 					},
 				},
@@ -10034,51 +10071,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1555, col: 1, offset: 36806},
+			pos:  position{line: 1559, col: 1, offset: 36911},
 			expr: &actionExpr{
-				pos: position{line: 1556, col: 5, offset: 36822},
+				pos: position{line: 1560, col: 5, offset: 36927},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1556, col: 5, offset: 36822},
+					pos: position{line: 1560, col: 5, offset: 36927},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1556, col: 5, offset: 36822},
+							pos:   position{line: 1560, col: 5, offset: 36927},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1556, col: 11, offset: 36828},
+								pos:  position{line: 1560, col: 11, offset: 36933},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1556, col: 22, offset: 36839},
+							pos:   position{line: 1560, col: 22, offset: 36944},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1556, col: 27, offset: 36844},
+								pos: position{line: 1560, col: 27, offset: 36949},
 								expr: &actionExpr{
-									pos: position{line: 1556, col: 28, offset: 36845},
+									pos: position{line: 1560, col: 28, offset: 36950},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1556, col: 28, offset: 36845},
+										pos: position{line: 1560, col: 28, offset: 36950},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1556, col: 28, offset: 36845},
+												pos:  position{line: 1560, col: 28, offset: 36950},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1556, col: 31, offset: 36848},
+												pos:        position{line: 1560, col: 31, offset: 36953},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1556, col: 35, offset: 36852},
+												pos:  position{line: 1560, col: 35, offset: 36957},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1556, col: 38, offset: 36855},
+												pos:   position{line: 1560, col: 38, offset: 36960},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1556, col: 43, offset: 36860},
+													pos:  position{line: 1560, col: 43, offset: 36965},
 													name: "Identifier",
 												},
 											},
@@ -10095,22 +10132,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1560, col: 1, offset: 36938},
+			pos:  position{line: 1564, col: 1, offset: 37043},
 			expr: &choiceExpr{
-				pos: position{line: 1561, col: 5, offset: 36956},
+				pos: position{line: 1565, col: 5, offset: 37061},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1561, col: 5, offset: 36956},
+						pos:  position{line: 1565, col: 5, offset: 37061},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1562, col: 5, offset: 36971},
+						pos: position{line: 1566, col: 5, offset: 37076},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1562, col: 5, offset: 36971},
+							pos:   position{line: 1566, col: 5, offset: 37076},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1562, col: 7, offset: 36973},
+								pos:  position{line: 1566, col: 7, offset: 37078},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10122,29 +10159,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1564, col: 1, offset: 37058},
+			pos:  position{line: 1568, col: 1, offset: 37163},
 			expr: &choiceExpr{
-				pos: position{line: 1565, col: 5, offset: 37077},
+				pos: position{line: 1569, col: 5, offset: 37182},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1565, col: 5, offset: 37077},
+						pos: position{line: 1569, col: 5, offset: 37182},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1565, col: 5, offset: 37077},
+							pos: position{line: 1569, col: 5, offset: 37182},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1565, col: 5, offset: 37077},
+									pos: position{line: 1569, col: 5, offset: 37182},
 									expr: &seqExpr{
-										pos: position{line: 1565, col: 7, offset: 37079},
+										pos: position{line: 1569, col: 7, offset: 37184},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1565, col: 7, offset: 37079},
+												pos:  position{line: 1569, col: 7, offset: 37184},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1565, col: 15, offset: 37087},
+												pos: position{line: 1569, col: 15, offset: 37192},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1565, col: 16, offset: 37088},
+													pos:  position{line: 1569, col: 16, offset: 37193},
 													name: "IdentifierRest",
 												},
 											},
@@ -10152,13 +10189,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1565, col: 32, offset: 37104},
+									pos:  position{line: 1569, col: 32, offset: 37209},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1565, col: 48, offset: 37120},
+									pos: position{line: 1569, col: 48, offset: 37225},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1565, col: 48, offset: 37120},
+										pos:  position{line: 1569, col: 48, offset: 37225},
 										name: "IdentifierRest",
 									},
 								},
@@ -10166,7 +10203,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1566, col: 5, offset: 37171},
+						pos:  position{line: 1570, col: 5, offset: 37276},
 						name: "BacktickString",
 					},
 				},
@@ -10176,22 +10213,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1568, col: 1, offset: 37187},
+			pos:  position{line: 1572, col: 1, offset: 37292},
 			expr: &choiceExpr{
-				pos: position{line: 1569, col: 5, offset: 37207},
+				pos: position{line: 1573, col: 5, offset: 37312},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1569, col: 5, offset: 37207},
+						pos:  position{line: 1573, col: 5, offset: 37312},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1570, col: 5, offset: 37225},
+						pos:        position{line: 1574, col: 5, offset: 37330},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1571, col: 5, offset: 37233},
+						pos:        position{line: 1575, col: 5, offset: 37338},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10203,24 +10240,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1573, col: 1, offset: 37238},
+			pos:  position{line: 1577, col: 1, offset: 37343},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 5, offset: 37257},
+				pos: position{line: 1578, col: 5, offset: 37362},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1574, col: 5, offset: 37257},
+						pos:  position{line: 1578, col: 5, offset: 37362},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1575, col: 5, offset: 37277},
+						pos:  position{line: 1579, col: 5, offset: 37382},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1576, col: 5, offset: 37302},
+						pos:  position{line: 1580, col: 5, offset: 37407},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1577, col: 5, offset: 37319},
+						pos:  position{line: 1581, col: 5, offset: 37424},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10230,24 +10267,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1579, col: 1, offset: 37348},
+			pos:  position{line: 1583, col: 1, offset: 37453},
 			expr: &choiceExpr{
-				pos: position{line: 1580, col: 5, offset: 37360},
+				pos: position{line: 1584, col: 5, offset: 37465},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1580, col: 5, offset: 37360},
+						pos:  position{line: 1584, col: 5, offset: 37465},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1581, col: 5, offset: 37379},
+						pos:  position{line: 1585, col: 5, offset: 37484},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1582, col: 5, offset: 37395},
+						pos:  position{line: 1586, col: 5, offset: 37500},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 5, offset: 37403},
+						pos:  position{line: 1587, col: 5, offset: 37508},
 						name: "Infinity",
 					},
 				},
@@ -10257,25 +10294,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1585, col: 1, offset: 37413},
+			pos:  position{line: 1589, col: 1, offset: 37518},
 			expr: &actionExpr{
-				pos: position{line: 1586, col: 5, offset: 37422},
+				pos: position{line: 1590, col: 5, offset: 37527},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1586, col: 5, offset: 37422},
+					pos: position{line: 1590, col: 5, offset: 37527},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1586, col: 5, offset: 37422},
+							pos:  position{line: 1590, col: 5, offset: 37527},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1586, col: 14, offset: 37431},
+							pos:        position{line: 1590, col: 14, offset: 37536},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1586, col: 18, offset: 37435},
+							pos:  position{line: 1590, col: 18, offset: 37540},
 							name: "FullTime",
 						},
 					},
@@ -10286,32 +10323,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1590, col: 1, offset: 37511},
+			pos:  position{line: 1594, col: 1, offset: 37616},
 			expr: &seqExpr{
-				pos: position{line: 1590, col: 12, offset: 37522},
+				pos: position{line: 1594, col: 12, offset: 37627},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 12, offset: 37522},
+						pos:  position{line: 1594, col: 12, offset: 37627},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1590, col: 15, offset: 37525},
+						pos:        position{line: 1594, col: 15, offset: 37630},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 19, offset: 37529},
+						pos:  position{line: 1594, col: 19, offset: 37634},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1590, col: 22, offset: 37532},
+						pos:        position{line: 1594, col: 22, offset: 37637},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 26, offset: 37536},
+						pos:  position{line: 1594, col: 26, offset: 37641},
 						name: "D2",
 					},
 				},
@@ -10321,33 +10358,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1592, col: 1, offset: 37540},
+			pos:  position{line: 1596, col: 1, offset: 37645},
 			expr: &seqExpr{
-				pos: position{line: 1592, col: 6, offset: 37545},
+				pos: position{line: 1596, col: 6, offset: 37650},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1592, col: 6, offset: 37545},
+						pos:        position{line: 1596, col: 6, offset: 37650},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1592, col: 11, offset: 37550},
+						pos:        position{line: 1596, col: 11, offset: 37655},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1592, col: 16, offset: 37555},
+						pos:        position{line: 1596, col: 16, offset: 37660},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1592, col: 21, offset: 37560},
+						pos:        position{line: 1596, col: 21, offset: 37665},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10360,19 +10397,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1593, col: 1, offset: 37566},
+			pos:  position{line: 1597, col: 1, offset: 37671},
 			expr: &seqExpr{
-				pos: position{line: 1593, col: 6, offset: 37571},
+				pos: position{line: 1597, col: 6, offset: 37676},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1593, col: 6, offset: 37571},
+						pos:        position{line: 1597, col: 6, offset: 37676},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1593, col: 11, offset: 37576},
+						pos:        position{line: 1597, col: 11, offset: 37681},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10385,16 +10422,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1595, col: 1, offset: 37583},
+			pos:  position{line: 1599, col: 1, offset: 37688},
 			expr: &seqExpr{
-				pos: position{line: 1595, col: 12, offset: 37594},
+				pos: position{line: 1599, col: 12, offset: 37699},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1595, col: 12, offset: 37594},
+						pos:  position{line: 1599, col: 12, offset: 37699},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1595, col: 24, offset: 37606},
+						pos:  position{line: 1599, col: 24, offset: 37711},
 						name: "TimeOffset",
 					},
 				},
@@ -10404,49 +10441,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1597, col: 1, offset: 37618},
+			pos:  position{line: 1601, col: 1, offset: 37723},
 			expr: &seqExpr{
-				pos: position{line: 1597, col: 15, offset: 37632},
+				pos: position{line: 1601, col: 15, offset: 37737},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 15, offset: 37632},
+						pos:  position{line: 1601, col: 15, offset: 37737},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1597, col: 18, offset: 37635},
+						pos:        position{line: 1601, col: 18, offset: 37740},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 22, offset: 37639},
+						pos:  position{line: 1601, col: 22, offset: 37744},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1597, col: 25, offset: 37642},
+						pos:        position{line: 1601, col: 25, offset: 37747},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 29, offset: 37646},
+						pos:  position{line: 1601, col: 29, offset: 37751},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1597, col: 32, offset: 37649},
+						pos: position{line: 1601, col: 32, offset: 37754},
 						expr: &seqExpr{
-							pos: position{line: 1597, col: 33, offset: 37650},
+							pos: position{line: 1601, col: 33, offset: 37755},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1597, col: 33, offset: 37650},
+									pos:        position{line: 1601, col: 33, offset: 37755},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1597, col: 37, offset: 37654},
+									pos: position{line: 1601, col: 37, offset: 37759},
 									expr: &charClassMatcher{
-										pos:        position{line: 1597, col: 37, offset: 37654},
+										pos:        position{line: 1601, col: 37, offset: 37759},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10463,30 +10500,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1599, col: 1, offset: 37664},
+			pos:  position{line: 1603, col: 1, offset: 37769},
 			expr: &choiceExpr{
-				pos: position{line: 1600, col: 5, offset: 37679},
+				pos: position{line: 1604, col: 5, offset: 37784},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1600, col: 5, offset: 37679},
+						pos:        position{line: 1604, col: 5, offset: 37784},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1601, col: 5, offset: 37687},
+						pos: position{line: 1605, col: 5, offset: 37792},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1601, col: 6, offset: 37688},
+								pos: position{line: 1605, col: 6, offset: 37793},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1601, col: 6, offset: 37688},
+										pos:        position{line: 1605, col: 6, offset: 37793},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1601, col: 12, offset: 37694},
+										pos:        position{line: 1605, col: 12, offset: 37799},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10494,34 +10531,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1601, col: 17, offset: 37699},
+								pos:  position{line: 1605, col: 17, offset: 37804},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1601, col: 20, offset: 37702},
+								pos:        position{line: 1605, col: 20, offset: 37807},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1601, col: 24, offset: 37706},
+								pos:  position{line: 1605, col: 24, offset: 37811},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1601, col: 27, offset: 37709},
+								pos: position{line: 1605, col: 27, offset: 37814},
 								expr: &seqExpr{
-									pos: position{line: 1601, col: 28, offset: 37710},
+									pos: position{line: 1605, col: 28, offset: 37815},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1601, col: 28, offset: 37710},
+											pos:        position{line: 1605, col: 28, offset: 37815},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1601, col: 32, offset: 37714},
+											pos: position{line: 1605, col: 32, offset: 37819},
 											expr: &charClassMatcher{
-												pos:        position{line: 1601, col: 32, offset: 37714},
+												pos:        position{line: 1605, col: 32, offset: 37819},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10540,33 +10577,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1603, col: 1, offset: 37724},
+			pos:  position{line: 1607, col: 1, offset: 37829},
 			expr: &actionExpr{
-				pos: position{line: 1604, col: 5, offset: 37737},
+				pos: position{line: 1608, col: 5, offset: 37842},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1604, col: 5, offset: 37737},
+					pos: position{line: 1608, col: 5, offset: 37842},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1604, col: 5, offset: 37737},
+							pos: position{line: 1608, col: 5, offset: 37842},
 							expr: &litMatcher{
-								pos:        position{line: 1604, col: 5, offset: 37737},
+								pos:        position{line: 1608, col: 5, offset: 37842},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1604, col: 10, offset: 37742},
+							pos: position{line: 1608, col: 10, offset: 37847},
 							expr: &seqExpr{
-								pos: position{line: 1604, col: 11, offset: 37743},
+								pos: position{line: 1608, col: 11, offset: 37848},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1604, col: 11, offset: 37743},
+										pos:  position{line: 1608, col: 11, offset: 37848},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1604, col: 19, offset: 37751},
+										pos:  position{line: 1608, col: 19, offset: 37856},
 										name: "TimeUnit",
 									},
 								},
@@ -10580,27 +10617,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1608, col: 1, offset: 37833},
+			pos:  position{line: 1612, col: 1, offset: 37938},
 			expr: &seqExpr{
-				pos: position{line: 1608, col: 11, offset: 37843},
+				pos: position{line: 1612, col: 11, offset: 37948},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1608, col: 11, offset: 37843},
+						pos:  position{line: 1612, col: 11, offset: 37948},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1608, col: 16, offset: 37848},
+						pos: position{line: 1612, col: 16, offset: 37953},
 						expr: &seqExpr{
-							pos: position{line: 1608, col: 17, offset: 37849},
+							pos: position{line: 1612, col: 17, offset: 37954},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1608, col: 17, offset: 37849},
+									pos:        position{line: 1612, col: 17, offset: 37954},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1608, col: 21, offset: 37853},
+									pos:  position{line: 1612, col: 21, offset: 37958},
 									name: "UInt",
 								},
 							},
@@ -10613,60 +10650,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1610, col: 1, offset: 37861},
+			pos:  position{line: 1614, col: 1, offset: 37966},
 			expr: &choiceExpr{
-				pos: position{line: 1611, col: 5, offset: 37874},
+				pos: position{line: 1615, col: 5, offset: 37979},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1611, col: 5, offset: 37874},
+						pos:        position{line: 1615, col: 5, offset: 37979},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1612, col: 5, offset: 37883},
+						pos:        position{line: 1616, col: 5, offset: 37988},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1613, col: 5, offset: 37892},
+						pos:        position{line: 1617, col: 5, offset: 37997},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1614, col: 5, offset: 37901},
+						pos:        position{line: 1618, col: 5, offset: 38006},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1615, col: 5, offset: 37909},
+						pos:        position{line: 1619, col: 5, offset: 38014},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1616, col: 5, offset: 37917},
+						pos:        position{line: 1620, col: 5, offset: 38022},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1617, col: 5, offset: 37925},
+						pos:        position{line: 1621, col: 5, offset: 38030},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1618, col: 5, offset: 37933},
+						pos:        position{line: 1622, col: 5, offset: 38038},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1619, col: 5, offset: 37941},
+						pos:        position{line: 1623, col: 5, offset: 38046},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10678,45 +10715,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1621, col: 1, offset: 37946},
+			pos:  position{line: 1625, col: 1, offset: 38051},
 			expr: &actionExpr{
-				pos: position{line: 1622, col: 5, offset: 37953},
+				pos: position{line: 1626, col: 5, offset: 38058},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1622, col: 5, offset: 37953},
+					pos: position{line: 1626, col: 5, offset: 38058},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1622, col: 5, offset: 37953},
+							pos:  position{line: 1626, col: 5, offset: 38058},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1622, col: 10, offset: 37958},
+							pos:        position{line: 1626, col: 10, offset: 38063},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1622, col: 14, offset: 37962},
+							pos:  position{line: 1626, col: 14, offset: 38067},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1622, col: 19, offset: 37967},
+							pos:        position{line: 1626, col: 19, offset: 38072},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1622, col: 23, offset: 37971},
+							pos:  position{line: 1626, col: 23, offset: 38076},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1622, col: 28, offset: 37976},
+							pos:        position{line: 1626, col: 28, offset: 38081},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1622, col: 32, offset: 37980},
+							pos:  position{line: 1626, col: 32, offset: 38085},
 							name: "UInt",
 						},
 					},
@@ -10727,43 +10764,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1624, col: 1, offset: 38017},
+			pos:  position{line: 1628, col: 1, offset: 38122},
 			expr: &actionExpr{
-				pos: position{line: 1625, col: 5, offset: 38025},
+				pos: position{line: 1629, col: 5, offset: 38130},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1625, col: 5, offset: 38025},
+					pos: position{line: 1629, col: 5, offset: 38130},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1625, col: 5, offset: 38025},
+							pos: position{line: 1629, col: 5, offset: 38130},
 							expr: &seqExpr{
-								pos: position{line: 1625, col: 7, offset: 38027},
+								pos: position{line: 1629, col: 7, offset: 38132},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1625, col: 7, offset: 38027},
+										pos:  position{line: 1629, col: 7, offset: 38132},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1625, col: 11, offset: 38031},
+										pos:        position{line: 1629, col: 11, offset: 38136},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1625, col: 15, offset: 38035},
+										pos:  position{line: 1629, col: 15, offset: 38140},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1625, col: 19, offset: 38039},
+										pos: position{line: 1629, col: 19, offset: 38144},
 										expr: &choiceExpr{
-											pos: position{line: 1625, col: 21, offset: 38041},
+											pos: position{line: 1629, col: 21, offset: 38146},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1625, col: 21, offset: 38041},
+													pos:  position{line: 1629, col: 21, offset: 38146},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1625, col: 32, offset: 38052},
+													pos:        position{line: 1629, col: 32, offset: 38157},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10775,10 +10812,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1625, col: 38, offset: 38058},
+							pos:   position{line: 1629, col: 38, offset: 38163},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1625, col: 40, offset: 38060},
+								pos:  position{line: 1629, col: 40, offset: 38165},
 								name: "IP6Variations",
 							},
 						},
@@ -10790,32 +10827,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1629, col: 1, offset: 38224},
+			pos:  position{line: 1633, col: 1, offset: 38329},
 			expr: &choiceExpr{
-				pos: position{line: 1630, col: 5, offset: 38242},
+				pos: position{line: 1634, col: 5, offset: 38347},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1630, col: 5, offset: 38242},
+						pos: position{line: 1634, col: 5, offset: 38347},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1630, col: 5, offset: 38242},
+							pos: position{line: 1634, col: 5, offset: 38347},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1630, col: 5, offset: 38242},
+									pos:   position{line: 1634, col: 5, offset: 38347},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1630, col: 7, offset: 38244},
+										pos: position{line: 1634, col: 7, offset: 38349},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1630, col: 7, offset: 38244},
+											pos:  position{line: 1634, col: 7, offset: 38349},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 17, offset: 38254},
+									pos:   position{line: 1634, col: 17, offset: 38359},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1630, col: 19, offset: 38256},
+										pos:  position{line: 1634, col: 19, offset: 38361},
 										name: "IP6Tail",
 									},
 								},
@@ -10823,52 +10860,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1633, col: 5, offset: 38320},
+						pos: position{line: 1637, col: 5, offset: 38425},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1633, col: 5, offset: 38320},
+							pos: position{line: 1637, col: 5, offset: 38425},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1633, col: 5, offset: 38320},
+									pos:   position{line: 1637, col: 5, offset: 38425},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1633, col: 7, offset: 38322},
+										pos:  position{line: 1637, col: 7, offset: 38427},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1633, col: 11, offset: 38326},
+									pos:   position{line: 1637, col: 11, offset: 38431},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1633, col: 13, offset: 38328},
+										pos: position{line: 1637, col: 13, offset: 38433},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1633, col: 13, offset: 38328},
+											pos:  position{line: 1637, col: 13, offset: 38433},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1633, col: 23, offset: 38338},
+									pos:        position{line: 1637, col: 23, offset: 38443},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1633, col: 28, offset: 38343},
+									pos:   position{line: 1637, col: 28, offset: 38448},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1633, col: 30, offset: 38345},
+										pos: position{line: 1637, col: 30, offset: 38450},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1633, col: 30, offset: 38345},
+											pos:  position{line: 1637, col: 30, offset: 38450},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1633, col: 40, offset: 38355},
+									pos:   position{line: 1637, col: 40, offset: 38460},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1633, col: 42, offset: 38357},
+										pos:  position{line: 1637, col: 42, offset: 38462},
 										name: "IP6Tail",
 									},
 								},
@@ -10876,33 +10913,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1636, col: 5, offset: 38456},
+						pos: position{line: 1640, col: 5, offset: 38561},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1636, col: 5, offset: 38456},
+							pos: position{line: 1640, col: 5, offset: 38561},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1636, col: 5, offset: 38456},
+									pos:        position{line: 1640, col: 5, offset: 38561},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1636, col: 10, offset: 38461},
+									pos:   position{line: 1640, col: 10, offset: 38566},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1636, col: 12, offset: 38463},
+										pos: position{line: 1640, col: 12, offset: 38568},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1636, col: 12, offset: 38463},
+											pos:  position{line: 1640, col: 12, offset: 38568},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1636, col: 22, offset: 38473},
+									pos:   position{line: 1640, col: 22, offset: 38578},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1636, col: 24, offset: 38475},
+										pos:  position{line: 1640, col: 24, offset: 38580},
 										name: "IP6Tail",
 									},
 								},
@@ -10910,40 +10947,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1639, col: 5, offset: 38546},
+						pos: position{line: 1643, col: 5, offset: 38651},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1639, col: 5, offset: 38546},
+							pos: position{line: 1643, col: 5, offset: 38651},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1639, col: 5, offset: 38546},
+									pos:   position{line: 1643, col: 5, offset: 38651},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1639, col: 7, offset: 38548},
+										pos:  position{line: 1643, col: 7, offset: 38653},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1639, col: 11, offset: 38552},
+									pos:   position{line: 1643, col: 11, offset: 38657},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1639, col: 13, offset: 38554},
+										pos: position{line: 1643, col: 13, offset: 38659},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1639, col: 13, offset: 38554},
+											pos:  position{line: 1643, col: 13, offset: 38659},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1639, col: 23, offset: 38564},
+									pos:        position{line: 1643, col: 23, offset: 38669},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1639, col: 28, offset: 38569},
+									pos: position{line: 1643, col: 28, offset: 38674},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1639, col: 29, offset: 38570},
+										pos:  position{line: 1643, col: 29, offset: 38675},
 										name: "TypeAsValue",
 									},
 								},
@@ -10951,10 +10988,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1642, col: 5, offset: 38645},
+						pos: position{line: 1646, col: 5, offset: 38750},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1642, col: 5, offset: 38645},
+							pos:        position{line: 1646, col: 5, offset: 38750},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10967,16 +11004,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1646, col: 1, offset: 38682},
+			pos:  position{line: 1650, col: 1, offset: 38787},
 			expr: &choiceExpr{
-				pos: position{line: 1647, col: 5, offset: 38694},
+				pos: position{line: 1651, col: 5, offset: 38799},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1647, col: 5, offset: 38694},
+						pos:  position{line: 1651, col: 5, offset: 38799},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1648, col: 5, offset: 38701},
+						pos:  position{line: 1652, col: 5, offset: 38806},
 						name: "Hex",
 					},
 				},
@@ -10986,24 +11023,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1650, col: 1, offset: 38706},
+			pos:  position{line: 1654, col: 1, offset: 38811},
 			expr: &actionExpr{
-				pos: position{line: 1650, col: 12, offset: 38717},
+				pos: position{line: 1654, col: 12, offset: 38822},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1650, col: 12, offset: 38717},
+					pos: position{line: 1654, col: 12, offset: 38822},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1650, col: 12, offset: 38717},
+							pos:        position{line: 1654, col: 12, offset: 38822},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1650, col: 16, offset: 38721},
+							pos:   position{line: 1654, col: 16, offset: 38826},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1650, col: 18, offset: 38723},
+								pos:  position{line: 1654, col: 18, offset: 38828},
 								name: "Hex",
 							},
 						},
@@ -11015,23 +11052,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1652, col: 1, offset: 38761},
+			pos:  position{line: 1656, col: 1, offset: 38866},
 			expr: &actionExpr{
-				pos: position{line: 1652, col: 12, offset: 38772},
+				pos: position{line: 1656, col: 12, offset: 38877},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1652, col: 12, offset: 38772},
+					pos: position{line: 1656, col: 12, offset: 38877},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1652, col: 12, offset: 38772},
+							pos:   position{line: 1656, col: 12, offset: 38877},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1652, col: 14, offset: 38774},
+								pos:  position{line: 1656, col: 14, offset: 38879},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1652, col: 18, offset: 38778},
+							pos:        position{line: 1656, col: 18, offset: 38883},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11044,32 +11081,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1654, col: 1, offset: 38816},
+			pos:  position{line: 1658, col: 1, offset: 38921},
 			expr: &actionExpr{
-				pos: position{line: 1655, col: 5, offset: 38827},
+				pos: position{line: 1659, col: 5, offset: 38932},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1655, col: 5, offset: 38827},
+					pos: position{line: 1659, col: 5, offset: 38932},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1655, col: 5, offset: 38827},
+							pos:   position{line: 1659, col: 5, offset: 38932},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1655, col: 7, offset: 38829},
+								pos:  position{line: 1659, col: 7, offset: 38934},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1655, col: 10, offset: 38832},
+							pos:        position{line: 1659, col: 10, offset: 38937},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1655, col: 14, offset: 38836},
+							pos:   position{line: 1659, col: 14, offset: 38941},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1655, col: 16, offset: 38838},
+								pos:  position{line: 1659, col: 16, offset: 38943},
 								name: "UIntString",
 							},
 						},
@@ -11081,32 +11118,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1659, col: 1, offset: 38906},
+			pos:  position{line: 1663, col: 1, offset: 39011},
 			expr: &actionExpr{
-				pos: position{line: 1660, col: 5, offset: 38917},
+				pos: position{line: 1664, col: 5, offset: 39022},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1660, col: 5, offset: 38917},
+					pos: position{line: 1664, col: 5, offset: 39022},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1660, col: 5, offset: 38917},
+							pos:   position{line: 1664, col: 5, offset: 39022},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1660, col: 7, offset: 38919},
+								pos:  position{line: 1664, col: 7, offset: 39024},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1660, col: 11, offset: 38923},
+							pos:        position{line: 1664, col: 11, offset: 39028},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1660, col: 15, offset: 38927},
+							pos:   position{line: 1664, col: 15, offset: 39032},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1660, col: 17, offset: 38929},
+								pos:  position{line: 1664, col: 17, offset: 39034},
 								name: "UIntString",
 							},
 						},
@@ -11118,15 +11155,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1664, col: 1, offset: 38997},
+			pos:  position{line: 1668, col: 1, offset: 39102},
 			expr: &actionExpr{
-				pos: position{line: 1665, col: 4, offset: 39005},
+				pos: position{line: 1669, col: 4, offset: 39110},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1665, col: 4, offset: 39005},
+					pos:   position{line: 1669, col: 4, offset: 39110},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1665, col: 6, offset: 39007},
+						pos:  position{line: 1669, col: 6, offset: 39112},
 						name: "UIntString",
 					},
 				},
@@ -11136,16 +11173,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1667, col: 1, offset: 39047},
+			pos:  position{line: 1671, col: 1, offset: 39152},
 			expr: &choiceExpr{
-				pos: position{line: 1668, col: 5, offset: 39061},
+				pos: position{line: 1672, col: 5, offset: 39166},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1668, col: 5, offset: 39061},
+						pos:  position{line: 1672, col: 5, offset: 39166},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1669, col: 5, offset: 39076},
+						pos:  position{line: 1673, col: 5, offset: 39181},
 						name: "MinusIntString",
 					},
 				},
@@ -11155,14 +11192,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1671, col: 1, offset: 39092},
+			pos:  position{line: 1675, col: 1, offset: 39197},
 			expr: &actionExpr{
-				pos: position{line: 1671, col: 14, offset: 39105},
+				pos: position{line: 1675, col: 14, offset: 39210},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1671, col: 14, offset: 39105},
+					pos: position{line: 1675, col: 14, offset: 39210},
 					expr: &charClassMatcher{
-						pos:        position{line: 1671, col: 14, offset: 39105},
+						pos:        position{line: 1675, col: 14, offset: 39210},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11175,21 +11212,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1673, col: 1, offset: 39144},
+			pos:  position{line: 1677, col: 1, offset: 39249},
 			expr: &actionExpr{
-				pos: position{line: 1674, col: 5, offset: 39163},
+				pos: position{line: 1678, col: 5, offset: 39268},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1674, col: 5, offset: 39163},
+					pos: position{line: 1678, col: 5, offset: 39268},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1674, col: 5, offset: 39163},
+							pos:        position{line: 1678, col: 5, offset: 39268},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1674, col: 9, offset: 39167},
+							pos:  position{line: 1678, col: 9, offset: 39272},
 							name: "UIntString",
 						},
 					},
@@ -11200,29 +11237,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1676, col: 1, offset: 39210},
+			pos:  position{line: 1680, col: 1, offset: 39315},
 			expr: &choiceExpr{
-				pos: position{line: 1677, col: 5, offset: 39226},
+				pos: position{line: 1681, col: 5, offset: 39331},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1677, col: 5, offset: 39226},
+						pos: position{line: 1681, col: 5, offset: 39331},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1677, col: 5, offset: 39226},
+							pos: position{line: 1681, col: 5, offset: 39331},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1677, col: 5, offset: 39226},
+									pos: position{line: 1681, col: 5, offset: 39331},
 									expr: &litMatcher{
-										pos:        position{line: 1677, col: 5, offset: 39226},
+										pos:        position{line: 1681, col: 5, offset: 39331},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1677, col: 10, offset: 39231},
+									pos: position{line: 1681, col: 10, offset: 39336},
 									expr: &charClassMatcher{
-										pos:        position{line: 1677, col: 10, offset: 39231},
+										pos:        position{line: 1681, col: 10, offset: 39336},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11230,15 +11267,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1677, col: 17, offset: 39238},
+									pos:        position{line: 1681, col: 17, offset: 39343},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1677, col: 21, offset: 39242},
+									pos: position{line: 1681, col: 21, offset: 39347},
 									expr: &charClassMatcher{
-										pos:        position{line: 1677, col: 21, offset: 39242},
+										pos:        position{line: 1681, col: 21, offset: 39347},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11246,9 +11283,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1677, col: 28, offset: 39249},
+									pos: position{line: 1681, col: 28, offset: 39354},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1677, col: 28, offset: 39249},
+										pos:  position{line: 1681, col: 28, offset: 39354},
 										name: "ExponentPart",
 									},
 								},
@@ -11256,30 +11293,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1678, col: 5, offset: 39298},
+						pos: position{line: 1682, col: 5, offset: 39403},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1678, col: 5, offset: 39298},
+							pos: position{line: 1682, col: 5, offset: 39403},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1678, col: 5, offset: 39298},
+									pos: position{line: 1682, col: 5, offset: 39403},
 									expr: &litMatcher{
-										pos:        position{line: 1678, col: 5, offset: 39298},
+										pos:        position{line: 1682, col: 5, offset: 39403},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1678, col: 10, offset: 39303},
+									pos:        position{line: 1682, col: 10, offset: 39408},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1678, col: 14, offset: 39307},
+									pos: position{line: 1682, col: 14, offset: 39412},
 									expr: &charClassMatcher{
-										pos:        position{line: 1678, col: 14, offset: 39307},
+										pos:        position{line: 1682, col: 14, offset: 39412},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11287,9 +11324,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1678, col: 21, offset: 39314},
+									pos: position{line: 1682, col: 21, offset: 39419},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1678, col: 21, offset: 39314},
+										pos:  position{line: 1682, col: 21, offset: 39419},
 										name: "ExponentPart",
 									},
 								},
@@ -11297,17 +11334,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1679, col: 5, offset: 39363},
+						pos: position{line: 1683, col: 5, offset: 39468},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1679, col: 6, offset: 39364},
+							pos: position{line: 1683, col: 6, offset: 39469},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1679, col: 6, offset: 39364},
+									pos:  position{line: 1683, col: 6, offset: 39469},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1679, col: 12, offset: 39370},
+									pos:  position{line: 1683, col: 12, offset: 39475},
 									name: "Infinity",
 								},
 							},
@@ -11320,20 +11357,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1682, col: 1, offset: 39413},
+			pos:  position{line: 1686, col: 1, offset: 39518},
 			expr: &seqExpr{
-				pos: position{line: 1682, col: 16, offset: 39428},
+				pos: position{line: 1686, col: 16, offset: 39533},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1682, col: 16, offset: 39428},
+						pos:        position{line: 1686, col: 16, offset: 39533},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1682, col: 21, offset: 39433},
+						pos: position{line: 1686, col: 21, offset: 39538},
 						expr: &charClassMatcher{
-							pos:        position{line: 1682, col: 21, offset: 39433},
+							pos:        position{line: 1686, col: 21, offset: 39538},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11341,7 +11378,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1682, col: 27, offset: 39439},
+						pos:  position{line: 1686, col: 27, offset: 39544},
 						name: "UIntString",
 					},
 				},
@@ -11351,9 +11388,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1684, col: 1, offset: 39451},
+			pos:  position{line: 1688, col: 1, offset: 39556},
 			expr: &litMatcher{
-				pos:        position{line: 1684, col: 7, offset: 39457},
+				pos:        position{line: 1688, col: 7, offset: 39562},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11363,23 +11400,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1686, col: 1, offset: 39464},
+			pos:  position{line: 1690, col: 1, offset: 39569},
 			expr: &seqExpr{
-				pos: position{line: 1686, col: 12, offset: 39475},
+				pos: position{line: 1690, col: 12, offset: 39580},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1686, col: 12, offset: 39475},
+						pos: position{line: 1690, col: 12, offset: 39580},
 						expr: &choiceExpr{
-							pos: position{line: 1686, col: 13, offset: 39476},
+							pos: position{line: 1690, col: 13, offset: 39581},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1686, col: 13, offset: 39476},
+									pos:        position{line: 1690, col: 13, offset: 39581},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1686, col: 19, offset: 39482},
+									pos:        position{line: 1690, col: 19, offset: 39587},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11388,7 +11425,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1686, col: 25, offset: 39488},
+						pos:        position{line: 1690, col: 25, offset: 39593},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11400,14 +11437,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1688, col: 1, offset: 39495},
+			pos:  position{line: 1692, col: 1, offset: 39600},
 			expr: &actionExpr{
-				pos: position{line: 1688, col: 7, offset: 39501},
+				pos: position{line: 1692, col: 7, offset: 39606},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1688, col: 7, offset: 39501},
+					pos: position{line: 1692, col: 7, offset: 39606},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1688, col: 7, offset: 39501},
+						pos:  position{line: 1692, col: 7, offset: 39606},
 						name: "HexDigit",
 					},
 				},
@@ -11417,9 +11454,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1690, col: 1, offset: 39543},
+			pos:  position{line: 1694, col: 1, offset: 39648},
 			expr: &charClassMatcher{
-				pos:        position{line: 1690, col: 12, offset: 39554},
+				pos:        position{line: 1694, col: 12, offset: 39659},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11430,32 +11467,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1692, col: 1, offset: 39567},
+			pos:  position{line: 1696, col: 1, offset: 39672},
 			expr: &actionExpr{
-				pos: position{line: 1693, col: 5, offset: 39590},
+				pos: position{line: 1697, col: 5, offset: 39695},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1693, col: 5, offset: 39590},
+					pos: position{line: 1697, col: 5, offset: 39695},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1693, col: 5, offset: 39590},
+							pos:        position{line: 1697, col: 5, offset: 39695},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1693, col: 9, offset: 39594},
+							pos:   position{line: 1697, col: 9, offset: 39699},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1693, col: 11, offset: 39596},
+								pos: position{line: 1697, col: 11, offset: 39701},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1693, col: 11, offset: 39596},
+									pos:  position{line: 1697, col: 11, offset: 39701},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1693, col: 29, offset: 39614},
+							pos:        position{line: 1697, col: 29, offset: 39719},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11468,32 +11505,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1695, col: 1, offset: 39648},
+			pos:  position{line: 1699, col: 1, offset: 39753},
 			expr: &actionExpr{
-				pos: position{line: 1696, col: 5, offset: 39671},
+				pos: position{line: 1700, col: 5, offset: 39776},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1696, col: 5, offset: 39671},
+					pos: position{line: 1700, col: 5, offset: 39776},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1696, col: 5, offset: 39671},
+							pos:        position{line: 1700, col: 5, offset: 39776},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1696, col: 9, offset: 39675},
+							pos:   position{line: 1700, col: 9, offset: 39780},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1696, col: 11, offset: 39677},
+								pos: position{line: 1700, col: 11, offset: 39782},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1696, col: 11, offset: 39677},
+									pos:  position{line: 1700, col: 11, offset: 39782},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1696, col: 29, offset: 39695},
+							pos:        position{line: 1700, col: 29, offset: 39800},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11506,57 +11543,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1698, col: 1, offset: 39729},
+			pos:  position{line: 1702, col: 1, offset: 39834},
 			expr: &choiceExpr{
-				pos: position{line: 1699, col: 5, offset: 39750},
+				pos: position{line: 1703, col: 5, offset: 39855},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1699, col: 5, offset: 39750},
+						pos: position{line: 1703, col: 5, offset: 39855},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1699, col: 5, offset: 39750},
+							pos: position{line: 1703, col: 5, offset: 39855},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1699, col: 5, offset: 39750},
+									pos: position{line: 1703, col: 5, offset: 39855},
 									expr: &choiceExpr{
-										pos: position{line: 1699, col: 7, offset: 39752},
+										pos: position{line: 1703, col: 7, offset: 39857},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1699, col: 7, offset: 39752},
+												pos:        position{line: 1703, col: 7, offset: 39857},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1699, col: 13, offset: 39758},
+												pos:  position{line: 1703, col: 13, offset: 39863},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1699, col: 26, offset: 39771,
+									line: 1703, col: 26, offset: 39876,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1700, col: 5, offset: 39808},
+						pos: position{line: 1704, col: 5, offset: 39913},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1700, col: 5, offset: 39808},
+							pos: position{line: 1704, col: 5, offset: 39913},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1700, col: 5, offset: 39808},
+									pos:        position{line: 1704, col: 5, offset: 39913},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1700, col: 10, offset: 39813},
+									pos:   position{line: 1704, col: 10, offset: 39918},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1700, col: 12, offset: 39815},
+										pos:  position{line: 1704, col: 12, offset: 39920},
 										name: "EscapeSequence",
 									},
 								},
@@ -11570,32 +11607,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1702, col: 1, offset: 39849},
+			pos:  position{line: 1706, col: 1, offset: 39954},
 			expr: &choiceExpr{
-				pos: position{line: 1703, col: 5, offset: 39861},
+				pos: position{line: 1707, col: 5, offset: 39966},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1703, col: 5, offset: 39861},
+						pos: position{line: 1707, col: 5, offset: 39966},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1703, col: 5, offset: 39861},
+							pos: position{line: 1707, col: 5, offset: 39966},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1703, col: 5, offset: 39861},
+									pos:        position{line: 1707, col: 5, offset: 39966},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1703, col: 10, offset: 39866},
+									pos:   position{line: 1707, col: 10, offset: 39971},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1703, col: 12, offset: 39868},
+										pos:  position{line: 1707, col: 12, offset: 39973},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1703, col: 27, offset: 39883},
+									pos:        position{line: 1707, col: 27, offset: 39988},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11604,33 +11641,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1704, col: 5, offset: 39918},
+						pos: position{line: 1708, col: 5, offset: 40023},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1704, col: 5, offset: 39918},
+							pos: position{line: 1708, col: 5, offset: 40023},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1704, col: 5, offset: 39918},
+									pos:        position{line: 1708, col: 5, offset: 40023},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1704, col: 9, offset: 39922},
+									pos:        position{line: 1708, col: 9, offset: 40027},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1704, col: 13, offset: 39926},
+									pos:   position{line: 1708, col: 13, offset: 40031},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1704, col: 15, offset: 39928},
+										pos:  position{line: 1708, col: 15, offset: 40033},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1704, col: 30, offset: 39943},
+									pos:        position{line: 1708, col: 30, offset: 40048},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11645,26 +11682,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1706, col: 1, offset: 39975},
+			pos:  position{line: 1710, col: 1, offset: 40080},
 			expr: &actionExpr{
-				pos: position{line: 1707, col: 5, offset: 39994},
+				pos: position{line: 1711, col: 5, offset: 40099},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1707, col: 5, offset: 39994},
+					pos: position{line: 1711, col: 5, offset: 40099},
 					expr: &seqExpr{
-						pos: position{line: 1707, col: 6, offset: 39995},
+						pos: position{line: 1711, col: 6, offset: 40100},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1707, col: 6, offset: 39995},
+								pos: position{line: 1711, col: 6, offset: 40100},
 								expr: &litMatcher{
-									pos:        position{line: 1707, col: 7, offset: 39996},
+									pos:        position{line: 1711, col: 7, offset: 40101},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1707, col: 11, offset: 40000,
+								line: 1711, col: 11, offset: 40105,
 							},
 						},
 					},
@@ -11675,26 +11712,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1709, col: 1, offset: 40036},
+			pos:  position{line: 1713, col: 1, offset: 40141},
 			expr: &actionExpr{
-				pos: position{line: 1710, col: 5, offset: 40055},
+				pos: position{line: 1714, col: 5, offset: 40160},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1710, col: 5, offset: 40055},
+					pos: position{line: 1714, col: 5, offset: 40160},
 					expr: &seqExpr{
-						pos: position{line: 1710, col: 6, offset: 40056},
+						pos: position{line: 1714, col: 6, offset: 40161},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1710, col: 6, offset: 40056},
+								pos: position{line: 1714, col: 6, offset: 40161},
 								expr: &litMatcher{
-									pos:        position{line: 1710, col: 7, offset: 40057},
+									pos:        position{line: 1714, col: 7, offset: 40162},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1710, col: 11, offset: 40061,
+								line: 1714, col: 11, offset: 40166,
 							},
 						},
 					},
@@ -11705,32 +11742,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1712, col: 1, offset: 40097},
+			pos:  position{line: 1716, col: 1, offset: 40202},
 			expr: &actionExpr{
-				pos: position{line: 1713, col: 5, offset: 40116},
+				pos: position{line: 1717, col: 5, offset: 40221},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1713, col: 5, offset: 40116},
+					pos: position{line: 1717, col: 5, offset: 40221},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1713, col: 5, offset: 40116},
+							pos:        position{line: 1717, col: 5, offset: 40221},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1713, col: 9, offset: 40120},
+							pos:   position{line: 1717, col: 9, offset: 40225},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1713, col: 11, offset: 40122},
+								pos: position{line: 1717, col: 11, offset: 40227},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1713, col: 11, offset: 40122},
+									pos:  position{line: 1717, col: 11, offset: 40227},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1713, col: 25, offset: 40136},
+							pos:        position{line: 1717, col: 25, offset: 40241},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11743,57 +11780,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1715, col: 1, offset: 40170},
+			pos:  position{line: 1719, col: 1, offset: 40275},
 			expr: &choiceExpr{
-				pos: position{line: 1716, col: 5, offset: 40187},
+				pos: position{line: 1720, col: 5, offset: 40292},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1716, col: 5, offset: 40187},
+						pos: position{line: 1720, col: 5, offset: 40292},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1716, col: 5, offset: 40187},
+							pos: position{line: 1720, col: 5, offset: 40292},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1716, col: 5, offset: 40187},
+									pos: position{line: 1720, col: 5, offset: 40292},
 									expr: &choiceExpr{
-										pos: position{line: 1716, col: 7, offset: 40189},
+										pos: position{line: 1720, col: 7, offset: 40294},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1716, col: 7, offset: 40189},
+												pos:        position{line: 1720, col: 7, offset: 40294},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1716, col: 13, offset: 40195},
+												pos:  position{line: 1720, col: 13, offset: 40300},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1716, col: 26, offset: 40208,
+									line: 1720, col: 26, offset: 40313,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1717, col: 5, offset: 40245},
+						pos: position{line: 1721, col: 5, offset: 40350},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1717, col: 5, offset: 40245},
+							pos: position{line: 1721, col: 5, offset: 40350},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1717, col: 5, offset: 40245},
+									pos:        position{line: 1721, col: 5, offset: 40350},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1717, col: 10, offset: 40250},
+									pos:   position{line: 1721, col: 10, offset: 40355},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1717, col: 12, offset: 40252},
+										pos:  position{line: 1721, col: 12, offset: 40357},
 										name: "EscapeSequence",
 									},
 								},
@@ -11807,28 +11844,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1719, col: 1, offset: 40286},
+			pos:  position{line: 1723, col: 1, offset: 40391},
 			expr: &actionExpr{
-				pos: position{line: 1720, col: 5, offset: 40298},
+				pos: position{line: 1724, col: 5, offset: 40403},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1720, col: 5, offset: 40298},
+					pos: position{line: 1724, col: 5, offset: 40403},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1720, col: 5, offset: 40298},
+							pos:   position{line: 1724, col: 5, offset: 40403},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1720, col: 10, offset: 40303},
+								pos:  position{line: 1724, col: 10, offset: 40408},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1720, col: 23, offset: 40316},
+							pos:   position{line: 1724, col: 23, offset: 40421},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1720, col: 28, offset: 40321},
+								pos: position{line: 1724, col: 28, offset: 40426},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1720, col: 28, offset: 40321},
+									pos:  position{line: 1724, col: 28, offset: 40426},
 									name: "KeyWordRest",
 								},
 							},
@@ -11841,16 +11878,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1722, col: 1, offset: 40383},
+			pos:  position{line: 1726, col: 1, offset: 40488},
 			expr: &choiceExpr{
-				pos: position{line: 1723, col: 5, offset: 40400},
+				pos: position{line: 1727, col: 5, offset: 40505},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1723, col: 5, offset: 40400},
+						pos:  position{line: 1727, col: 5, offset: 40505},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1724, col: 5, offset: 40417},
+						pos:  position{line: 1728, col: 5, offset: 40522},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11860,16 +11897,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1726, col: 1, offset: 40429},
+			pos:  position{line: 1730, col: 1, offset: 40534},
 			expr: &choiceExpr{
-				pos: position{line: 1727, col: 5, offset: 40445},
+				pos: position{line: 1731, col: 5, offset: 40550},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1727, col: 5, offset: 40445},
+						pos:  position{line: 1731, col: 5, offset: 40550},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1728, col: 5, offset: 40462},
+						pos:        position{line: 1732, col: 5, offset: 40567},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11882,19 +11919,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1730, col: 1, offset: 40469},
+			pos:  position{line: 1734, col: 1, offset: 40574},
 			expr: &actionExpr{
-				pos: position{line: 1730, col: 16, offset: 40484},
+				pos: position{line: 1734, col: 16, offset: 40589},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1730, col: 17, offset: 40485},
+					pos: position{line: 1734, col: 17, offset: 40590},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1730, col: 17, offset: 40485},
+							pos:  position{line: 1734, col: 17, offset: 40590},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1730, col: 33, offset: 40501},
+							pos:        position{line: 1734, col: 33, offset: 40606},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11908,31 +11945,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1732, col: 1, offset: 40545},
+			pos:  position{line: 1736, col: 1, offset: 40650},
 			expr: &actionExpr{
-				pos: position{line: 1732, col: 14, offset: 40558},
+				pos: position{line: 1736, col: 14, offset: 40663},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1732, col: 14, offset: 40558},
+					pos: position{line: 1736, col: 14, offset: 40663},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1732, col: 14, offset: 40558},
+							pos:        position{line: 1736, col: 14, offset: 40663},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1732, col: 19, offset: 40563},
+							pos:   position{line: 1736, col: 19, offset: 40668},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1732, col: 22, offset: 40566},
+								pos: position{line: 1736, col: 22, offset: 40671},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1732, col: 22, offset: 40566},
+										pos:  position{line: 1736, col: 22, offset: 40671},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1732, col: 38, offset: 40582},
+										pos:  position{line: 1736, col: 38, offset: 40687},
 										name: "EscapeSequence",
 									},
 								},
@@ -11946,42 +11983,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1734, col: 1, offset: 40617},
+			pos:  position{line: 1738, col: 1, offset: 40722},
 			expr: &actionExpr{
-				pos: position{line: 1735, col: 5, offset: 40633},
+				pos: position{line: 1739, col: 5, offset: 40738},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1735, col: 5, offset: 40633},
+					pos: position{line: 1739, col: 5, offset: 40738},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1735, col: 5, offset: 40633},
+							pos: position{line: 1739, col: 5, offset: 40738},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1735, col: 6, offset: 40634},
+								pos:  position{line: 1739, col: 6, offset: 40739},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1735, col: 22, offset: 40650},
+							pos: position{line: 1739, col: 22, offset: 40755},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1735, col: 23, offset: 40651},
+								pos:  position{line: 1739, col: 23, offset: 40756},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1735, col: 35, offset: 40663},
+							pos:   position{line: 1739, col: 35, offset: 40768},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1735, col: 40, offset: 40668},
+								pos:  position{line: 1739, col: 40, offset: 40773},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1735, col: 50, offset: 40678},
+							pos:   position{line: 1739, col: 50, offset: 40783},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1735, col: 55, offset: 40683},
+								pos: position{line: 1739, col: 55, offset: 40788},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1735, col: 55, offset: 40683},
+									pos:  position{line: 1739, col: 55, offset: 40788},
 									name: "GlobRest",
 								},
 							},
@@ -11994,28 +12031,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1739, col: 1, offset: 40752},
+			pos:  position{line: 1743, col: 1, offset: 40857},
 			expr: &choiceExpr{
-				pos: position{line: 1739, col: 19, offset: 40770},
+				pos: position{line: 1743, col: 19, offset: 40875},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1739, col: 19, offset: 40770},
+						pos:  position{line: 1743, col: 19, offset: 40875},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1739, col: 34, offset: 40785},
+						pos: position{line: 1743, col: 34, offset: 40890},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1739, col: 34, offset: 40785},
+								pos: position{line: 1743, col: 34, offset: 40890},
 								expr: &litMatcher{
-									pos:        position{line: 1739, col: 34, offset: 40785},
+									pos:        position{line: 1743, col: 34, offset: 40890},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1739, col: 39, offset: 40790},
+								pos:  position{line: 1743, col: 39, offset: 40895},
 								name: "KeyWordRest",
 							},
 						},
@@ -12027,19 +12064,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1740, col: 1, offset: 40802},
+			pos:  position{line: 1744, col: 1, offset: 40907},
 			expr: &seqExpr{
-				pos: position{line: 1740, col: 15, offset: 40816},
+				pos: position{line: 1744, col: 15, offset: 40921},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1740, col: 15, offset: 40816},
+						pos: position{line: 1744, col: 15, offset: 40921},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1740, col: 15, offset: 40816},
+							pos:  position{line: 1744, col: 15, offset: 40921},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1740, col: 28, offset: 40829},
+						pos:        position{line: 1744, col: 28, offset: 40934},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12051,23 +12088,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1742, col: 1, offset: 40834},
+			pos:  position{line: 1746, col: 1, offset: 40939},
 			expr: &choiceExpr{
-				pos: position{line: 1743, col: 5, offset: 40848},
+				pos: position{line: 1747, col: 5, offset: 40953},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1743, col: 5, offset: 40848},
+						pos:  position{line: 1747, col: 5, offset: 40953},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 5, offset: 40865},
+						pos:  position{line: 1748, col: 5, offset: 40970},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1745, col: 5, offset: 40877},
+						pos: position{line: 1749, col: 5, offset: 40982},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1745, col: 5, offset: 40877},
+							pos:        position{line: 1749, col: 5, offset: 40982},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12080,16 +12117,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1747, col: 1, offset: 40902},
+			pos:  position{line: 1751, col: 1, offset: 41007},
 			expr: &choiceExpr{
-				pos: position{line: 1748, col: 5, offset: 40915},
+				pos: position{line: 1752, col: 5, offset: 41020},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1748, col: 5, offset: 40915},
+						pos:  position{line: 1752, col: 5, offset: 41020},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1749, col: 5, offset: 40929},
+						pos:        position{line: 1753, col: 5, offset: 41034},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12102,31 +12139,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1751, col: 1, offset: 40936},
+			pos:  position{line: 1755, col: 1, offset: 41041},
 			expr: &actionExpr{
-				pos: position{line: 1751, col: 11, offset: 40946},
+				pos: position{line: 1755, col: 11, offset: 41051},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1751, col: 11, offset: 40946},
+					pos: position{line: 1755, col: 11, offset: 41051},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1751, col: 11, offset: 40946},
+							pos:        position{line: 1755, col: 11, offset: 41051},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1751, col: 16, offset: 40951},
+							pos:   position{line: 1755, col: 16, offset: 41056},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1751, col: 19, offset: 40954},
+								pos: position{line: 1755, col: 19, offset: 41059},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1751, col: 19, offset: 40954},
+										pos:  position{line: 1755, col: 19, offset: 41059},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1751, col: 32, offset: 40967},
+										pos:  position{line: 1755, col: 32, offset: 41072},
 										name: "EscapeSequence",
 									},
 								},
@@ -12140,32 +12177,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1753, col: 1, offset: 41002},
+			pos:  position{line: 1757, col: 1, offset: 41107},
 			expr: &choiceExpr{
-				pos: position{line: 1754, col: 5, offset: 41017},
+				pos: position{line: 1758, col: 5, offset: 41122},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1754, col: 5, offset: 41017},
+						pos: position{line: 1758, col: 5, offset: 41122},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1754, col: 5, offset: 41017},
+							pos:        position{line: 1758, col: 5, offset: 41122},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1755, col: 5, offset: 41045},
+						pos: position{line: 1759, col: 5, offset: 41150},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1755, col: 5, offset: 41045},
+							pos:        position{line: 1759, col: 5, offset: 41150},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1756, col: 5, offset: 41075},
+						pos:        position{line: 1760, col: 5, offset: 41180},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12178,57 +12215,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1758, col: 1, offset: 41081},
+			pos:  position{line: 1762, col: 1, offset: 41186},
 			expr: &choiceExpr{
-				pos: position{line: 1759, col: 5, offset: 41102},
+				pos: position{line: 1763, col: 5, offset: 41207},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1759, col: 5, offset: 41102},
+						pos: position{line: 1763, col: 5, offset: 41207},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1759, col: 5, offset: 41102},
+							pos: position{line: 1763, col: 5, offset: 41207},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1759, col: 5, offset: 41102},
+									pos: position{line: 1763, col: 5, offset: 41207},
 									expr: &choiceExpr{
-										pos: position{line: 1759, col: 7, offset: 41104},
+										pos: position{line: 1763, col: 7, offset: 41209},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1759, col: 7, offset: 41104},
+												pos:        position{line: 1763, col: 7, offset: 41209},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1759, col: 13, offset: 41110},
+												pos:  position{line: 1763, col: 13, offset: 41215},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1759, col: 26, offset: 41123,
+									line: 1763, col: 26, offset: 41228,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1760, col: 5, offset: 41160},
+						pos: position{line: 1764, col: 5, offset: 41265},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1760, col: 5, offset: 41160},
+							pos: position{line: 1764, col: 5, offset: 41265},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1760, col: 5, offset: 41160},
+									pos:        position{line: 1764, col: 5, offset: 41265},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1760, col: 10, offset: 41165},
+									pos:   position{line: 1764, col: 10, offset: 41270},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1760, col: 12, offset: 41167},
+										pos:  position{line: 1764, col: 12, offset: 41272},
 										name: "EscapeSequence",
 									},
 								},
@@ -12242,16 +12279,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1762, col: 1, offset: 41201},
+			pos:  position{line: 1766, col: 1, offset: 41306},
 			expr: &choiceExpr{
-				pos: position{line: 1763, col: 5, offset: 41220},
+				pos: position{line: 1767, col: 5, offset: 41325},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1763, col: 5, offset: 41220},
+						pos:  position{line: 1767, col: 5, offset: 41325},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1764, col: 5, offset: 41241},
+						pos:  position{line: 1768, col: 5, offset: 41346},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12261,87 +12298,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1766, col: 1, offset: 41256},
+			pos:  position{line: 1770, col: 1, offset: 41361},
 			expr: &choiceExpr{
-				pos: position{line: 1767, col: 5, offset: 41277},
+				pos: position{line: 1771, col: 5, offset: 41382},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1767, col: 5, offset: 41277},
+						pos:        position{line: 1771, col: 5, offset: 41382},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1768, col: 5, offset: 41285},
+						pos: position{line: 1772, col: 5, offset: 41390},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1768, col: 5, offset: 41285},
+							pos:        position{line: 1772, col: 5, offset: 41390},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1769, col: 5, offset: 41325},
+						pos:        position{line: 1773, col: 5, offset: 41430},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1770, col: 5, offset: 41334},
+						pos: position{line: 1774, col: 5, offset: 41439},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1770, col: 5, offset: 41334},
+							pos:        position{line: 1774, col: 5, offset: 41439},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1771, col: 5, offset: 41363},
+						pos: position{line: 1775, col: 5, offset: 41468},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1771, col: 5, offset: 41363},
+							pos:        position{line: 1775, col: 5, offset: 41468},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1772, col: 5, offset: 41392},
+						pos: position{line: 1776, col: 5, offset: 41497},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1772, col: 5, offset: 41392},
+							pos:        position{line: 1776, col: 5, offset: 41497},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1773, col: 5, offset: 41421},
+						pos: position{line: 1777, col: 5, offset: 41526},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1773, col: 5, offset: 41421},
+							pos:        position{line: 1777, col: 5, offset: 41526},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1774, col: 5, offset: 41450},
+						pos: position{line: 1778, col: 5, offset: 41555},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1774, col: 5, offset: 41450},
+							pos:        position{line: 1778, col: 5, offset: 41555},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1775, col: 5, offset: 41479},
+						pos: position{line: 1779, col: 5, offset: 41584},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1775, col: 5, offset: 41479},
+							pos:        position{line: 1779, col: 5, offset: 41584},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12354,32 +12391,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1777, col: 1, offset: 41505},
+			pos:  position{line: 1781, col: 1, offset: 41610},
 			expr: &choiceExpr{
-				pos: position{line: 1778, col: 5, offset: 41523},
+				pos: position{line: 1782, col: 5, offset: 41628},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1778, col: 5, offset: 41523},
+						pos: position{line: 1782, col: 5, offset: 41628},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1778, col: 5, offset: 41523},
+							pos:        position{line: 1782, col: 5, offset: 41628},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1779, col: 5, offset: 41551},
+						pos: position{line: 1783, col: 5, offset: 41656},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1779, col: 5, offset: 41551},
+							pos:        position{line: 1783, col: 5, offset: 41656},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1780, col: 5, offset: 41579},
+						pos:        position{line: 1784, col: 5, offset: 41684},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12392,42 +12429,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1782, col: 1, offset: 41585},
+			pos:  position{line: 1786, col: 1, offset: 41690},
 			expr: &choiceExpr{
-				pos: position{line: 1783, col: 5, offset: 41603},
+				pos: position{line: 1787, col: 5, offset: 41708},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1783, col: 5, offset: 41603},
+						pos: position{line: 1787, col: 5, offset: 41708},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1783, col: 5, offset: 41603},
+							pos: position{line: 1787, col: 5, offset: 41708},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1783, col: 5, offset: 41603},
+									pos:        position{line: 1787, col: 5, offset: 41708},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1783, col: 9, offset: 41607},
+									pos:   position{line: 1787, col: 9, offset: 41712},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1783, col: 16, offset: 41614},
+										pos: position{line: 1787, col: 16, offset: 41719},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1783, col: 16, offset: 41614},
+												pos:  position{line: 1787, col: 16, offset: 41719},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1783, col: 25, offset: 41623},
+												pos:  position{line: 1787, col: 25, offset: 41728},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1783, col: 34, offset: 41632},
+												pos:  position{line: 1787, col: 34, offset: 41737},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1783, col: 43, offset: 41641},
+												pos:  position{line: 1787, col: 43, offset: 41746},
 												name: "HexDigit",
 											},
 										},
@@ -12437,65 +12474,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1786, col: 5, offset: 41704},
+						pos: position{line: 1790, col: 5, offset: 41809},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1786, col: 5, offset: 41704},
+							pos: position{line: 1790, col: 5, offset: 41809},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1786, col: 5, offset: 41704},
+									pos:        position{line: 1790, col: 5, offset: 41809},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1786, col: 9, offset: 41708},
+									pos:        position{line: 1790, col: 9, offset: 41813},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1786, col: 13, offset: 41712},
+									pos:   position{line: 1790, col: 13, offset: 41817},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1786, col: 20, offset: 41719},
+										pos: position{line: 1790, col: 20, offset: 41824},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1786, col: 20, offset: 41719},
+												pos:  position{line: 1790, col: 20, offset: 41824},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1786, col: 29, offset: 41728},
+												pos: position{line: 1790, col: 29, offset: 41833},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1786, col: 29, offset: 41728},
+													pos:  position{line: 1790, col: 29, offset: 41833},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1786, col: 39, offset: 41738},
+												pos: position{line: 1790, col: 39, offset: 41843},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1786, col: 39, offset: 41738},
+													pos:  position{line: 1790, col: 39, offset: 41843},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1786, col: 49, offset: 41748},
+												pos: position{line: 1790, col: 49, offset: 41853},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1786, col: 49, offset: 41748},
+													pos:  position{line: 1790, col: 49, offset: 41853},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1786, col: 59, offset: 41758},
+												pos: position{line: 1790, col: 59, offset: 41863},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1786, col: 59, offset: 41758},
+													pos:  position{line: 1790, col: 59, offset: 41863},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1786, col: 69, offset: 41768},
+												pos: position{line: 1790, col: 69, offset: 41873},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1786, col: 69, offset: 41768},
+													pos:  position{line: 1790, col: 69, offset: 41873},
 													name: "HexDigit",
 												},
 											},
@@ -12503,7 +12540,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1786, col: 80, offset: 41779},
+									pos:        position{line: 1790, col: 80, offset: 41884},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12518,9 +12555,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1791, col: 1, offset: 41834},
+			pos:  position{line: 1795, col: 1, offset: 41939},
 			expr: &charClassMatcher{
-				pos:        position{line: 1792, col: 5, offset: 41850},
+				pos:        position{line: 1796, col: 5, offset: 41955},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12532,11 +12569,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1794, col: 1, offset: 41865},
+			pos:  position{line: 1798, col: 1, offset: 41970},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1794, col: 5, offset: 41869},
+				pos: position{line: 1798, col: 5, offset: 41974},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1794, col: 5, offset: 41869},
+					pos:  position{line: 1798, col: 5, offset: 41974},
 					name: "AnySpace",
 				},
 			},
@@ -12545,11 +12582,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1796, col: 1, offset: 41880},
+			pos:  position{line: 1800, col: 1, offset: 41985},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1796, col: 6, offset: 41885},
+				pos: position{line: 1800, col: 6, offset: 41990},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1796, col: 6, offset: 41885},
+					pos:  position{line: 1800, col: 6, offset: 41990},
 					name: "AnySpace",
 				},
 			},
@@ -12558,20 +12595,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1798, col: 1, offset: 41896},
+			pos:  position{line: 1802, col: 1, offset: 42001},
 			expr: &choiceExpr{
-				pos: position{line: 1799, col: 5, offset: 41909},
+				pos: position{line: 1803, col: 5, offset: 42014},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1799, col: 5, offset: 41909},
+						pos:  position{line: 1803, col: 5, offset: 42014},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1800, col: 5, offset: 41924},
+						pos:  position{line: 1804, col: 5, offset: 42029},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1801, col: 5, offset: 41943},
+						pos:  position{line: 1805, col: 5, offset: 42048},
 						name: "Comment",
 					},
 				},
@@ -12581,32 +12618,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1803, col: 1, offset: 41952},
+			pos:  position{line: 1807, col: 1, offset: 42057},
 			expr: &choiceExpr{
-				pos: position{line: 1804, col: 5, offset: 41970},
+				pos: position{line: 1808, col: 5, offset: 42075},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1804, col: 5, offset: 41970},
+						pos:  position{line: 1808, col: 5, offset: 42075},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1805, col: 5, offset: 41977},
+						pos:  position{line: 1809, col: 5, offset: 42082},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1806, col: 5, offset: 41984},
+						pos:  position{line: 1810, col: 5, offset: 42089},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1807, col: 5, offset: 41991},
+						pos:  position{line: 1811, col: 5, offset: 42096},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1808, col: 5, offset: 41998},
+						pos:  position{line: 1812, col: 5, offset: 42103},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1809, col: 5, offset: 42005},
+						pos:  position{line: 1813, col: 5, offset: 42110},
 						name: "Nl",
 					},
 				},
@@ -12616,16 +12653,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1811, col: 1, offset: 42009},
+			pos:  position{line: 1815, col: 1, offset: 42114},
 			expr: &choiceExpr{
-				pos: position{line: 1812, col: 5, offset: 42034},
+				pos: position{line: 1816, col: 5, offset: 42139},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1812, col: 5, offset: 42034},
+						pos:  position{line: 1816, col: 5, offset: 42139},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1813, col: 5, offset: 42041},
+						pos:  position{line: 1817, col: 5, offset: 42146},
 						name: "Mc",
 					},
 				},
@@ -12635,9 +12672,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1815, col: 1, offset: 42045},
+			pos:  position{line: 1819, col: 1, offset: 42150},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1816, col: 5, offset: 42062},
+				pos:  position{line: 1820, col: 5, offset: 42167},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12645,9 +12682,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1818, col: 1, offset: 42066},
+			pos:  position{line: 1822, col: 1, offset: 42171},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1819, col: 5, offset: 42098},
+				pos:  position{line: 1823, col: 5, offset: 42203},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12655,9 +12692,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1825, col: 1, offset: 42279},
+			pos:  position{line: 1829, col: 1, offset: 42384},
 			expr: &charClassMatcher{
-				pos:        position{line: 1825, col: 6, offset: 42284},
+				pos:        position{line: 1829, col: 6, offset: 42389},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12669,9 +12706,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1828, col: 1, offset: 46436},
+			pos:  position{line: 1832, col: 1, offset: 46541},
 			expr: &charClassMatcher{
-				pos:        position{line: 1828, col: 6, offset: 46441},
+				pos:        position{line: 1832, col: 6, offset: 46546},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12683,9 +12720,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1831, col: 1, offset: 46926},
+			pos:  position{line: 1835, col: 1, offset: 47031},
 			expr: &charClassMatcher{
-				pos:        position{line: 1831, col: 6, offset: 46931},
+				pos:        position{line: 1835, col: 6, offset: 47036},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12697,9 +12734,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1834, col: 1, offset: 50378},
+			pos:  position{line: 1838, col: 1, offset: 50483},
 			expr: &charClassMatcher{
-				pos:        position{line: 1834, col: 6, offset: 50383},
+				pos:        position{line: 1838, col: 6, offset: 50488},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12711,9 +12748,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1837, col: 1, offset: 50489},
+			pos:  position{line: 1841, col: 1, offset: 50594},
 			expr: &charClassMatcher{
-				pos:        position{line: 1837, col: 6, offset: 50494},
+				pos:        position{line: 1841, col: 6, offset: 50599},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12725,9 +12762,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1840, col: 1, offset: 54495},
+			pos:  position{line: 1844, col: 1, offset: 54600},
 			expr: &charClassMatcher{
-				pos:        position{line: 1840, col: 6, offset: 54500},
+				pos:        position{line: 1844, col: 6, offset: 54605},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12739,9 +12776,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1843, col: 1, offset: 55688},
+			pos:  position{line: 1847, col: 1, offset: 55793},
 			expr: &charClassMatcher{
-				pos:        position{line: 1843, col: 6, offset: 55693},
+				pos:        position{line: 1847, col: 6, offset: 55798},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12753,9 +12790,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1846, col: 1, offset: 57873},
+			pos:  position{line: 1850, col: 1, offset: 57978},
 			expr: &charClassMatcher{
-				pos:        position{line: 1846, col: 6, offset: 57878},
+				pos:        position{line: 1850, col: 6, offset: 57983},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12766,9 +12803,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1849, col: 1, offset: 58381},
+			pos:  position{line: 1853, col: 1, offset: 58486},
 			expr: &charClassMatcher{
-				pos:        position{line: 1849, col: 6, offset: 58386},
+				pos:        position{line: 1853, col: 6, offset: 58491},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12780,9 +12817,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1852, col: 1, offset: 58500},
+			pos:  position{line: 1856, col: 1, offset: 58605},
 			expr: &charClassMatcher{
-				pos:        position{line: 1852, col: 6, offset: 58505},
+				pos:        position{line: 1856, col: 6, offset: 58610},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12794,9 +12831,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1855, col: 1, offset: 58586},
+			pos:  position{line: 1859, col: 1, offset: 58691},
 			expr: &charClassMatcher{
-				pos:        position{line: 1855, col: 6, offset: 58591},
+				pos:        position{line: 1859, col: 6, offset: 58696},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12808,9 +12845,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1857, col: 1, offset: 58644},
+			pos:  position{line: 1861, col: 1, offset: 58749},
 			expr: &anyMatcher{
-				line: 1858, col: 5, offset: 58664,
+				line: 1862, col: 5, offset: 58769,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12818,48 +12855,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1860, col: 1, offset: 58667},
+			pos:         position{line: 1864, col: 1, offset: 58772},
 			expr: &choiceExpr{
-				pos: position{line: 1861, col: 5, offset: 58695},
+				pos: position{line: 1865, col: 5, offset: 58800},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1861, col: 5, offset: 58695},
+						pos:        position{line: 1865, col: 5, offset: 58800},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1862, col: 5, offset: 58704},
+						pos:        position{line: 1866, col: 5, offset: 58809},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1863, col: 5, offset: 58713},
+						pos:        position{line: 1867, col: 5, offset: 58818},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1864, col: 5, offset: 58722},
+						pos:        position{line: 1868, col: 5, offset: 58827},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1865, col: 5, offset: 58730},
+						pos:        position{line: 1869, col: 5, offset: 58835},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1866, col: 5, offset: 58743},
+						pos:        position{line: 1870, col: 5, offset: 58848},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1867, col: 5, offset: 58756},
+						pos:  position{line: 1871, col: 5, offset: 58861},
 						name: "Zs",
 					},
 				},
@@ -12869,9 +12906,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1869, col: 1, offset: 58760},
+			pos:  position{line: 1873, col: 1, offset: 58865},
 			expr: &charClassMatcher{
-				pos:        position{line: 1870, col: 5, offset: 58779},
+				pos:        position{line: 1874, col: 5, offset: 58884},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12883,16 +12920,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1872, col: 1, offset: 58799},
+			pos:         position{line: 1876, col: 1, offset: 58904},
 			expr: &choiceExpr{
-				pos: position{line: 1873, col: 5, offset: 58821},
+				pos: position{line: 1877, col: 5, offset: 58926},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1873, col: 5, offset: 58821},
+						pos:  position{line: 1877, col: 5, offset: 58926},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1874, col: 5, offset: 58842},
+						pos:  position{line: 1878, col: 5, offset: 58947},
 						name: "SingleLineComment",
 					},
 				},
@@ -12902,39 +12939,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1876, col: 1, offset: 58861},
+			pos:  position{line: 1880, col: 1, offset: 58966},
 			expr: &seqExpr{
-				pos: position{line: 1877, col: 5, offset: 58882},
+				pos: position{line: 1881, col: 5, offset: 58987},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1877, col: 5, offset: 58882},
+						pos:        position{line: 1881, col: 5, offset: 58987},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1877, col: 10, offset: 58887},
+						pos: position{line: 1881, col: 10, offset: 58992},
 						expr: &seqExpr{
-							pos: position{line: 1877, col: 11, offset: 58888},
+							pos: position{line: 1881, col: 11, offset: 58993},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1877, col: 11, offset: 58888},
+									pos: position{line: 1881, col: 11, offset: 58993},
 									expr: &litMatcher{
-										pos:        position{line: 1877, col: 12, offset: 58889},
+										pos:        position{line: 1881, col: 12, offset: 58994},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1877, col: 17, offset: 58894},
+									pos:  position{line: 1881, col: 17, offset: 58999},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1877, col: 35, offset: 58912},
+						pos:        position{line: 1881, col: 35, offset: 59017},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12946,30 +12983,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1879, col: 1, offset: 58918},
+			pos:  position{line: 1883, col: 1, offset: 59023},
 			expr: &seqExpr{
-				pos: position{line: 1880, col: 5, offset: 58940},
+				pos: position{line: 1884, col: 5, offset: 59045},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1880, col: 5, offset: 58940},
+						pos:        position{line: 1884, col: 5, offset: 59045},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1880, col: 10, offset: 58945},
+						pos: position{line: 1884, col: 10, offset: 59050},
 						expr: &seqExpr{
-							pos: position{line: 1880, col: 11, offset: 58946},
+							pos: position{line: 1884, col: 11, offset: 59051},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1880, col: 11, offset: 58946},
+									pos: position{line: 1884, col: 11, offset: 59051},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1880, col: 12, offset: 58947},
+										pos:  position{line: 1884, col: 12, offset: 59052},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1880, col: 27, offset: 58962},
+									pos:  position{line: 1884, col: 27, offset: 59067},
 									name: "SourceCharacter",
 								},
 							},
@@ -12982,19 +13019,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1882, col: 1, offset: 58981},
+			pos:  position{line: 1886, col: 1, offset: 59086},
 			expr: &seqExpr{
-				pos: position{line: 1882, col: 7, offset: 58987},
+				pos: position{line: 1886, col: 7, offset: 59092},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1882, col: 7, offset: 58987},
+						pos: position{line: 1886, col: 7, offset: 59092},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1882, col: 7, offset: 58987},
+							pos:  position{line: 1886, col: 7, offset: 59092},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1882, col: 19, offset: 58999},
+						pos:  position{line: 1886, col: 19, offset: 59104},
 						name: "LineTerminator",
 					},
 				},
@@ -13004,16 +13041,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1884, col: 1, offset: 59015},
+			pos:  position{line: 1888, col: 1, offset: 59120},
 			expr: &choiceExpr{
-				pos: position{line: 1884, col: 7, offset: 59021},
+				pos: position{line: 1888, col: 7, offset: 59126},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1884, col: 7, offset: 59021},
+						pos:  position{line: 1888, col: 7, offset: 59126},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1884, col: 11, offset: 59025},
+						pos:  position{line: 1888, col: 11, offset: 59130},
 						name: "EOF",
 					},
 				},
@@ -13023,11 +13060,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1886, col: 1, offset: 59030},
+			pos:  position{line: 1890, col: 1, offset: 59135},
 			expr: &notExpr{
-				pos: position{line: 1886, col: 7, offset: 59036},
+				pos: position{line: 1890, col: 7, offset: 59141},
 				expr: &anyMatcher{
-					line: 1886, col: 8, offset: 59037,
+					line: 1890, col: 8, offset: 59142,
 				},
 			},
 			leader:        false,
@@ -13035,15 +13072,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1890, col: 1, offset: 59062},
+			pos:  position{line: 1894, col: 1, offset: 59167},
 			expr: &actionExpr{
-				pos: position{line: 1891, col: 5, offset: 59074},
+				pos: position{line: 1895, col: 5, offset: 59179},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1891, col: 5, offset: 59074},
+					pos:   position{line: 1895, col: 5, offset: 59179},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1891, col: 7, offset: 59076},
+						pos:  position{line: 1895, col: 7, offset: 59181},
 						name: "Seq",
 					},
 				},
@@ -13053,42 +13090,42 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1899, col: 1, offset: 59222},
+			pos:  position{line: 1903, col: 1, offset: 59327},
 			expr: &actionExpr{
-				pos: position{line: 1900, col: 5, offset: 59235},
+				pos: position{line: 1904, col: 5, offset: 59340},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1900, col: 5, offset: 59235},
+					pos: position{line: 1904, col: 5, offset: 59340},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1900, col: 5, offset: 59235},
+							pos:   position{line: 1904, col: 5, offset: 59340},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1900, col: 10, offset: 59240},
+								pos:  position{line: 1904, col: 10, offset: 59345},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1901, col: 5, offset: 59258},
+							pos:   position{line: 1905, col: 5, offset: 59363},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1901, col: 10, offset: 59263},
+								pos:  position{line: 1905, col: 10, offset: 59368},
 								name: "SelectSetOperation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1902, col: 5, offset: 59286},
+							pos:   position{line: 1906, col: 5, offset: 59391},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1902, col: 13, offset: 59294},
+								pos:  position{line: 1906, col: 13, offset: 59399},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1903, col: 5, offset: 59315},
+							pos:   position{line: 1907, col: 5, offset: 59420},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1903, col: 10, offset: 59320},
+								pos:  position{line: 1907, col: 10, offset: 59425},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -13100,39 +13137,39 @@ var g = &grammar{
 		},
 		{
 			name: "SelectSetOperation",
-			pos:  position{line: 1923, col: 1, offset: 59721},
+			pos:  position{line: 1927, col: 1, offset: 59826},
 			expr: &actionExpr{
-				pos: position{line: 1924, col: 5, offset: 59744},
+				pos: position{line: 1928, col: 5, offset: 59849},
 				run: (*parser).callonSelectSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 1924, col: 5, offset: 59744},
+					pos: position{line: 1928, col: 5, offset: 59849},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1924, col: 5, offset: 59744},
+							pos:   position{line: 1928, col: 5, offset: 59849},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1924, col: 11, offset: 59750},
+								pos:  position{line: 1928, col: 11, offset: 59855},
 								name: "SimpleSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1924, col: 24, offset: 59763},
+							pos:   position{line: 1928, col: 24, offset: 59868},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1924, col: 29, offset: 59768},
+								pos: position{line: 1928, col: 29, offset: 59873},
 								expr: &seqExpr{
-									pos: position{line: 1924, col: 30, offset: 59769},
+									pos: position{line: 1928, col: 30, offset: 59874},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1924, col: 30, offset: 59769},
+											pos:  position{line: 1928, col: 30, offset: 59874},
 											name: "SetOp",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1924, col: 36, offset: 59775},
+											pos:  position{line: 1928, col: 36, offset: 59880},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1924, col: 38, offset: 59777},
+											pos:  position{line: 1928, col: 38, offset: 59882},
 											name: "SimpleSelect",
 										},
 									},
@@ -13147,52 +13184,52 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleSelect",
-			pos:  position{line: 1938, col: 1, offset: 60074},
+			pos:  position{line: 1942, col: 1, offset: 60179},
 			expr: &choiceExpr{
-				pos: position{line: 1939, col: 5, offset: 60091},
+				pos: position{line: 1943, col: 5, offset: 60196},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1939, col: 5, offset: 60091},
+						pos:  position{line: 1943, col: 5, offset: 60196},
 						name: "Select",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1940, col: 5, offset: 60102},
+						pos:  position{line: 1944, col: 5, offset: 60207},
 						name: "FromSelect",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1941, col: 5, offset: 60117},
+						pos:  position{line: 1945, col: 5, offset: 60222},
 						name: "SQLValues",
 					},
 					&actionExpr{
-						pos: position{line: 1942, col: 5, offset: 60131},
+						pos: position{line: 1946, col: 5, offset: 60236},
 						run: (*parser).callonSimpleSelect5,
 						expr: &seqExpr{
-							pos: position{line: 1942, col: 5, offset: 60131},
+							pos: position{line: 1946, col: 5, offset: 60236},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1942, col: 5, offset: 60131},
+									pos:        position{line: 1946, col: 5, offset: 60236},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1942, col: 9, offset: 60135},
+									pos:  position{line: 1946, col: 9, offset: 60240},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1942, col: 12, offset: 60138},
+									pos:   position{line: 1946, col: 12, offset: 60243},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1942, col: 14, offset: 60140},
+										pos:  position{line: 1946, col: 14, offset: 60245},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1942, col: 22, offset: 60148},
+									pos:  position{line: 1946, col: 22, offset: 60253},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1942, col: 24, offset: 60150},
+									pos:        position{line: 1946, col: 24, offset: 60255},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -13207,74 +13244,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1944, col: 1, offset: 60173},
+			pos:  position{line: 1948, col: 1, offset: 60278},
 			expr: &actionExpr{
-				pos: position{line: 1945, col: 5, offset: 60184},
+				pos: position{line: 1949, col: 5, offset: 60289},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1945, col: 5, offset: 60184},
+					pos: position{line: 1949, col: 5, offset: 60289},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1945, col: 5, offset: 60184},
+							pos:  position{line: 1949, col: 5, offset: 60289},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1946, col: 5, offset: 60195},
+							pos:   position{line: 1950, col: 5, offset: 60300},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1946, col: 14, offset: 60204},
+								pos:  position{line: 1950, col: 14, offset: 60309},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1947, col: 5, offset: 60220},
+							pos:   position{line: 1951, col: 5, offset: 60325},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 11, offset: 60226},
+								pos:  position{line: 1951, col: 11, offset: 60331},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1950, col: 5, offset: 60365},
+							pos:  position{line: 1954, col: 5, offset: 60470},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1950, col: 7, offset: 60367},
+							pos:   position{line: 1954, col: 7, offset: 60472},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1950, col: 17, offset: 60377},
+								pos:  position{line: 1954, col: 17, offset: 60482},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1951, col: 5, offset: 60391},
+							pos:   position{line: 1955, col: 5, offset: 60496},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1951, col: 10, offset: 60396},
+								pos:  position{line: 1955, col: 10, offset: 60501},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1952, col: 5, offset: 60414},
+							pos:   position{line: 1956, col: 5, offset: 60519},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1952, col: 11, offset: 60420},
+								pos:  position{line: 1956, col: 11, offset: 60525},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1953, col: 5, offset: 60439},
+							pos:   position{line: 1957, col: 5, offset: 60544},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1953, col: 11, offset: 60445},
+								pos:  position{line: 1957, col: 11, offset: 60550},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1954, col: 5, offset: 60464},
+							pos:   position{line: 1958, col: 5, offset: 60569},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1954, col: 12, offset: 60471},
+								pos:  position{line: 1958, col: 12, offset: 60576},
 								name: "OptHavingClause",
 							},
 						},
@@ -13286,78 +13323,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1980, col: 1, offset: 61086},
+			pos:  position{line: 1984, col: 1, offset: 61191},
 			expr: &actionExpr{
-				pos: position{line: 1981, col: 5, offset: 61101},
+				pos: position{line: 1985, col: 5, offset: 61206},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1981, col: 5, offset: 61101},
+					pos: position{line: 1985, col: 5, offset: 61206},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1981, col: 5, offset: 61101},
+							pos:   position{line: 1985, col: 5, offset: 61206},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1981, col: 10, offset: 61106},
+								pos:  position{line: 1985, col: 10, offset: 61211},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1981, col: 17, offset: 61113},
+							pos:  position{line: 1985, col: 17, offset: 61218},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1981, col: 19, offset: 61115},
+							pos:  position{line: 1985, col: 19, offset: 61220},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 5, offset: 61126},
+							pos:   position{line: 1986, col: 5, offset: 61231},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 14, offset: 61135},
+								pos:  position{line: 1986, col: 14, offset: 61240},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1983, col: 5, offset: 61151},
+							pos:   position{line: 1987, col: 5, offset: 61256},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1983, col: 11, offset: 61157},
+								pos:  position{line: 1987, col: 11, offset: 61262},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1986, col: 5, offset: 61296},
+							pos:  position{line: 1990, col: 5, offset: 61401},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1986, col: 7, offset: 61298},
+							pos:   position{line: 1990, col: 7, offset: 61403},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1986, col: 17, offset: 61308},
+								pos:  position{line: 1990, col: 17, offset: 61413},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1987, col: 5, offset: 61322},
+							pos:   position{line: 1991, col: 5, offset: 61427},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 11, offset: 61328},
+								pos:  position{line: 1991, col: 11, offset: 61433},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1988, col: 5, offset: 61347},
+							pos:   position{line: 1992, col: 5, offset: 61452},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1988, col: 11, offset: 61353},
+								pos:  position{line: 1992, col: 11, offset: 61458},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1989, col: 5, offset: 61372},
+							pos:   position{line: 1993, col: 5, offset: 61477},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1989, col: 12, offset: 61379},
+								pos:  position{line: 1993, col: 12, offset: 61484},
 								name: "OptHavingClause",
 							},
 						},
@@ -13369,26 +13406,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 2013, col: 1, offset: 61961},
+			pos:  position{line: 2017, col: 1, offset: 62066},
 			expr: &actionExpr{
-				pos: position{line: 2014, col: 5, offset: 61975},
+				pos: position{line: 2018, col: 5, offset: 62080},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 2014, col: 5, offset: 61975},
+					pos: position{line: 2018, col: 5, offset: 62080},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2014, col: 5, offset: 61975},
+							pos:  position{line: 2018, col: 5, offset: 62080},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2014, col: 12, offset: 61982},
+							pos:  position{line: 2018, col: 12, offset: 62087},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2014, col: 15, offset: 61985},
+							pos:   position{line: 2018, col: 15, offset: 62090},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2014, col: 22, offset: 61992},
+								pos:  position{line: 2018, col: 22, offset: 62097},
 								name: "SQLTuples",
 							},
 						},
@@ -13400,26 +13437,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 2022, col: 1, offset: 62149},
+			pos:  position{line: 2026, col: 1, offset: 62254},
 			expr: &actionExpr{
-				pos: position{line: 2023, col: 5, offset: 62162},
+				pos: position{line: 2027, col: 5, offset: 62267},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 2023, col: 5, offset: 62162},
+					pos: position{line: 2027, col: 5, offset: 62267},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 5, offset: 62162},
+							pos:  position{line: 2027, col: 5, offset: 62267},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 12, offset: 62169},
+							pos:  position{line: 2027, col: 12, offset: 62274},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2023, col: 14, offset: 62171},
+							pos:   position{line: 2027, col: 14, offset: 62276},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2023, col: 20, offset: 62177},
+								pos:  position{line: 2027, col: 20, offset: 62282},
 								name: "Exprs",
 							},
 						},
@@ -13431,51 +13468,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 2032, col: 1, offset: 62324},
+			pos:  position{line: 2036, col: 1, offset: 62429},
 			expr: &actionExpr{
-				pos: position{line: 2033, col: 5, offset: 62338},
+				pos: position{line: 2037, col: 5, offset: 62443},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 2033, col: 5, offset: 62338},
+					pos: position{line: 2037, col: 5, offset: 62443},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2033, col: 5, offset: 62338},
+							pos:   position{line: 2037, col: 5, offset: 62443},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2033, col: 11, offset: 62344},
+								pos:  position{line: 2037, col: 11, offset: 62449},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2033, col: 20, offset: 62353},
+							pos:   position{line: 2037, col: 20, offset: 62458},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2033, col: 25, offset: 62358},
+								pos: position{line: 2037, col: 25, offset: 62463},
 								expr: &actionExpr{
-									pos: position{line: 2033, col: 26, offset: 62359},
+									pos: position{line: 2037, col: 26, offset: 62464},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 2033, col: 26, offset: 62359},
+										pos: position{line: 2037, col: 26, offset: 62464},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2033, col: 26, offset: 62359},
+												pos:  position{line: 2037, col: 26, offset: 62464},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2033, col: 29, offset: 62362},
+												pos:        position{line: 2037, col: 29, offset: 62467},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2033, col: 33, offset: 62366},
+												pos:  position{line: 2037, col: 33, offset: 62471},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2033, col: 36, offset: 62369},
+												pos:   position{line: 2037, col: 36, offset: 62474},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2033, col: 38, offset: 62371},
+													pos:  position{line: 2037, col: 38, offset: 62476},
 													name: "SQLTuple",
 												},
 											},
@@ -13492,37 +13529,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 2037, col: 1, offset: 62448},
+			pos:  position{line: 2041, col: 1, offset: 62553},
 			expr: &actionExpr{
-				pos: position{line: 2038, col: 5, offset: 62461},
+				pos: position{line: 2042, col: 5, offset: 62566},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 2038, col: 5, offset: 62461},
+					pos: position{line: 2042, col: 5, offset: 62566},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2038, col: 5, offset: 62461},
+							pos:        position{line: 2042, col: 5, offset: 62566},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2038, col: 9, offset: 62465},
+							pos:  position{line: 2042, col: 9, offset: 62570},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2038, col: 12, offset: 62468},
+							pos:   position{line: 2042, col: 12, offset: 62573},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2038, col: 18, offset: 62474},
+								pos:  position{line: 2042, col: 18, offset: 62579},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2038, col: 24, offset: 62480},
+							pos:  position{line: 2042, col: 24, offset: 62585},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2038, col: 27, offset: 62483},
+							pos:        position{line: 2042, col: 27, offset: 62588},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13535,49 +13572,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 2046, col: 1, offset: 62627},
+			pos:  position{line: 2050, col: 1, offset: 62732},
 			expr: &choiceExpr{
-				pos: position{line: 2047, col: 5, offset: 62643},
+				pos: position{line: 2051, col: 5, offset: 62748},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2047, col: 5, offset: 62643},
+						pos: position{line: 2051, col: 5, offset: 62748},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2047, col: 5, offset: 62643},
+							pos: position{line: 2051, col: 5, offset: 62748},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2047, col: 5, offset: 62643},
+									pos:  position{line: 2051, col: 5, offset: 62748},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2047, col: 7, offset: 62645},
+									pos:  position{line: 2051, col: 7, offset: 62750},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2048, col: 5, offset: 62682},
+						pos: position{line: 2052, col: 5, offset: 62787},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2048, col: 5, offset: 62682},
+							pos: position{line: 2052, col: 5, offset: 62787},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2048, col: 5, offset: 62682},
+									pos:  position{line: 2052, col: 5, offset: 62787},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2048, col: 7, offset: 62684},
+									pos:  position{line: 2052, col: 7, offset: 62789},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2049, col: 5, offset: 62720},
+						pos: position{line: 2053, col: 5, offset: 62825},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2049, col: 5, offset: 62720},
+							pos:        position{line: 2053, col: 5, offset: 62825},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13590,57 +13627,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2051, col: 1, offset: 62759},
+			pos:  position{line: 2055, col: 1, offset: 62864},
 			expr: &choiceExpr{
-				pos: position{line: 2052, col: 5, offset: 62778},
+				pos: position{line: 2056, col: 5, offset: 62883},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2052, col: 5, offset: 62778},
+						pos: position{line: 2056, col: 5, offset: 62883},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2052, col: 5, offset: 62778},
+							pos: position{line: 2056, col: 5, offset: 62883},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2052, col: 5, offset: 62778},
+									pos:  position{line: 2056, col: 5, offset: 62883},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2052, col: 7, offset: 62780},
+									pos:  position{line: 2056, col: 7, offset: 62885},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2052, col: 10, offset: 62783},
+									pos:  position{line: 2056, col: 10, offset: 62888},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2052, col: 12, offset: 62785},
+									pos:  position{line: 2056, col: 12, offset: 62890},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2053, col: 5, offset: 62817},
+						pos: position{line: 2057, col: 5, offset: 62922},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2053, col: 5, offset: 62817},
+							pos: position{line: 2057, col: 5, offset: 62922},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2053, col: 5, offset: 62817},
+									pos:  position{line: 2057, col: 5, offset: 62922},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2053, col: 7, offset: 62819},
+									pos:  position{line: 2057, col: 7, offset: 62924},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2054, col: 5, offset: 62890},
+						pos: position{line: 2058, col: 5, offset: 62995},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2054, col: 5, offset: 62890},
+							pos:        position{line: 2058, col: 5, offset: 62995},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13653,19 +13690,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2056, col: 1, offset: 62933},
+			pos:  position{line: 2060, col: 1, offset: 63038},
 			expr: &choiceExpr{
-				pos: position{line: 2057, col: 5, offset: 62951},
+				pos: position{line: 2061, col: 5, offset: 63056},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2057, col: 5, offset: 62951},
+						pos:  position{line: 2061, col: 5, offset: 63056},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2058, col: 5, offset: 62966},
+						pos: position{line: 2062, col: 5, offset: 63071},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2058, col: 5, offset: 62966},
+							pos:        position{line: 2062, col: 5, offset: 63071},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13678,39 +13715,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2060, col: 1, offset: 62999},
+			pos:  position{line: 2064, col: 1, offset: 63104},
 			expr: &actionExpr{
-				pos: position{line: 2061, col: 5, offset: 63014},
+				pos: position{line: 2065, col: 5, offset: 63119},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2061, col: 5, offset: 63014},
+					pos: position{line: 2065, col: 5, offset: 63119},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2061, col: 5, offset: 63014},
+							pos:  position{line: 2065, col: 5, offset: 63119},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2061, col: 10, offset: 63019},
+							pos:   position{line: 2065, col: 10, offset: 63124},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2061, col: 12, offset: 63021},
+								pos:  position{line: 2065, col: 12, offset: 63126},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2061, col: 25, offset: 63034},
+							pos:  position{line: 2065, col: 25, offset: 63139},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2061, col: 27, offset: 63036},
+							pos:   position{line: 2065, col: 27, offset: 63141},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2061, col: 32, offset: 63041},
+								pos:  position{line: 2065, col: 32, offset: 63146},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2061, col: 40, offset: 63049},
+							pos:  position{line: 2065, col: 40, offset: 63154},
 							name: "__",
 						},
 					},
@@ -13721,32 +13758,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2070, col: 1, offset: 63237},
+			pos:  position{line: 2074, col: 1, offset: 63342},
 			expr: &choiceExpr{
-				pos: position{line: 2071, col: 5, offset: 63254},
+				pos: position{line: 2075, col: 5, offset: 63359},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2071, col: 5, offset: 63254},
+						pos: position{line: 2075, col: 5, offset: 63359},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2071, col: 5, offset: 63254},
+							pos: position{line: 2075, col: 5, offset: 63359},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2071, col: 5, offset: 63254},
+									pos:  position{line: 2075, col: 5, offset: 63359},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2071, col: 7, offset: 63256},
+									pos:  position{line: 2075, col: 7, offset: 63361},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2072, col: 5, offset: 63292},
+						pos: position{line: 2076, col: 5, offset: 63397},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2072, col: 5, offset: 63292},
+							pos:        position{line: 2076, col: 5, offset: 63397},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13759,51 +13796,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2074, col: 1, offset: 63331},
+			pos:  position{line: 2078, col: 1, offset: 63436},
 			expr: &actionExpr{
-				pos: position{line: 2074, col: 11, offset: 63341},
+				pos: position{line: 2078, col: 11, offset: 63446},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2074, col: 11, offset: 63341},
+					pos: position{line: 2078, col: 11, offset: 63446},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2074, col: 11, offset: 63341},
+							pos:   position{line: 2078, col: 11, offset: 63446},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2074, col: 17, offset: 63347},
+								pos:  position{line: 2078, col: 17, offset: 63452},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2074, col: 21, offset: 63351},
+							pos:   position{line: 2078, col: 21, offset: 63456},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2074, col: 26, offset: 63356},
+								pos: position{line: 2078, col: 26, offset: 63461},
 								expr: &actionExpr{
-									pos: position{line: 2074, col: 28, offset: 63358},
+									pos: position{line: 2078, col: 28, offset: 63463},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2074, col: 28, offset: 63358},
+										pos: position{line: 2078, col: 28, offset: 63463},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2074, col: 28, offset: 63358},
+												pos:  position{line: 2078, col: 28, offset: 63463},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2074, col: 31, offset: 63361},
+												pos:        position{line: 2078, col: 31, offset: 63466},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2074, col: 35, offset: 63365},
+												pos:  position{line: 2078, col: 35, offset: 63470},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2074, col: 38, offset: 63368},
+												pos:   position{line: 2078, col: 38, offset: 63473},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2074, col: 42, offset: 63372},
+													pos:  position{line: 2078, col: 42, offset: 63477},
 													name: "Cte",
 												},
 											},
@@ -13820,65 +13857,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2078, col: 1, offset: 63440},
+			pos:  position{line: 2082, col: 1, offset: 63545},
 			expr: &actionExpr{
-				pos: position{line: 2079, col: 5, offset: 63448},
+				pos: position{line: 2083, col: 5, offset: 63553},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2079, col: 5, offset: 63448},
+					pos: position{line: 2083, col: 5, offset: 63553},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2079, col: 5, offset: 63448},
+							pos:   position{line: 2083, col: 5, offset: 63553},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2079, col: 10, offset: 63453},
+								pos:  position{line: 2083, col: 10, offset: 63558},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 24, offset: 63467},
+							pos:  position{line: 2083, col: 24, offset: 63572},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 26, offset: 63469},
+							pos:  position{line: 2083, col: 26, offset: 63574},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2079, col: 29, offset: 63472},
+							pos:   position{line: 2083, col: 29, offset: 63577},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2079, col: 31, offset: 63474},
+								pos:  position{line: 2083, col: 31, offset: 63579},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 47, offset: 63490},
+							pos:  position{line: 2083, col: 47, offset: 63595},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2079, col: 50, offset: 63493},
+							pos:        position{line: 2083, col: 50, offset: 63598},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 54, offset: 63497},
+							pos:  position{line: 2083, col: 54, offset: 63602},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2079, col: 57, offset: 63500},
+							pos:   position{line: 2083, col: 57, offset: 63605},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2079, col: 59, offset: 63502},
+								pos:  position{line: 2083, col: 59, offset: 63607},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2079, col: 67, offset: 63510},
+							pos:  position{line: 2083, col: 67, offset: 63615},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2079, col: 70, offset: 63513},
+							pos:        position{line: 2083, col: 70, offset: 63618},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13891,65 +13928,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2088, col: 1, offset: 63699},
+			pos:  position{line: 2092, col: 1, offset: 63804},
 			expr: &choiceExpr{
-				pos: position{line: 2089, col: 5, offset: 63719},
+				pos: position{line: 2093, col: 5, offset: 63824},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2089, col: 5, offset: 63719},
+						pos: position{line: 2093, col: 5, offset: 63824},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2089, col: 5, offset: 63719},
+							pos: position{line: 2093, col: 5, offset: 63824},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2089, col: 5, offset: 63719},
+									pos:  position{line: 2093, col: 5, offset: 63824},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2089, col: 7, offset: 63721},
+									pos:  position{line: 2093, col: 7, offset: 63826},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2089, col: 20, offset: 63734},
+									pos:  position{line: 2093, col: 20, offset: 63839},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2090, col: 5, offset: 63773},
+						pos: position{line: 2094, col: 5, offset: 63878},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2090, col: 5, offset: 63773},
+							pos: position{line: 2094, col: 5, offset: 63878},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 5, offset: 63773},
+									pos:  position{line: 2094, col: 5, offset: 63878},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 7, offset: 63775},
+									pos:  position{line: 2094, col: 7, offset: 63880},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 11, offset: 63779},
+									pos:  position{line: 2094, col: 11, offset: 63884},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 13, offset: 63781},
+									pos:  position{line: 2094, col: 13, offset: 63886},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2090, col: 26, offset: 63794},
+									pos:  position{line: 2094, col: 26, offset: 63899},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2091, col: 5, offset: 63825},
+						pos: position{line: 2095, col: 5, offset: 63930},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2091, col: 5, offset: 63825},
+							pos:        position{line: 2095, col: 5, offset: 63930},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13962,25 +13999,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2093, col: 1, offset: 63880},
+			pos:  position{line: 2097, col: 1, offset: 63985},
 			expr: &choiceExpr{
-				pos: position{line: 2094, col: 5, offset: 63897},
+				pos: position{line: 2098, col: 5, offset: 64002},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2094, col: 5, offset: 63897},
+						pos: position{line: 2098, col: 5, offset: 64002},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2094, col: 5, offset: 63897},
+								pos:  position{line: 2098, col: 5, offset: 64002},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2094, col: 7, offset: 63899},
+								pos:  position{line: 2098, col: 7, offset: 64004},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2095, col: 5, offset: 63907},
+						pos:        position{line: 2099, col: 5, offset: 64012},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -13992,25 +14029,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2097, col: 1, offset: 63911},
+			pos:  position{line: 2101, col: 1, offset: 64016},
 			expr: &choiceExpr{
-				pos: position{line: 2098, col: 5, offset: 63929},
+				pos: position{line: 2102, col: 5, offset: 64034},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2098, col: 5, offset: 63929},
+						pos: position{line: 2102, col: 5, offset: 64034},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2098, col: 5, offset: 63929},
+							pos: position{line: 2102, col: 5, offset: 64034},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 5, offset: 63929},
+									pos:  position{line: 2102, col: 5, offset: 64034},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2098, col: 7, offset: 63931},
+									pos:   position{line: 2102, col: 7, offset: 64036},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2098, col: 12, offset: 63936},
+										pos:  position{line: 2102, col: 12, offset: 64041},
 										name: "FromOp",
 									},
 								},
@@ -14018,10 +14055,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2101, col: 5, offset: 63978},
+						pos: position{line: 2105, col: 5, offset: 64083},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2101, col: 5, offset: 63978},
+							pos:        position{line: 2105, col: 5, offset: 64083},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14034,27 +14071,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2103, col: 1, offset: 64019},
+			pos:  position{line: 2107, col: 1, offset: 64124},
 			expr: &choiceExpr{
-				pos: position{line: 2104, col: 5, offset: 64038},
+				pos: position{line: 2108, col: 5, offset: 64143},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2104, col: 5, offset: 64038},
+						pos: position{line: 2108, col: 5, offset: 64143},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2104, col: 5, offset: 64038},
+							pos:   position{line: 2108, col: 5, offset: 64143},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2104, col: 11, offset: 64044},
+								pos:  position{line: 2108, col: 11, offset: 64149},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2105, col: 5, offset: 64086},
+						pos: position{line: 2109, col: 5, offset: 64191},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2105, col: 5, offset: 64086},
+							pos:        position{line: 2109, col: 5, offset: 64191},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14067,25 +14104,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2107, col: 1, offset: 64131},
+			pos:  position{line: 2111, col: 1, offset: 64236},
 			expr: &choiceExpr{
-				pos: position{line: 2108, col: 5, offset: 64150},
+				pos: position{line: 2112, col: 5, offset: 64255},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2108, col: 5, offset: 64150},
+						pos: position{line: 2112, col: 5, offset: 64255},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2108, col: 5, offset: 64150},
+							pos: position{line: 2112, col: 5, offset: 64255},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2108, col: 5, offset: 64150},
+									pos:  position{line: 2112, col: 5, offset: 64255},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2108, col: 7, offset: 64152},
+									pos:   position{line: 2112, col: 7, offset: 64257},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2108, col: 13, offset: 64158},
+										pos:  position{line: 2112, col: 13, offset: 64263},
 										name: "GroupClause",
 									},
 								},
@@ -14093,10 +14130,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2109, col: 5, offset: 64196},
+						pos: position{line: 2113, col: 5, offset: 64301},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2109, col: 5, offset: 64196},
+							pos:        position{line: 2113, col: 5, offset: 64301},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14109,34 +14146,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2111, col: 1, offset: 64237},
+			pos:  position{line: 2115, col: 1, offset: 64342},
 			expr: &actionExpr{
-				pos: position{line: 2112, col: 5, offset: 64253},
+				pos: position{line: 2116, col: 5, offset: 64358},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2112, col: 5, offset: 64253},
+					pos: position{line: 2116, col: 5, offset: 64358},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2112, col: 5, offset: 64253},
+							pos:  position{line: 2116, col: 5, offset: 64358},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2112, col: 11, offset: 64259},
+							pos:  position{line: 2116, col: 11, offset: 64364},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2112, col: 13, offset: 64261},
+							pos:  position{line: 2116, col: 13, offset: 64366},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2112, col: 16, offset: 64264},
+							pos:  position{line: 2116, col: 16, offset: 64369},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2112, col: 18, offset: 64266},
+							pos:   position{line: 2116, col: 18, offset: 64371},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2112, col: 23, offset: 64271},
+								pos:  position{line: 2116, col: 23, offset: 64376},
 								name: "GroupByList",
 							},
 						},
@@ -14148,51 +14185,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2114, col: 1, offset: 64305},
+			pos:  position{line: 2118, col: 1, offset: 64410},
 			expr: &actionExpr{
-				pos: position{line: 2115, col: 5, offset: 64321},
+				pos: position{line: 2119, col: 5, offset: 64426},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2115, col: 5, offset: 64321},
+					pos: position{line: 2119, col: 5, offset: 64426},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2115, col: 5, offset: 64321},
+							pos:   position{line: 2119, col: 5, offset: 64426},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2115, col: 11, offset: 64327},
+								pos:  position{line: 2119, col: 11, offset: 64432},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2115, col: 23, offset: 64339},
+							pos:   position{line: 2119, col: 23, offset: 64444},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2115, col: 28, offset: 64344},
+								pos: position{line: 2119, col: 28, offset: 64449},
 								expr: &actionExpr{
-									pos: position{line: 2115, col: 30, offset: 64346},
+									pos: position{line: 2119, col: 30, offset: 64451},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2115, col: 30, offset: 64346},
+										pos: position{line: 2119, col: 30, offset: 64451},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2115, col: 30, offset: 64346},
+												pos:  position{line: 2119, col: 30, offset: 64451},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2115, col: 33, offset: 64349},
+												pos:        position{line: 2119, col: 33, offset: 64454},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2115, col: 37, offset: 64353},
+												pos:  position{line: 2119, col: 37, offset: 64458},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2115, col: 40, offset: 64356},
+												pos:   position{line: 2119, col: 40, offset: 64461},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2115, col: 42, offset: 64358},
+													pos:  position{line: 2119, col: 42, offset: 64463},
 													name: "GroupByItem",
 												},
 											},
@@ -14209,9 +14246,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2119, col: 1, offset: 64439},
+			pos:  position{line: 2123, col: 1, offset: 64544},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2119, col: 15, offset: 64453},
+				pos:  position{line: 2123, col: 15, offset: 64558},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14219,25 +14256,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2121, col: 1, offset: 64459},
+			pos:  position{line: 2125, col: 1, offset: 64564},
 			expr: &choiceExpr{
-				pos: position{line: 2122, col: 5, offset: 64479},
+				pos: position{line: 2126, col: 5, offset: 64584},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2122, col: 5, offset: 64479},
+						pos: position{line: 2126, col: 5, offset: 64584},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2122, col: 5, offset: 64479},
+							pos: position{line: 2126, col: 5, offset: 64584},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2122, col: 5, offset: 64479},
+									pos:  position{line: 2126, col: 5, offset: 64584},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2122, col: 7, offset: 64481},
+									pos:   position{line: 2126, col: 7, offset: 64586},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2122, col: 9, offset: 64483},
+										pos:  position{line: 2126, col: 9, offset: 64588},
 										name: "HavingClause",
 									},
 								},
@@ -14245,10 +14282,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2123, col: 5, offset: 64518},
+						pos: position{line: 2127, col: 5, offset: 64623},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2123, col: 5, offset: 64518},
+							pos:        position{line: 2127, col: 5, offset: 64623},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14261,26 +14298,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2125, col: 1, offset: 64542},
+			pos:  position{line: 2129, col: 1, offset: 64647},
 			expr: &actionExpr{
-				pos: position{line: 2126, col: 5, offset: 64559},
+				pos: position{line: 2130, col: 5, offset: 64664},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2126, col: 5, offset: 64559},
+					pos: position{line: 2130, col: 5, offset: 64664},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2126, col: 5, offset: 64559},
+							pos:  position{line: 2130, col: 5, offset: 64664},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2126, col: 12, offset: 64566},
+							pos:  position{line: 2130, col: 12, offset: 64671},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2126, col: 14, offset: 64568},
+							pos:   position{line: 2130, col: 14, offset: 64673},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2126, col: 16, offset: 64570},
+								pos:  position{line: 2130, col: 16, offset: 64675},
 								name: "Expr",
 							},
 						},
@@ -14292,16 +14329,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2128, col: 1, offset: 64594},
+			pos:  position{line: 2132, col: 1, offset: 64699},
 			expr: &choiceExpr{
-				pos: position{line: 2129, col: 5, offset: 64612},
+				pos: position{line: 2133, col: 5, offset: 64717},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2129, col: 5, offset: 64612},
+						pos:  position{line: 2133, col: 5, offset: 64717},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2130, col: 5, offset: 64626},
+						pos:  position{line: 2134, col: 5, offset: 64731},
 						name: "ConditionJoin",
 					},
 				},
@@ -14311,30 +14348,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2132, col: 1, offset: 64641},
+			pos:  position{line: 2136, col: 1, offset: 64746},
 			expr: &actionExpr{
-				pos: position{line: 2133, col: 5, offset: 64655},
+				pos: position{line: 2137, col: 5, offset: 64760},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2133, col: 5, offset: 64655},
+					pos: position{line: 2137, col: 5, offset: 64760},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2133, col: 5, offset: 64655},
+							pos:   position{line: 2137, col: 5, offset: 64760},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2133, col: 10, offset: 64660},
+								pos:  position{line: 2137, col: 10, offset: 64765},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2133, col: 19, offset: 64669},
+							pos:  position{line: 2137, col: 19, offset: 64774},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2133, col: 31, offset: 64681},
+							pos:   position{line: 2137, col: 31, offset: 64786},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2133, col: 37, offset: 64687},
+								pos:  position{line: 2137, col: 37, offset: 64792},
 								name: "FromElem",
 							},
 						},
@@ -14346,50 +14383,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2142, col: 1, offset: 64895},
+			pos:  position{line: 2146, col: 1, offset: 65000},
 			expr: &choiceExpr{
-				pos: position{line: 2143, col: 5, offset: 64911},
+				pos: position{line: 2147, col: 5, offset: 65016},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2143, col: 5, offset: 64911},
+						pos: position{line: 2147, col: 5, offset: 65016},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2143, col: 5, offset: 64911},
+								pos:  position{line: 2147, col: 5, offset: 65016},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2143, col: 8, offset: 64914},
+								pos:        position{line: 2147, col: 8, offset: 65019},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2143, col: 12, offset: 64918},
+								pos:  position{line: 2147, col: 12, offset: 65023},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2144, col: 5, offset: 64925},
+						pos: position{line: 2148, col: 5, offset: 65030},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2144, col: 5, offset: 64925},
+								pos:  position{line: 2148, col: 5, offset: 65030},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2144, col: 7, offset: 64927},
+								pos:  position{line: 2148, col: 7, offset: 65032},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2144, col: 13, offset: 64933},
+								pos:  position{line: 2148, col: 13, offset: 65038},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2144, col: 15, offset: 64935},
+								pos:  position{line: 2148, col: 15, offset: 65040},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2144, col: 20, offset: 64940},
+								pos:  position{line: 2148, col: 20, offset: 65045},
 								name: "_",
 							},
 						},
@@ -14401,50 +14438,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2146, col: 1, offset: 64943},
+			pos:  position{line: 2150, col: 1, offset: 65048},
 			expr: &actionExpr{
-				pos: position{line: 2147, col: 5, offset: 64961},
+				pos: position{line: 2151, col: 5, offset: 65066},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2147, col: 5, offset: 64961},
+					pos: position{line: 2151, col: 5, offset: 65066},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2147, col: 5, offset: 64961},
+							pos:   position{line: 2151, col: 5, offset: 65066},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2147, col: 10, offset: 64966},
+								pos:  position{line: 2151, col: 10, offset: 65071},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2147, col: 19, offset: 64975},
+							pos:   position{line: 2151, col: 19, offset: 65080},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2147, col: 25, offset: 64981},
+								pos:  position{line: 2151, col: 25, offset: 65086},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2147, col: 38, offset: 64994},
+							pos:  position{line: 2151, col: 38, offset: 65099},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2147, col: 40, offset: 64996},
+							pos:   position{line: 2151, col: 40, offset: 65101},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2147, col: 46, offset: 65002},
+								pos:  position{line: 2151, col: 46, offset: 65107},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2147, col: 55, offset: 65011},
+							pos:  position{line: 2151, col: 55, offset: 65116},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2147, col: 57, offset: 65013},
+							pos:   position{line: 2151, col: 57, offset: 65118},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2147, col: 59, offset: 65015},
+								pos:  position{line: 2151, col: 59, offset: 65120},
 								name: "JoinCond",
 							},
 						},
@@ -14456,161 +14493,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2158, col: 1, offset: 65284},
+			pos:  position{line: 2162, col: 1, offset: 65389},
 			expr: &choiceExpr{
-				pos: position{line: 2159, col: 5, offset: 65301},
+				pos: position{line: 2163, col: 5, offset: 65406},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2159, col: 5, offset: 65301},
+						pos: position{line: 2163, col: 5, offset: 65406},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2159, col: 5, offset: 65301},
+							pos: position{line: 2163, col: 5, offset: 65406},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2159, col: 5, offset: 65301},
+									pos: position{line: 2163, col: 5, offset: 65406},
 									expr: &seqExpr{
-										pos: position{line: 2159, col: 6, offset: 65302},
+										pos: position{line: 2163, col: 6, offset: 65407},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2159, col: 6, offset: 65302},
+												pos:  position{line: 2163, col: 6, offset: 65407},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2159, col: 8, offset: 65304},
+												pos:  position{line: 2163, col: 8, offset: 65409},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2159, col: 16, offset: 65312},
+									pos:  position{line: 2163, col: 16, offset: 65417},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2159, col: 18, offset: 65314},
+									pos:  position{line: 2163, col: 18, offset: 65419},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2160, col: 5, offset: 65359},
+						pos: position{line: 2164, col: 5, offset: 65464},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2160, col: 5, offset: 65359},
+							pos: position{line: 2164, col: 5, offset: 65464},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2160, col: 5, offset: 65359},
+									pos:  position{line: 2164, col: 5, offset: 65464},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2160, col: 7, offset: 65361},
+									pos:  position{line: 2164, col: 7, offset: 65466},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2160, col: 12, offset: 65366},
+									pos: position{line: 2164, col: 12, offset: 65471},
 									expr: &seqExpr{
-										pos: position{line: 2160, col: 13, offset: 65367},
+										pos: position{line: 2164, col: 13, offset: 65472},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2160, col: 13, offset: 65367},
+												pos:  position{line: 2164, col: 13, offset: 65472},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2160, col: 15, offset: 65369},
+												pos:  position{line: 2164, col: 15, offset: 65474},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2160, col: 23, offset: 65377},
+									pos:  position{line: 2164, col: 23, offset: 65482},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2160, col: 25, offset: 65379},
+									pos:  position{line: 2164, col: 25, offset: 65484},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2161, col: 5, offset: 65413},
+						pos: position{line: 2165, col: 5, offset: 65518},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2161, col: 5, offset: 65413},
+							pos: position{line: 2165, col: 5, offset: 65518},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2161, col: 5, offset: 65413},
+									pos:  position{line: 2165, col: 5, offset: 65518},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2161, col: 7, offset: 65415},
+									pos:  position{line: 2165, col: 7, offset: 65520},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2161, col: 12, offset: 65420},
+									pos: position{line: 2165, col: 12, offset: 65525},
 									expr: &seqExpr{
-										pos: position{line: 2161, col: 13, offset: 65421},
+										pos: position{line: 2165, col: 13, offset: 65526},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2161, col: 13, offset: 65421},
+												pos:  position{line: 2165, col: 13, offset: 65526},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2161, col: 15, offset: 65423},
+												pos:  position{line: 2165, col: 15, offset: 65528},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2161, col: 23, offset: 65431},
+									pos:  position{line: 2165, col: 23, offset: 65536},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2161, col: 25, offset: 65433},
+									pos:  position{line: 2165, col: 25, offset: 65538},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2162, col: 5, offset: 65467},
+						pos: position{line: 2166, col: 5, offset: 65572},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2162, col: 5, offset: 65467},
+							pos: position{line: 2166, col: 5, offset: 65572},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2162, col: 5, offset: 65467},
+									pos:  position{line: 2166, col: 5, offset: 65572},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2162, col: 7, offset: 65469},
+									pos:  position{line: 2166, col: 7, offset: 65574},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2162, col: 13, offset: 65475},
+									pos: position{line: 2166, col: 13, offset: 65580},
 									expr: &seqExpr{
-										pos: position{line: 2162, col: 14, offset: 65476},
+										pos: position{line: 2166, col: 14, offset: 65581},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2162, col: 14, offset: 65476},
+												pos:  position{line: 2166, col: 14, offset: 65581},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2162, col: 16, offset: 65478},
+												pos:  position{line: 2166, col: 16, offset: 65583},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2162, col: 24, offset: 65486},
+									pos:  position{line: 2166, col: 24, offset: 65591},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2162, col: 26, offset: 65488},
+									pos:  position{line: 2166, col: 26, offset: 65593},
 									name: "JOIN",
 								},
 							},
@@ -14623,29 +14660,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2164, col: 1, offset: 65520},
+			pos:  position{line: 2168, col: 1, offset: 65625},
 			expr: &choiceExpr{
-				pos: position{line: 2165, col: 5, offset: 65533},
+				pos: position{line: 2169, col: 5, offset: 65638},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2165, col: 5, offset: 65533},
+						pos: position{line: 2169, col: 5, offset: 65638},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2165, col: 5, offset: 65533},
+							pos: position{line: 2169, col: 5, offset: 65638},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2165, col: 5, offset: 65533},
+									pos:  position{line: 2169, col: 5, offset: 65638},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2165, col: 8, offset: 65536},
+									pos:  position{line: 2169, col: 8, offset: 65641},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2165, col: 10, offset: 65538},
+									pos:   position{line: 2169, col: 10, offset: 65643},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2165, col: 12, offset: 65540},
+										pos:  position{line: 2169, col: 12, offset: 65645},
 										name: "Expr",
 									},
 								},
@@ -14653,43 +14690,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2172, col: 5, offset: 65693},
+						pos: position{line: 2176, col: 5, offset: 65798},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2172, col: 5, offset: 65693},
+							pos: position{line: 2176, col: 5, offset: 65798},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 5, offset: 65693},
+									pos:  position{line: 2176, col: 5, offset: 65798},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 11, offset: 65699},
+									pos:  position{line: 2176, col: 11, offset: 65804},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2172, col: 14, offset: 65702},
+									pos:        position{line: 2176, col: 14, offset: 65807},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 18, offset: 65706},
+									pos:  position{line: 2176, col: 18, offset: 65811},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2172, col: 21, offset: 65709},
+									pos:   position{line: 2176, col: 21, offset: 65814},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2172, col: 28, offset: 65716},
+										pos:  position{line: 2176, col: 28, offset: 65821},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 34, offset: 65722},
+									pos:  position{line: 2176, col: 34, offset: 65827},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2172, col: 37, offset: 65725},
+									pos:        position{line: 2176, col: 37, offset: 65830},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14704,40 +14741,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2180, col: 1, offset: 65895},
+			pos:  position{line: 2184, col: 1, offset: 66000},
 			expr: &choiceExpr{
-				pos: position{line: 2181, col: 5, offset: 65913},
+				pos: position{line: 2185, col: 5, offset: 66018},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2181, col: 5, offset: 65913},
+						pos: position{line: 2185, col: 5, offset: 66018},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2181, col: 5, offset: 65913},
+							pos: position{line: 2185, col: 5, offset: 66018},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 5, offset: 65913},
+									pos:  position{line: 2185, col: 5, offset: 66018},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 7, offset: 65915},
+									pos:  position{line: 2185, col: 7, offset: 66020},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 12, offset: 65920},
+									pos:  position{line: 2185, col: 12, offset: 66025},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 14, offset: 65922},
+									pos:  position{line: 2185, col: 14, offset: 66027},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2187, col: 5, offset: 66051},
+						pos: position{line: 2191, col: 5, offset: 66156},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2187, col: 5, offset: 66051},
+							pos:        position{line: 2191, col: 5, offset: 66156},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14750,25 +14787,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2189, col: 1, offset: 66100},
+			pos:  position{line: 2193, col: 1, offset: 66205},
 			expr: &choiceExpr{
-				pos: position{line: 2190, col: 5, offset: 66113},
+				pos: position{line: 2194, col: 5, offset: 66218},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2190, col: 5, offset: 66113},
+						pos: position{line: 2194, col: 5, offset: 66218},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2190, col: 5, offset: 66113},
+							pos: position{line: 2194, col: 5, offset: 66218},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2190, col: 5, offset: 66113},
+									pos:  position{line: 2194, col: 5, offset: 66218},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2190, col: 7, offset: 66115},
+									pos:   position{line: 2194, col: 7, offset: 66220},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2190, col: 9, offset: 66117},
+										pos:  position{line: 2194, col: 9, offset: 66222},
 										name: "AliasClause",
 									},
 								},
@@ -14776,10 +14813,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2191, col: 5, offset: 66151},
+						pos: position{line: 2195, col: 5, offset: 66256},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2191, col: 5, offset: 66151},
+							pos:        position{line: 2195, col: 5, offset: 66256},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14792,51 +14829,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2193, col: 1, offset: 66188},
+			pos:  position{line: 2197, col: 1, offset: 66293},
 			expr: &actionExpr{
-				pos: position{line: 2194, col: 4, offset: 66203},
+				pos: position{line: 2198, col: 4, offset: 66308},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2194, col: 4, offset: 66203},
+					pos: position{line: 2198, col: 4, offset: 66308},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2194, col: 4, offset: 66203},
+							pos: position{line: 2198, col: 4, offset: 66308},
 							expr: &seqExpr{
-								pos: position{line: 2194, col: 5, offset: 66204},
+								pos: position{line: 2198, col: 5, offset: 66309},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2194, col: 5, offset: 66204},
+										pos:  position{line: 2198, col: 5, offset: 66309},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2194, col: 8, offset: 66207},
+										pos:  position{line: 2198, col: 8, offset: 66312},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2194, col: 12, offset: 66211},
+							pos: position{line: 2198, col: 12, offset: 66316},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2194, col: 13, offset: 66212},
+								pos:  position{line: 2198, col: 13, offset: 66317},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2194, col: 22, offset: 66221},
+							pos:   position{line: 2198, col: 22, offset: 66326},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2194, col: 27, offset: 66226},
+								pos:  position{line: 2198, col: 27, offset: 66331},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2194, col: 42, offset: 66241},
+							pos:   position{line: 2198, col: 42, offset: 66346},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2194, col: 47, offset: 66246},
+								pos: position{line: 2198, col: 47, offset: 66351},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2194, col: 47, offset: 66246},
+									pos:  position{line: 2198, col: 47, offset: 66351},
 									name: "Columns",
 								},
 							},
@@ -14849,65 +14886,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2202, col: 1, offset: 66445},
+			pos:  position{line: 2206, col: 1, offset: 66550},
 			expr: &actionExpr{
-				pos: position{line: 2203, col: 5, offset: 66457},
+				pos: position{line: 2207, col: 5, offset: 66562},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2203, col: 5, offset: 66457},
+					pos: position{line: 2207, col: 5, offset: 66562},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2203, col: 5, offset: 66457},
+							pos:  position{line: 2207, col: 5, offset: 66562},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2203, col: 8, offset: 66460},
+							pos:        position{line: 2207, col: 8, offset: 66565},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2203, col: 12, offset: 66464},
+							pos:  position{line: 2207, col: 12, offset: 66569},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2203, col: 15, offset: 66467},
+							pos:   position{line: 2207, col: 15, offset: 66572},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2203, col: 21, offset: 66473},
+								pos:  position{line: 2207, col: 21, offset: 66578},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2203, col: 35, offset: 66487},
+							pos:   position{line: 2207, col: 35, offset: 66592},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2203, col: 40, offset: 66492},
+								pos: position{line: 2207, col: 40, offset: 66597},
 								expr: &actionExpr{
-									pos: position{line: 2203, col: 42, offset: 66494},
+									pos: position{line: 2207, col: 42, offset: 66599},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2203, col: 42, offset: 66494},
+										pos: position{line: 2207, col: 42, offset: 66599},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2203, col: 42, offset: 66494},
+												pos:  position{line: 2207, col: 42, offset: 66599},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2203, col: 45, offset: 66497},
+												pos:        position{line: 2207, col: 45, offset: 66602},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2203, col: 49, offset: 66501},
+												pos:  position{line: 2207, col: 49, offset: 66606},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2203, col: 52, offset: 66504},
+												pos:   position{line: 2207, col: 52, offset: 66609},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2203, col: 54, offset: 66506},
+													pos:  position{line: 2207, col: 54, offset: 66611},
 													name: "SQLIdentifier",
 												},
 											},
@@ -14917,11 +14954,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2203, col: 87, offset: 66539},
+							pos:  position{line: 2207, col: 87, offset: 66644},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2203, col: 90, offset: 66542},
+							pos:        position{line: 2207, col: 90, offset: 66647},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14934,51 +14971,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2207, col: 1, offset: 66613},
+			pos:  position{line: 2211, col: 1, offset: 66718},
 			expr: &actionExpr{
-				pos: position{line: 2208, col: 5, offset: 66627},
+				pos: position{line: 2212, col: 5, offset: 66732},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2208, col: 5, offset: 66627},
+					pos: position{line: 2212, col: 5, offset: 66732},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2208, col: 5, offset: 66627},
+							pos:   position{line: 2212, col: 5, offset: 66732},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2208, col: 11, offset: 66633},
+								pos:  position{line: 2212, col: 11, offset: 66738},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2208, col: 22, offset: 66644},
+							pos:   position{line: 2212, col: 22, offset: 66749},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2208, col: 27, offset: 66649},
+								pos: position{line: 2212, col: 27, offset: 66754},
 								expr: &actionExpr{
-									pos: position{line: 2208, col: 29, offset: 66651},
+									pos: position{line: 2212, col: 29, offset: 66756},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2208, col: 29, offset: 66651},
+										pos: position{line: 2212, col: 29, offset: 66756},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2208, col: 29, offset: 66651},
+												pos:  position{line: 2212, col: 29, offset: 66756},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2208, col: 32, offset: 66654},
+												pos:        position{line: 2212, col: 32, offset: 66759},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2208, col: 36, offset: 66658},
+												pos:  position{line: 2212, col: 36, offset: 66763},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2208, col: 39, offset: 66661},
+												pos:   position{line: 2212, col: 39, offset: 66766},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2208, col: 41, offset: 66663},
+													pos:  position{line: 2212, col: 41, offset: 66768},
 													name: "SelectElem",
 												},
 											},
@@ -14995,38 +15032,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2217, col: 1, offset: 66898},
+			pos:  position{line: 2221, col: 1, offset: 67003},
 			expr: &choiceExpr{
-				pos: position{line: 2218, col: 5, offset: 66913},
+				pos: position{line: 2222, col: 5, offset: 67018},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2218, col: 5, offset: 66913},
+						pos: position{line: 2222, col: 5, offset: 67018},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2218, col: 5, offset: 66913},
+							pos: position{line: 2222, col: 5, offset: 67018},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2218, col: 5, offset: 66913},
+									pos:   position{line: 2222, col: 5, offset: 67018},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2218, col: 11, offset: 66919},
+										pos: position{line: 2222, col: 11, offset: 67024},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2218, col: 11, offset: 66919},
+												pos:  position{line: 2222, col: 11, offset: 67024},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2218, col: 25, offset: 66933},
+												pos:  position{line: 2222, col: 25, offset: 67038},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2218, col: 31, offset: 66939},
+									pos:   position{line: 2222, col: 31, offset: 67044},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2218, col: 34, offset: 66942},
+										pos:  position{line: 2222, col: 34, offset: 67047},
 										name: "OptAsClause",
 									},
 								},
@@ -15034,10 +15071,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2229, col: 5, offset: 67170},
+						pos: position{line: 2233, col: 5, offset: 67275},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2229, col: 5, offset: 67170},
+							pos:        position{line: 2233, col: 5, offset: 67275},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15050,33 +15087,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2234, col: 1, offset: 67275},
+			pos:  position{line: 2238, col: 1, offset: 67380},
 			expr: &choiceExpr{
-				pos: position{line: 2235, col: 5, offset: 67291},
+				pos: position{line: 2239, col: 5, offset: 67396},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2235, col: 5, offset: 67291},
+						pos: position{line: 2239, col: 5, offset: 67396},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2235, col: 5, offset: 67291},
+							pos: position{line: 2239, col: 5, offset: 67396},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2235, col: 5, offset: 67291},
+									pos:  position{line: 2239, col: 5, offset: 67396},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2235, col: 7, offset: 67293},
+									pos:  position{line: 2239, col: 7, offset: 67398},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2235, col: 10, offset: 67296},
+									pos:  position{line: 2239, col: 10, offset: 67401},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2235, col: 12, offset: 67298},
+									pos:   position{line: 2239, col: 12, offset: 67403},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2235, col: 15, offset: 67301},
+										pos:  position{line: 2239, col: 15, offset: 67406},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15084,27 +15121,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2236, col: 5, offset: 67338},
+						pos: position{line: 2240, col: 5, offset: 67443},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2236, col: 5, offset: 67338},
+							pos: position{line: 2240, col: 5, offset: 67443},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2236, col: 5, offset: 67338},
+									pos:  position{line: 2240, col: 5, offset: 67443},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2236, col: 7, offset: 67340},
+									pos: position{line: 2240, col: 7, offset: 67445},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2236, col: 8, offset: 67341},
+										pos:  position{line: 2240, col: 8, offset: 67446},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2236, col: 17, offset: 67350},
+									pos:   position{line: 2240, col: 17, offset: 67455},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2236, col: 20, offset: 67353},
+										pos:  position{line: 2240, col: 20, offset: 67458},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15112,10 +15149,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2237, col: 5, offset: 67390},
+						pos: position{line: 2241, col: 5, offset: 67495},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2237, col: 5, offset: 67390},
+							pos:        position{line: 2241, col: 5, offset: 67495},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15128,41 +15165,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2239, col: 1, offset: 67415},
+			pos:  position{line: 2243, col: 1, offset: 67520},
 			expr: &choiceExpr{
-				pos: position{line: 2240, col: 5, offset: 67436},
+				pos: position{line: 2244, col: 5, offset: 67541},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2240, col: 5, offset: 67436},
+						pos: position{line: 2244, col: 5, offset: 67541},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2240, col: 5, offset: 67436},
+							pos: position{line: 2244, col: 5, offset: 67541},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 5, offset: 67436},
+									pos:  position{line: 2244, col: 5, offset: 67541},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 7, offset: 67438},
+									pos:  position{line: 2244, col: 7, offset: 67543},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 13, offset: 67444},
+									pos:  position{line: 2244, col: 13, offset: 67549},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 15, offset: 67446},
+									pos:  position{line: 2244, col: 15, offset: 67551},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 18, offset: 67449},
+									pos:  position{line: 2244, col: 18, offset: 67554},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2240, col: 20, offset: 67451},
+									pos:   position{line: 2244, col: 20, offset: 67556},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2240, col: 25, offset: 67456},
+										pos:  position{line: 2244, col: 25, offset: 67561},
 										name: "OrderByList",
 									},
 								},
@@ -15170,10 +15207,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2247, col: 5, offset: 67620},
+						pos: position{line: 2251, col: 5, offset: 67725},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2247, col: 5, offset: 67620},
+							pos:        position{line: 2251, col: 5, offset: 67725},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15186,51 +15223,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2249, col: 1, offset: 67653},
+			pos:  position{line: 2253, col: 1, offset: 67758},
 			expr: &actionExpr{
-				pos: position{line: 2250, col: 5, offset: 67669},
+				pos: position{line: 2254, col: 5, offset: 67774},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2250, col: 5, offset: 67669},
+					pos: position{line: 2254, col: 5, offset: 67774},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2250, col: 5, offset: 67669},
+							pos:   position{line: 2254, col: 5, offset: 67774},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2250, col: 11, offset: 67675},
+								pos:  position{line: 2254, col: 11, offset: 67780},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2250, col: 23, offset: 67687},
+							pos:   position{line: 2254, col: 23, offset: 67792},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2250, col: 28, offset: 67692},
+								pos: position{line: 2254, col: 28, offset: 67797},
 								expr: &actionExpr{
-									pos: position{line: 2250, col: 30, offset: 67694},
+									pos: position{line: 2254, col: 30, offset: 67799},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2250, col: 30, offset: 67694},
+										pos: position{line: 2254, col: 30, offset: 67799},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2250, col: 30, offset: 67694},
+												pos:  position{line: 2254, col: 30, offset: 67799},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2250, col: 33, offset: 67697},
+												pos:        position{line: 2254, col: 33, offset: 67802},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2250, col: 37, offset: 67701},
+												pos:  position{line: 2254, col: 37, offset: 67806},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2250, col: 40, offset: 67704},
+												pos:   position{line: 2254, col: 40, offset: 67809},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2250, col: 42, offset: 67706},
+													pos:  position{line: 2254, col: 42, offset: 67811},
 													name: "OrderByItem",
 												},
 											},
@@ -15247,34 +15284,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2254, col: 1, offset: 67807},
+			pos:  position{line: 2258, col: 1, offset: 67912},
 			expr: &actionExpr{
-				pos: position{line: 2255, col: 5, offset: 67823},
+				pos: position{line: 2259, col: 5, offset: 67928},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2255, col: 5, offset: 67823},
+					pos: position{line: 2259, col: 5, offset: 67928},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2255, col: 5, offset: 67823},
+							pos:   position{line: 2259, col: 5, offset: 67928},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 7, offset: 67825},
+								pos:  position{line: 2259, col: 7, offset: 67930},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2255, col: 12, offset: 67830},
+							pos:   position{line: 2259, col: 12, offset: 67935},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 18, offset: 67836},
+								pos:  position{line: 2259, col: 18, offset: 67941},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2255, col: 29, offset: 67847},
+							pos:   position{line: 2259, col: 29, offset: 67952},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 35, offset: 67853},
+								pos:  position{line: 2259, col: 35, offset: 67958},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15286,49 +15323,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2266, col: 1, offset: 68103},
+			pos:  position{line: 2270, col: 1, offset: 68208},
 			expr: &choiceExpr{
-				pos: position{line: 2267, col: 5, offset: 68118},
+				pos: position{line: 2271, col: 5, offset: 68223},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2267, col: 5, offset: 68118},
+						pos: position{line: 2271, col: 5, offset: 68223},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2267, col: 5, offset: 68118},
+							pos: position{line: 2271, col: 5, offset: 68223},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 5, offset: 68118},
+									pos:  position{line: 2271, col: 5, offset: 68223},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 7, offset: 68120},
+									pos:  position{line: 2271, col: 7, offset: 68225},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2268, col: 5, offset: 68192},
+						pos: position{line: 2272, col: 5, offset: 68297},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2268, col: 5, offset: 68192},
+							pos: position{line: 2272, col: 5, offset: 68297},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2268, col: 5, offset: 68192},
+									pos:  position{line: 2272, col: 5, offset: 68297},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2268, col: 7, offset: 68194},
+									pos:  position{line: 2272, col: 7, offset: 68299},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2269, col: 5, offset: 68266},
+						pos: position{line: 2273, col: 5, offset: 68371},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2269, col: 5, offset: 68266},
+							pos:        position{line: 2273, col: 5, offset: 68371},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15341,65 +15378,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2271, col: 1, offset: 68298},
+			pos:  position{line: 2275, col: 1, offset: 68403},
 			expr: &choiceExpr{
-				pos: position{line: 2272, col: 5, offset: 68316},
+				pos: position{line: 2276, col: 5, offset: 68421},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2272, col: 5, offset: 68316},
+						pos: position{line: 2276, col: 5, offset: 68421},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2272, col: 5, offset: 68316},
+							pos: position{line: 2276, col: 5, offset: 68421},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2272, col: 5, offset: 68316},
+									pos:  position{line: 2276, col: 5, offset: 68421},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2272, col: 7, offset: 68318},
+									pos:  position{line: 2276, col: 7, offset: 68423},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2272, col: 13, offset: 68324},
+									pos:  position{line: 2276, col: 13, offset: 68429},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2272, col: 15, offset: 68326},
+									pos:  position{line: 2276, col: 15, offset: 68431},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2273, col: 5, offset: 68402},
+						pos: position{line: 2277, col: 5, offset: 68507},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2273, col: 5, offset: 68402},
+							pos: position{line: 2277, col: 5, offset: 68507},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2273, col: 5, offset: 68402},
+									pos:  position{line: 2277, col: 5, offset: 68507},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2273, col: 7, offset: 68404},
+									pos:  position{line: 2277, col: 7, offset: 68509},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2273, col: 13, offset: 68410},
+									pos:  position{line: 2277, col: 13, offset: 68515},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2273, col: 15, offset: 68412},
+									pos:  position{line: 2277, col: 15, offset: 68517},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2274, col: 5, offset: 68487},
+						pos: position{line: 2278, col: 5, offset: 68592},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2274, col: 5, offset: 68487},
+							pos:        position{line: 2278, col: 5, offset: 68592},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15412,25 +15449,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2276, col: 1, offset: 68532},
+			pos:  position{line: 2280, col: 1, offset: 68637},
 			expr: &choiceExpr{
-				pos: position{line: 2277, col: 5, offset: 68554},
+				pos: position{line: 2281, col: 5, offset: 68659},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2277, col: 5, offset: 68554},
+						pos: position{line: 2281, col: 5, offset: 68659},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2277, col: 5, offset: 68554},
+							pos: position{line: 2281, col: 5, offset: 68659},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2277, col: 5, offset: 68554},
+									pos:  position{line: 2281, col: 5, offset: 68659},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2277, col: 7, offset: 68556},
+									pos:   position{line: 2281, col: 7, offset: 68661},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2277, col: 10, offset: 68559},
+										pos:  position{line: 2281, col: 10, offset: 68664},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15438,10 +15475,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2278, col: 5, offset: 68597},
+						pos: position{line: 2282, col: 5, offset: 68702},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2278, col: 5, offset: 68597},
+							pos:        position{line: 2282, col: 5, offset: 68702},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15454,29 +15491,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2280, col: 1, offset: 68638},
+			pos:  position{line: 2284, col: 1, offset: 68743},
 			expr: &choiceExpr{
-				pos: position{line: 2281, col: 5, offset: 68657},
+				pos: position{line: 2285, col: 5, offset: 68762},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2281, col: 5, offset: 68657},
+						pos: position{line: 2285, col: 5, offset: 68762},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2281, col: 5, offset: 68657},
+							pos: position{line: 2285, col: 5, offset: 68762},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2281, col: 5, offset: 68657},
+									pos:   position{line: 2285, col: 5, offset: 68762},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2281, col: 7, offset: 68659},
+										pos:  position{line: 2285, col: 7, offset: 68764},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2281, col: 19, offset: 68671},
+									pos:   position{line: 2285, col: 19, offset: 68776},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2281, col: 21, offset: 68673},
+										pos:  position{line: 2285, col: 21, offset: 68778},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15484,24 +15521,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2294, col: 5, offset: 68937},
+						pos: position{line: 2298, col: 5, offset: 69042},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2294, col: 5, offset: 68937},
+							pos: position{line: 2298, col: 5, offset: 69042},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2294, col: 5, offset: 68937},
+									pos:   position{line: 2298, col: 5, offset: 69042},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2294, col: 7, offset: 68939},
+										pos:  position{line: 2298, col: 7, offset: 69044},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2294, col: 20, offset: 68952},
+									pos:   position{line: 2298, col: 20, offset: 69057},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2294, col: 22, offset: 68954},
+										pos:  position{line: 2298, col: 22, offset: 69059},
 										name: "OptLimitClause",
 									},
 								},
@@ -15515,25 +15552,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2306, col: 1, offset: 69183},
+			pos:  position{line: 2310, col: 1, offset: 69288},
 			expr: &choiceExpr{
-				pos: position{line: 2307, col: 5, offset: 69202},
+				pos: position{line: 2311, col: 5, offset: 69307},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2307, col: 5, offset: 69202},
+						pos: position{line: 2311, col: 5, offset: 69307},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2307, col: 5, offset: 69202},
+							pos: position{line: 2311, col: 5, offset: 69307},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2307, col: 5, offset: 69202},
+									pos:  position{line: 2311, col: 5, offset: 69307},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2307, col: 7, offset: 69204},
+									pos:   position{line: 2311, col: 7, offset: 69309},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2307, col: 9, offset: 69206},
+										pos:  position{line: 2311, col: 9, offset: 69311},
 										name: "LimitClause",
 									},
 								},
@@ -15541,10 +15578,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2308, col: 5, offset: 69240},
+						pos: position{line: 2312, col: 5, offset: 69345},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2308, col: 5, offset: 69240},
+							pos:        position{line: 2312, col: 5, offset: 69345},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15557,50 +15594,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2310, col: 1, offset: 69277},
+			pos:  position{line: 2314, col: 1, offset: 69382},
 			expr: &choiceExpr{
-				pos: position{line: 2311, col: 5, offset: 69293},
+				pos: position{line: 2315, col: 5, offset: 69398},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2311, col: 5, offset: 69293},
+						pos: position{line: 2315, col: 5, offset: 69398},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2311, col: 5, offset: 69293},
+							pos: position{line: 2315, col: 5, offset: 69398},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2311, col: 5, offset: 69293},
+									pos:  position{line: 2315, col: 5, offset: 69398},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2311, col: 11, offset: 69299},
+									pos:  position{line: 2315, col: 11, offset: 69404},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2311, col: 13, offset: 69301},
+									pos:  position{line: 2315, col: 13, offset: 69406},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2312, col: 5, offset: 69329},
+						pos: position{line: 2316, col: 5, offset: 69434},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2312, col: 5, offset: 69329},
+							pos: position{line: 2316, col: 5, offset: 69434},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2312, col: 5, offset: 69329},
+									pos:  position{line: 2316, col: 5, offset: 69434},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2312, col: 11, offset: 69335},
+									pos:  position{line: 2316, col: 11, offset: 69440},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2312, col: 13, offset: 69337},
+									pos:   position{line: 2316, col: 13, offset: 69442},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2312, col: 15, offset: 69339},
+										pos:  position{line: 2316, col: 15, offset: 69444},
 										name: "Expr",
 									},
 								},
@@ -15614,25 +15651,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2314, col: 1, offset: 69363},
+			pos:  position{line: 2318, col: 1, offset: 69468},
 			expr: &choiceExpr{
-				pos: position{line: 2315, col: 5, offset: 69383},
+				pos: position{line: 2319, col: 5, offset: 69488},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2315, col: 5, offset: 69383},
+						pos: position{line: 2319, col: 5, offset: 69488},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2315, col: 5, offset: 69383},
+							pos: position{line: 2319, col: 5, offset: 69488},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2315, col: 5, offset: 69383},
+									pos:  position{line: 2319, col: 5, offset: 69488},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2315, col: 7, offset: 69385},
+									pos:   position{line: 2319, col: 7, offset: 69490},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2315, col: 9, offset: 69387},
+										pos:  position{line: 2319, col: 9, offset: 69492},
 										name: "OffsetClause",
 									},
 								},
@@ -15640,10 +15677,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2316, col: 5, offset: 69423},
+						pos: position{line: 2320, col: 5, offset: 69528},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2316, col: 5, offset: 69423},
+							pos:        position{line: 2320, col: 5, offset: 69528},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15656,26 +15693,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2318, col: 1, offset: 69448},
+			pos:  position{line: 2322, col: 1, offset: 69553},
 			expr: &actionExpr{
-				pos: position{line: 2319, col: 5, offset: 69465},
+				pos: position{line: 2323, col: 5, offset: 69570},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2319, col: 5, offset: 69465},
+					pos: position{line: 2323, col: 5, offset: 69570},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2319, col: 5, offset: 69465},
+							pos:  position{line: 2323, col: 5, offset: 69570},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2319, col: 12, offset: 69472},
+							pos:  position{line: 2323, col: 12, offset: 69577},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2319, col: 14, offset: 69474},
+							pos:   position{line: 2323, col: 14, offset: 69579},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2319, col: 16, offset: 69476},
+								pos:  position{line: 2323, col: 16, offset: 69581},
 								name: "Expr",
 							},
 						},
@@ -15687,60 +15724,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2321, col: 1, offset: 69501},
+			pos:  position{line: 2325, col: 1, offset: 69606},
 			expr: &choiceExpr{
-				pos: position{line: 2322, col: 5, offset: 69511},
+				pos: position{line: 2326, col: 5, offset: 69616},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2322, col: 5, offset: 69511},
+						pos: position{line: 2326, col: 5, offset: 69616},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2322, col: 5, offset: 69511},
+							pos: position{line: 2326, col: 5, offset: 69616},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2322, col: 5, offset: 69511},
+									pos:  position{line: 2326, col: 5, offset: 69616},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2322, col: 7, offset: 69513},
+									pos:  position{line: 2326, col: 7, offset: 69618},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2322, col: 13, offset: 69519},
+									pos:  position{line: 2326, col: 13, offset: 69624},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2322, col: 15, offset: 69521},
+									pos:  position{line: 2326, col: 15, offset: 69626},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2323, col: 5, offset: 69557},
+						pos: position{line: 2327, col: 5, offset: 69662},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2323, col: 5, offset: 69557},
+							pos: position{line: 2327, col: 5, offset: 69662},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 5, offset: 69557},
+									pos:  position{line: 2327, col: 5, offset: 69662},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 7, offset: 69559},
+									pos:  position{line: 2327, col: 7, offset: 69664},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2323, col: 13, offset: 69565},
+									pos: position{line: 2327, col: 13, offset: 69670},
 									expr: &seqExpr{
-										pos: position{line: 2323, col: 14, offset: 69566},
+										pos: position{line: 2327, col: 14, offset: 69671},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2323, col: 14, offset: 69566},
+												pos:  position{line: 2327, col: 14, offset: 69671},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2323, col: 16, offset: 69568},
+												pos:  position{line: 2327, col: 16, offset: 69673},
 												name: "DISTINCT",
 											},
 										},
@@ -15756,84 +15793,84 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2326, col: 1, offset: 69620},
+			pos:  position{line: 2330, col: 1, offset: 69725},
 			expr: &choiceExpr{
-				pos: position{line: 2327, col: 5, offset: 69635},
+				pos: position{line: 2331, col: 5, offset: 69740},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2327, col: 5, offset: 69635},
+						pos:  position{line: 2331, col: 5, offset: 69740},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2327, col: 12, offset: 69642},
+						pos:  position{line: 2331, col: 12, offset: 69747},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2327, col: 20, offset: 69650},
+						pos:  position{line: 2331, col: 20, offset: 69755},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2327, col: 29, offset: 69659},
+						pos:  position{line: 2331, col: 29, offset: 69764},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2327, col: 38, offset: 69668},
+						pos:  position{line: 2331, col: 38, offset: 69773},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2328, col: 5, offset: 69682},
+						pos:  position{line: 2332, col: 5, offset: 69787},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2328, col: 13, offset: 69690},
+						pos:  position{line: 2332, col: 13, offset: 69795},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2328, col: 20, offset: 69697},
+						pos:  position{line: 2332, col: 20, offset: 69802},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2328, col: 28, offset: 69705},
+						pos:  position{line: 2332, col: 28, offset: 69810},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2328, col: 36, offset: 69713},
+						pos:  position{line: 2332, col: 36, offset: 69818},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2328, col: 44, offset: 69721},
+						pos:  position{line: 2332, col: 44, offset: 69826},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2329, col: 5, offset: 69730},
+						pos:  position{line: 2333, col: 5, offset: 69835},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2330, col: 5, offset: 69740},
+						pos:  position{line: 2334, col: 5, offset: 69845},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2331, col: 5, offset: 69750},
+						pos:  position{line: 2335, col: 5, offset: 69855},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2332, col: 5, offset: 69761},
+						pos:  position{line: 2336, col: 5, offset: 69866},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2333, col: 5, offset: 69771},
+						pos:  position{line: 2337, col: 5, offset: 69876},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2334, col: 5, offset: 69781},
+						pos:  position{line: 2338, col: 5, offset: 69886},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2335, col: 5, offset: 69790},
+						pos:  position{line: 2339, col: 5, offset: 69895},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 5, offset: 69800},
+						pos:  position{line: 2340, col: 5, offset: 69905},
 						name: "ON",
 					},
 				},
@@ -15843,20 +15880,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2338, col: 1, offset: 69804},
+			pos:  position{line: 2342, col: 1, offset: 69909},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 69817},
+				pos: position{line: 2342, col: 14, offset: 69922},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 69817},
+						pos:        position{line: 2342, col: 14, offset: 69922},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 69836},
+						pos: position{line: 2342, col: 33, offset: 69941},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 69837},
+							pos:  position{line: 2342, col: 34, offset: 69942},
 							name: "IdentifierRest",
 						},
 					},
@@ -15867,20 +15904,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2339, col: 1, offset: 69852},
+			pos:  position{line: 2343, col: 1, offset: 69957},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 69865},
+				pos: position{line: 2343, col: 14, offset: 69970},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 69865},
+						pos:        position{line: 2343, col: 14, offset: 69970},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 69884},
+						pos: position{line: 2343, col: 33, offset: 69989},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 69885},
+							pos:  position{line: 2343, col: 34, offset: 69990},
 							name: "IdentifierRest",
 						},
 					},
@@ -15891,23 +15928,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2340, col: 1, offset: 69900},
+			pos:  position{line: 2344, col: 1, offset: 70005},
 			expr: &actionExpr{
-				pos: position{line: 2340, col: 14, offset: 69913},
+				pos: position{line: 2344, col: 14, offset: 70018},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2340, col: 14, offset: 69913},
+					pos: position{line: 2344, col: 14, offset: 70018},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2340, col: 14, offset: 69913},
+							pos:        position{line: 2344, col: 14, offset: 70018},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2340, col: 33, offset: 69932},
+							pos: position{line: 2344, col: 33, offset: 70037},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2340, col: 34, offset: 69933},
+								pos:  position{line: 2344, col: 34, offset: 70038},
 								name: "IdentifierRest",
 							},
 						},
@@ -15919,20 +15956,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2341, col: 1, offset: 69970},
+			pos:  position{line: 2345, col: 1, offset: 70075},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 69983},
+				pos: position{line: 2345, col: 14, offset: 70088},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 69983},
+						pos:        position{line: 2345, col: 14, offset: 70088},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 70002},
+						pos: position{line: 2345, col: 33, offset: 70107},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 70003},
+							pos:  position{line: 2345, col: 34, offset: 70108},
 							name: "IdentifierRest",
 						},
 					},
@@ -15943,20 +15980,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2342, col: 1, offset: 70018},
+			pos:  position{line: 2346, col: 1, offset: 70123},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 70031},
+				pos: position{line: 2346, col: 14, offset: 70136},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 70031},
+						pos:        position{line: 2346, col: 14, offset: 70136},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 70050},
+						pos: position{line: 2346, col: 33, offset: 70155},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 70051},
+							pos:  position{line: 2346, col: 34, offset: 70156},
 							name: "IdentifierRest",
 						},
 					},
@@ -15967,23 +16004,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2343, col: 1, offset: 70066},
+			pos:  position{line: 2347, col: 1, offset: 70171},
 			expr: &actionExpr{
-				pos: position{line: 2343, col: 14, offset: 70079},
+				pos: position{line: 2347, col: 14, offset: 70184},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2343, col: 14, offset: 70079},
+					pos: position{line: 2347, col: 14, offset: 70184},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2343, col: 14, offset: 70079},
+							pos:        position{line: 2347, col: 14, offset: 70184},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2343, col: 33, offset: 70098},
+							pos: position{line: 2347, col: 33, offset: 70203},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2343, col: 34, offset: 70099},
+								pos:  position{line: 2347, col: 34, offset: 70204},
 								name: "IdentifierRest",
 							},
 						},
@@ -15995,20 +16032,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2344, col: 1, offset: 70136},
+			pos:  position{line: 2348, col: 1, offset: 70241},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 70149},
+				pos: position{line: 2348, col: 14, offset: 70254},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 70149},
+						pos:        position{line: 2348, col: 14, offset: 70254},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 70168},
+						pos: position{line: 2348, col: 33, offset: 70273},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 70169},
+							pos:  position{line: 2348, col: 34, offset: 70274},
 							name: "IdentifierRest",
 						},
 					},
@@ -16019,20 +16056,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2345, col: 1, offset: 70184},
+			pos:  position{line: 2349, col: 1, offset: 70289},
 			expr: &seqExpr{
-				pos: position{line: 2345, col: 14, offset: 70197},
+				pos: position{line: 2349, col: 14, offset: 70302},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2345, col: 14, offset: 70197},
+						pos:        position{line: 2349, col: 14, offset: 70302},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2345, col: 33, offset: 70216},
+						pos: position{line: 2349, col: 33, offset: 70321},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2345, col: 34, offset: 70217},
+							pos:  position{line: 2349, col: 34, offset: 70322},
 							name: "IdentifierRest",
 						},
 					},
@@ -16043,20 +16080,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2346, col: 1, offset: 70232},
+			pos:  position{line: 2350, col: 1, offset: 70337},
 			expr: &seqExpr{
-				pos: position{line: 2346, col: 14, offset: 70245},
+				pos: position{line: 2350, col: 14, offset: 70350},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2346, col: 14, offset: 70245},
+						pos:        position{line: 2350, col: 14, offset: 70350},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2346, col: 33, offset: 70264},
+						pos: position{line: 2350, col: 33, offset: 70369},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2346, col: 34, offset: 70265},
+							pos:  position{line: 2350, col: 34, offset: 70370},
 							name: "IdentifierRest",
 						},
 					},
@@ -16067,20 +16104,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2347, col: 1, offset: 70280},
+			pos:  position{line: 2351, col: 1, offset: 70385},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 70293},
+				pos: position{line: 2351, col: 14, offset: 70398},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 70293},
+						pos:        position{line: 2351, col: 14, offset: 70398},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 70312},
+						pos: position{line: 2351, col: 33, offset: 70417},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 70313},
+							pos:  position{line: 2351, col: 34, offset: 70418},
 							name: "IdentifierRest",
 						},
 					},
@@ -16091,20 +16128,20 @@ var g = &grammar{
 		},
 		{
 			name: "CALL",
-			pos:  position{line: 2348, col: 1, offset: 70328},
+			pos:  position{line: 2352, col: 1, offset: 70433},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 70341},
+				pos: position{line: 2352, col: 14, offset: 70446},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 70341},
+						pos:        position{line: 2352, col: 14, offset: 70446},
 						val:        "call",
 						ignoreCase: true,
 						want:       "\"CALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 70360},
+						pos: position{line: 2352, col: 33, offset: 70465},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 70361},
+							pos:  position{line: 2352, col: 34, offset: 70466},
 							name: "IdentifierRest",
 						},
 					},
@@ -16115,20 +16152,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2349, col: 1, offset: 70376},
+			pos:  position{line: 2353, col: 1, offset: 70481},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 70389},
+				pos: position{line: 2353, col: 14, offset: 70494},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 70389},
+						pos:        position{line: 2353, col: 14, offset: 70494},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 70408},
+						pos: position{line: 2353, col: 33, offset: 70513},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 70409},
+							pos:  position{line: 2353, col: 34, offset: 70514},
 							name: "IdentifierRest",
 						},
 					},
@@ -16139,20 +16176,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2350, col: 1, offset: 70424},
+			pos:  position{line: 2354, col: 1, offset: 70529},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 70437},
+				pos: position{line: 2354, col: 14, offset: 70542},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 70437},
+						pos:        position{line: 2354, col: 14, offset: 70542},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 70456},
+						pos: position{line: 2354, col: 33, offset: 70561},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 70457},
+							pos:  position{line: 2354, col: 34, offset: 70562},
 							name: "IdentifierRest",
 						},
 					},
@@ -16163,20 +16200,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2351, col: 1, offset: 70472},
+			pos:  position{line: 2355, col: 1, offset: 70577},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 70485},
+				pos: position{line: 2355, col: 14, offset: 70590},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 70485},
+						pos:        position{line: 2355, col: 14, offset: 70590},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 70504},
+						pos: position{line: 2355, col: 33, offset: 70609},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 70505},
+							pos:  position{line: 2355, col: 34, offset: 70610},
 							name: "IdentifierRest",
 						},
 					},
@@ -16187,20 +16224,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2352, col: 1, offset: 70520},
+			pos:  position{line: 2356, col: 1, offset: 70625},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 70533},
+				pos: position{line: 2356, col: 14, offset: 70638},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 70533},
+						pos:        position{line: 2356, col: 14, offset: 70638},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 70552},
+						pos: position{line: 2356, col: 33, offset: 70657},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 70553},
+							pos:  position{line: 2356, col: 34, offset: 70658},
 							name: "IdentifierRest",
 						},
 					},
@@ -16211,20 +16248,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2353, col: 1, offset: 70568},
+			pos:  position{line: 2357, col: 1, offset: 70673},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 70581},
+				pos: position{line: 2357, col: 14, offset: 70686},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 70581},
+						pos:        position{line: 2357, col: 14, offset: 70686},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 70600},
+						pos: position{line: 2357, col: 33, offset: 70705},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 70601},
+							pos:  position{line: 2357, col: 34, offset: 70706},
 							name: "IdentifierRest",
 						},
 					},
@@ -16235,20 +16272,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2354, col: 1, offset: 70616},
+			pos:  position{line: 2358, col: 1, offset: 70721},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 70629},
+				pos: position{line: 2358, col: 14, offset: 70734},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 70629},
+						pos:        position{line: 2358, col: 14, offset: 70734},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 70648},
+						pos: position{line: 2358, col: 33, offset: 70753},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 70649},
+							pos:  position{line: 2358, col: 34, offset: 70754},
 							name: "IdentifierRest",
 						},
 					},
@@ -16259,23 +16296,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2355, col: 1, offset: 70664},
+			pos:  position{line: 2359, col: 1, offset: 70769},
 			expr: &actionExpr{
-				pos: position{line: 2355, col: 14, offset: 70677},
+				pos: position{line: 2359, col: 14, offset: 70782},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2355, col: 14, offset: 70677},
+					pos: position{line: 2359, col: 14, offset: 70782},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2355, col: 14, offset: 70677},
+							pos:        position{line: 2359, col: 14, offset: 70782},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2355, col: 33, offset: 70696},
+							pos: position{line: 2359, col: 33, offset: 70801},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2355, col: 34, offset: 70697},
+								pos:  position{line: 2359, col: 34, offset: 70802},
 								name: "IdentifierRest",
 							},
 						},
@@ -16287,20 +16324,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2356, col: 1, offset: 70735},
+			pos:  position{line: 2360, col: 1, offset: 70840},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 70748},
+				pos: position{line: 2360, col: 14, offset: 70853},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 70748},
+						pos:        position{line: 2360, col: 14, offset: 70853},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 70767},
+						pos: position{line: 2360, col: 33, offset: 70872},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 70768},
+							pos:  position{line: 2360, col: 34, offset: 70873},
 							name: "IdentifierRest",
 						},
 					},
@@ -16311,20 +16348,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2357, col: 1, offset: 70783},
+			pos:  position{line: 2361, col: 1, offset: 70888},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 70796},
+				pos: position{line: 2361, col: 14, offset: 70901},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 70796},
+						pos:        position{line: 2361, col: 14, offset: 70901},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 70815},
+						pos: position{line: 2361, col: 33, offset: 70920},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 70816},
+							pos:  position{line: 2361, col: 34, offset: 70921},
 							name: "IdentifierRest",
 						},
 					},
@@ -16335,23 +16372,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2358, col: 1, offset: 70831},
+			pos:  position{line: 2362, col: 1, offset: 70936},
 			expr: &actionExpr{
-				pos: position{line: 2358, col: 14, offset: 70844},
+				pos: position{line: 2362, col: 14, offset: 70949},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2358, col: 14, offset: 70844},
+					pos: position{line: 2362, col: 14, offset: 70949},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2358, col: 14, offset: 70844},
+							pos:        position{line: 2362, col: 14, offset: 70949},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2358, col: 33, offset: 70863},
+							pos: position{line: 2362, col: 33, offset: 70968},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2358, col: 34, offset: 70864},
+								pos:  position{line: 2362, col: 34, offset: 70969},
 								name: "IdentifierRest",
 							},
 						},
@@ -16363,20 +16400,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2359, col: 1, offset: 70902},
+			pos:  position{line: 2363, col: 1, offset: 71007},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 70915},
+				pos: position{line: 2363, col: 14, offset: 71020},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 70915},
+						pos:        position{line: 2363, col: 14, offset: 71020},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 70934},
+						pos: position{line: 2363, col: 33, offset: 71039},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 70935},
+							pos:  position{line: 2363, col: 34, offset: 71040},
 							name: "IdentifierRest",
 						},
 					},
@@ -16387,20 +16424,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2360, col: 1, offset: 70950},
+			pos:  position{line: 2364, col: 1, offset: 71055},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 70963},
+				pos: position{line: 2364, col: 14, offset: 71068},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 70963},
+						pos:        position{line: 2364, col: 14, offset: 71068},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 70982},
+						pos: position{line: 2364, col: 33, offset: 71087},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 70983},
+							pos:  position{line: 2364, col: 34, offset: 71088},
 							name: "IdentifierRest",
 						},
 					},
@@ -16411,20 +16448,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2361, col: 1, offset: 70998},
+			pos:  position{line: 2365, col: 1, offset: 71103},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 71011},
+				pos: position{line: 2365, col: 14, offset: 71116},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 71011},
+						pos:        position{line: 2365, col: 14, offset: 71116},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 71030},
+						pos: position{line: 2365, col: 33, offset: 71135},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 71031},
+							pos:  position{line: 2365, col: 34, offset: 71136},
 							name: "IdentifierRest",
 						},
 					},
@@ -16435,20 +16472,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2362, col: 1, offset: 71046},
+			pos:  position{line: 2366, col: 1, offset: 71151},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 71059},
+				pos: position{line: 2366, col: 14, offset: 71164},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 71059},
+						pos:        position{line: 2366, col: 14, offset: 71164},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 71078},
+						pos: position{line: 2366, col: 33, offset: 71183},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 71079},
+							pos:  position{line: 2366, col: 34, offset: 71184},
 							name: "IdentifierRest",
 						},
 					},
@@ -16459,20 +16496,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2363, col: 1, offset: 71094},
+			pos:  position{line: 2367, col: 1, offset: 71199},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 71107},
+				pos: position{line: 2367, col: 14, offset: 71212},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 71107},
+						pos:        position{line: 2367, col: 14, offset: 71212},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 71126},
+						pos: position{line: 2367, col: 33, offset: 71231},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 71127},
+							pos:  position{line: 2367, col: 34, offset: 71232},
 							name: "IdentifierRest",
 						},
 					},
@@ -16483,20 +16520,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2364, col: 1, offset: 71142},
+			pos:  position{line: 2368, col: 1, offset: 71247},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 71155},
+				pos: position{line: 2368, col: 14, offset: 71260},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 71155},
+						pos:        position{line: 2368, col: 14, offset: 71260},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 71174},
+						pos: position{line: 2368, col: 33, offset: 71279},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 71175},
+							pos:  position{line: 2368, col: 34, offset: 71280},
 							name: "IdentifierRest",
 						},
 					},
@@ -16507,20 +16544,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2365, col: 1, offset: 71190},
+			pos:  position{line: 2369, col: 1, offset: 71295},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 71203},
+				pos: position{line: 2369, col: 14, offset: 71308},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 71203},
+						pos:        position{line: 2369, col: 14, offset: 71308},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 71222},
+						pos: position{line: 2369, col: 33, offset: 71327},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 71223},
+							pos:  position{line: 2369, col: 34, offset: 71328},
 							name: "IdentifierRest",
 						},
 					},
@@ -16531,20 +16568,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2366, col: 1, offset: 71238},
+			pos:  position{line: 2370, col: 1, offset: 71343},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 71251},
+				pos: position{line: 2370, col: 14, offset: 71356},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 71251},
+						pos:        position{line: 2370, col: 14, offset: 71356},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 71270},
+						pos: position{line: 2370, col: 33, offset: 71375},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 71271},
+							pos:  position{line: 2370, col: 34, offset: 71376},
 							name: "IdentifierRest",
 						},
 					},
@@ -16555,20 +16592,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2367, col: 1, offset: 71286},
+			pos:  position{line: 2371, col: 1, offset: 71391},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 71299},
+				pos: position{line: 2371, col: 14, offset: 71404},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 71299},
+						pos:        position{line: 2371, col: 14, offset: 71404},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 71318},
+						pos: position{line: 2371, col: 33, offset: 71423},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 71319},
+							pos:  position{line: 2371, col: 34, offset: 71424},
 							name: "IdentifierRest",
 						},
 					},
@@ -16579,20 +16616,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2368, col: 1, offset: 71334},
+			pos:  position{line: 2372, col: 1, offset: 71439},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 71347},
+				pos: position{line: 2372, col: 14, offset: 71452},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 71347},
+						pos:        position{line: 2372, col: 14, offset: 71452},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 71366},
+						pos: position{line: 2372, col: 33, offset: 71471},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 71367},
+							pos:  position{line: 2372, col: 34, offset: 71472},
 							name: "IdentifierRest",
 						},
 					},
@@ -16603,20 +16640,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2369, col: 1, offset: 71382},
+			pos:  position{line: 2373, col: 1, offset: 71487},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 71395},
+				pos: position{line: 2373, col: 14, offset: 71500},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 71395},
+						pos:        position{line: 2373, col: 14, offset: 71500},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 71414},
+						pos: position{line: 2373, col: 33, offset: 71519},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 71415},
+							pos:  position{line: 2373, col: 34, offset: 71520},
 							name: "IdentifierRest",
 						},
 					},
@@ -16627,20 +16664,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2370, col: 1, offset: 71430},
+			pos:  position{line: 2374, col: 1, offset: 71535},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 71443},
+				pos: position{line: 2374, col: 14, offset: 71548},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 71443},
+						pos:        position{line: 2374, col: 14, offset: 71548},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 71462},
+						pos: position{line: 2374, col: 33, offset: 71567},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 71463},
+							pos:  position{line: 2374, col: 34, offset: 71568},
 							name: "IdentifierRest",
 						},
 					},
@@ -16651,20 +16688,20 @@ var g = &grammar{
 		},
 		{
 			name: "FN",
-			pos:  position{line: 2371, col: 1, offset: 71478},
+			pos:  position{line: 2375, col: 1, offset: 71583},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 71491},
+				pos: position{line: 2375, col: 14, offset: 71596},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 71491},
+						pos:        position{line: 2375, col: 14, offset: 71596},
 						val:        "fn",
 						ignoreCase: true,
 						want:       "\"FN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 71510},
+						pos: position{line: 2375, col: 33, offset: 71615},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 71511},
+							pos:  position{line: 2375, col: 34, offset: 71616},
 							name: "IdentifierRest",
 						},
 					},
@@ -16675,20 +16712,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2372, col: 1, offset: 71526},
+			pos:  position{line: 2376, col: 1, offset: 71631},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 71539},
+				pos: position{line: 2376, col: 14, offset: 71644},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 71539},
+						pos:        position{line: 2376, col: 14, offset: 71644},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 71558},
+						pos: position{line: 2376, col: 33, offset: 71663},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 71559},
+							pos:  position{line: 2376, col: 34, offset: 71664},
 							name: "IdentifierRest",
 						},
 					},
@@ -16699,20 +16736,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2373, col: 1, offset: 71574},
+			pos:  position{line: 2377, col: 1, offset: 71679},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 71587},
+				pos: position{line: 2377, col: 14, offset: 71692},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 71587},
+						pos:        position{line: 2377, col: 14, offset: 71692},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 71606},
+						pos: position{line: 2377, col: 33, offset: 71711},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 71607},
+							pos:  position{line: 2377, col: 34, offset: 71712},
 							name: "IdentifierRest",
 						},
 					},
@@ -16723,20 +16760,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2374, col: 1, offset: 71622},
+			pos:  position{line: 2378, col: 1, offset: 71727},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 71635},
+				pos: position{line: 2378, col: 14, offset: 71740},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 71635},
+						pos:        position{line: 2378, col: 14, offset: 71740},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 71654},
+						pos: position{line: 2378, col: 33, offset: 71759},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 71655},
+							pos:  position{line: 2378, col: 34, offset: 71760},
 							name: "IdentifierRest",
 						},
 					},
@@ -16747,20 +16784,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2375, col: 1, offset: 71670},
+			pos:  position{line: 2379, col: 1, offset: 71775},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 71683},
+				pos: position{line: 2379, col: 14, offset: 71788},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 71683},
+						pos:        position{line: 2379, col: 14, offset: 71788},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 71702},
+						pos: position{line: 2379, col: 33, offset: 71807},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 71703},
+							pos:  position{line: 2379, col: 34, offset: 71808},
 							name: "IdentifierRest",
 						},
 					},
@@ -16771,20 +16808,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2376, col: 1, offset: 71718},
+			pos:  position{line: 2380, col: 1, offset: 71823},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 71731},
+				pos: position{line: 2380, col: 14, offset: 71836},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 71731},
+						pos:        position{line: 2380, col: 14, offset: 71836},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 71750},
+						pos: position{line: 2380, col: 33, offset: 71855},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 71751},
+							pos:  position{line: 2380, col: 34, offset: 71856},
 							name: "IdentifierRest",
 						},
 					},
@@ -16795,20 +16832,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2377, col: 1, offset: 71766},
+			pos:  position{line: 2381, col: 1, offset: 71871},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 71779},
+				pos: position{line: 2381, col: 14, offset: 71884},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 71779},
+						pos:        position{line: 2381, col: 14, offset: 71884},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 71798},
+						pos: position{line: 2381, col: 33, offset: 71903},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 71799},
+							pos:  position{line: 2381, col: 34, offset: 71904},
 							name: "IdentifierRest",
 						},
 					},
@@ -16819,20 +16856,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2378, col: 1, offset: 71814},
+			pos:  position{line: 2382, col: 1, offset: 71919},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 71827},
+				pos: position{line: 2382, col: 14, offset: 71932},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 71827},
+						pos:        position{line: 2382, col: 14, offset: 71932},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 71846},
+						pos: position{line: 2382, col: 33, offset: 71951},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 71847},
+							pos:  position{line: 2382, col: 34, offset: 71952},
 							name: "IdentifierRest",
 						},
 					},
@@ -16843,20 +16880,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2379, col: 1, offset: 71862},
+			pos:  position{line: 2383, col: 1, offset: 71967},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 71875},
+				pos: position{line: 2383, col: 14, offset: 71980},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 71875},
+						pos:        position{line: 2383, col: 14, offset: 71980},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 71894},
+						pos: position{line: 2383, col: 33, offset: 71999},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 71895},
+							pos:  position{line: 2383, col: 34, offset: 72000},
 							name: "IdentifierRest",
 						},
 					},
@@ -16867,20 +16904,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2380, col: 1, offset: 71910},
+			pos:  position{line: 2384, col: 1, offset: 72015},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 71923},
+				pos: position{line: 2384, col: 14, offset: 72028},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 71923},
+						pos:        position{line: 2384, col: 14, offset: 72028},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 71942},
+						pos: position{line: 2384, col: 33, offset: 72047},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 71943},
+							pos:  position{line: 2384, col: 34, offset: 72048},
 							name: "IdentifierRest",
 						},
 					},
@@ -16891,20 +16928,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2381, col: 1, offset: 71958},
+			pos:  position{line: 2385, col: 1, offset: 72063},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 71971},
+				pos: position{line: 2385, col: 14, offset: 72076},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 71971},
+						pos:        position{line: 2385, col: 14, offset: 72076},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 71990},
+						pos: position{line: 2385, col: 33, offset: 72095},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 71991},
+							pos:  position{line: 2385, col: 34, offset: 72096},
 							name: "IdentifierRest",
 						},
 					},
@@ -16915,20 +16952,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2382, col: 1, offset: 72006},
+			pos:  position{line: 2386, col: 1, offset: 72111},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 72019},
+				pos: position{line: 2386, col: 14, offset: 72124},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 72019},
+						pos:        position{line: 2386, col: 14, offset: 72124},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 72038},
+						pos: position{line: 2386, col: 33, offset: 72143},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 72039},
+							pos:  position{line: 2386, col: 34, offset: 72144},
 							name: "IdentifierRest",
 						},
 					},
@@ -16939,20 +16976,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2383, col: 1, offset: 72054},
+			pos:  position{line: 2387, col: 1, offset: 72159},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 72067},
+				pos: position{line: 2387, col: 14, offset: 72172},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 72067},
+						pos:        position{line: 2387, col: 14, offset: 72172},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 72086},
+						pos: position{line: 2387, col: 33, offset: 72191},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 72087},
+							pos:  position{line: 2387, col: 34, offset: 72192},
 							name: "IdentifierRest",
 						},
 					},
@@ -16963,20 +17000,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAMBDA",
-			pos:  position{line: 2384, col: 1, offset: 72102},
+			pos:  position{line: 2388, col: 1, offset: 72207},
 			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 72115},
+				pos: position{line: 2388, col: 14, offset: 72220},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 72115},
+						pos:        position{line: 2388, col: 14, offset: 72220},
 						val:        "lambda",
 						ignoreCase: true,
 						want:       "\"LAMBDA\"i",
 					},
 					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 72134},
+						pos: position{line: 2388, col: 33, offset: 72239},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 72135},
+							pos:  position{line: 2388, col: 34, offset: 72240},
 							name: "IdentifierRest",
 						},
 					},
@@ -16987,20 +17024,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2385, col: 1, offset: 72150},
+			pos:  position{line: 2389, col: 1, offset: 72255},
 			expr: &seqExpr{
-				pos: position{line: 2385, col: 14, offset: 72163},
+				pos: position{line: 2389, col: 14, offset: 72268},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2385, col: 14, offset: 72163},
+						pos:        position{line: 2389, col: 14, offset: 72268},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2385, col: 33, offset: 72182},
+						pos: position{line: 2389, col: 33, offset: 72287},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 34, offset: 72183},
+							pos:  position{line: 2389, col: 34, offset: 72288},
 							name: "IdentifierRest",
 						},
 					},
@@ -17011,20 +17048,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2386, col: 1, offset: 72198},
+			pos:  position{line: 2390, col: 1, offset: 72303},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 72211},
+				pos: position{line: 2390, col: 14, offset: 72316},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 72211},
+						pos:        position{line: 2390, col: 14, offset: 72316},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 72230},
+						pos: position{line: 2390, col: 33, offset: 72335},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 72231},
+							pos:  position{line: 2390, col: 34, offset: 72336},
 							name: "IdentifierRest",
 						},
 					},
@@ -17035,20 +17072,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2387, col: 1, offset: 72246},
+			pos:  position{line: 2391, col: 1, offset: 72351},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 72259},
+				pos: position{line: 2391, col: 14, offset: 72364},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 72259},
+						pos:        position{line: 2391, col: 14, offset: 72364},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 72278},
+						pos: position{line: 2391, col: 33, offset: 72383},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 72279},
+							pos:  position{line: 2391, col: 34, offset: 72384},
 							name: "IdentifierRest",
 						},
 					},
@@ -17059,20 +17096,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2388, col: 1, offset: 72294},
+			pos:  position{line: 2392, col: 1, offset: 72399},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 72307},
+				pos: position{line: 2392, col: 14, offset: 72412},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 72307},
+						pos:        position{line: 2392, col: 14, offset: 72412},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 72326},
+						pos: position{line: 2392, col: 33, offset: 72431},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 72327},
+							pos:  position{line: 2392, col: 34, offset: 72432},
 							name: "IdentifierRest",
 						},
 					},
@@ -17083,20 +17120,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2389, col: 1, offset: 72342},
+			pos:  position{line: 2393, col: 1, offset: 72447},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 72355},
+				pos: position{line: 2393, col: 14, offset: 72460},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 72355},
+						pos:        position{line: 2393, col: 14, offset: 72460},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 72374},
+						pos: position{line: 2393, col: 33, offset: 72479},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 72375},
+							pos:  position{line: 2393, col: 34, offset: 72480},
 							name: "IdentifierRest",
 						},
 					},
@@ -17107,20 +17144,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2390, col: 1, offset: 72390},
+			pos:  position{line: 2394, col: 1, offset: 72495},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 16, offset: 72405},
+				pos: position{line: 2394, col: 16, offset: 72510},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 16, offset: 72405},
+						pos:        position{line: 2394, col: 16, offset: 72510},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 72422},
+						pos: position{line: 2394, col: 33, offset: 72527},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 72423},
+							pos:  position{line: 2394, col: 34, offset: 72528},
 							name: "IdentifierRest",
 						},
 					},
@@ -17131,20 +17168,20 @@ var g = &grammar{
 		},
 		{
 			name: "MAP",
-			pos:  position{line: 2391, col: 1, offset: 72438},
+			pos:  position{line: 2395, col: 1, offset: 72543},
 			expr: &seqExpr{
-				pos: position{line: 2391, col: 14, offset: 72451},
+				pos: position{line: 2395, col: 14, offset: 72556},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2391, col: 14, offset: 72451},
+						pos:        position{line: 2395, col: 14, offset: 72556},
 						val:        "map",
 						ignoreCase: true,
 						want:       "\"MAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2391, col: 33, offset: 72470},
+						pos: position{line: 2395, col: 33, offset: 72575},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2391, col: 34, offset: 72471},
+							pos:  position{line: 2395, col: 34, offset: 72576},
 							name: "IdentifierRest",
 						},
 					},
@@ -17155,20 +17192,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2392, col: 1, offset: 72486},
+			pos:  position{line: 2396, col: 1, offset: 72591},
 			expr: &seqExpr{
-				pos: position{line: 2392, col: 14, offset: 72499},
+				pos: position{line: 2396, col: 14, offset: 72604},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2392, col: 14, offset: 72499},
+						pos:        position{line: 2396, col: 14, offset: 72604},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2392, col: 33, offset: 72518},
+						pos: position{line: 2396, col: 33, offset: 72623},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2392, col: 34, offset: 72519},
+							pos:  position{line: 2396, col: 34, offset: 72624},
 							name: "IdentifierRest",
 						},
 					},
@@ -17179,20 +17216,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2393, col: 1, offset: 72534},
+			pos:  position{line: 2397, col: 1, offset: 72639},
 			expr: &seqExpr{
-				pos: position{line: 2393, col: 14, offset: 72547},
+				pos: position{line: 2397, col: 14, offset: 72652},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2393, col: 14, offset: 72547},
+						pos:        position{line: 2397, col: 14, offset: 72652},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2393, col: 33, offset: 72566},
+						pos: position{line: 2397, col: 33, offset: 72671},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2393, col: 34, offset: 72567},
+							pos:  position{line: 2397, col: 34, offset: 72672},
 							name: "IdentifierRest",
 						},
 					},
@@ -17203,20 +17240,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2394, col: 1, offset: 72582},
+			pos:  position{line: 2398, col: 1, offset: 72687},
 			expr: &seqExpr{
-				pos: position{line: 2394, col: 14, offset: 72595},
+				pos: position{line: 2398, col: 14, offset: 72700},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2394, col: 14, offset: 72595},
+						pos:        position{line: 2398, col: 14, offset: 72700},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2394, col: 33, offset: 72614},
+						pos: position{line: 2398, col: 33, offset: 72719},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2394, col: 34, offset: 72615},
+							pos:  position{line: 2398, col: 34, offset: 72720},
 							name: "IdentifierRest",
 						},
 					},
@@ -17227,20 +17264,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2395, col: 1, offset: 72630},
+			pos:  position{line: 2399, col: 1, offset: 72735},
 			expr: &seqExpr{
-				pos: position{line: 2395, col: 14, offset: 72643},
+				pos: position{line: 2399, col: 14, offset: 72748},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2395, col: 14, offset: 72643},
+						pos:        position{line: 2399, col: 14, offset: 72748},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2395, col: 33, offset: 72662},
+						pos: position{line: 2399, col: 33, offset: 72767},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2395, col: 34, offset: 72663},
+							pos:  position{line: 2399, col: 34, offset: 72768},
 							name: "IdentifierRest",
 						},
 					},
@@ -17251,20 +17288,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2396, col: 1, offset: 72678},
+			pos:  position{line: 2400, col: 1, offset: 72783},
 			expr: &seqExpr{
-				pos: position{line: 2396, col: 14, offset: 72691},
+				pos: position{line: 2400, col: 14, offset: 72796},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2396, col: 14, offset: 72691},
+						pos:        position{line: 2400, col: 14, offset: 72796},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2396, col: 33, offset: 72710},
+						pos: position{line: 2400, col: 33, offset: 72815},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2396, col: 34, offset: 72711},
+							pos:  position{line: 2400, col: 34, offset: 72816},
 							name: "IdentifierRest",
 						},
 					},
@@ -17275,20 +17312,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2397, col: 1, offset: 72726},
+			pos:  position{line: 2401, col: 1, offset: 72831},
 			expr: &seqExpr{
-				pos: position{line: 2397, col: 14, offset: 72739},
+				pos: position{line: 2401, col: 14, offset: 72844},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2397, col: 14, offset: 72739},
+						pos:        position{line: 2401, col: 14, offset: 72844},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2397, col: 33, offset: 72758},
+						pos: position{line: 2401, col: 33, offset: 72863},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2397, col: 34, offset: 72759},
+							pos:  position{line: 2401, col: 34, offset: 72864},
 							name: "IdentifierRest",
 						},
 					},
@@ -17299,20 +17336,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2398, col: 1, offset: 72774},
+			pos:  position{line: 2402, col: 1, offset: 72879},
 			expr: &seqExpr{
-				pos: position{line: 2398, col: 14, offset: 72787},
+				pos: position{line: 2402, col: 14, offset: 72892},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2398, col: 14, offset: 72787},
+						pos:        position{line: 2402, col: 14, offset: 72892},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2398, col: 33, offset: 72806},
+						pos: position{line: 2402, col: 33, offset: 72911},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2398, col: 34, offset: 72807},
+							pos:  position{line: 2402, col: 34, offset: 72912},
 							name: "IdentifierRest",
 						},
 					},
@@ -17323,23 +17360,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2399, col: 1, offset: 72822},
+			pos:  position{line: 2403, col: 1, offset: 72927},
 			expr: &actionExpr{
-				pos: position{line: 2399, col: 14, offset: 72835},
+				pos: position{line: 2403, col: 14, offset: 72940},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2399, col: 14, offset: 72835},
+					pos: position{line: 2403, col: 14, offset: 72940},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2399, col: 14, offset: 72835},
+							pos:        position{line: 2403, col: 14, offset: 72940},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2399, col: 33, offset: 72854},
+							pos: position{line: 2403, col: 33, offset: 72959},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2399, col: 34, offset: 72855},
+								pos:  position{line: 2403, col: 34, offset: 72960},
 								name: "IdentifierRest",
 							},
 						},
@@ -17351,20 +17388,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2400, col: 1, offset: 72891},
+			pos:  position{line: 2404, col: 1, offset: 72996},
 			expr: &seqExpr{
-				pos: position{line: 2400, col: 14, offset: 72904},
+				pos: position{line: 2404, col: 14, offset: 73009},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2400, col: 14, offset: 72904},
+						pos:        position{line: 2404, col: 14, offset: 73009},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2400, col: 33, offset: 72923},
+						pos: position{line: 2404, col: 33, offset: 73028},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2400, col: 34, offset: 72924},
+							pos:  position{line: 2404, col: 34, offset: 73029},
 							name: "IdentifierRest",
 						},
 					},
@@ -17375,20 +17412,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2401, col: 1, offset: 72939},
+			pos:  position{line: 2405, col: 1, offset: 73044},
 			expr: &seqExpr{
-				pos: position{line: 2401, col: 14, offset: 72952},
+				pos: position{line: 2405, col: 14, offset: 73057},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2401, col: 14, offset: 72952},
+						pos:        position{line: 2405, col: 14, offset: 73057},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2401, col: 33, offset: 72971},
+						pos: position{line: 2405, col: 33, offset: 73076},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2401, col: 34, offset: 72972},
+							pos:  position{line: 2405, col: 34, offset: 73077},
 							name: "IdentifierRest",
 						},
 					},
@@ -17399,20 +17436,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2402, col: 1, offset: 72987},
+			pos:  position{line: 2406, col: 1, offset: 73092},
 			expr: &seqExpr{
-				pos: position{line: 2402, col: 14, offset: 73000},
+				pos: position{line: 2406, col: 14, offset: 73105},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2402, col: 14, offset: 73000},
+						pos:        position{line: 2406, col: 14, offset: 73105},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2402, col: 33, offset: 73019},
+						pos: position{line: 2406, col: 33, offset: 73124},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2402, col: 34, offset: 73020},
+							pos:  position{line: 2406, col: 34, offset: 73125},
 							name: "IdentifierRest",
 						},
 					},
@@ -17423,20 +17460,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2403, col: 1, offset: 73035},
+			pos:  position{line: 2407, col: 1, offset: 73140},
 			expr: &seqExpr{
-				pos: position{line: 2403, col: 14, offset: 73048},
+				pos: position{line: 2407, col: 14, offset: 73153},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2403, col: 14, offset: 73048},
+						pos:        position{line: 2407, col: 14, offset: 73153},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2403, col: 33, offset: 73067},
+						pos: position{line: 2407, col: 33, offset: 73172},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2403, col: 34, offset: 73068},
+							pos:  position{line: 2407, col: 34, offset: 73173},
 							name: "IdentifierRest",
 						},
 					},
@@ -17447,20 +17484,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2404, col: 1, offset: 73083},
+			pos:  position{line: 2408, col: 1, offset: 73188},
 			expr: &seqExpr{
-				pos: position{line: 2404, col: 14, offset: 73096},
+				pos: position{line: 2408, col: 14, offset: 73201},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2404, col: 14, offset: 73096},
+						pos:        position{line: 2408, col: 14, offset: 73201},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2404, col: 33, offset: 73115},
+						pos: position{line: 2408, col: 33, offset: 73220},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2404, col: 34, offset: 73116},
+							pos:  position{line: 2408, col: 34, offset: 73221},
 							name: "IdentifierRest",
 						},
 					},
@@ -17471,20 +17508,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2405, col: 1, offset: 73131},
+			pos:  position{line: 2409, col: 1, offset: 73236},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 73144},
+				pos: position{line: 2409, col: 14, offset: 73249},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 73144},
+						pos:        position{line: 2409, col: 14, offset: 73249},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 73163},
+						pos: position{line: 2409, col: 33, offset: 73268},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 73164},
+							pos:  position{line: 2409, col: 34, offset: 73269},
 							name: "IdentifierRest",
 						},
 					},
@@ -17495,20 +17532,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2406, col: 1, offset: 73179},
+			pos:  position{line: 2410, col: 1, offset: 73284},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 73192},
+				pos: position{line: 2410, col: 14, offset: 73297},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 73192},
+						pos:        position{line: 2410, col: 14, offset: 73297},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 73211},
+						pos: position{line: 2410, col: 33, offset: 73316},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 73212},
+							pos:  position{line: 2410, col: 34, offset: 73317},
 							name: "IdentifierRest",
 						},
 					},
@@ -17519,20 +17556,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2407, col: 1, offset: 73227},
+			pos:  position{line: 2411, col: 1, offset: 73332},
 			expr: &seqExpr{
-				pos: position{line: 2407, col: 14, offset: 73240},
+				pos: position{line: 2411, col: 14, offset: 73345},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2407, col: 14, offset: 73240},
+						pos:        position{line: 2411, col: 14, offset: 73345},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2407, col: 33, offset: 73259},
+						pos: position{line: 2411, col: 33, offset: 73364},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2407, col: 34, offset: 73260},
+							pos:  position{line: 2411, col: 34, offset: 73365},
 							name: "IdentifierRest",
 						},
 					},
@@ -17543,20 +17580,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2408, col: 1, offset: 73275},
+			pos:  position{line: 2412, col: 1, offset: 73380},
 			expr: &seqExpr{
-				pos: position{line: 2408, col: 14, offset: 73288},
+				pos: position{line: 2412, col: 14, offset: 73393},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2408, col: 14, offset: 73288},
+						pos:        position{line: 2412, col: 14, offset: 73393},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2408, col: 33, offset: 73307},
+						pos: position{line: 2412, col: 33, offset: 73412},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2408, col: 34, offset: 73308},
+							pos:  position{line: 2412, col: 34, offset: 73413},
 							name: "IdentifierRest",
 						},
 					},
@@ -17567,20 +17604,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2409, col: 1, offset: 73323},
+			pos:  position{line: 2413, col: 1, offset: 73428},
 			expr: &seqExpr{
-				pos: position{line: 2409, col: 14, offset: 73336},
+				pos: position{line: 2413, col: 14, offset: 73441},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2409, col: 14, offset: 73336},
+						pos:        position{line: 2413, col: 14, offset: 73441},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2409, col: 33, offset: 73355},
+						pos: position{line: 2413, col: 33, offset: 73460},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2409, col: 34, offset: 73356},
+							pos:  position{line: 2413, col: 34, offset: 73461},
 							name: "IdentifierRest",
 						},
 					},
@@ -17591,20 +17628,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2410, col: 1, offset: 73371},
+			pos:  position{line: 2414, col: 1, offset: 73476},
 			expr: &seqExpr{
-				pos: position{line: 2410, col: 14, offset: 73384},
+				pos: position{line: 2414, col: 14, offset: 73489},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2410, col: 14, offset: 73384},
+						pos:        position{line: 2414, col: 14, offset: 73489},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2410, col: 33, offset: 73403},
+						pos: position{line: 2414, col: 33, offset: 73508},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2410, col: 34, offset: 73404},
+							pos:  position{line: 2414, col: 34, offset: 73509},
 							name: "IdentifierRest",
 						},
 					},
@@ -17615,20 +17652,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2411, col: 1, offset: 73419},
+			pos:  position{line: 2415, col: 1, offset: 73524},
 			expr: &seqExpr{
-				pos: position{line: 2411, col: 14, offset: 73432},
+				pos: position{line: 2415, col: 14, offset: 73537},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2411, col: 14, offset: 73432},
+						pos:        position{line: 2415, col: 14, offset: 73537},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2411, col: 33, offset: 73451},
+						pos: position{line: 2415, col: 33, offset: 73556},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2411, col: 34, offset: 73452},
+							pos:  position{line: 2415, col: 34, offset: 73557},
 							name: "IdentifierRest",
 						},
 					},
@@ -17639,20 +17676,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2412, col: 1, offset: 73467},
+			pos:  position{line: 2416, col: 1, offset: 73572},
 			expr: &seqExpr{
-				pos: position{line: 2412, col: 14, offset: 73480},
+				pos: position{line: 2416, col: 14, offset: 73585},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2412, col: 14, offset: 73480},
+						pos:        position{line: 2416, col: 14, offset: 73585},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2412, col: 33, offset: 73499},
+						pos: position{line: 2416, col: 33, offset: 73604},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2412, col: 34, offset: 73500},
+							pos:  position{line: 2416, col: 34, offset: 73605},
 							name: "IdentifierRest",
 						},
 					},
@@ -17663,20 +17700,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2413, col: 1, offset: 73515},
+			pos:  position{line: 2417, col: 1, offset: 73620},
 			expr: &seqExpr{
-				pos: position{line: 2413, col: 14, offset: 73528},
+				pos: position{line: 2417, col: 14, offset: 73633},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2413, col: 14, offset: 73528},
+						pos:        position{line: 2417, col: 14, offset: 73633},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2413, col: 33, offset: 73547},
+						pos: position{line: 2417, col: 33, offset: 73652},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2413, col: 34, offset: 73548},
+							pos:  position{line: 2417, col: 34, offset: 73653},
 							name: "IdentifierRest",
 						},
 					},
@@ -17687,20 +17724,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2414, col: 1, offset: 73563},
+			pos:  position{line: 2418, col: 1, offset: 73668},
 			expr: &seqExpr{
-				pos: position{line: 2414, col: 14, offset: 73576},
+				pos: position{line: 2418, col: 14, offset: 73681},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2414, col: 14, offset: 73576},
+						pos:        position{line: 2418, col: 14, offset: 73681},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2414, col: 33, offset: 73595},
+						pos: position{line: 2418, col: 33, offset: 73700},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2414, col: 34, offset: 73596},
+							pos:  position{line: 2418, col: 34, offset: 73701},
 							name: "IdentifierRest",
 						},
 					},
@@ -17711,20 +17748,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2415, col: 1, offset: 73611},
+			pos:  position{line: 2419, col: 1, offset: 73716},
 			expr: &seqExpr{
-				pos: position{line: 2415, col: 14, offset: 73624},
+				pos: position{line: 2419, col: 14, offset: 73729},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2415, col: 14, offset: 73624},
+						pos:        position{line: 2419, col: 14, offset: 73729},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2415, col: 33, offset: 73643},
+						pos: position{line: 2419, col: 33, offset: 73748},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2415, col: 34, offset: 73644},
+							pos:  position{line: 2419, col: 34, offset: 73749},
 							name: "IdentifierRest",
 						},
 					},
@@ -17735,20 +17772,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2416, col: 1, offset: 73659},
+			pos:  position{line: 2420, col: 1, offset: 73764},
 			expr: &seqExpr{
-				pos: position{line: 2416, col: 14, offset: 73672},
+				pos: position{line: 2420, col: 14, offset: 73777},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2416, col: 14, offset: 73672},
+						pos:        position{line: 2420, col: 14, offset: 73777},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2416, col: 33, offset: 73691},
+						pos: position{line: 2420, col: 33, offset: 73796},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2416, col: 34, offset: 73692},
+							pos:  position{line: 2420, col: 34, offset: 73797},
 							name: "IdentifierRest",
 						},
 					},
@@ -17759,20 +17796,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2417, col: 1, offset: 73707},
+			pos:  position{line: 2421, col: 1, offset: 73812},
 			expr: &seqExpr{
-				pos: position{line: 2417, col: 14, offset: 73720},
+				pos: position{line: 2421, col: 14, offset: 73825},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2417, col: 14, offset: 73720},
+						pos:        position{line: 2421, col: 14, offset: 73825},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2417, col: 33, offset: 73739},
+						pos: position{line: 2421, col: 33, offset: 73844},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2417, col: 34, offset: 73740},
+							pos:  position{line: 2421, col: 34, offset: 73845},
 							name: "IdentifierRest",
 						},
 					},
@@ -17783,20 +17820,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2418, col: 1, offset: 73755},
+			pos:  position{line: 2422, col: 1, offset: 73860},
 			expr: &seqExpr{
-				pos: position{line: 2418, col: 14, offset: 73768},
+				pos: position{line: 2422, col: 14, offset: 73873},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2418, col: 14, offset: 73768},
+						pos:        position{line: 2422, col: 14, offset: 73873},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2418, col: 33, offset: 73787},
+						pos: position{line: 2422, col: 33, offset: 73892},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2418, col: 34, offset: 73788},
+							pos:  position{line: 2422, col: 34, offset: 73893},
 							name: "IdentifierRest",
 						},
 					},
@@ -17807,20 +17844,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2419, col: 1, offset: 73803},
+			pos:  position{line: 2423, col: 1, offset: 73908},
 			expr: &seqExpr{
-				pos: position{line: 2419, col: 14, offset: 73816},
+				pos: position{line: 2423, col: 14, offset: 73921},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2419, col: 14, offset: 73816},
+						pos:        position{line: 2423, col: 14, offset: 73921},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2419, col: 33, offset: 73835},
+						pos: position{line: 2423, col: 33, offset: 73940},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2419, col: 34, offset: 73836},
+							pos:  position{line: 2423, col: 34, offset: 73941},
 							name: "IdentifierRest",
 						},
 					},
@@ -17831,23 +17868,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2420, col: 1, offset: 73851},
+			pos:  position{line: 2424, col: 1, offset: 73956},
 			expr: &actionExpr{
-				pos: position{line: 2420, col: 14, offset: 73864},
+				pos: position{line: 2424, col: 14, offset: 73969},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2420, col: 14, offset: 73864},
+					pos: position{line: 2424, col: 14, offset: 73969},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2420, col: 14, offset: 73864},
+							pos:        position{line: 2424, col: 14, offset: 73969},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2420, col: 33, offset: 73883},
+							pos: position{line: 2424, col: 33, offset: 73988},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2420, col: 34, offset: 73884},
+								pos:  position{line: 2424, col: 34, offset: 73989},
 								name: "IdentifierRest",
 							},
 						},
@@ -17859,20 +17896,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2421, col: 1, offset: 73927},
+			pos:  position{line: 2425, col: 1, offset: 74032},
 			expr: &seqExpr{
-				pos: position{line: 2421, col: 14, offset: 73940},
+				pos: position{line: 2425, col: 14, offset: 74045},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2421, col: 14, offset: 73940},
+						pos:        position{line: 2425, col: 14, offset: 74045},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2421, col: 33, offset: 73959},
+						pos: position{line: 2425, col: 33, offset: 74064},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2421, col: 34, offset: 73960},
+							pos:  position{line: 2425, col: 34, offset: 74065},
 							name: "IdentifierRest",
 						},
 					},
@@ -17883,20 +17920,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2422, col: 1, offset: 73975},
+			pos:  position{line: 2426, col: 1, offset: 74080},
 			expr: &seqExpr{
-				pos: position{line: 2422, col: 14, offset: 73988},
+				pos: position{line: 2426, col: 14, offset: 74093},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2422, col: 14, offset: 73988},
+						pos:        position{line: 2426, col: 14, offset: 74093},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2422, col: 33, offset: 74007},
+						pos: position{line: 2426, col: 33, offset: 74112},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2422, col: 34, offset: 74008},
+							pos:  position{line: 2426, col: 34, offset: 74113},
 							name: "IdentifierRest",
 						},
 					},
@@ -17907,20 +17944,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2423, col: 1, offset: 74023},
+			pos:  position{line: 2427, col: 1, offset: 74128},
 			expr: &seqExpr{
-				pos: position{line: 2423, col: 14, offset: 74036},
+				pos: position{line: 2427, col: 14, offset: 74141},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2423, col: 14, offset: 74036},
+						pos:        position{line: 2427, col: 14, offset: 74141},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2423, col: 33, offset: 74055},
+						pos: position{line: 2427, col: 33, offset: 74160},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2423, col: 34, offset: 74056},
+							pos:  position{line: 2427, col: 34, offset: 74161},
 							name: "IdentifierRest",
 						},
 					},
@@ -17931,20 +17968,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2424, col: 1, offset: 74071},
+			pos:  position{line: 2428, col: 1, offset: 74176},
 			expr: &seqExpr{
-				pos: position{line: 2424, col: 14, offset: 74084},
+				pos: position{line: 2428, col: 14, offset: 74189},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2424, col: 14, offset: 74084},
+						pos:        position{line: 2428, col: 14, offset: 74189},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2424, col: 33, offset: 74103},
+						pos: position{line: 2428, col: 33, offset: 74208},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2424, col: 34, offset: 74104},
+							pos:  position{line: 2428, col: 34, offset: 74209},
 							name: "IdentifierRest",
 						},
 					},
@@ -17955,20 +17992,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2425, col: 1, offset: 74119},
+			pos:  position{line: 2429, col: 1, offset: 74224},
 			expr: &seqExpr{
-				pos: position{line: 2425, col: 14, offset: 74132},
+				pos: position{line: 2429, col: 14, offset: 74237},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2425, col: 14, offset: 74132},
+						pos:        position{line: 2429, col: 14, offset: 74237},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2425, col: 33, offset: 74151},
+						pos: position{line: 2429, col: 33, offset: 74256},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2425, col: 34, offset: 74152},
+							pos:  position{line: 2429, col: 34, offset: 74257},
 							name: "IdentifierRest",
 						},
 					},
@@ -17979,20 +18016,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2426, col: 1, offset: 74167},
+			pos:  position{line: 2430, col: 1, offset: 74272},
 			expr: &seqExpr{
-				pos: position{line: 2426, col: 14, offset: 74180},
+				pos: position{line: 2430, col: 14, offset: 74285},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2426, col: 14, offset: 74180},
+						pos:        position{line: 2430, col: 14, offset: 74285},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2426, col: 33, offset: 74199},
+						pos: position{line: 2430, col: 33, offset: 74304},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2426, col: 34, offset: 74200},
+							pos:  position{line: 2430, col: 34, offset: 74305},
 							name: "IdentifierRest",
 						},
 					},
@@ -18003,20 +18040,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2427, col: 1, offset: 74215},
+			pos:  position{line: 2431, col: 1, offset: 74320},
 			expr: &seqExpr{
-				pos: position{line: 2427, col: 14, offset: 74228},
+				pos: position{line: 2431, col: 14, offset: 74333},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2427, col: 14, offset: 74228},
+						pos:        position{line: 2431, col: 14, offset: 74333},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2427, col: 33, offset: 74247},
+						pos: position{line: 2431, col: 33, offset: 74352},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2427, col: 34, offset: 74248},
+							pos:  position{line: 2431, col: 34, offset: 74353},
 							name: "IdentifierRest",
 						},
 					},
@@ -18027,20 +18064,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2428, col: 1, offset: 74263},
+			pos:  position{line: 2432, col: 1, offset: 74368},
 			expr: &seqExpr{
-				pos: position{line: 2428, col: 14, offset: 74276},
+				pos: position{line: 2432, col: 14, offset: 74381},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2428, col: 14, offset: 74276},
+						pos:        position{line: 2432, col: 14, offset: 74381},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2428, col: 33, offset: 74295},
+						pos: position{line: 2432, col: 33, offset: 74400},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2428, col: 34, offset: 74296},
+							pos:  position{line: 2432, col: 34, offset: 74401},
 							name: "IdentifierRest",
 						},
 					},
@@ -18051,20 +18088,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2429, col: 1, offset: 74311},
+			pos:  position{line: 2433, col: 1, offset: 74416},
 			expr: &seqExpr{
-				pos: position{line: 2429, col: 14, offset: 74324},
+				pos: position{line: 2433, col: 14, offset: 74429},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2429, col: 14, offset: 74324},
+						pos:        position{line: 2433, col: 14, offset: 74429},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2429, col: 33, offset: 74343},
+						pos: position{line: 2433, col: 33, offset: 74448},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2429, col: 34, offset: 74344},
+							pos:  position{line: 2433, col: 34, offset: 74449},
 							name: "IdentifierRest",
 						},
 					},
@@ -18075,20 +18112,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2430, col: 1, offset: 74359},
+			pos:  position{line: 2434, col: 1, offset: 74464},
 			expr: &seqExpr{
-				pos: position{line: 2430, col: 14, offset: 74372},
+				pos: position{line: 2434, col: 14, offset: 74477},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2430, col: 14, offset: 74372},
+						pos:        position{line: 2434, col: 14, offset: 74477},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2430, col: 33, offset: 74391},
+						pos: position{line: 2434, col: 33, offset: 74496},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2430, col: 34, offset: 74392},
+							pos:  position{line: 2434, col: 34, offset: 74497},
 							name: "IdentifierRest",
 						},
 					},
@@ -18099,20 +18136,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2431, col: 1, offset: 74407},
+			pos:  position{line: 2435, col: 1, offset: 74512},
 			expr: &seqExpr{
-				pos: position{line: 2431, col: 14, offset: 74420},
+				pos: position{line: 2435, col: 14, offset: 74525},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2431, col: 14, offset: 74420},
+						pos:        position{line: 2435, col: 14, offset: 74525},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2431, col: 33, offset: 74439},
+						pos: position{line: 2435, col: 33, offset: 74544},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2431, col: 34, offset: 74440},
+							pos:  position{line: 2435, col: 34, offset: 74545},
 							name: "IdentifierRest",
 						},
 					},
@@ -18123,20 +18160,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2432, col: 1, offset: 74455},
+			pos:  position{line: 2436, col: 1, offset: 74560},
 			expr: &seqExpr{
-				pos: position{line: 2432, col: 14, offset: 74468},
+				pos: position{line: 2436, col: 14, offset: 74573},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2432, col: 14, offset: 74468},
+						pos:        position{line: 2436, col: 14, offset: 74573},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2432, col: 33, offset: 74487},
+						pos: position{line: 2436, col: 33, offset: 74592},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2432, col: 34, offset: 74488},
+							pos:  position{line: 2436, col: 34, offset: 74593},
 							name: "IdentifierRest",
 						},
 					},
@@ -20595,6 +20632,19 @@ func (p *parser) callonPrimary19() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPrimary19(stack["expr"])
+}
+
+func (c *current) onPrimary27(expr any) (any, error) {
+
+	expr.(*ast.Subquery).Array = true
+	return expr, nil
+
+}
+
+func (p *parser) callonPrimary27() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPrimary27(stack["expr"])
 }
 
 func (c *current) onCaseExpr2(cases, else_ any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -1131,6 +1131,10 @@ Primary
   / Tuple
   / "(" __ expr:Expr __ ")" { return expr, nil }
   / "(" __ expr:Subquery __ ")" { return expr, nil }
+  / "[" __ expr:Subquery __ "]" { 
+      expr.(*ast.Subquery).Array = true
+      return expr, nil 
+    }
 
 CaseExpr
   = CASE cases:When+ else_:(_ ELSE _ Expr)? _ END (_ CASE)? {

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -161,7 +161,11 @@ func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 			Value: sup.FormatValue(val),
 		}
 	case *ast.Subquery:
-		return a.semSubquery(e.Body)
+		s := a.semSubquery(e.Body)
+		if e.Array {
+			s.Body = collectThis(s.Body)
+		}
+		return s
 	case *ast.RecordExpr:
 		fields := map[string]struct{}{}
 		var out []dag.RecordElem

--- a/compiler/semantic/ztests/array-subquery-op.yaml
+++ b/compiler/semantic/ztests/array-subquery-op.yaml
@@ -5,6 +5,6 @@ spq: |
 
 output: |
   1
-  error("query expression produced multiple values (consider [(subquery)])")
+  error("query expression produced multiple values (consider [subquery])")
   [1]
   [1,2]

--- a/compiler/semantic/ztests/array-subquery.yaml
+++ b/compiler/semantic/ztests/array-subquery.yaml
@@ -1,7 +1,7 @@
-spq: values (values 1), (values 1,2), [(values 1)], [(values 1,2)]
+spq: values (values 1), (values 1,2), [values 1], [values 1,2]
 
 output: |
   1
-  error("query expression produced multiple values (consider [(subquery)])")
+  error("query expression produced multiple values (consider [subquery])")
   [1]
   [1,2]

--- a/compiler/sfmt/ast.go
+++ b/compiler/sfmt/ast.go
@@ -239,13 +239,17 @@ func (c *canon) expr(e ast.Expr, parent string) {
 		}
 		c.write("}|")
 	case *ast.Subquery:
-		c.open("(")
+		open, close := "(", ")"
+		if e.Array {
+			open, close = "[", "]"
+		}
+		c.open(open)
 		c.head = true
 		c.seq(e.Body)
 		c.close()
 		c.ret()
 		c.flush()
-		c.write(")")
+		c.write(close)
 	case *ast.Exists:
 		c.open("exists(")
 		c.head = true

--- a/runtime/sam/op/subquery/subquery.go
+++ b/runtime/sam/op/subquery/subquery.go
@@ -96,7 +96,7 @@ func (q *Subquery) Eval(this super.Value) super.Value {
 		}
 		if b == nil {
 			if count > 1 {
-				return q.sctx.NewErrorf("query expression produced multiple values (consider [(subquery)])")
+				return q.sctx.NewErrorf("query expression produced multiple values (consider [subquery])")
 			}
 			return val
 		}

--- a/runtime/ztests/expr/queryexpr-multiple-err.yaml
+++ b/runtime/ztests/expr/queryexpr-multiple-err.yaml
@@ -3,4 +3,4 @@ spq: values (values 1,2,3)
 vector: true
 
 output: |
-  error("query expression produced multiple values (consider [(subquery)])")
+  error("query expression produced multiple values (consider [subquery])")


### PR DESCRIPTION
This commit allows users to specify an array-wrapped subquery using only brackets wrapping the subquery and not requiring the parenthesis usually needed for subqueries.