### PR TITLE
runtime/vam/op: use scode.Builder.Truncate in hashJoin.wrap

### DIFF
--- a/runtime/vam/op/hashjoin.go
+++ b/runtime/vam/op/hashjoin.go
@@ -280,7 +280,7 @@ func (j *hashJoin) wrap(l, r *super.Value) super.Value {
 	if j.style == "right" {
 		l, r = r, l
 	}
-	j.builder.Reset()
+	j.builder.Truncate()
 	var fields []super.Field
 	if l != nil {
 		left := l.Deunion()


### PR DESCRIPTION
This noticeably improves wrap performance by eliminating allocations. Switching from Builder.Reset to Truncate is safe because the super.Value returned by any call to wrap is unreachable when the next call occurs.