### PR TITLE
Fix spurious "wrong number of fields" reading a CSV file with -csv.delim

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -308,7 +308,7 @@ func (t *translator) fileType(path, format string) (super.Type, error) {
 	if engine == nil {
 		return t.checker.unknown, nil
 	}
-	return anyio.FileType(t.ctx, t.sctx, engine, path, anyio.ReaderOpts{Format: format}, t.env.SampleSize)
+	return anyio.FileType(t.ctx, t.sctx, engine, path, t.env.FileReaderOpts(format), t.env.SampleSize)
 }
 
 func (t *translator) fromFileGlob(globLoc ast.Node, pattern string, args []ast.OpArg) sem.Op {

--- a/runtime/exec/environment.go
+++ b/runtime/exec/environment.go
@@ -102,6 +102,13 @@ func (e *Environment) readerOpts(p sbuf.Pushdown, format string, concurrentReade
 	return o
 }
 
+// FileReaderOpts returns the options Open uses for a scan of the given format
+// so that anything reading a file ahead of the scan, like type inference, reads
+// it the same way the scan will.
+func (e *Environment) FileReaderOpts(format string) anyio.ReaderOpts {
+	return e.readerOpts(nil, format, 0)
+}
+
 func (e *Environment) OpenHTTP(ctx context.Context, sctx *super.Context, url, format, method string, headers http.Header, body io.Reader, p sbuf.Pushdown) (vio.Puller, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {

--- a/sio/csvio/ztests/issue-7203.yaml
+++ b/sio/csvio/ztests/issue-7203.yaml
@@ -1,0 +1,25 @@
+script: |
+  super -s -i csv -csv.delim ';' semi.csv
+  echo // standard input
+  cat semi.csv | super -s -i csv -csv.delim ';' -
+  echo // default delimiter
+  super -s -i csv comma.csv
+
+inputs:
+  - name: semi.csv
+    data: |
+      h1;h2;h3
+      x;a,b;y
+  - name: comma.csv
+    data: |
+      h1,h2,h3
+      x,"a;b",y
+
+outputs:
+  - name: stdout
+    data: |
+      {h1:"x",h2:"a,b",h3:"y"}
+      // standard input
+      {h1:"x",h2:"a,b",h3:"y"}
+      // default delimiter
+      {h1:"x",h2:"a;b",h3:"y"}


### PR DESCRIPTION
This PR proposes a fix for the spurious `wrong number of fields` error when a CSV file is read from seekable input with a non-comma `-csv.delim` (Fixes #7203). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/328. You can sign in with your GitHub ID to claim ownership of the project.

## What goes wrong

Static type inference opens each input file ahead of the scan, but `translator.fileType` in `compiler/semantic/op.go` built its reader options from scratch as `anyio.ReaderOpts{Format: format}`, so every reader option other than the format was dropped on the way in. The file was therefore typed with a comma delimiter regardless of `-csv.delim`, and `encoding/csv` rejected it as soon as a data row happened to carry a different number of commas than the header. The same input over a pipe reads fine because a pipe is not seekable and `anyio.FileType` returns early on non-seekable input, so type inference never looks at it. The `-bsup.*` options were dropped the same way.

Reproduced on current `main` (3051feebff3618d70013dd501e3c3298298ac6e1):

```
$ printf 'h1;h2;h3\nx;a,b;y\n' > t.csv
$ mkdir -p dist && go build -o dist ./cmd/...

$ ./dist/super -s -i csv -csv.delim ';' t.csv
t.csv: record on line 2: wrong number of fields

$ cat t.csv | ./dist/super -s -i csv -csv.delim ';' -    # pipe: not seekable
{h1:"x",h2:"a,b",h3:"y"}

$ ./dist/super -s -dynamic -i csv -csv.delim ';' t.csv   # no type inference
{h1:"x",h2:"a,b",h3:"y"}
```

## The change

`exec.Environment` already has the rule for building a scan's reader options — `readerOpts`, which `Open` calls, layers the per-scan format over `env.ReaderOpts` — so type inference now goes through that same rule instead of assembling its own. The new `Environment.FileReaderOpts` is a thin exported wrapper over it, which keeps the two paths from drifting apart, and it preserves the existing precedence: a per-scan format still overrides the environment's `-i`, and an empty one still falls back to it. The wrapper is additive; `readerOpts`, `Open` and every existing call site are untouched.

After the change, all three forms above agree, including the seekable-stdin form the redirect produces:

```
$ ./dist/super -s -i csv -csv.delim ';' t.csv
{h1:"x",h2:"a,b",h3:"y"}
$ ./dist/super -s -i csv -csv.delim ';' - < t.csv
{h1:"x",h2:"a,b",h3:"y"}
```

## Tests

`sio/csvio/ztests/issue-7203.yaml` is a script-style ztest covering the seekable file, the same input over a pipe, and a comma-delimited file with a semicolon inside a quoted field — the last two pin the behavior that already worked, since both now flow through the shared options. On `main` it fails with exactly the reported error; with the change it passes:

```
# before
--- FAIL: TestSPQ/sio/csvio/ztests/issue-7203.yaml/1
    sio/csvio/ztests/issue-7203.yaml:1: script failed: exit status 1
    === stderr ===
    semi.csv: record on line 2: wrong number of fields

# after
$ ZTEST_PATH="$PWD/dist:$PWD/bin" go test -short . -run 'TestSPQ/sio/csvio/ztests'
ok  	github.com/brimdata/super	5.847s
```

The whole suite is slow on the machine used here, so the checks were scoped rather than run whole, and run twice — once on a clean tree and once with the change — to compare failures rather than counts. `go test -short ./compiler/... ./runtime/exec/... ./sio/... ./cli/...` is green in both runs. `ZTEST_PATH="$PWD/dist:$PWD/bin" go test -short .`, which exercises every ztest in the tree as a subprocess against the built binary, gives an identical failure set in both runs: the `cmd/super/ztests/s3-*` and `db/ztests/s3` cases, which want a local minio that was not built here. `go vet` and `gofmt -l` are clean on the two changed files. Boomerang tests were skipped via `-short` and are untouched by this change; a full `make test-system` on your CI is the confirming run.

## How this was managed

We ran this work on a board imported from this repo's own issues, pull requests and milestones. The story it was tracked on is [Spurious "wrong number of fields" on non-comma-delimited CSV read on seekable input](https://eastagiletracker.com/projects/328/stories/210644), and the board is at https://eastagiletracker.com/projects/328.

![board](https://raw.githubusercontent.com/eastagiletracker/super/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
