### PR TITLE
support for restartable dag.FileScans so repeated from-subqueries work

### DIFF
--- a/compiler/rungen/op.go
+++ b/compiler/rungen/op.go
@@ -298,7 +298,16 @@ func (b *Builder) compileLeaf(o dag.Op, parent sbuf.Puller) (sbuf.Puller, error)
 		if v.Pushdown.DataFilter != nil {
 			dataFilter = v.Pushdown.DataFilter.Expr
 		}
-		return b.env.Open(b.rctx.Context, b.sctx(), v.Path, v.Format, b.newPushdown(dataFilter, v.Pushdown.Projection))
+		puller, err := b.env.Open(b.rctx.Context, b.sctx(), v.Path, v.Format, b.newPushdown(dataFilter, v.Pushdown.Projection))
+		if err != nil {
+			return puller, err
+		}
+		return &rewinder{
+			puller: puller,
+			reopen: func() (sbuf.Puller, error) {
+				return b.env.Open(b.rctx.Context, b.sctx(), v.Path, v.Format, b.newPushdown(dataFilter, v.Pushdown.Projection))
+			},
+		}, nil
 	case *dag.RobotScan:
 		e, err := compileExpr(v.Expr)
 		if err != nil {
@@ -380,6 +389,26 @@ func (b *Builder) compileLeaf(o dag.Op, parent sbuf.Puller) (sbuf.Puller, error)
 	default:
 		return nil, fmt.Errorf("unknown DAG operator type: %v", v)
 	}
+}
+
+type rewinder struct {
+	puller sbuf.Puller
+	reopen func() (sbuf.Puller, error)
+}
+
+func (r *rewinder) Pull(done bool) (sbuf.Batch, error) {
+	if r.puller == nil {
+		puller, err := r.reopen()
+		if err != nil {
+			return nil, err
+		}
+		r.puller = puller
+	}
+	batch, err := r.puller.Pull(done)
+	if batch == nil || err != nil {
+		r.puller = nil
+	}
+	return batch, err
 }
 
 func (b *Builder) compileUnnest(parent sbuf.Puller, u *dag.Unnest) (sbuf.Puller, error) {

--- a/compiler/ztests/repeated-from-subquery.yaml
+++ b/compiler/ztests/repeated-from-subquery.yaml
@@ -1,0 +1,14 @@
+script: super -s -c "values 1,2,3 | {x:[cross join (from in.sup)]}"
+
+inputs:
+  - name: in.sup
+    data: |
+      2
+      3
+
+outputs:
+  - name: stdout
+    data: |
+      {x:[{left:1,right:2},{left:1,right:3}]}
+      {x:[{left:2,right:2},{left:2,right:3}]}
+      {x:[{left:3,right:2},{left:3,right:3}]}

--- a/runtime/vam/op/hashjoin.go
+++ b/runtime/vam/op/hashjoin.go
@@ -324,7 +324,7 @@ func (b *bufPuller) pull(done bool) (vector.Any, error) {
 	if vec == nil || err != nil {
 		b.done = true
 	}
-	return vec, nil
+	return vec, err
 }
 
 func hashKey(val super.Value) string {

--- a/runtime/vam/op/hashjoin.go
+++ b/runtime/vam/op/hashjoin.go
@@ -222,7 +222,7 @@ func (j *hashJoin) probeRight() (vector.Any, error) {
 			return nil, err
 		}
 		if vec == nil {
-			if j.hits != nil && j.style != "inner" {
+			if len(j.hits) != 0 && j.style != "inner" {
 				return j.drainLeftTable(), nil
 			}
 			return nil, nil

--- a/runtime/vam/op/hashjoin.go
+++ b/runtime/vam/op/hashjoin.go
@@ -222,7 +222,7 @@ func (j *hashJoin) probeRight() (vector.Any, error) {
 			return nil, err
 		}
 		if vec == nil {
-			if len(j.hits) != 0 && j.style != "inner" {
+			if j.hits != nil && j.style != "inner" {
 				return j.drainLeftTable(), nil
 			}
 			return nil, nil
@@ -267,7 +267,7 @@ func (j *hashJoin) drainLeftTable() vector.Any {
 			b.Write(j.wrap(val.Ptr(), nil))
 		}
 	}
-	j.hits = make(map[string]bool)
+	j.hits = nil
 	return b.Build()
 }
 

--- a/runtime/vam/op/hashjoin.go
+++ b/runtime/vam/op/hashjoin.go
@@ -267,7 +267,7 @@ func (j *hashJoin) drainLeftTable() vector.Any {
 			b.Write(j.wrap(val.Ptr(), nil))
 		}
 	}
-	j.hits = nil
+	j.hits = make(map[string]bool)
 	return b.Build()
 }
 

--- a/runtime/vam/op/hashjoin.go
+++ b/runtime/vam/op/hashjoin.go
@@ -295,12 +295,13 @@ type bufPuller struct {
 	vecs   []vector.Any
 	EOS    bool
 	puller vector.Puller
+	done   bool
 }
 
 func (b *bufPuller) Pull(done bool) (vector.Any, error) {
 	if done {
 		if !b.EOS {
-			return b.puller.Pull(done)
+			return b.pull(done)
 		}
 		return nil, nil
 	}
@@ -312,7 +313,18 @@ func (b *bufPuller) Pull(done bool) (vector.Any, error) {
 	if b.EOS {
 		return nil, nil
 	}
-	return b.puller.Pull(false)
+	return b.pull(false)
+}
+
+func (b *bufPuller) pull(done bool) (vector.Any, error) {
+	if b.done {
+		return nil, nil
+	}
+	vec, err := b.puller.Pull(done)
+	if vec == nil || err != nil {
+		b.done = true
+	}
+	return vec, nil
 }
 
 func hashKey(val super.Value) string {


### PR DESCRIPTION
This commit adds support for restarting file scans so that repeated from-subqueries involving file paths work. This is a temporary solution to make progress on docs and testing.  It does not work for databases and fails silently for non-seekable streams.

A more comprhensive solution will come in a future PR.