### PR TITLE
fix(semantic): avoid duplicate-field panic when a deduped column alias collides with an explicit one

### DIFF
--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -720,10 +720,21 @@ func (t *translator) resolveOrdinalOuter(ts tableScope, n ast.Node, prefix strin
 func dedup(scores map[string]int, s string) string {
 	cnt := scores[s]
 	scores[s] = cnt + 1
-	if cnt != 0 {
-		s = fmt.Sprintf("%s_%d", s, cnt)
+	if cnt == 0 {
+		return s
 	}
-	return s
+	// Suffix duplicate names with "_<n>", but skip any candidate that is
+	// already taken by another column (explicit or previously generated) so
+	// the projected record cannot end up with two identical field names, which
+	// would panic in MustLookupTypeRecord (e.g. "SELECT 1 AS x, 2 AS x, 3 AS x_1").
+	for {
+		candidate := fmt.Sprintf("%s_%d", s, cnt)
+		if scores[candidate] == 0 {
+			scores[candidate] = 1
+			return candidate
+		}
+		cnt++
+	}
 }
 
 func valuesExpr(e sem.Expr, seq sem.Seq) sem.Seq {

--- a/compiler/ztests/sql/select-dup-alias-collision.yaml
+++ b/compiler/ztests/sql/select-dup-alias-collision.yaml
@@ -1,0 +1,9 @@
+script: |
+  super compile -C -O "select 1 as x, 2 as x, 3 as x_1"
+
+outputs:
+  - name: stdout
+    data: |
+      null
+      | values {x:1,x_1:2,x_1_1:3}
+      | output main


### PR DESCRIPTION
## Summary

A SQL projection whose auto-deduplicated column alias collides with an explicit alias panicked the compiler with `panic: duplicate field`. This makes the deduplicator pick a suffix that is not already taken (and record it), so the projected record type always has unique field names.

## Motivation

```
$ super -c "SELECT 1 AS x, 2 AS x, 3 AS x_1;"
panic: duplicate field: "x_1"
  ...super.(*Context).MustLookupTypeRecord(...)  context.go:143
  ...semantic.(*translator).emitProjection(...)  compiler/semantic/sql.go:258
```

`dedup` (`compiler/semantic/sql.go`) renames the second `x` to `x_1` by appending `_<count>`, but it did not check whether that generated name was already used, nor did it record the generated name. So the explicit third column, also `x_1`, kept its name and the projection ended up with two `x_1` fields — which panics in `MustLookupTypeRecord`, aborting the whole query at compile time.

Fixes #7123.

## Fix

`dedup` now, for a duplicate name, scans for the first `"<name>_<n>"` candidate that is not already present in the score map (covering both explicit columns and previously generated names) and records that candidate as occupied before returning it. The projection therefore always has unique field names.

With the fix:

```
$ super compile -C -O "select 1 as x, 2 as x, 3 as x_1"
null
| values {x:1,x_1:2,x_1_1:3}
| output main
```

(`SELECT 1 AS x, 2 AS x, 3 AS x` still yields `x, x_1, x_2` as before.)

## Testing

Added `compiler/ztests/sql/select-dup-alias-collision.yaml`, which compiles the reproducing query and asserts the deterministic, collision-free projection instead of a panic. Verified it passes against the built binary (`ZTEST_PATH=<dir> go test . -run 'TestSPQ/compiler/ztests/sql/select-dup-alias-collision'`), and the existing compiler/parser tests pass. `gofmt`, `go vet`, and `go build ./cmd/super` are clean.
