### PR TITLE
compiler/semantic: fix duplicate field panic

### DIFF
--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -718,12 +718,20 @@ func (t *translator) resolveOrdinalOuter(ts tableScope, n ast.Node, prefix strin
 }
 
 func dedup(scores map[string]int, s string) string {
-	cnt := scores[s]
-	scores[s] = cnt + 1
-	if cnt != 0 {
-		s = fmt.Sprintf("%s_%d", s, cnt)
+	score, ok := scores[s]
+	if !ok {
+		scores[s] = 0
+		return s
 	}
-	return s
+	for {
+		score++
+		s2 := fmt.Sprintf("%s_%d", s, score)
+		if _, ok := scores[s2]; !ok {
+			scores[s] = score
+			scores[s2] = 0
+			return s2
+		}
+	}
 }
 
 func valuesExpr(e sem.Expr, seq sem.Seq) sem.Seq {

--- a/compiler/ztests/sql/as-duplicate.yaml
+++ b/compiler/ztests/sql/as-duplicate.yaml
@@ -1,7 +1,7 @@
 script: |
-  super -s -c 'SELECT 1 as foo, 2 as foo'
+  super -s -c 'SELECT 1 as a, 2 as a, 3 as a_1, 4 as a_1, 5 as a_2, 6 as a, 7 as a_2'
 
 outputs:
   - name: stdout
     data: |
-      {foo:1,foo_1:2}
+      {a:1,a_1:2,a_1_1:3,a_1_2:4,a_2:5,a_3:6,a_2_1:7}


### PR DESCRIPTION
Fix panic on "select 1 as a, 2 as a, 3 as a_1" caused by attempting to create a record with two fields named a_1.

Fixes #7123.