### PR TITLE
fix db/meta test after defuse change

### DIFF
--- a/db/ztests/meta.yaml
+++ b/db/ztests/meta.yaml
@@ -58,8 +58,8 @@ outputs:
       ===
       {
         nameof: "data.Object",
-        min: 1::any,
-        max: 2::any,
+        min: 1,
+        max: 2,
         count: 2::uint64,
         size: 20
       }


### PR DESCRIPTION
PR #7189 made it some values are defused in the drop operator, which made it so this test no longer has the expected `::any` value. Fix the test to align with the new reality.