### PR TITLE
fix panic in "unnest {a,b}" when b is an empty array

### DIFF
--- a/runtime/vam/op/unnest.go
+++ b/runtime/vam/op/unnest.go
@@ -70,6 +70,9 @@ func (u *Unnest) flatten(vec vector.Any, slot uint32) vector.Any {
 			return vector.NewWrappedError(u.sctx, "unnest: encountered record without an array/set type for second field", vec)
 		}
 		right := u.flatten(fields[1], slot)
+		if right == nil {
+			return nil
+		}
 		lindex := make([]uint32, right.Len())
 		for i := range lindex {
 			lindex[i] = slot

--- a/runtime/ztests/op/unnest.yaml
+++ b/runtime/ztests/op/unnest.yaml
@@ -36,6 +36,7 @@ spq: unnest {a,b} | values a+b
 input: |
   {a:1,b:[1,2,3]}
   {a:2,b:[10,20,30]}
+  {a:1,b:[]}
 
 output: |
   2


### PR DESCRIPTION
Fixes #7206.