### PR TITLE
Add docs for array_agg aggregate function

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -168,6 +168,7 @@
     - [Aggregate Functions](super-sql/aggregates/intro.md)
         - [and](super-sql/aggregates/and.md)
         - [any](super-sql/aggregates/any.md)
+        - [array_agg](super-sql/aggregates/array_agg.md)
         - [avg](super-sql/aggregates/avg.md)
         - [blend](super-sql/aggregates/blend.md)
         - [collect](super-sql/aggregates/collect.md)

--- a/book/src/super-sql/aggregates/array_agg.md
+++ b/book/src/super-sql/aggregates/array_agg.md
@@ -1,0 +1,51 @@
+# array_agg
+
+aggregate values into array
+
+## Synopsis
+
+```
+array_agg(any) -> [any]
+```
+
+## Description
+
+The _array_agg_ aggregate function organizes its input into an array.
+If the input values vary in type, the return type will be an array
+of union of the types encountered.
+
+>[!NOTE]
+>_array_agg_ is like [collect](collect.md) but matches PostgreSQL in returning
+>`null`, rather than an empty array, when no values are aggregated.
+
+## Examples
+
+Simple sequence aggregated into an array (see [collect](collect.md) docs for more examples):
+```mdtest-spq
+# spq
+array_agg(this)
+# input
+1
+2
+3
+4
+# expected output
+[1,2,3,4]
+```
+
+Contrast `array_agg` with `collect` when no values have been aggregated:
+```mdtest-spq
+# spq
+aggregate
+  array_agg(a) filter (a > 1),
+  collect(a) filter (a > 1)
+  by k
+| sort
+# input
+{a:1,k:1}
+{a:2,k:2}
+{a:3,k:2}
+# expected output
+{k:1,array_agg:null,collect:[]}
+{k:2,array_agg:[2,3],collect:[2,3]}
+```

--- a/book/src/super-sql/aggregates/array_agg.md
+++ b/book/src/super-sql/aggregates/array_agg.md
@@ -11,12 +11,13 @@ array_agg(any) -> [any]|null
 ## Description
 
 The _array_agg_ aggregate function organizes its input into an array.
-If the input values vary in type, the return type will be an array
-of union of the types encountered.
+If the aggregated values vary in type, the return type will be an array
+of union of the types encountered.  If no values are aggregated, the
+return value is `null`.
 
 >[!NOTE]
->_array_agg_ is like [collect](collect.md) but follows the SQL standard in returning
->`null`, rather than an empty array, when no values are aggregated.
+>See [collect](collect.md) for a variant that returns an empty array when no
+>values are aggregated.  The `null` return follows the SQL standard.
 
 ## Examples
 

--- a/book/src/super-sql/aggregates/array_agg.md
+++ b/book/src/super-sql/aggregates/array_agg.md
@@ -5,7 +5,7 @@ aggregate values into array
 ## Synopsis
 
 ```
-array_agg(any) -> [any]
+array_agg(any) -> [any]|null
 ```
 
 ## Description

--- a/book/src/super-sql/aggregates/array_agg.md
+++ b/book/src/super-sql/aggregates/array_agg.md
@@ -15,7 +15,7 @@ If the input values vary in type, the return type will be an array
 of union of the types encountered.
 
 >[!NOTE]
->_array_agg_ is like [collect](collect.md) but matches PostgreSQL in returning
+>_array_agg_ is like [collect](collect.md) but follows the SQL standard in returning
 >`null`, rather than an empty array, when no values are aggregated.
 
 ## Examples

--- a/book/src/super-sql/aggregates/collect.md
+++ b/book/src/super-sql/aggregates/collect.md
@@ -14,6 +14,10 @@ The _collect_ aggregate function organizes its input into an array.
 If the input values vary in type, the return type will be an array
 of union of the types encountered.
 
+>[!NOTE]
+>See [array_agg](array_agg.md) for a variant that matches PostgreSQL when
+>no values are aggregated.
+
 ## Examples
 
 Simple sequence collected into an array:
@@ -56,4 +60,21 @@ collect(a) by k | sort
 # expected output
 {k:1,collect:[1,2]}
 {k:2,collect:[3,4]}
+```
+
+Contrast `collect` with `array_agg` when no values have been aggregated:
+```mdtest-spq
+# spq
+aggregate
+  collect(a) filter (a > 1),
+  array_agg(a) filter (a > 1)
+  by k
+| sort
+# input
+{a:1,k:1}
+{a:2,k:2}
+{a:3,k:2}
+# expected output
+{k:1,collect:[],array_agg:null}
+{k:2,collect:[2,3],array_agg:[2,3]}
 ```

--- a/book/src/super-sql/aggregates/collect.md
+++ b/book/src/super-sql/aggregates/collect.md
@@ -11,12 +11,13 @@ collect(any) -> [any]
 ## Description
 
 The _collect_ aggregate function organizes its input into an array.
-If the input values vary in type, the return type will be an array
-of union of the types encountered.
+If the aggregated values vary in type, the return type will be an array
+of union of the types encountered.  If no values are aggregated, the
+return value is an empty array.
 
 >[!NOTE]
->See [array_agg](array_agg.md) for a variant that matches PostgreSQL when
->no values are aggregated.
+>See [array_agg](array_agg.md) for a variant that returns `null` when no values
+>are aggregated, following the SQL standard.
 
 ## Examples
 


### PR DESCRIPTION
These are user-facing docs for `array_agg` that was added in #7165.

I intentionally stopped short of duplicating all the examples from the `collect` page and instead tried to focus on disclosing the key difference. That said, I still opted to include a very basic example on `array_agg` since all the other pages have them.

I also intentionally held back from using words like "SQL compatibility" since `array_agg` is not quite fully SQL compatible until we address #7178 and #7218.