### PR TITLE
any(): Do not rip fusion inputs

### DIFF
--- a/compiler/rungen/vop.go
+++ b/compiler/rungen/vop.go
@@ -376,16 +376,19 @@ func (b *Builder) compileVamAggregate(s *dag.AggregateOp, parent vio.Puller) (vi
 	var aggs []*vamexpr.Aggregator
 	for _, assignment := range s.Aggs {
 		aggNames = append(aggNames, assignment.LHS.(*dag.ThisExpr).Path)
-		lhs, err := b.compileVamExpr(assignment.LHS)
-		if err != nil {
-			return nil, err
-		}
-		aggExprs = append(aggExprs, lhs)
 		agg, err := b.compileVamAgg(assignment.RHS.(*dag.AggExpr))
 		if err != nil {
 			return nil, err
 		}
 		aggs = append(aggs, agg)
+		lhs, err := b.compileVamExpr(assignment.LHS)
+		if err != nil {
+			return nil, err
+		}
+		if agg.NoRip {
+			lhs = vamexpr.NoRipEval(lhs)
+		}
+		aggExprs = append(aggExprs, lhs)
 	}
 	// compile keys
 	var keyNames []field.Path

--- a/runtime/vam/expr/agg/any.go
+++ b/runtime/vam/expr/agg/any.go
@@ -13,11 +13,38 @@ func NewAny() *Any {
 	return &Any{}
 }
 
+func (a *Any) NoRip() bool { return true }
+
 func (a *Any) Consume(vec vector.Any) {
-	if a.result != nil || vec.Kind() == vector.KindNull {
+	if a.result != nil {
 		return
 	}
-	a.result = vector.Pick(vec, []uint32{0})
+	slot := firstNonNullSlot(vec)
+	if slot != -1 {
+		a.result = vector.Pick(vec, []uint32{uint32(slot)})
+	}
+}
+
+func firstNonNullSlot(vec vector.Any) int {
+	if vec.Len() == 0 {
+		return -1
+	}
+	switch vec.Kind() {
+	case vector.KindNull:
+		return -1
+	case vector.KindFusion:
+		return firstNonNullSlot(vector.Super(vec))
+	case vector.KindUnion:
+		union := vec.(*vector.Union)
+		for i, vec := range union.Values() {
+			if slot := firstNonNullSlot(vec); slot != -1 {
+				return int(union.Dynamic().ReverseTagMap()[i][slot])
+			}
+		}
+		return -1
+	default:
+		return 0
+	}
 }
 
 func (a *Any) ConsumeAsPartial(vec vector.Any) {

--- a/runtime/vam/expr/aggregator.go
+++ b/runtime/vam/expr/aggregator.go
@@ -12,7 +12,7 @@ type Aggregator struct {
 	Distinct bool
 	Expr     Evaluator
 	Where    Evaluator
-	norip    bool
+	NoRip    bool
 }
 
 func NewAggregator(name string, distinct bool, expr Evaluator, where Evaluator) (*Aggregator, error) {
@@ -35,14 +35,14 @@ func NewAggregator(name string, distinct bool, expr Evaluator, where Evaluator) 
 		Distinct: distinct,
 		Expr:     expr,
 		Where:    where,
-		norip:    norip,
+		NoRip:    norip,
 	}, nil
 }
 
 func (a *Aggregator) Eval(this vector.Any) vector.Any {
 	vec := a.Expr.Eval(this)
 	if a.Where == nil {
-		if a.norip {
+		if a.NoRip {
 			vec = vector.AddNoRip(vec)
 		}
 		return vec
@@ -58,8 +58,20 @@ func (a *Aggregator) Eval(this vector.Any) vector.Any {
 		nulls := vector.NewNull(vec.Len() - uint32(len(index)))
 		vec = vector.Combine(nulls, index, vector.Pick(vec, index))
 	}
-	if a.norip {
+	if a.NoRip {
 		vec = vector.AddNoRip(vec)
 	}
 	return vec
+}
+
+type noRipEval struct {
+	eval Evaluator
+}
+
+func NoRipEval(e Evaluator) Evaluator {
+	return &noRipEval{e}
+}
+
+func (n *noRipEval) Eval(vec vector.Any) vector.Any {
+	return vector.AddNoRip(n.eval.Eval(vec))
 }

--- a/runtime/ztests/op/aggregate/any.yaml
+++ b/runtime/ztests/op/aggregate/any.yaml
@@ -6,9 +6,11 @@ input: |
   {k:"k2",v:null}
   {k:"k3",v:error("missing")}
   {k:"k4",v:error("quiet")}
+  {k:"k5",v:fusion({a:1,b?:_::int64},<{a:int64}>)} 
 
 output: |
   {k:"k1",any:1}
   {k:"k2",any:null}
   {k:"k3",any:error("missing")}
   {k:"k4",any:null}
+  {k:"k5",any:{a:1}}

--- a/runtime/ztests/op/aggregate/null.yaml
+++ b/runtime/ztests/op/aggregate/null.yaml
@@ -3,6 +3,7 @@ spq: avg(x), count(x), dcount(x), any(x), max(x), min(x), sum(x)
 input: |
   {x:null}
   {x:null::(int64|null)}
+  {x:fusion(null::(int64|null),<null>)}
 
 output: |
   {avg:null,count:0,dcount:0,any:null,max:null,min:null,sum:null}


### PR DESCRIPTION
This commit fixes an issue with the any aggregator where fusion values were not getting perserved. It also adds vector.NoRip to aggregator aggExprs because this was also ripping fusion values where we do not want them to.

Fixes #6897
Fixes #6916