### PR TITLE
jsonio.valReader: use io.ReadFull to read buffer

### DIFF
--- a/sio/anyio/ztests/huge.yaml
+++ b/sio/anyio/ztests/huge.yaml
@@ -15,7 +15,7 @@ outputs:
       	bsup: BSUP version mismatch: expected 5, found 0
       	csup: invalid CSUP header
       	csv: line 1: delimiter ',' not found
-      	json: line 1: invalid JSON value
+      	json: buffer exceeded max size trying to infer input format
       	line: auto-detection not supported
       	parquet: invalid header
       	sup: buffer exceeded max size trying to infer input format

--- a/sio/jsonio/stream.go
+++ b/sio/jsonio/stream.go
@@ -92,12 +92,17 @@ func newBytesTable() *vector.BytesTable {
 func readBatch(r *valReader) (*vector.BytesTable, int, error) {
 	t := newBytesTable()
 	start := r.lineNumber()
+	var err error
 	for range VecBatchSize {
-		b, err := r.Next()
-		if err != nil {
-			return t, start, err
+		var b []byte
+		if b, err = r.Next(); err != nil {
+			break
 		}
 		t.Append(b)
 	}
-	return t, start, nil
+	if t.Len() == 0 {
+		bytesTablePool.Put(t)
+		t = nil
+	}
+	return t, start, err
 }

--- a/sio/jsonio/valreader.go
+++ b/sio/jsonio/valreader.go
@@ -72,8 +72,8 @@ func (r *valReader) Next() ([]byte, error) {
 func (r *valReader) fill() error {
 	// copy rest of cursor to buf
 	cc := copy(r.buf, r.cursor)
-	n, err := r.r.Read(r.buf[cc:])
-	if errors.Is(err, io.EOF) {
+	n, err := io.ReadFull(r.r, r.buf[cc:])
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		r.EOF = true
 		err = nil
 	}


### PR DESCRIPTION
This commit changes the behavior of the fill() method in valReader to use use io.ReadFull to fill the buffer. The code was mistakenly assuming calls to Read would fill the passed buffer unless EOF was reached.

This commit also resolves a panic that occurs when no values are read from a batch by returning nil if the vector.BytesTable is empty.

Closes #7163