### PR TITLE
Fix some nits in the book docs to avoid codespell exceptions

### DIFF
--- a/book/src/formats/sup.md
+++ b/book/src/formats/sup.md
@@ -419,7 +419,7 @@ A relational table might look like this:
 ```
 { city: "Berkeley", state: "CA", population: 121643::uint32 }::=city_schema
 { city: "Broad Cove", state: "ME", population: 806::uint32 }::=city_schema
-{ city: "Baton Rouge", state: "LA", population: 221599::uint32 }::=city_schema
+{ city: "Sioux Falls", state: "SD", population: 192517::uint32 }::=city_schema
 ```
 The text here depicts three record values.  It defines a type called `city_schema`
 and the inferred type of the `city_schema` has the signature:

--- a/book/src/super-sql/operators/put.md
+++ b/book/src/super-sql/operators/put.md
@@ -28,7 +28,7 @@ while modified fields are mutated in place.
 If multiple fields are written in a single `put`, all the new field values are
 computed first and then they are all written simultaneously.  As a result,
 a computed value cannot be referenced in another expression.  If you need
-to re-use a computed result, this can be done by chaining multiple `put` operators.
+to reuse a computed result, this can be done by chaining multiple `put` operators.
 
 The `put` keyword is optional since it can be used as a [shortcut](intro.md#shortcuts).
 When used as a shortcut, the `<field>:=` portion of `<assignment>` is not optional.

--- a/sup/ztests/outer-schema.yaml
+++ b/sup/ztests/outer-schema.yaml
@@ -7,7 +7,7 @@ inputs:
       type city_schema={city:string,state:string,population:int64}
       {city:"Berkeley",state:"CA",population:121643}::city_schema
       {city:"Broad Cove",state:"ME",population:806}::city_schema
-      {city:"Baton Rouge",state:"LA",population:221599}::city_schema
+      {city:"Sioux Falls",state:"SD",population:192517}::city_schema
 
 outputs:
   - name: stdout
@@ -15,4 +15,4 @@ outputs:
       type city_schema={city:string,state:string,population:int64}
       {city:"Berkeley",state:"CA",population:121643}::city_schema
       {city:"Broad Cove",state:"ME",population:806}::city_schema
-      {city:"Baton Rouge",state:"LA",population:221599}::city_schema
+      {city:"Sioux Falls",state:"SD",population:192517}::city_schema


### PR DESCRIPTION
I'm close to being able to turn on [codespell](https://github.com/codespell-project/codespell) for the book docs to help us catch typos and misspellings more quickly in the future. That means any words flagged by codespell that we want to leave as is would need to be added to an "exceptions" list. While we're free to do that, here I advocate fixing a couple nits in the current docs so we can avoid a couple of those exceptions.