### PR TITLE
vector.DeoptionWithMissing: handle fusion values

### DIFF
--- a/runtime/ztests/expr/dot.yaml
+++ b/runtime/ztests/expr/dot.yaml
@@ -10,6 +10,7 @@ input: |
   {a:1}
   {}
   null
+  {a:{b:fusion(_::(string|null|none),<none>)}}
 
 output: |
   1
@@ -17,6 +18,7 @@ output: |
   1
   1
   1
+  error("missing")
   error("missing")
   error("missing")
   error("missing")

--- a/vector/union.go
+++ b/vector/union.go
@@ -293,6 +293,24 @@ func DeoptionWithMissing(sctx *super.Context, vec Any) Any {
 			out = DeoptionWithMissing(sctx, out)
 			return out
 		}
+	case *Fusion:
+		if hasOptionTypesOrNones([]Any{vec.Values}) {
+			types := vec.Subtypes.Types()
+			var index []uint32
+			for id, typ := range types {
+				if typ == super.TypeNone {
+					index = append(index, uint32(id))
+				}
+			}
+			if len(index) == 0 {
+				return vec
+			}
+			missing := NewMissing(sctx, uint32(len(index)))
+			if missing.Len() == vec.Len() {
+				return missing
+			}
+			return Combine(vec, index, missing)
+		}
 	}
 	return vec
 }


### PR DESCRIPTION
This commit adjust vector.DeoptionWithMissing to return error("missing") for none values within fusion values.