### PR TITLE
fix: Isolate parse_sup parser state per input

### DIFF
--- a/runtime/sam/expr/function/parse.go
+++ b/runtime/sam/expr/function/parse.go
@@ -86,13 +86,10 @@ func (p *ParseURI) Call(args []super.Value) super.Value {
 
 type ParseSUP struct {
 	sctx *super.Context
-	sr   *strings.Reader
-	zr   *supio.Reader
 }
 
 func newParseSUP(sctx *super.Context) *ParseSUP {
-	var sr strings.Reader
-	return &ParseSUP{sctx, &sr, supio.NewReader(sctx, &sr)}
+	return &ParseSUP{sctx}
 }
 
 func (p *ParseSUP) Call(args []super.Value) super.Value {
@@ -103,8 +100,8 @@ func (p *ParseSUP) Call(args []super.Value) super.Value {
 	if !in.IsString() {
 		return p.sctx.WrapError("parse_sup: string arg required", args[0])
 	}
-	p.sr.Reset(super.DecodeString(in.Bytes()))
-	val, err := p.zr.Read()
+	zr := supio.NewReader(p.sctx, strings.NewReader(super.DecodeString(in.Bytes())))
+	val, err := zr.Read()
 	if err != nil {
 		return p.sctx.WrapError("parse_sup: "+err.Error(), args[0])
 	}

--- a/runtime/sam/expr/function/parse_test.go
+++ b/runtime/sam/expr/function/parse_test.go
@@ -1,0 +1,19 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/sup"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSUPIsolatesParserState(t *testing.T) {
+	parse := newParseSUP(super.NewContext())
+
+	got := parse.Call([]super.Value{super.NewString(",")})
+	assert.Equal(t, `error({message:"parse_sup: line 1: syntax error",on:","})`, sup.FormatValue(got))
+
+	got = parse.Call([]super.Value{super.NewString("{a:1}")})
+	assert.Equal(t, "{a:1}", sup.FormatValue(got))
+}

--- a/runtime/vam/expr/function/parse.go
+++ b/runtime/vam/expr/function/parse.go
@@ -41,13 +41,10 @@ func (p *ParseURI) Call(args ...vector.Any) vector.Any {
 
 type ParseSUP struct {
 	sctx *super.Context
-	sr   *strings.Reader
-	zr   *supio.Reader
 }
 
 func newParseSUP(sctx *super.Context) *ParseSUP {
-	var sr strings.Reader
-	return &ParseSUP{sctx, &sr, supio.NewReader(sctx, &sr)}
+	return &ParseSUP{sctx}
 }
 
 func (p *ParseSUP) Call(args ...vector.Any) vector.Any {
@@ -63,8 +60,8 @@ func (p *ParseSUP) Call(args ...vector.Any) vector.Any {
 	builder := vector.NewDynamicValueBuilder()
 	for i := range vec.Len() {
 		s := vector.StringValue(vec, i)
-		p.sr.Reset(s)
-		val, err := p.zr.Read()
+		zr := supio.NewReader(p.sctx, strings.NewReader(s))
+		val, err := zr.Read()
 		if err != nil {
 			errs = append(errs, i)
 			errMsgs.Append("parse_sup: " + err.Error())

--- a/runtime/ztests/expr/function/parse-sup.yaml
+++ b/runtime/ztests/expr/function/parse-sup.yaml
@@ -2,6 +2,8 @@ spq: parse_sup(this)
 
 input: |
   "{a:1}"
+  ""
+  " "
   null
   {}
   "!"
@@ -9,5 +11,37 @@ input: |
 output: |
   {a:1}
   null
+  null
+  null
   error({message:"parse_sup: string arg required",on:{}})
   error({message:"parse_sup: line 1: syntax error",on:"!"})
+
+---
+
+spq: parse_sup(this)
+
+input: |
+  "{a:1}"
+  ","
+  "{b:2}"
+  "{c:3}"
+
+output: |
+  {a:1}
+  error({message:"parse_sup: line 1: syntax error",on:","})
+  {b:2}
+  {c:3}
+
+---
+
+spq: parse_sup(this)
+
+input: |
+  "{a:{b:1}}"
+  "{a:{b:2}]"
+  "{a:{b:3}}"
+
+output: |
+  {a:{b:1}}
+  error({message:"parse_sup: line 1: parse error: mismatched braces while parsing record type",on:"{a:{b:2}]"})
+  {a:{b:3}}


### PR DESCRIPTION
Update `runtime/sam/expr/function/parse.go` so each string argument is handled by a fresh SUP reader/parser lifecycle rather than resetting an input reader beneath an already-initialized parser. `parse_sup` reuses a `supio.Reader` while resetting only its underlying `strings.Reader`, so the SUP parser's lexer cursor and error state can survive between logically independent function inputs.

Parse valid record, malformed bare comma, and multiple subsequent valid records through one `parse_sup` execution; only the comma position returns a syntax error and every later record retains its own value; Parse valid record, mismatched nested braces, and a subsequent valid record; the malformed input returns the mismatched-braces error and the following record is not replaced by a leaked scalar value.

Closes #6234
