### PR TITLE
runtime/vam: return error on cast of invalid UTF-8 bytes to string

### DIFF
--- a/runtime/vam/expr/cast/bool.go
+++ b/runtime/vam/expr/cast/bool.go
@@ -6,7 +6,7 @@ import (
 	"github.com/brimdata/super/vector/bitvec"
 )
 
-func castToBool(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
+func castToBool(vec vector.Any, index []uint32) (vector.Any, []uint32, string, bool) {
 	var out *vector.Bool
 	switch vec := vec.(type) {
 	case *vector.Int:
@@ -17,9 +17,9 @@ func castToBool(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
 		out = numberToBool(vec.Values, index)
 	case *vector.String:
 		vvec, errs := stringToBool(vec, index)
-		return vvec, errs, true
+		return vvec, errs, "", true
 	default:
-		return nil, nil, false
+		return nil, nil, "", false
 	}
 	nulls := vector.NullsOf(vec)
 	if index == nil {
@@ -27,7 +27,7 @@ func castToBool(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
 	} else {
 		out.Nulls = nulls.Pick(index)
 	}
-	return out, nil, true
+	return out, nil, "", true
 }
 
 func numberToBool[E numeric](s []E, index []uint32) *vector.Bool {

--- a/runtime/vam/expr/cast/bytes.go
+++ b/runtime/vam/expr/cast/bytes.go
@@ -4,14 +4,14 @@ import (
 	"github.com/brimdata/super/vector"
 )
 
-func castToBytes(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
+func castToBytes(vec vector.Any, index []uint32) (vector.Any, []uint32, string, bool) {
 	strVec, ok := vec.(*vector.String)
 	if !ok {
-		return nil, nil, false
+		return nil, nil, "", false
 	}
 	out := vector.Any(vector.NewBytes(strVec.Table(), vector.NullsOf(strVec)))
 	if index != nil {
 		out = vector.Pick(out, index)
 	}
-	return out, nil, true
+	return out, nil, "", true
 }

--- a/runtime/vam/expr/cast/ip.go
+++ b/runtime/vam/expr/cast/ip.go
@@ -8,10 +8,10 @@ import (
 	"github.com/brimdata/super/vector/bitvec"
 )
 
-func castToIP(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
+func castToIP(vec vector.Any, index []uint32) (vector.Any, []uint32, string, bool) {
 	switch vec := vec.(type) {
 	case *vector.IP:
-		return vec, nil, true
+		return vec, nil, "", true
 	case *vector.String:
 		n := lengthOf(vec, index)
 		var nulls bitvec.Bits
@@ -37,16 +37,16 @@ func castToIP(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
 			}
 			ips = append(ips, ip)
 		}
-		return vector.NewIP(ips, nulls), errs, true
+		return vector.NewIP(ips, nulls), errs, "", true
 	default:
-		return nil, nil, false
+		return nil, nil, "", false
 	}
 }
 
-func castToNet(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
+func castToNet(vec vector.Any, index []uint32) (vector.Any, []uint32, string, bool) {
 	switch vec := vec.(type) {
 	case *vector.Net:
-		return vec, nil, true
+		return vec, nil, "", true
 	case *vector.String:
 		n := lengthOf(vec, index)
 		var nulls bitvec.Bits
@@ -72,8 +72,8 @@ func castToNet(vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
 			}
 			nets = append(nets, net)
 		}
-		return vector.NewNet(nets, nulls), errs, true
+		return vector.NewNet(nets, nulls), errs, "", true
 	default:
-		return nil, nil, false
+		return nil, nil, "", false
 	}
 }

--- a/runtime/vam/expr/cast/number.go
+++ b/runtime/vam/expr/cast/number.go
@@ -17,10 +17,10 @@ type numeric interface {
 	constraints.Float | constraints.Integer
 }
 
-func castToNumber(vec vector.Any, typ super.Type, index []uint32) (vector.Any, []uint32, bool) {
+func castToNumber(vec vector.Any, typ super.Type, index []uint32) (vector.Any, []uint32, string, bool) {
 	if vec.Type().ID() == super.IDString {
 		out, errs := castStringToNumber(vec, typ, index)
-		return out, errs, true
+		return out, errs, "", true
 	}
 	nulls := vector.NullsOf(vec)
 	if index != nil {
@@ -32,21 +32,21 @@ func castToNumber(vec vector.Any, typ super.Type, index []uint32) (vector.Any, [
 		if len(errs) > 0 {
 			nulls = nulls.Pick(inverseIndex(errs, nulls.Len()))
 		}
-		return vector.NewInt(typ, vals, nulls), errs, true
+		return vector.NewInt(typ, vals, nulls), errs, "", true
 	case super.IsUnsigned(id):
 		vals, errs := toNumeric[uint64](vec, typ, index)
 		if len(errs) > 0 {
 			nulls = nulls.Pick(inverseIndex(errs, nulls.Len()))
 		}
-		return vector.NewUint(typ, vals, nulls), errs, true
+		return vector.NewUint(typ, vals, nulls), errs, "", true
 	case super.IsFloat(id):
 		vals, errs := toNumeric[float64](vec, typ, index)
 		if errs != nil {
 			nulls = nulls.Pick(inverseIndex(errs, nulls.Len()))
 		}
-		return vector.NewFloat(typ, vals, nulls), errs, true
+		return vector.NewFloat(typ, vals, nulls), errs, "", true
 	default:
-		return nil, nil, false
+		return nil, nil, "", false
 	}
 }
 

--- a/runtime/vam/expr/cast/type.go
+++ b/runtime/vam/expr/cast/type.go
@@ -7,10 +7,10 @@ import (
 	"github.com/brimdata/super/vector/bitvec"
 )
 
-func castToType(sctx *super.Context, vec vector.Any, index []uint32) (vector.Any, []uint32, bool) {
+func castToType(sctx *super.Context, vec vector.Any, index []uint32) (vector.Any, []uint32, string, bool) {
 	switch vec := vec.(type) {
 	case *vector.TypeValue:
-		return vec, nil, true
+		return vec, nil, "", true
 	case *vector.String:
 		n := lengthOf(vec, index)
 		out := vector.NewTypeValueEmpty(0, bitvec.Zero)
@@ -36,8 +36,8 @@ func castToType(sctx *super.Context, vec vector.Any, index []uint32) (vector.Any
 			}
 			out.Append(val.Bytes())
 		}
-		return out, errs, true
+		return out, errs, "", true
 	default:
-		return nil, nil, false
+		return nil, nil, "", false
 	}
 }

--- a/runtime/ztests/expr/cast/string.yaml
+++ b/runtime/ztests/expr/cast/string.yaml
@@ -21,6 +21,8 @@ input: |
   1.2.3.4/32
   0x68692c20776f726c64
   0x666f6f20626172
+  0x00
+  0xc328
   "hi, world"
   "foo bar"
   {foo:"bar"}
@@ -46,6 +48,8 @@ output: |
   "1.2.3.4/32"
   "hi, world"
   "foo bar"
+  "\u0000"
+  error({message:"cannot cast to string: invalid UTF-8",on:0xc328})
   "hi, world"
   "foo bar"
   "{foo:\"bar\"}"


### PR DESCRIPTION
The sequential runtime returns a structured error when a bytes value containing invalid UTF-8 is cast to a string.  Do the same in the vector runtime.

The change in runtime/vam/expr/cast.castToString implements the new behavior.  The remaining changes just add a msgSuffix parameter to errCastFailed so castToString can produce the same error message as the sequential runtime.

There are some possible optimizations here but they can wait until castToString appears in CPU profiles.