### PR TITLE
compiler/optimizer: fix addPathToExpr bug

### DIFF
--- a/compiler/ztests/lift-filters.yaml
+++ b/compiler/ztests/lift-filters.yaml
@@ -7,6 +7,8 @@ script: |
   echo ===
   # https://github.com/brimdata/super/issues/6223
   super compile -C -O 'values {a:b,c,d} | where a+1 between c and d'
+  echo ===
+  super compile -C -O 'values {a:{...b,...c}} | where a.d'
 
 outputs:
   - name: stdout
@@ -29,4 +31,9 @@ outputs:
       null
       | where b+1>=c and b+1<=d
       | values {a:b,c:c,d:d}
+      | output main
+      ===
+      null
+      | values {a:{...b,...c}}
+      | where a.d
       | output main

--- a/compiler/ztests/merge-values.yaml
+++ b/compiler/ztests/merge-values.yaml
@@ -14,6 +14,8 @@ script: |
   super compile -C -O 'select a, max(b) as c group by a | aggregate min(c) by a'
   echo ===
   super compile -C -O 'values {b:{d:1},c:{d:2}} | values {d:3,...b,...c}'
+  echo ===
+  super compile -C -O 'values {a:{...b,...c}} | values a.d'
 
 outputs:
   - name: stdout
@@ -54,4 +56,9 @@ outputs:
       ===
       null
       | values {d:2}
+      | output main
+      ===
+      null
+      | values {a:{...b,...c}}
+      | values a.d
       | output main


### PR DESCRIPTION
The bug incorrectly allows the optimizer to transform `values {a:{...b,...c}} | values a.d` to `values c.d` and `values {a:{...b,...c}} | where a.d` to
`where c.d | values {a{...b,...c}}`.