### PR TITLE
Add a sqllogictest job to the CI Actions workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,14 @@ jobs:
       - run: mkdir dist -ea 0
       - run: go build -o dist ./cmd/...
       - run: go test -v ./mdtest
+  sqllogictest:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make test-sqllogic
   output-check:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## What's Changing

This is a follow-on to #6236 so these tests will run in CI via Actions.

## Why

To catch regressions in base SQL coverage.

## Details

A [sample run](https://github.com/brimdata/super/actions/runs/17871506051/job/50825863035) shows these tests currently take ~5 minutes in Actions, which is about 3x the time of the prior longest running job in the workflow "test-windows" which comes in around 1.7 minutes. It should get faster when the work on join pushdown merges, though more sqllogic ztests will also be added over time that'll increase runtime. I'm open to discussion on the preferred way to achieve balance here.