### PR TITLE
allow only strings to be cast to bytes

### DIFF
--- a/compiler/ztests/f-string.yaml
+++ b/compiler/ztests/f-string.yaml
@@ -1,9 +1,9 @@
 spq: |
   values
     f"hello {this}",
-    f'hello {hex(this::bytes)}',
+    f'hello {len(this)}',
     f"hello \{this}",
-    f'hello \{hex(this)}',
+    f'hello \{len(this)}',
     f'yo {f"dawg {this}"}',
     f'{this}',
     "==="
@@ -13,16 +13,16 @@ input: |
 
 output: |
    "hello world"
-   "hello 776f726c64"
+   "hello 5"
    "hello {this}"
-   "hello {hex(this)}"
+   "hello {len(this)}"
    "yo dawg world"
    "world"
    "==="
    "hello 127.0.0.1"
-   "hello 7f000001"
+   "hello 4"
    "hello {this}"
-   "hello {hex(this)}"
+   "hello {len(this)}"
    "yo dawg 127.0.0.1"
    "127.0.0.1"
    "==="

--- a/runtime/sam/expr/cast.go
+++ b/runtime/sam/expr/cast.go
@@ -38,7 +38,7 @@ func LookupPrimitiveCaster(sctx *super.Context, typ super.Type) Evaluator {
 	case super.TypeString:
 		return &casterString{sctx}
 	case super.TypeBytes:
-		return &casterBytes{}
+		return &casterBytes{sctx}
 	case super.TypeType:
 		return &casterType{sctx}
 	default:
@@ -231,9 +231,14 @@ func (c *casterString) Eval(val super.Value) super.Value {
 	return super.NewString(sup.FormatValue(val))
 }
 
-type casterBytes struct{}
+type casterBytes struct {
+	sctx *super.Context
+}
 
 func (c *casterBytes) Eval(val super.Value) super.Value {
+	if val.Type().ID() != super.IDString {
+		return c.sctx.WrapError("cannot cast to bytes", val)
+	}
 	return super.NewBytes(val.Bytes())
 }
 

--- a/runtime/vam/expr/cast/bytes.go
+++ b/runtime/vam/expr/cast/bytes.go
@@ -1,26 +1,17 @@
 package cast
 
 import (
-	"github.com/brimdata/super/scode"
 	"github.com/brimdata/super/vector"
 )
 
 func castToBytes(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
-	n := lengthOf(vec, index)
-	nulls := vector.NullsOf(vec)
-	if index != nil {
-		nulls = nulls.Pick(index)
+	strVec, ok := vec.(*vector.String)
+	if !ok {
+		return nil, nil, false
 	}
-	out := vector.NewBytesEmpty(n, nulls)
-	var b scode.Builder
-	for i := range n {
-		idx := i
-		if index != nil {
-			idx = index[i]
-		}
-		b.Reset()
-		vec.Serialize(&b, idx)
-		out.Append(b.Bytes().Body())
+	out := vector.Any(vector.NewBytes(strVec.Table(), vector.NullsOf(strVec)))
+	if index != nil {
+		out = vector.Pick(out, index)
 	}
 	return out, nil, true
 }

--- a/runtime/ztests/expr/cast/bytes.yaml
+++ b/runtime/ztests/expr/cast/bytes.yaml
@@ -5,13 +5,13 @@ vector: true
 input: |
   "foo"
   "bar"::=named
+  ""
   null::string
   {x:"foo"}
-  {x:"bar"}
 
 output: |
   0x666f6f
   0x626172
+  0x
   null::bytes
-  0x04666f6f
-  0x04626172
+  error({message:"cannot cast to bytes",on:{x:"foo"}})


### PR DESCRIPTION
A value of any type may be cast to bytes.  Change that to allow only a string value to be cast to bytes as specified in the cast() documentation.

Closes #6023.