### PR TITLE
add new cast implementation for complex types

### DIFF
--- a/book/src/super-sql/functions/types/cast.md
+++ b/book/src/super-sql/functions/types/cast.md
@@ -198,8 +198,8 @@ cast(this, <{b:string}>)
 {a:3}
 {b:4}
 # expected output
-{a:1,b:"2"}
-{a:3}
+{b:"2"}
+{b:null::string}
 {b:"4"}
 ```
 

--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -253,7 +253,11 @@ func (b *Builder) compileVamCast(args []dag.Expr) (vamexpr.Evaluator, error) {
 			return cast, nil
 		}
 	}
-	return b.compileVamShaper(args, expr.Cast)
+	e, err := b.compileCall(&dag.Call{Tag: "cast", Args: args})
+	if err != nil {
+		return nil, err
+	}
+	return vamexpr.NewSamExpr(e), nil
 }
 
 func (b *Builder) compileVamShaper(args []dag.Expr, tf expr.ShaperTransform) (vamexpr.Evaluator, error) {

--- a/runtime/sam/expr/function/cast.go
+++ b/runtime/sam/expr/function/cast.go
@@ -33,7 +33,7 @@ func (c *cast) Call(args []super.Value) super.Value {
 		}
 		return c.cast(from, typ)
 	}
-	return c.sctx.WrapError("cannot cast to "+sup.FormatValue(to), from)
+	return c.sctx.WrapError("cast target must be a type or type name", to)
 }
 
 func (c *cast) cast(from super.Value, to super.Type) super.Value {

--- a/runtime/sam/expr/function/cast.go
+++ b/runtime/sam/expr/function/cast.go
@@ -1,0 +1,225 @@
+package function
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/runtime/sam/expr"
+	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/sup"
+)
+
+type cast struct {
+	sctx *super.Context
+}
+
+func (c *cast) Call(args []super.Value) super.Value {
+	from, to := args[0], args[1]
+	if from.IsError() {
+		return from
+	}
+	switch toUnder := to.Under(); toUnder.Type().ID() {
+	case super.IDString:
+		typ, err := c.sctx.LookupTypeNamed(toUnder.AsString(), super.TypeUnder(from.Type()))
+		if err != nil {
+			return c.sctx.WrapError("cannot cast to named type: "+err.Error(), from)
+		}
+		return super.NewValue(typ, from.Bytes())
+	case super.IDType:
+		typ, err := c.sctx.LookupByValue(toUnder.Bytes())
+		if err != nil {
+			panic(err)
+		}
+		return c.cast(from, typ)
+	}
+	return c.sctx.WrapError("cannot cast to "+sup.FormatValue(to), from)
+}
+
+func (c *cast) cast(from super.Value, to super.Type) super.Value {
+	if from.IsNull() {
+		return super.NewValue(to, nil)
+	}
+	switch fromType := from.Type(); {
+	case fromType == to:
+		return from
+	case fromType.ID() == to.ID():
+		return super.NewValue(to, from.Bytes())
+	}
+	switch to := to.(type) {
+	case *super.TypeRecord:
+		return c.toRecord(from, to)
+	case *super.TypeArray, *super.TypeSet:
+		return c.toArrayOrSet(from, to)
+	case *super.TypeMap:
+		return c.toMap(from, to)
+	case *super.TypeUnion:
+		return c.toUnion(from, to)
+	case *super.TypeError:
+		return c.toError(from, to)
+	case *super.TypeNamed:
+		return c.toNamed(from, to)
+	default:
+		from = from.Under()
+		if from.IsNull() {
+			return super.NewValue(to, nil)
+		}
+		caster := expr.LookupPrimitiveCaster(c.sctx, to)
+		if caster == nil {
+			return c.error(from, to)
+		}
+		return caster.Eval(from)
+	}
+}
+
+func (c *cast) error(from super.Value, to super.Type) super.Value {
+	return c.sctx.WrapError("cannot cast to "+sup.FormatType(to), from)
+}
+
+func (c *cast) toRecord(from super.Value, to *super.TypeRecord) super.Value {
+	from = from.Under()
+	if !super.IsRecordType(from.Type()) {
+		return c.error(from, to)
+	}
+	var b scode.Builder
+	var fields []super.Field
+	for i, f := range to.Fields {
+		var val2 super.Value
+		if fieldVal := from.Deref(f.Name); fieldVal != nil {
+			val2 = c.cast(*fieldVal, f.Type)
+		} else {
+			val2 = super.NewValue(f.Type, nil)
+		}
+		if t := val2.Type(); t != f.Type {
+			if fields == nil {
+				fields = slices.Clone(to.Fields)
+			}
+			fields[i].Type = t
+		}
+		b.Append(val2.Bytes())
+	}
+	if fields != nil {
+		to = c.sctx.MustLookupTypeRecord(fields)
+	}
+	return super.NewValue(to, b.Bytes())
+}
+
+func (c *cast) toArrayOrSet(from super.Value, to super.Type) super.Value {
+	from = from.Under()
+	fromInner := super.InnerType(from.Type())
+	toInner := super.InnerType(to)
+	if fromInner == nil {
+		// XXX Should also return an error if casting from fromInner to
+		// toInner will always fail.
+		return c.error(from, to)
+	}
+	types := map[super.Type]struct{}{}
+	var vals []super.Value
+	for it := from.Iter(); !it.Done(); {
+		val := c.castNext(&it, fromInner, toInner)
+		types[val.Type()] = struct{}{}
+		vals = append(vals, val)
+	}
+	if len(vals) == 0 {
+		return super.NewValue(to, from.Bytes())
+	}
+	inner := c.maybeConvertToUnion(vals, types)
+	if inner != toInner {
+		if to.Kind() == super.ArrayKind {
+			to = c.sctx.LookupTypeArray(inner)
+		} else {
+			to = c.sctx.LookupTypeSet(inner)
+		}
+	}
+	var bytes scode.Bytes
+	for _, val := range vals {
+		bytes = scode.Append(bytes, val.Bytes())
+	}
+	if to.Kind() == super.SetKind {
+		bytes = super.NormalizeSet(bytes)
+	}
+	return super.NewValue(to, bytes)
+}
+
+func (c *cast) castNext(it *scode.Iter, from, to super.Type) super.Value {
+	val := super.NewValue(from, it.Next())
+	return c.cast(val, to)
+}
+
+func (c *cast) maybeConvertToUnion(vals []super.Value, types map[super.Type]struct{}) super.Type {
+	typesSlice := slices.Collect(maps.Keys(types))
+	if len(typesSlice) == 1 {
+		return typesSlice[0]
+	}
+	union := c.sctx.LookupTypeUnion(typesSlice)
+	for i, val := range vals {
+		vals[i] = c.toUnion(val, union)
+	}
+	return union
+}
+
+func (c *cast) toMap(from super.Value, to *super.TypeMap) super.Value {
+	from = from.Under()
+	fromType, ok := from.Type().(*super.TypeMap)
+	if !ok {
+		return c.error(from, to)
+	}
+	keyTypes := map[super.Type]struct{}{}
+	valTypes := map[super.Type]struct{}{}
+	var keyVals, valVals []super.Value
+	for it := from.Iter(); !it.Done(); {
+		keyVal := c.castNext(&it, fromType.KeyType, to.KeyType)
+		keyVals = append(keyVals, keyVal)
+		keyTypes[keyVal.Type()] = struct{}{}
+		valVal := c.castNext(&it, fromType.ValType, to.ValType)
+		valTypes[valVal.Type()] = struct{}{}
+		valVals = append(valVals, valVal)
+	}
+	if len(keyVals) == 0 {
+		return super.NewValue(to, from.Bytes())
+	}
+	keyType := c.maybeConvertToUnion(keyVals, keyTypes)
+	valType := c.maybeConvertToUnion(valVals, valTypes)
+	if keyType != to.KeyType || valType != to.ValType {
+		to = c.sctx.LookupTypeMap(keyType, valType)
+	}
+	var bytes scode.Bytes
+	for i := range keyVals {
+		bytes = scode.Append(bytes, keyVals[i].Bytes())
+		bytes = scode.Append(bytes, valVals[i].Bytes())
+	}
+	return super.NewValue(to, super.NormalizeMap(bytes))
+}
+
+func (c *cast) toUnion(from super.Value, to *super.TypeUnion) super.Value {
+	tag := expr.BestUnionTag(from.Type(), to)
+	if tag < 0 {
+		from2 := from.Deunion()
+		tag = expr.BestUnionTag(from2.Type(), to)
+		if tag < 0 {
+			return c.error(from, to)
+		}
+		from = from2
+	}
+	bytes := from.Bytes()
+	if bytes != nil {
+		bytes = scode.Append(scode.Append(nil, super.EncodeInt(int64(tag))), bytes)
+	}
+	return super.NewValue(to, bytes)
+}
+
+func (c *cast) toError(from super.Value, to *super.TypeError) super.Value {
+	from = c.cast(from, to.Type)
+	if from.Type() != to.Type {
+		return from
+	}
+	return super.NewValue(to, from.Bytes())
+}
+
+func (c *cast) toNamed(from super.Value, to *super.TypeNamed) super.Value {
+	from = c.cast(from, to.Type)
+	if from.Type() != to.Type {
+		return from
+	}
+	return super.NewValue(to, from.Bytes())
+}

--- a/runtime/sam/expr/function/function.go
+++ b/runtime/sam/expr/function/function.go
@@ -28,6 +28,10 @@ func New(sctx *super.Context, name string, narg int) (expr.Function, error) {
 		argmin = 2
 		argmax = 2
 		f = &Bucket{sctx: sctx, name: name}
+	case "cast":
+		argmin = 2
+		argmax = 2
+		f = &cast{sctx}
 	case "ceil":
 		f = &Ceil{sctx: sctx}
 	case "cidr_match":

--- a/runtime/sam/expr/functions_test.go
+++ b/runtime/sam/expr/functions_test.go
@@ -1,7 +1,6 @@
 package expr_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/brimdata/super/runtime/sam/expr/function"
@@ -139,20 +138,21 @@ func TestLen(t *testing.T) {
 func TestCast(t *testing.T) {
 	// Constant type argument
 	testSuccessful(t, "cast(1, <uint64>)", "", "1::uint64")
-	testError(t, "cast(1, 2)", errors.New("shaper type argument is not a type: 2"))
+	testSuccessful(t, "cast(1, 2)", "", `error({message:"cannot cast to 2",on:1})`)
 
 	// Constant name argument
 	testSuccessful(t, `cast(1, "my_int64")`, "", "1::=my_int64")
-	testError(t, `cast(1, "uint64")`, errors.New(`bad type name "uint64": primitive type name`))
+	testSuccessful(t, `cast(1, "uint64")`, "",
+		`error({message:"cannot cast to named type: bad type name \"uint64\": primitive type name",on:1})`)
 
 	// Variable type argument
 	testSuccessful(t, "cast(1, type)", "{type:<uint64>}", "1::uint64")
-	testSuccessful(t, "cast(1, type)", "{type:2}", `error({message:"shaper type argument is not a type",on:2})`)
+	testSuccessful(t, "cast(1, type)", "{type:2}", `error({message:"cannot cast to 2",on:1})`)
 
 	// Variable name argument
 	testSuccessful(t, "cast(1, name)", `{name:"my_int64"}`, "1::=my_int64")
-	testSuccessful(t, "cast(1, name)", `{name:"uint64"}`, `error("bad type name \"uint64\": primitive type name")`)
-
+	testSuccessful(t, "cast(1, name)", `{name:"uint64"}`,
+		`error({message:"cannot cast to named type: bad type name \"uint64\": primitive type name",on:1})`)
 	testCompilationError(t, "cast()", function.ErrTooFewArgs)
 	testCompilationError(t, "cast(1, 2, 3)", function.ErrTooManyArgs)
 }

--- a/runtime/sam/expr/functions_test.go
+++ b/runtime/sam/expr/functions_test.go
@@ -138,7 +138,7 @@ func TestLen(t *testing.T) {
 func TestCast(t *testing.T) {
 	// Constant type argument
 	testSuccessful(t, "cast(1, <uint64>)", "", "1::uint64")
-	testSuccessful(t, "cast(1, 2)", "", `error({message:"cannot cast to 2",on:1})`)
+	testSuccessful(t, "cast(1, 2)", "", `error({message:"cast target must be a type or type name",on:2})`)
 
 	// Constant name argument
 	testSuccessful(t, `cast(1, "my_int64")`, "", "1::=my_int64")
@@ -147,7 +147,8 @@ func TestCast(t *testing.T) {
 
 	// Variable type argument
 	testSuccessful(t, "cast(1, type)", "{type:<uint64>}", "1::uint64")
-	testSuccessful(t, "cast(1, type)", "{type:2}", `error({message:"cannot cast to 2",on:1})`)
+	testSuccessful(t, "cast(1, type)", "{type:2}",
+		`error({message:"cast target must be a type or type name",on:2})`)
 
 	// Variable name argument
 	testSuccessful(t, "cast(1, name)", `{name:"my_int64"}`, "1::=my_int64")

--- a/runtime/sam/expr/shaper.go
+++ b/runtime/sam/expr/shaper.go
@@ -27,8 +27,6 @@ const (
 
 func NewShaperTransform(s string) ShaperTransform {
 	switch s {
-	case "cast":
-		return Cast
 	case "crop":
 		return Crop
 	case "fill":
@@ -209,7 +207,7 @@ func shaperType(sctx *super.Context, tf ShaperTransform, in, out super.Type) (su
 			}
 			return out, nil
 		}
-		if bestUnionTag(in, outUnder) > -1 {
+		if BestUnionTag(in, outUnder) > -1 {
 			return out, nil
 		}
 	} else if inUnder == outUnder {
@@ -293,14 +291,14 @@ func shaperFields(sctx *super.Context, tf ShaperTransform, in, out *super.TypeRe
 	return fields, nil
 }
 
-// bestUnionTag tries to return the most specific union tag for in
+// BestUnionTag tries to return the most specific union tag for in
 // within out.  It returns -1 if out is not a union or contains no type
 // compatible with in.  (Types are compatible if they have the same underlying
-// type.)  If out contains in, bestUnionTag returns its tag.
-// Otherwise, if out contains in's underlying type, bestUnionTag returns
-// its tag.  Finally, bestUnionTag returns the smallest tag in
+// type.)  If out contains in, BestUnionTag returns its tag.
+// Otherwise, if out contains in's underlying type, BestUnionTag returns
+// its tag.  Finally, BestUnionTag returns the smallest tag in
 // out whose type is compatible with in.
-func bestUnionTag(in, out super.Type) int {
+func BestUnionTag(in, out super.Type) int {
 	outUnion, ok := super.TypeUnder(out).(*super.TypeUnion)
 	if !ok {
 		return -1
@@ -395,7 +393,7 @@ Switch:
 		}
 		return step{op: castFromUnion, toType: out, children: steps}, nil
 	}
-	if tag := bestUnionTag(in, out); tag != -1 {
+	if tag := BestUnionTag(in, out); tag != -1 {
 		return step{op: castToUnion, fromType: in, toTag: tag, toType: out}, nil
 	}
 	return step{}, fmt.Errorf("createStep: incompatible types %s and %s", sup.FormatType(in), sup.FormatType(out))

--- a/runtime/sam/expr/shaper_test.go
+++ b/runtime/sam/expr/shaper_test.go
@@ -18,14 +18,14 @@ func TestBestUnionTag(t *testing.T) {
 	u8named3, err := sctx.LookupTypeNamed("u8named3", u8)
 	require.NoError(t, err)
 
-	assert.Equal(t, -1, bestUnionTag(u8, nil))
-	assert.Equal(t, -1, bestUnionTag(u8, u8))
-	assert.Equal(t, -1, bestUnionTag(super.TypeUint16, sctx.LookupTypeUnion([]super.Type{u8})))
+	assert.Equal(t, -1, BestUnionTag(u8, nil))
+	assert.Equal(t, -1, BestUnionTag(u8, u8))
+	assert.Equal(t, -1, BestUnionTag(super.TypeUint16, sctx.LookupTypeUnion([]super.Type{u8})))
 
 	test := func(expected, needle super.Type, haystack []super.Type) {
 		t.Helper()
 		union := sctx.LookupTypeUnion(haystack)
-		typ, err := union.Type(bestUnionTag(needle, union))
+		typ, err := union.Type(BestUnionTag(needle, union))
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, typ)
 		}

--- a/runtime/ztests/expr/cast/map.yaml
+++ b/runtime/ztests/expr/cast/map.yaml
@@ -1,0 +1,16 @@
+spq: |
+  values this::|{int64:|{string:int64}|}|
+
+vector: true
+
+input: |
+  |{}|
+  |{1:|{"2":3,4:"5"}|,"7":8,"9":|{10:[],[]:11,null:null}|}|
+  null
+  1
+
+output: |
+  |{}|
+  |{1:|{"2":3,"4":5}|,7:error({message:"cannot cast to |{string:int64}|",on:8}),9:|{null::string:null,"10":error({message:"cannot cast to int64",on:[]::[null]}),"[]":11}|}|
+  null::|{int64:|{string:int64}|}|
+  error({message:"cannot cast to |{int64:|{string:int64}|}|",on:1})

--- a/runtime/ztests/expr/cast/record.yaml
+++ b/runtime/ztests/expr/cast/record.yaml
@@ -1,0 +1,22 @@
+spq: |
+  values this::{a:int64,b:string,c:{},d:[{e:string,f:int64}]}
+
+vector: true
+
+input: |
+  {}
+  {a:"1",b:{}}
+  {b:1,c:2}
+  {a:"1",b:2,c:{cc:3},d:[{e:4,f:"5"},{f:6,e:"7"},8]}
+  {d:[{e:1,f:"2"},{f:3,e:"4"},5],c:null,b:6,a:"7"}
+  null
+  1
+
+output: |
+  {a:null::int64,b:null::string,c:null::{},d:null::[{e:string,f:int64}]}
+  {a:1,b:"{}",c:null::{},d:null::[{e:string,f:int64}]}
+  {a:null::int64,b:"1",c:error({message:"cannot cast to {}",on:2}),d:null::[{e:string,f:int64}]}
+  {a:1,b:"2",c:null::{},d:[{e:"4",f:5},{e:"7",f:6},error({message:"cannot cast to {e:string,f:int64}",on:8})]}
+  {a:7,b:"6",c:null::{},d:[{e:"1",f:2},{e:"4",f:3},error({message:"cannot cast to {e:string,f:int64}",on:5})]}
+  null::{a:int64,b:string,c:{},d:[{e:string,f:int64}]}
+  error({message:"cannot cast to {a:int64,b:string,c:{},d:[{e:string,f:int64}]}",on:1})

--- a/runtime/ztests/expr/shape-cast-from-union.yaml
+++ b/runtime/ztests/expr/shape-cast-from-union.yaml
@@ -24,11 +24,11 @@ output: |
   null::string
   "1"
   "1"
-  error("createStep: incompatible types int8|string and int64|string")
-  error("createStep: incompatible types int64|string and int8|string")
+  error({message:"cannot cast to int64|string",on:1::int8::(int8|string)})::error({message:string,on:int8|string})
+  error({message:"cannot cast to int8|string",on:1::(int64|string)})::error({message:string,on:int64|string})
   "one"
   ["1","one"]
-  error("createStep: incompatible types int64|string and int8|string")
-  error("createStep: incompatible types int64|string and int8|int16")
+  [error({message:"cannot cast to int8|string",on:1::(int64|string)})::error({message:string,on:int64|string}),"one"::(int8|string)]
+  [error({message:"cannot cast to int8|int16",on:1::(int64|string)})::error({message:string,on:int64|string}),error({message:"cannot cast to int8|int16",on:"one"::(int64|string)})::error({message:string,on:int64|string})]
   {a:["1","one"]}
-  error("createStep: incompatible types int64|string and int8|string")
+  {a:[error({message:"cannot cast to int8|string",on:1::(int64|string)})::error({message:string,on:int64|string}),"one"::(int8|string)]}

--- a/runtime/ztests/expr/shape-cast.yaml
+++ b/runtime/ztests/expr/shape-cast.yaml
@@ -2,7 +2,7 @@ spq: |
   put
   -- cast to type with same field order
   id:=cast(id, <{orig_h:ip,orig_p:port=uint16,resp_h:ip,resp_p:port}>),
-  -- cast to type with different field order, does not change output order
+  -- cast to type with different field order
   id2:=cast(id, <{resp_h:ip,resp_p:port=uint16,orig_h:ip,orig_p:port}>)
 
 vector: true
@@ -12,5 +12,5 @@ input: |
   {id:{orig_h:ff02::fb,orig_p:5353::(port=uint16),resp_p:5353::port,resp_h:"notanip"},other:123.}
 
 output: |
-  {id:{orig_h:ff02::fb,orig_p:5353::(port=uint16),resp_p:5353::port,resp_h:1.2.3.4},other:123.,id2:{orig_h:ff02::fb,orig_p:5353::port,resp_p:5353::port,resp_h:1.2.3.4}}
-  {id:{orig_h:ff02::fb,orig_p:5353::(port=uint16),resp_p:5353::port,resp_h:error({message:"cannot cast to ip",on:"notanip"})},other:123.,id2:{orig_h:ff02::fb,orig_p:5353::port,resp_p:5353::port,resp_h:error({message:"cannot cast to ip",on:"notanip"})}}
+  {id:{orig_h:ff02::fb,orig_p:5353::(port=uint16),resp_h:1.2.3.4,resp_p:5353::port},other:123.,id2:{resp_h:1.2.3.4,resp_p:5353::port,orig_h:ff02::fb,orig_p:5353::port}}
+  {id:{orig_h:ff02::fb,orig_p:5353::(port=uint16),resp_h:error({message:"cannot cast to ip",on:"notanip"}),resp_p:5353::port},other:123.,id2:{resp_h:error({message:"cannot cast to ip",on:"notanip"}),resp_p:5353::port,orig_h:ff02::fb,orig_p:5353::port}}

--- a/value.go
+++ b/value.go
@@ -429,6 +429,16 @@ func (v *Value) MissingAsNull() Value {
 	return *v
 }
 
+func (v Value) Deunion() Value {
+	for {
+		union, ok := v.Type().(*TypeUnion)
+		if !ok || v.IsNull() {
+			return v
+		}
+		v = NewValue(union.Untag(v.bytes()))
+	}
+}
+
 // Under resolves named types and untags unions repeatedly, returning a value
 // guaranteed to have neither a named type nor a union type.
 func (v Value) Under() Value {


### PR DESCRIPTION
Casting of complex types is implemented in runtime/sam/expr/shaper.go.
Replace it with a new implementation in
runtime/sam/expr/function/cast.go with these differences:

* Always generates a structured error when casting fails 

* Preserves target type field order when casting records

* Able to cast maps

* More maintainable

Fixes #2894
Fixes #4315
Closes #5168