### PR TITLE
compile/semantic: fix -csv.delim handling

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -308,7 +308,9 @@ func (t *translator) fileType(path, format string) (super.Type, error) {
 	if engine == nil {
 		return t.checker.unknown, nil
 	}
-	return anyio.FileType(t.ctx, t.sctx, engine, path, anyio.ReaderOpts{Format: format}, t.env.SampleSize)
+	opts := t.env.ReaderOpts
+	opts.Format = format
+	return anyio.FileType(t.ctx, t.sctx, engine, path, opts, t.env.SampleSize)
 }
 
 func (t *translator) fromFileGlob(globLoc ast.Node, pattern string, args []ast.OpArg) sem.Op {

--- a/compiler/semantic/ztests/csv-delim.yaml
+++ b/compiler/semantic/ztests/csv-delim.yaml
@@ -1,0 +1,14 @@
+# Read from a file so the semantic pass runs.
+script: |
+  super -s -i csv -csv.delim ';' a.csv
+
+inputs:
+  - name: a.csv
+    data: |
+      a;b;c
+      x;y,y;z
+
+outputs:
+  - name: stdout
+    data: |
+      {a:"x",b:"y,y",c:"z"}


### PR DESCRIPTION
The semantic pass ignores the -csv.delim flag (as well as any other settings in runtime/exec.Environment.ReaderOpts).  Fix this in translator.FileType by passing t.env.ReaderOpts to anyio.FileType.

Fixes #7203.