### PR TITLE
Point Zeek links in docs at new locations and exclude them from link checker

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -3,6 +3,7 @@ dirs:
 useGitIgnore: true
 excludedDirs:
   - node_modules
+userAgent: 'linkspector (+https://github.com/brimdata/super; docs link check)'
 
 ignorePatterns:
 
@@ -19,3 +20,8 @@ ignorePatterns:
 
 # Not crawling the following due to persistent HTTP 503 errors
   - pattern: '^https://sqlite.org'
+
+# Not crawling the following due to a Cloudflare challenge that causes HTTP
+# 429/403 errors during link checking
+# See https://github.com/zeek/zeek/issues/5819
+  - pattern: '^https://docs\.zeek\.org'

--- a/book/src/command/formats.md
+++ b/book/src/command/formats.md
@@ -13,7 +13,7 @@ The supported [input](input.md) and [output](output.md) formats include the foll
 | `parquet` |  yes | `.parquet` | [Apache Parquet](https://github.com/apache/parquet-format) |
 | `sup`     |  yes | `.sup` | [SUP](../formats/sup.md) |
 | `tsv`     |  yes | `.tsv` | [Tab-Separated Values](https://en.wikipedia.org/wiki/Tab-separated_values) |
-| `zeek`    |  yes | `.zeek` | [Zeek Logs](https://docs.zeek.org/en/current/logs/index.html) |
+| `zeek`    |  yes | `.zeek` | [Zeek Logs](https://docs.zeek.org/en/current/reference/logs/index.html) |
 
 >[!NOTE]
 > Best performance is typically achieved when operating on data in binary columnar formats

--- a/book/src/dev/integrations/zeek/logs.md
+++ b/book/src/dev/integrations/zeek/logs.md
@@ -4,12 +4,12 @@ SuperDB can read both of the common Zeek log formats. This section
 provides guidance for what to expect when reading logs of these formats using
 the [super](../../../command/super.md) command.
 
-[Zeek TSV](https://docs.zeek.org/en/current/log-formats.html#zeek-log-formats)
+[Zeek TSV](https://docs.zeek.org/en/current/tutorial/logs.html#zeek-log-formats)
 is Zeek's default output format for logs. This format can be read automatically
 (i.e., no `-i` command line flag is necessary to indicate the input format)
 with [super](../../../command/super.md).
 s
-The following example shows a TSV [conn.log](https://docs.zeek.org/en/current/logs/conn.html) being read via `super` and
+The following example shows a TSV [conn.log](https://docs.zeek.org/en/current/reference/logs/conn.html) being read via `super` and
 output as [Super (SUP)](../../../formats/sup.md).
 
 ## conn.log
@@ -74,7 +74,7 @@ equivalent [super-structured types](../../../formats/model.md#1-primitive-types)
 ## The Role of `_path`
 
 Zeek's `_path` field plays an important role in differentiating between its
-different [log types](https://docs.zeek.org/en/current/script-reference/log-files.html)
+different [log types](https://docs.zeek.org/en/current/reference/zeekscript/log-files.html)
 (`conn`, `dns`, etc.) For instance,
 [shaping Zeek JSON](shaping.md) relies on the value of
 the `_path` field to know which type to apply to an input JSON

--- a/book/src/dev/integrations/zeek/shaping.md
+++ b/book/src/dev/integrations/zeek/shaping.md
@@ -105,7 +105,7 @@ fields or keep them while assigning inferred types.
 ## Reference Shaper Contents
 
 The following reference `shaper.spq` may seem large, but ultimately it follows a
-fairly simple pattern that repeats across the many [Zeek log types](https://docs.zeek.org/en/current/script-reference/log-files.html).
+fairly simple pattern that repeats across the many [Zeek log types](https://docs.zeek.org/en/current/reference/zeekscript/log-files.html).
 
 ```mdtest-input shaper.spq
 -- This reference shaper for Zeek JSON logs was most recently tested with

--- a/book/src/dev/integrations/zeek/types.md
+++ b/book/src/dev/integrations/zeek/types.md
@@ -1,7 +1,7 @@
 # Type System
 
 As the [super-structured data model](../../../formats/model.md) was in many ways inspired by the
-[Zeek TSV log format](https://docs.zeek.org/en/current/log-formats.html#zeek-log-formats),
+[Zeek TSV log format](https://docs.zeek.org/en/current/tutorial/logs.html#zeek-log-formats),
 SuperDB's rich storage formats ([SUP](../../../formats/sup.md),
 [CSUP](../../../formats/csup.md), etc.) maintain comprehensive interoperability
 with Zeek.
@@ -25,7 +25,7 @@ when output as SUP.
 ## Equivalent Types
 
 The following table summarizes which Zed data type corresponds to each
-[Zeek data type](https://docs.zeek.org/en/current/script-reference/types.html)
+[Zeek data type](https://docs.zeek.org/en/current/reference/zeekscript/types.html)
 that may appear in a Zeek TSV log. While most types have a simple 1-to-1
 mapping from Zeek to Zed and back to Zeek again, the sections linked from the
 **Additional Detail** column describe cosmetic differences and other subtleties
@@ -33,25 +33,25 @@ applicable to handling certain types.
 
 | Zeek Type  | Zed Type   | Additional Detail |
 |------------|------------|-------------------|
-| [`bool`](https://docs.zeek.org/en/current/script-reference/types.html#type-bool)         | [`bool`](../../../formats/model.md#1-primitive-types)     | |
-| [`count`](https://docs.zeek.org/en/current/script-reference/types.html#type-count)       | [`uint64`](../../../formats/model.md#1-primitive-types)   | |
-| [`int`](https://docs.zeek.org/en/current/script-reference/types.html#type-int)           | [`int64`](../../../formats/model.md#1-primitive-types)    | |
-| [`double`](https://docs.zeek.org/en/current/script-reference/types.html#type-double)     | [`float64`](../../../formats/model.md#1-primitive-types)  | See [`double` details](#double) |
-| [`time`](https://docs.zeek.org/en/current/script-reference/types.html#type-time)         | [`time`](../../../formats/model.md#1-primitive-types)     | |
-| [`interval`](https://docs.zeek.org/en/current/script-reference/types.html#type-interval) | [`duration`](../../../formats/model.md#1-primitive-types) | |
-| [`string`](https://docs.zeek.org/en/current/script-reference/types.html#type-string)     | [`string`](../../../formats/model.md#1-primitive-types)   | See [`string` details about escaping](#string) |
-| [`port`](https://docs.zeek.org/en/current/script-reference/types.html#type-port)         | [`uint16`](../../../formats/model.md#1-primitive-types)   | See [`port` details](#port) |
-| [`addr`](https://docs.zeek.org/en/current/script-reference/types.html#type-addr)         | [`ip`](../../../formats/model.md#1-primitive-types)       | |
-| [`subnet`](https://docs.zeek.org/en/current/script-reference/types.html#type-subnet)     | [`net`](../../../formats/model.md#1-primitive-types)      | |
-| [`enum`](https://docs.zeek.org/en/current/script-reference/types.html#type-enum)         | [`string`](../../../formats/model.md#1-primitive-types)   | See [`enum` details](#enum) |
-| [`set`](https://docs.zeek.org/en/current/script-reference/types.html#type-set)           | [`set`](../../../formats/model.md#23-set)                 | See [`set` details](#set) |
-| [`vector`](https://docs.zeek.org/en/current/script-reference/types.html#type-vector)     | [`array`](../../../formats/model.md#22-array)              | |
-| [`record`](https://docs.zeek.org/en/current/script-reference/types.html#type-record)     | [`record`](../../../formats/model.md#21-record)            | See [`record` details](#record) |
+| [`bool`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-bool)         | [`bool`](../../../formats/model.md#1-primitive-types)     | |
+| [`count`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-count)       | [`uint64`](../../../formats/model.md#1-primitive-types)   | |
+| [`int`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-int)           | [`int64`](../../../formats/model.md#1-primitive-types)    | |
+| [`double`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-double)     | [`float64`](../../../formats/model.md#1-primitive-types)  | See [`double` details](#double) |
+| [`time`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-time)         | [`time`](../../../formats/model.md#1-primitive-types)     | |
+| [`interval`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-interval) | [`duration`](../../../formats/model.md#1-primitive-types) | |
+| [`string`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-string)     | [`string`](../../../formats/model.md#1-primitive-types)   | See [`string` details about escaping](#string) |
+| [`port`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-port)         | [`uint16`](../../../formats/model.md#1-primitive-types)   | See [`port` details](#port) |
+| [`addr`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-addr)         | [`ip`](../../../formats/model.md#1-primitive-types)       | |
+| [`subnet`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-subnet)     | [`net`](../../../formats/model.md#1-primitive-types)      | |
+| [`enum`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-enum)         | [`string`](../../../formats/model.md#1-primitive-types)   | See [`enum` details](#enum) |
+| [`set`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-set)           | [`set`](../../../formats/model.md#23-set)                 | See [`set` details](#set) |
+| [`vector`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-vector)     | [`array`](../../../formats/model.md#22-array)              | |
+| [`record`](https://docs.zeek.org/en/current/reference/zeekscript/types.html#type-record)     | [`record`](../../../formats/model.md#21-record)            | See [`record` details](#record) |
 
 >[!NOTE]
-> The [Zeek data types](https://docs.zeek.org/en/current/script-reference/types.html)
+> The [Zeek data types](https://docs.zeek.org/en/current/reference/zeekscript/types.html)
 > page describes the types in the context of the
-> [Zeek scripting language](https://docs.zeek.org/en/current/scripting/index.html).
+> [Zeek scripting language](https://docs.zeek.org/en/current/tutorial/scripting/index.html).
 > The Zeek types available in scripting are a superset of the data types that
 > may appear in Zeek log files. The encodings of the types also differ in some
 > ways between the two contexts. However, we link to this reference because


### PR DESCRIPTION
For the past few days our automated link checkers have been consistently getting HTTP 429/403 errors in the spots where we still link to the Zeek docs. I dug into this and updated to newer links to avoid redirects, but this alone did not address the problem. I've concluded that for now we should just exclude them from the link checker config, and I've opened https://github.com/zeek/zeek/issues/5819 with the Zeek team should they be interested in collaborating on a fix that would allow link checkers to still work.

## Details

After updating to the newer links didn't improve things, I also learned about the [Read the Docs guidance](https://docs.readthedocs.com/platform/stable/automated-access.html#automated-access-to-read-the-docs) that suggests adding a self-identifying User Agent might increase our chances of success. It didn't help, but I've kept that config intact here since I figure it doesn't hurt to be a better citizen.

The "Cloudflare challenge" called out in the comment next to the link exclusion boils down to only permitting clients that are capable of executing JavaScript. In my testing this was verified via GitHub Actions runners, a residential IP, and an unrelated third-party fetcher, all of which get HTTP 429/403 while a browser loads the same URLs fine. There's no request rate low enough to avoid it, as even a single cold request from a runner is challenged. The same Read the Docs guidance links off to the topic of being able to apply to be a "Cloudflare [verified bot](https://developers.cloudflare.com/bots/concepts/bot/verified-bots/)", but as this problem is not affecting us widely and I'm not sure of the likelihood of being whitelisted if we follow that process, for now I'm game to just add the link checker exclusions, see what comes of the issue with the Zeek team, and check links manually from time to time.