### PR TITLE
Update GoReleaser to v2 config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,9 @@
+# GoReleaser v2 configuration
+version: 2
+
+project_name: super
 builds:
   - main: ./cmd/super
-    id: sup
-    binary: super
     env:
       - CGO_ENABLED=0
     ldflags:
@@ -14,19 +16,18 @@ builds:
       - windows
       - darwin
 archives:
-  - name_template: super-{{ .Tag }}.{{ .Os }}-{{ .Arch }}
+  - name_template: "{{ .ProjectName }}-{{ .Tag }}.{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ "zip" ]
     files:
       - LICENSE.txt
       - acknowledgments.txt
 release:
   header: |
     View [change log](CHANGELOG.md#{{ replace .Tag "." "" }}).
-brews:
-  - name: super
-    repository:
+homebrew_casks:
+  - repository:
       owner: brimdata
       name: homebrew-tap
     commit_author:
@@ -34,12 +35,10 @@ brews:
       email: bot@brimdata.io
     homepage: https://github.com/brimdata/super
     description: |
-      An analytics database that puts JSON and relational tables on equal footing
-    install: |
-      bin.install "super"
+      An analytics database that fuses structured and semi-structured data
 checksum:
   name_template: 'super-checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-{{ .ShortCommit }}"
+  version_template: "{{ incpatch .Version }}-{{ .ShortCommit }}"
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## What's Changing

This updates our GoReleaser config to their "v2" syntax. It also points our Release workflow at a newer Action that defaults to GoReleaser v2.

## Why

I went to do some local tasks with my Homebrew-installed `goreleaser` and found it refused to work off the `.goreleaser.yaml` at current tip-of-`main` because it's not in "v2" format.

## Details

I tested this all out using a personal fork of the super repo by tagging a release version. You can see/download the artifacts at https://github.com/philrz/super/releases and the updated Homebrew Tap at https://github.com/philrz/homebrew-tap.

Note how GoReleaser now creates a Homebrew "Cask" rather than the "Formula" it did in the past. I had to give myself a crash course on this but the tl;dr is that it does seem the Cask concept is a better match for our approach of installing a precompiled binary rather than compiling from source. In line with Homebrew [conventions](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap#casks) this means when we do a GA release the `super.rb` will land below a `Casks/` directory in our [homebrew-tap repo](https://github.com/brimdata/homebrew-tap). This all worked fine in my test by doing `brew install philrz/tap/super` on a scratch host.