### PR TITLE
sio/jsonio: fix hang in stream.close

### DIFF
--- a/sio/jsonio/stream.go
+++ b/sio/jsonio/stream.go
@@ -72,9 +72,6 @@ func (s *stream) run() {
 
 func (s *stream) close() error {
 	close(s.done)
-	// drain channel
-	for range s.ch {
-	}
 	return nil
 }
 


### PR DESCRIPTION
stream.close can hang while draining stream.ch.  There's no need to drain that channel so don't.

@mattnibs: This should fix the hang we've been seeing in CI.