### PR TITLE
add field.Chain

### DIFF
--- a/compiler/dag/expr.go
+++ b/compiler/dag/expr.go
@@ -62,9 +62,10 @@ type (
 		Else Expr   `json:"else"`
 	}
 	DotExpr struct {
-		Kind string `json:"kind" unpack:""`
-		LHS  Expr   `json:"lhs"`
-		RHS  string `json:"rhs"`
+		Kind    string `json:"kind" unpack:""`
+		LHS     Expr   `json:"lhs"`
+		RHS     string `json:"rhs"`
+		Noneish bool   `json:"noneish"`
 	}
 	IndexExpr struct {
 		Kind  string `json:"kind" unpack:""`

--- a/compiler/dag/expr.go
+++ b/compiler/dag/expr.go
@@ -131,8 +131,8 @@ type (
 		Body       Seq    `json:"body"`
 	}
 	ThisExpr struct {
-		Kind string   `json:"kind" unpack:""`
-		Path []string `json:"path"`
+		Kind  string      `json:"kind" unpack:""`
+		Chain field.Chain `json:"chain"`
 	}
 	TypeExpr struct {
 		Kind string `json:"kind" unpack:""`
@@ -219,12 +219,12 @@ func NewCall(tag string, args []Expr) *CallExpr {
 	}
 }
 
-func NewThis(path []string) *ThisExpr {
-	return &ThisExpr{"ThisExpr", path}
+func NewThis(chain field.Chain) *ThisExpr {
+	return &ThisExpr{"ThisExpr", chain}
 }
 
 func (t *ThisExpr) String() string {
-	return field.Path(t.Path).String()
+	return t.Chain.String()
 }
 
 func NewUnaryExpr(op string, e Expr) *UnaryExpr {

--- a/compiler/describe/analyze.go
+++ b/compiler/describe/analyze.go
@@ -163,7 +163,7 @@ func describeOpAggs(op dag.Op, parents []field.List) []field.List {
 		// not nil.
 		keys := field.List{}
 		for _, k := range op.Keys {
-			keys = append(keys, k.RHS.(*dag.ThisExpr).Path)
+			keys = append(keys, k.RHS.(*dag.ThisExpr).Chain.Path())
 		}
 		return []field.List{keys}
 	case *dag.ForkOp:

--- a/compiler/optimizer/demand.go
+++ b/compiler/optimizer/demand.go
@@ -206,8 +206,8 @@ func demandForExpr(expr dag.Expr) demand.Demand {
 		return demand.Union(DemandForSeq(expr.Body, demand.All())...)
 	case *dag.ThisExpr:
 		d := demand.All()
-		for i := len(expr.Path) - 1; i >= 0; i-- {
-			d = demand.Key(expr.Path[i], d)
+		for i := len(expr.Chain) - 1; i >= 0; i-- {
+			d = demand.Key(expr.Chain[i].ID, d)
 		}
 		return d
 	case *dag.UnaryExpr:

--- a/compiler/optimizer/join.go
+++ b/compiler/optimizer/join.go
@@ -162,9 +162,9 @@ func equiJoinKeyExprs(e dag.Expr, leftAlias, rightAlias string) (left, right dag
 func firstThisPathComponent(e dag.Expr) (prefix string, ok bool) {
 	walkT(reflect.ValueOf(e), func(t dag.ThisExpr) dag.ThisExpr {
 		if prefix == "" {
-			prefix = t.Path[0]
+			prefix = t.Chain[0].ID
 			ok = true
-		} else if prefix != t.Path[0] {
+		} else if prefix != t.Chain[0].ID {
 			ok = false
 		}
 		return t
@@ -175,7 +175,7 @@ func firstThisPathComponent(e dag.Expr) (prefix string, ok bool) {
 // stripFirstThisPathComponent removes the first component of every dag.This.Path in e.
 func stripFirstThisPathComponent(e dag.Expr) {
 	walkT(reflect.ValueOf(e), func(t dag.ThisExpr) dag.ThisExpr {
-		t.Path = t.Path[1:]
+		t.Chain = t.Chain[1:]
 		return t
 	})
 }

--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -212,7 +212,7 @@ func fieldKey(f field.Path) string {
 
 func fieldOf(e dag.Expr) field.Path {
 	if this, ok := e.(*dag.ThisExpr); ok {
-		return this.Path
+		return this.Chain.Path()
 	}
 	return nil
 }
@@ -225,7 +225,7 @@ func FieldsOf(e dag.Expr) (field.List, bool) {
 	case *dag.SearchExpr, *dag.PrimitiveExpr:
 		return nil, true
 	case *dag.ThisExpr:
-		return field.List{e.Path}, true
+		return field.List{e.Chain.Path()}, true
 	case *dag.UnaryExpr:
 		return FieldsOf(e.Operand)
 	case *dag.BinaryExpr:

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/db"
 	"github.com/brimdata/super/order"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/runtime/exec"
 	"github.com/segmentio/ksuid"
 )
@@ -188,7 +189,7 @@ func (o *Optimizer) OptimizeDeleter(main *dag.Main, replicas int) error {
 		merge = &dag.MergeOp{
 			Kind: "MergeOp",
 			Exprs: []dag.SortExpr{{
-				Key:   dag.NewThis(sortKey.Key),
+				Key:   dag.NewThis(sortKey.Key.Chain()),
 				Order: sortKey.Order,
 				Nulls: sortKey.Order.NullsMax(true),
 			}},
@@ -345,7 +346,7 @@ func (o *Optimizer) propagateSortKeyOp(op dag.Op, parents []order.SortKeys) ([]o
 		var sortKeys order.SortKeys
 		sortExpr := op.Exprs[0]
 		if this, ok := sortExpr.Key.(*dag.ThisExpr); ok {
-			sortKeys = append(sortKeys, order.NewSortKey(sortExpr.Order, this.Path))
+			sortKeys = append(sortKeys, order.NewSortKey(sortExpr.Order, this.Chain.Path()))
 		}
 		if !sortKeys.Equal(parent) {
 			sortKeys = nil
@@ -534,10 +535,10 @@ func pullupExpr(alias string, expr dag.Expr) (dag.Expr, bool) {
 	} else if t, ok := e.RHS.(*dag.ThisExpr); ok && isConst(e.LHS) {
 		this, c = t, e.LHS
 	}
-	if c == nil || this == nil || len(this.Path) < 1 || this.Path[0] != alias {
+	if c == nil || this == nil || len(this.Chain) < 1 || this.Chain[0].ID != alias {
 		return nil, false
 	}
-	path := slices.Clone(this.Path[1:])
+	path := slices.Clone(this.Chain[1:])
 	return dag.NewBinaryExpr(e.Op, dag.NewThis(path), c), true
 }
 
@@ -592,17 +593,17 @@ func liftFilterOps(seq dag.Seq) dag.Seq {
 				if !ok {
 					return e
 				}
-				e1, ok := fields[this.Path[0]]
+				e1, ok := fields[this.Chain[0].ID]
 				if !ok {
 					if spread == nil {
 						return newErrorMissing()
 					}
 					// Copy spread so f and y don't share dag.Exprs.
-					e, liftOK = addPathToExpr(dag.CopyExpr(spread), this.Path)
+					e, liftOK = addPathToExpr(dag.CopyExpr(spread), this.Chain.Path())
 					return e
 				}
 				// Copy e1 so f and y don't share dag.Exprs.
-				e, liftOK = addPathToExpr(dag.CopyExpr(e1), this.Path[1:])
+				e, liftOK = addPathToExpr(dag.CopyExpr(e1), this.Chain.Path()[1:])
 				return e
 			})
 			if liftOK {
@@ -638,15 +639,15 @@ func mergeValuesOps(seq dag.Seq) dag.Seq {
 				if !ok {
 					return e
 				}
-				v1Expr, ok := v1TopLevelFields[this.Path[0]]
+				v1Expr, ok := v1TopLevelFields[this.Chain.Path()[0]]
 				if !ok {
 					if v1TopLevelSpread == nil {
 						return newErrorMissing()
 					}
-					e, mergeOK = addPathToExpr(v1TopLevelSpread, this.Path)
+					e, mergeOK = addPathToExpr(v1TopLevelSpread, this.Chain.Path())
 					return e
 				}
-				e, mergeOK = addPathToExpr(v1Expr, this.Path[1:])
+				e, mergeOK = addPathToExpr(v1Expr, this.Chain.Path()[1:])
 				return e
 			}
 			var mergedOp dag.Op
@@ -681,7 +682,7 @@ func mergeValuesOps(seq dag.Seq) dag.Seq {
 func hasThisWithEmptyPath(v any) bool {
 	var found bool
 	walkT(reflect.ValueOf(v), func(this *dag.ThisExpr) *dag.ThisExpr {
-		if len(this.Path) < 1 {
+		if len(this.Chain) < 1 {
 			found = true
 		}
 		return this
@@ -733,7 +734,7 @@ func addPathToExpr(e dag.Expr, path []string) (dag.Expr, bool) {
 		}
 		return addPathToExpr(spread.Expr, path)
 	case *dag.ThisExpr:
-		return dag.NewThis(slices.Concat(e.Path, path)), true
+		return dag.NewThis(slices.Concat(e.Chain, field.NewChain(path...))), true
 	}
 	for _, elem := range path {
 		e = &dag.DotExpr{Kind: "DotExpr", LHS: e, RHS: elem}

--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -332,7 +332,7 @@ func sortExprsForSortKeys(keys order.SortKeys) []dag.SortExpr {
 	var exprs []dag.SortExpr
 	for _, k := range keys {
 		exprs = append(exprs, dag.SortExpr{
-			Key:   dag.NewThis(k.Key),
+			Key:   dag.NewThis(k.Key.Chain()),
 			Order: k.Order,
 			Nulls: k.Order.NullsMax(true)},
 		)

--- a/compiler/optimizer/pruner.go
+++ b/compiler/optimizer/pruner.go
@@ -26,8 +26,8 @@ func maybeNewRangePruner(pred dag.Expr, sortKeys order.SortKeys) dag.Expr {
 // from a scan when we know the pool key range of the object could not satisfy
 // the filter predicate of any of the values in the object.
 func newRangePruner(pred dag.Expr, sortKey order.SortKey) dag.Expr {
-	min := dag.NewCall("defuse", []dag.Expr{dag.NewThis(field.Path{"min"})})
-	max := dag.NewCall("defuse", []dag.Expr{dag.NewThis(field.Path{"max"})})
+	min := dag.NewCall("defuse", []dag.Expr{dag.NewThis(field.NewChain("min"))})
+	max := dag.NewCall("defuse", []dag.Expr{dag.NewThis(field.NewChain("max"))})
 	if e := buildRangePruner(pred, sortKey.Key, min, max); e != nil {
 		return e
 	}
@@ -75,7 +75,7 @@ func buildRangePruner(pred dag.Expr, fld field.Path, min, max dag.Expr) *dag.Bin
 		return dag.NewBinaryExpr("and", lhs, rhs)
 	case "==", "<", "<=", ">", ">=":
 		this, literal, op := literalComparison(e)
-		if this == nil || !fld.Equal(this.Path) {
+		if this == nil || !fld.Equal(this.Chain.Path()) {
 			return nil
 		}
 		// At this point, we know we can definitely run a pruning decision based
@@ -176,8 +176,8 @@ func newMetadataPruner(pred dag.Expr) dag.Expr {
 		min := &dag.PrimitiveExpr{Kind: "PrimitiveExpr", Value: sup.QuotedString(prefix)}
 		max := &dag.PrimitiveExpr{Kind: "PrimitiveExpr", Value: sup.QuotedString(maxPrefix)}
 		return dag.NewBinaryExpr("and",
-			compare("<=", min, dag.NewThis(append(slices.Clone(this.Path), "max"))),
-			compare(">", max, dag.NewThis(append(slices.Clone(this.Path), "min"))))
+			compare("<=", min, dag.NewThis(slices.Clone(this.Chain).Append("max", false))),
+			compare(">", max, dag.NewThis(slices.Clone(this.Chain).Append("min", false))))
 	default:
 		return nil
 	}
@@ -306,8 +306,8 @@ func literalsInArrayOrSet(elems []dag.VectorElem) []*dag.PrimitiveExpr {
 }
 
 func metadataPrunerPred(op string, this *dag.ThisExpr, literal *dag.PrimitiveExpr) *dag.BinaryExpr {
-	min := dag.NewThis(append(slices.Clone(this.Path), "min"))
-	max := dag.NewThis(append(slices.Clone(this.Path), "max"))
+	min := dag.NewThis(slices.Clone(this.Chain).Append("min", false))
+	max := dag.NewThis(slices.Clone(this.Chain).Append("max", false))
 	switch op {
 	case "<":
 		return compare("<", min, literal)

--- a/compiler/optimizer/vam.go
+++ b/compiler/optimizer/vam.go
@@ -16,7 +16,7 @@ func IsCountByString(o dag.Op) (string, bool) {
 
 func isCount(a dag.Assignment) bool {
 	this, ok := a.LHS.(*dag.ThisExpr)
-	if !ok || len(this.Path) != 1 || this.Path[0] != "count" {
+	if !ok || len(this.Chain) != 1 || this.Chain[0].ID != "count" {
 		return false
 	}
 	agg, ok := a.RHS.(*dag.AggExpr)

--- a/compiler/rungen/expr.go
+++ b/compiler/rungen/expr.go
@@ -55,8 +55,8 @@ func (b *Builder) compileLval(e dag.Expr) (*expr.Lval, error) {
 		return container, nil
 	case *dag.ThisExpr:
 		var elems []expr.LvalElem
-		for _, elem := range e.Path {
-			elems = append(elems, &expr.StaticLvalElem{Name: elem})
+		for _, elem := range e.Chain {
+			elems = append(elems, &expr.StaticLvalElem{Name: elem.ID})
 		}
 		return expr.NewLval(elems), nil
 	}

--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/dag"
-	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/runtime/sam/expr"
 	vamexpr "github.com/brimdata/super/runtime/vam/expr"
 	vamfunction "github.com/brimdata/super/runtime/vam/expr/function"
@@ -61,7 +60,7 @@ func (b *Builder) compileVamExpr(e dag.Expr) (vamexpr.Evaluator, error) {
 	case *dag.SubqueryExpr:
 		return b.compileVamSubquery(e)
 	case *dag.ThisExpr:
-		return vamexpr.NewDottedExpr(b.sctx(), field.Path(e.Path)), nil
+		return vamexpr.NewDottedExpr(b.sctx(), e.Chain.Path()), nil
 	case *dag.TypeExpr:
 		typ, err := b.lookupType(e.ID)
 		if err != nil {

--- a/compiler/rungen/vop.go
+++ b/compiler/rungen/vop.go
@@ -262,7 +262,7 @@ func (b *Builder) compileVamLeaf(o dag.Op, parent vio.Puller) (vio.Puller, error
 		if err != nil {
 			return nil, err
 		}
-		mergeRecordExprWithPath(rec, nil)
+		mergeRecordExprWithChain(rec, nil)
 		e, err := b.compileVamRecordExpr(rec)
 		if err != nil {
 			return nil, err
@@ -324,12 +324,12 @@ func newRecordExprFromAssignments(assignments []dag.Assignment) (*dag.RecordExpr
 		if !ok {
 			return nil, fmt.Errorf("internal error: dynamic field name not supported: %#v", a.LHS)
 		}
-		addPathToRecordExpr(rec, lhs.Chain, a.RHS)
+		addChainToRecordExpr(rec, lhs.Chain, a.RHS)
 	}
 	return rec, nil
 }
 
-func addPathToRecordExpr(rec *dag.RecordExpr, chain field.Chain, expr dag.Expr) {
+func addChainToRecordExpr(rec *dag.RecordExpr, chain field.Chain, expr dag.Expr) {
 	if len(chain) == 1 {
 		rec.Elems = append(rec.Elems, &dag.Field{Kind: "Field", Name: chain[0].ID, Value: expr})
 		return
@@ -342,16 +342,16 @@ func addPathToRecordExpr(rec *dag.RecordExpr, chain field.Chain, expr dag.Expr) 
 		i = len(rec.Elems)
 		rec.Elems = append(rec.Elems, &dag.Field{Kind: "Field", Name: chain[0].ID, Value: &dag.RecordExpr{Kind: "RecordExpr"}})
 	}
-	addPathToRecordExpr(rec.Elems[i].(*dag.Field).Value.(*dag.RecordExpr), chain[1:], expr)
+	addChainToRecordExpr(rec.Elems[i].(*dag.Field).Value.(*dag.RecordExpr), chain[1:], expr)
 }
 
-func mergeRecordExprWithPath(rec *dag.RecordExpr, chain field.Chain) {
+func mergeRecordExprWithChain(rec *dag.RecordExpr, chain field.Chain) {
 	spread := &dag.Spread{Kind: "Spread", Expr: dag.NewThis(chain)}
 	rec.Elems = append([]dag.RecordElem{spread}, rec.Elems...)
 	for _, elem := range rec.Elems {
 		if field, ok := elem.(*dag.Field); ok {
 			if childrec, ok := field.Value.(*dag.RecordExpr); ok {
-				mergeRecordExprWithPath(childrec, chain.Append(field.Name, false))
+				mergeRecordExprWithChain(childrec, chain.Append(field.Name, false))
 			}
 		}
 	}

--- a/compiler/rungen/vop.go
+++ b/compiler/rungen/vop.go
@@ -226,7 +226,7 @@ func (b *Builder) compileVamLeaf(o dag.Op, parent vio.Puller) (vio.Puller, error
 	case *dag.DropOp:
 		fields := make(field.List, 0, len(o.Args))
 		for _, e := range o.Args {
-			fields = append(fields, e.(*dag.ThisExpr).Path)
+			fields = append(fields, e.(*dag.ThisExpr).Chain.Path())
 		}
 		dropper := vamexpr.NewDropper(b.sctx(), fields)
 		return vamop.NewValues(b.sctx(), parent, []vamexpr.Evaluator{dropper}), nil
@@ -324,34 +324,34 @@ func newRecordExprFromAssignments(assignments []dag.Assignment) (*dag.RecordExpr
 		if !ok {
 			return nil, fmt.Errorf("internal error: dynamic field name not supported: %#v", a.LHS)
 		}
-		addPathToRecordExpr(rec, lhs.Path, a.RHS)
+		addPathToRecordExpr(rec, lhs.Chain, a.RHS)
 	}
 	return rec, nil
 }
 
-func addPathToRecordExpr(rec *dag.RecordExpr, path []string, expr dag.Expr) {
-	if len(path) == 1 {
-		rec.Elems = append(rec.Elems, &dag.Field{Kind: "Field", Name: path[0], Value: expr})
+func addPathToRecordExpr(rec *dag.RecordExpr, chain field.Chain, expr dag.Expr) {
+	if len(chain) == 1 {
+		rec.Elems = append(rec.Elems, &dag.Field{Kind: "Field", Name: chain[0].ID, Value: expr})
 		return
 	}
 	i := slices.IndexFunc(rec.Elems, func(elem dag.RecordElem) bool {
 		f, ok := elem.(*dag.Field)
-		return ok && f.Name == path[0]
+		return ok && f.Name == chain[0].ID
 	})
 	if i == -1 {
 		i = len(rec.Elems)
-		rec.Elems = append(rec.Elems, &dag.Field{Kind: "Field", Name: path[0], Value: &dag.RecordExpr{Kind: "RecordExpr"}})
+		rec.Elems = append(rec.Elems, &dag.Field{Kind: "Field", Name: chain[0].ID, Value: &dag.RecordExpr{Kind: "RecordExpr"}})
 	}
-	addPathToRecordExpr(rec.Elems[i].(*dag.Field).Value.(*dag.RecordExpr), path[1:], expr)
+	addPathToRecordExpr(rec.Elems[i].(*dag.Field).Value.(*dag.RecordExpr), chain[1:], expr)
 }
 
-func mergeRecordExprWithPath(rec *dag.RecordExpr, path []string) {
-	spread := &dag.Spread{Kind: "Spread", Expr: dag.NewThis(path)}
+func mergeRecordExprWithPath(rec *dag.RecordExpr, chain field.Chain) {
+	spread := &dag.Spread{Kind: "Spread", Expr: dag.NewThis(chain)}
 	rec.Elems = append([]dag.RecordElem{spread}, rec.Elems...)
 	for _, elem := range rec.Elems {
 		if field, ok := elem.(*dag.Field); ok {
 			if childrec, ok := field.Value.(*dag.RecordExpr); ok {
-				mergeRecordExprWithPath(childrec, append(path, field.Name))
+				mergeRecordExprWithPath(childrec, chain.Append(field.Name, false))
 			}
 		}
 	}
@@ -374,7 +374,7 @@ func (b *Builder) compileVamAggregate(s *dag.AggregateOp, parent vio.Puller) (vi
 	var aggExprs []vamexpr.Evaluator
 	var aggs []*vamexpr.Aggregator
 	for _, assignment := range s.Aggs {
-		aggNames = append(aggNames, assignment.LHS.(*dag.ThisExpr).Path)
+		aggNames = append(aggNames, assignment.LHS.(*dag.ThisExpr).Chain.Path())
 		agg, err := b.compileVamAgg(assignment.RHS.(*dag.AggExpr))
 		if err != nil {
 			return nil, err
@@ -401,7 +401,7 @@ func (b *Builder) compileVamAggregate(s *dag.AggregateOp, parent vio.Puller) (vi
 		if err != nil {
 			return nil, err
 		}
-		keyNames = append(keyNames, lhs.Path)
+		keyNames = append(keyNames, lhs.Chain.Path())
 		keyExprs = append(keyExprs, rhs)
 	}
 	if len(keyExprs) == 0 {

--- a/compiler/semantic/checker.go
+++ b/compiler/semantic/checker.go
@@ -249,7 +249,7 @@ func (c *checker) assignments(in super.Type, assignments []sem.Assignment) []pat
 	for _, a := range assignments {
 		var path []string
 		if this, ok := a.LHS.(*sem.ThisExpr); ok {
-			path = this.Path.IDs()
+			path = this.Chain.Path()
 		}
 		typ := c.expr(in, a.RHS)
 		paths = append(paths, pathType{path, typ})
@@ -447,7 +447,7 @@ func (c *checker) binary(op string, loc, lloc, rloc ast.Node, lhs, rhs super.Typ
 }
 
 func (c *checker) this(loc ast.Node, this *sem.ThisExpr, typ super.Type) super.Type {
-	for _, comp := range this.Path {
+	for _, comp := range this.Chain {
 		//XXX type check should use comp.Nullish too
 		typ, _ = c.deref(loc, typ, comp.ID)
 	}
@@ -672,7 +672,7 @@ func (c *checker) lvalsToPaths(exprs []sem.Expr) []path {
 		if !ok {
 			return nil
 		}
-		paths = append(paths, path{loc: this.Node, elems: this.Path.IDs()})
+		paths = append(paths, path{loc: this.Node, elems: this.Chain.Path()})
 	}
 	return paths
 }

--- a/compiler/semantic/compare.go
+++ b/compiler/semantic/compare.go
@@ -270,11 +270,11 @@ func eqExpr(aexpr, bexpr sem.Expr) bool {
 		return ok && a.Correlated == b.Correlated && a.Array == b.Array && eqSeq(a.Body, b.Body)
 	case *sem.ThisExpr:
 		b, ok := bexpr.(*sem.ThisExpr)
-		if !ok || len(a.Path) != len(b.Path) {
+		if !ok || len(a.Chain) != len(b.Chain) {
 			return false
 		}
-		for k := range a.Path {
-			if a.Path[k] != b.Path[k] {
+		for k := range a.Chain {
+			if a.Chain[k] != b.Chain[k] {
 				return false
 			}
 		}

--- a/compiler/semantic/dagen.go
+++ b/compiler/semantic/dagen.go
@@ -398,9 +398,10 @@ func (d *dagen) expr(e sem.Expr) dag.Expr {
 		}
 	case *sem.DotExpr:
 		return &dag.DotExpr{
-			Kind: "DotExpr",
-			LHS:  d.expr(e.LHS),
-			RHS:  e.RHS,
+			Kind:    "DotExpr",
+			LHS:     d.expr(e.LHS),
+			RHS:     e.RHS,
+			Noneish: e.Noneish,
 		}
 	case *sem.IndexExpr:
 		return &dag.IndexExpr{

--- a/compiler/semantic/dagen.go
+++ b/compiler/semantic/dagen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brimdata/super/compiler/ast"
 	"github.com/brimdata/super/compiler/dag"
 	"github.com/brimdata/super/compiler/semantic/sem"
+	"github.com/brimdata/super/pkg/field"
 )
 
 type dagen struct {
@@ -470,8 +471,8 @@ func (d *dagen) expr(e sem.Expr) dag.Expr {
 		return d.subquery(e)
 	case *sem.ThisExpr:
 		return &dag.ThisExpr{
-			Kind: "ThisExpr",
-			Path: e.Path.IDs(),
+			Kind:  "ThisExpr",
+			Chain: e.Chain,
 		}
 	case *sem.TypeExpr:
 		return &dag.TypeExpr{
@@ -550,7 +551,7 @@ func (d *dagen) subquery(e *sem.SubqueryExpr) *dag.SubqueryExpr {
 func collectThis(seq dag.Seq) dag.Seq {
 	collect := dag.Assignment{
 		Kind: "Assignment",
-		LHS:  dag.NewThis([]string{"collect"}),
+		LHS:  dag.NewThis(field.NewChain("collect")),
 		RHS:  &dag.AggExpr{Kind: "AggExpr", Name: "collect", Expr: dag.NewThis(nil)},
 	}
 	aggOp := &dag.AggregateOp{
@@ -559,7 +560,7 @@ func collectThis(seq dag.Seq) dag.Seq {
 	}
 	emitOp := &dag.ValuesOp{
 		Kind:  "ValuesOp",
-		Exprs: []dag.Expr{dag.NewThis([]string{"collect"})},
+		Exprs: []dag.Expr{dag.NewThis(field.NewChain("collect"))},
 	}
 	seq = append(seq, aggOp)
 	return append(seq, emitOp)

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimdata/super/compiler/ast"
 	"github.com/brimdata/super/compiler/semantic/sem"
 	"github.com/brimdata/super/compiler/sfmt"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/pkg/nano"
 	"github.com/brimdata/super/pkg/reglob"
 	"github.com/brimdata/super/runtime/sam/expr"
@@ -454,18 +455,18 @@ func (t *translator) dottedBaseCase(loc ast.Node, lhs *ast.IDExpr, rhs *ast.IDEx
 	return t.deref(loc, id, rhs, nullish, typ)
 }
 
-func (t *translator) deref(loc ast.Node, lhs sem.Expr, id *ast.IDExpr, nullish bool, inType super.Type) (sem.Expr, super.Type) {
+func (t *translator) deref(loc ast.Node, lhs sem.Expr, id *ast.IDExpr, noneish bool, inType super.Type) (sem.Expr, super.Type) {
 	typ, _ := t.checker.deref(id, inType, id.Name)
 	if lhs, ok := lhs.(*sem.ThisExpr); ok {
-		lhs.Path = append(lhs.Path, sem.PathElem{ID: id.Name, Nullish: nullish})
+		lhs.Chain = lhs.Chain.Append(id.Name, noneish)
 		lhs.Node = loc
 		return lhs, typ
 	}
 	return &sem.DotExpr{
-		Node: loc,
-		LHS:  lhs,
-		RHS:  id.Name,
-		//XXX nullish
+		Node:    loc,
+		LHS:     lhs,
+		RHS:     id.Name,
+		Noneish: noneish,
 	}, typ
 }
 
@@ -479,11 +480,11 @@ func (t *translator) idExpr(id *ast.IDExpr, lval bool, inType super.Type) (sem.E
 		}
 		return t.scope.resolve(t, id, []string{id.Name}, inType)
 	}
-	var path sem.Path
+	var chain field.Chain
 	if id.Name != "this" {
-		path = sem.NewPath(id.Name)
+		chain = field.NewChain(id.Name)
 	}
-	this := sem.NewThis(id, path)
+	this := sem.NewThis(id, chain)
 	return this, t.checker.this(id, this, inType)
 }
 
@@ -665,7 +666,7 @@ func (t *translator) noneish(loc ast.Node, typ super.Type) {
 func (t *translator) isIndexOfThis(lhs, rhs sem.Expr) *sem.ThisExpr {
 	if this, ok := lhs.(*sem.ThisExpr); ok {
 		if s, ok := t.maybeEvalString(rhs); ok {
-			this.Path = append(this.Path, sem.PathElem{ID: s})
+			this.Chain = this.Chain.Append(s, false)
 			return this
 		}
 	}
@@ -973,7 +974,7 @@ func (t *translator) assignment(assign *ast.Assignment, inType super.Type) (sem.
 	rhs, typ := t.expr(assign.RHS, inType)
 	var lhs sem.Expr
 	if assign.LHS == nil {
-		lhs = sem.NewThis(assign.RHS, sem.NewPath(deriveNameFromExpr(assign.RHS)))
+		lhs = sem.NewThis(assign.RHS, field.NewChain(deriveNameFromExpr(assign.RHS)))
 	} else {
 		lhs = t.lval(assign.LHS)
 	}
@@ -982,7 +983,7 @@ func (t *translator) assignment(assign *ast.Assignment, inType super.Type) (sem.
 		t.error(assign, errors.New("illegal left-hand side of assignment"))
 		lhs = badExpr
 	}
-	if this, ok := lhs.(*sem.ThisExpr); ok && len(this.Path) == 0 {
+	if this, ok := lhs.(*sem.ThisExpr); ok && len(this.Chain) == 0 {
 		t.error(assign, errors.New("cannot assign to 'this'"))
 		lhs = badExpr
 	}
@@ -1014,7 +1015,7 @@ func isLval(e sem.Expr) ([]string, bool) {
 		}
 		return path, ok
 	case *sem.ThisExpr:
-		return e.Path.IDs(), true
+		return e.Chain.Path(), true
 	}
 	return nil, false
 }
@@ -1100,7 +1101,7 @@ func (t *translator) field(f ast.Expr, inType super.Type) (sem.Expr, super.Type)
 	e, typ := t.expr(f, inType)
 	switch e := e.(type) {
 	case *sem.ThisExpr:
-		if len(e.Path) == 0 {
+		if len(e.Chain) == 0 {
 			t.error(f, errors.New("cannot use 'this' as a field reference"))
 			return badExpr, t.checker.unknown
 		}
@@ -1198,7 +1199,7 @@ func DotExprToFieldPath(e ast.Expr) *sem.ThisExpr {
 			if !ok {
 				return nil
 			}
-			lhs.Path = append(lhs.Path, sem.PathElem{ID: id.Name, Nullish: e.Op == "?."})
+			lhs.Chain = lhs.Chain.Append(id.Name, e.Op == "?.")
 			return lhs
 		}
 	case *ast.IndexExpr:
@@ -1210,10 +1211,10 @@ func DotExprToFieldPath(e ast.Expr) *sem.ThisExpr {
 		if !ok || id.Type != "string" {
 			return nil
 		}
-		this.Path = append(this.Path, sem.PathElem{ID: id.Text})
+		this.Chain = this.Chain.Append(id.Text, false)
 		return this
 	case *ast.IDExpr:
-		return sem.NewThis(e, sem.NewPath(e.Name))
+		return sem.NewThis(e, field.NewChain(e.Name))
 	}
 	// This includes a null Expr, which can happen if the AST is missing
 	// a field or sets it to null.

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -748,7 +748,7 @@ func (t *translator) semOp(o ast.Op, seq sem.Seq, inType super.Type) (sem.Seq, s
 		var fields field.List
 		for _, a := range assignments {
 			if this, ok := a.LHS.(*sem.ThisExpr); ok {
-				fields = append(fields, this.Path.IDs())
+				fields = append(fields, this.Chain.Path())
 			}
 		}
 		if _, err := super.NewRecordBuilder(t.sctx, fields); err != nil {
@@ -899,7 +899,7 @@ func (t *translator) semOp(o ast.Op, seq sem.Seq, inType super.Type) (sem.Seq, s
 		var fields field.List
 		for _, a := range assignments {
 			if this, ok := a.LHS.(*sem.ThisExpr); ok {
-				fields = append(fields, this.Path.IDs())
+				fields = append(fields, this.Chain.Path())
 			}
 		}
 		if err := checkPutFields(fields); err != nil {
@@ -925,7 +925,7 @@ func (t *translator) semOp(o ast.Op, seq sem.Seq, inType super.Type) (sem.Seq, s
 			lhs, lhsOk := assign.LHS.(*sem.ThisExpr)
 			rhs, rhsOk := assign.RHS.(*sem.ThisExpr)
 			if rhsOk && lhsOk {
-				if err := expr.CheckRenameField(lhs.Path.IDs(), rhs.Path.IDs()); err != nil {
+				if err := expr.CheckRenameField(lhs.Chain.Path(), rhs.Chain.Path()); err != nil {
 					t.error(&fa, err)
 				}
 			}
@@ -985,19 +985,19 @@ func (t *translator) semOp(o ast.Op, seq sem.Seq, inType super.Type) (sem.Seq, s
 			Aggs: []sem.Assignment{
 				{
 					Node: o,
-					LHS:  sem.NewThis(o, sem.NewPath("sample")),
+					LHS:  sem.NewThis(o, field.NewChain("sample")),
 					RHS:  &sem.AggFunc{Node: o, Name: "any", Expr: e},
 				},
 			},
 			Keys: []sem.Assignment{
 				{
 					Node: o,
-					LHS:  sem.NewThis(o, sem.NewPath("shape")),
+					LHS:  sem.NewThis(o, field.NewChain("shape")),
 					RHS:  sem.NewCall(o, "typeof", []sem.Expr{e}),
 				},
 			},
 		})
-		return append(seq, sem.NewValues(o, sem.NewThis(o, sem.NewPath("sample")))), t.checker.unknown
+		return append(seq, sem.NewValues(o, sem.NewThis(o, field.NewChain("sample")))), t.checker.unknown
 	case *ast.AssertOp:
 		cond, _ := t.expr(o.Expr, inType)
 		// 'assert EXPR' is equivalent to
@@ -1172,7 +1172,7 @@ func (t *translator) pipeJoinCond(cond ast.JoinCond, leftAlias, rightAlias strin
 		t.checker.boolean(cond.Expr, typ)
 		// hack: e is wrapped in []sem.Expr to work around CanSet() model in WalkT
 		dag.WalkT(reflect.ValueOf([]sem.Expr{e}), func(e *sem.ThisExpr) *sem.ThisExpr {
-			if len(e.Path) == 0 {
+			if len(e.Chain) == 0 {
 				t.error(cond.Expr, errors.New(`join expression cannot refer to "this"`))
 			}
 			return e
@@ -1181,8 +1181,8 @@ func (t *translator) pipeJoinCond(cond ast.JoinCond, leftAlias, rightAlias strin
 	case *ast.JoinUsingCond:
 		var exprs []sem.Expr
 		for _, id := range cond.Fields {
-			lhs := sem.NewThis(id, sem.NewPath(leftAlias, id.Name))
-			rhs := sem.NewThis(id, sem.NewPath(rightAlias, id.Name))
+			lhs := sem.NewThis(id, field.NewChain(leftAlias, id.Name))
+			rhs := sem.NewThis(id, field.NewChain(rightAlias, id.Name))
 			exprs = append(exprs, sem.NewBinaryExpr(id, "==", lhs, rhs))
 		}
 		return andUsingExprs(cond, exprs)
@@ -1222,7 +1222,7 @@ func (t *translator) singletonAgg(assignment *ast.Assignment, seq sem.Seq, inTyp
 	}
 	out, path := t.assignment(assignment, inType)
 	this, ok := out.LHS.(*sem.ThisExpr)
-	if !ok || len(this.Path) != 1 {
+	if !ok || len(this.Chain) != 1 {
 		return nil, nil
 	}
 	// The return type is simply pulled out of the path since the
@@ -1243,7 +1243,7 @@ func (t *translator) singletonKey(agg ast.Assignment, seq sem.Seq, inType super.
 	}
 	out, path := t.assignment(&agg, inType)
 	this, ok := out.LHS.(*sem.ThisExpr)
-	if !ok || len(this.Path) != 1 {
+	if !ok || len(this.Chain) != 1 {
 		return nil, nil
 	}
 	return append(seq,
@@ -1566,12 +1566,12 @@ func (t *translator) maybeCallShortcut(call *ast.CallExpr, seq sem.Seq, inType s
 			Aggs: []sem.Assignment{
 				{
 					Node: call,
-					LHS:  sem.NewThis(f, sem.NewPath(name)),
+					LHS:  sem.NewThis(f, field.NewChain(name)),
 					RHS:  agg,
 				},
 			},
 		}
-		values := sem.NewValues(call, sem.NewThis(call, sem.NewPath(name)))
+		values := sem.NewValues(call, sem.NewThis(call, field.NewChain(name)))
 		return append(append(seq, aggregate), values), typ
 	}
 	if !function.HasBoolResult(strings.ToLower(name)) {
@@ -1591,12 +1591,12 @@ func (t *translator) aggFuncShortcut(agg *ast.AggFuncExpr, seq sem.Seq, inType s
 		Aggs: []sem.Assignment{
 			{
 				Node: aggFunc,
-				LHS:  sem.NewThis(agg, sem.NewPath(name)),
+				LHS:  sem.NewThis(agg, field.NewChain(name)),
 				RHS:  aggFunc,
 			},
 		},
 	}
-	values := sem.NewValues(agg, sem.NewThis(agg, sem.NewPath(name)))
+	values := sem.NewValues(agg, sem.NewThis(agg, field.NewChain(name)))
 	return append(seq, aggregate, values), typ
 }
 

--- a/compiler/semantic/projection.go
+++ b/compiler/semantic/projection.go
@@ -5,22 +5,23 @@ import (
 	"slices"
 
 	"github.com/brimdata/super/compiler/semantic/sem"
+	"github.com/brimdata/super/pkg/field"
 )
 
 func replaceGroupings(t *translator, in sem.Expr, groupings []exprloc) (sem.Expr, bool) {
 	ok := true
 	out := exprWalk(in, func(e sem.Expr) (sem.Expr, bool) {
 		if i := exprMatch(e, groupings); i >= 0 {
-			return sem.NewThis(e, sem.NewPath("g", groupTmp(i))), true
+			return sem.NewThis(e, field.NewChain("g", groupTmp(i))), true
 		}
 		switch e := e.(type) {
 		case *sem.ThisExpr:
-			if len(e.Path) >= 1 {
-				s := e.Path[0].ID
+			if len(e.Chain) >= 1 {
+				s := e.Chain[0].ID
 				switch s {
 				case "in":
 					ok = false
-					t.error(e, fmt.Errorf("column %q must appear in GROUP BY clause", e.Path[len(e.Path)-1].ID))
+					t.error(e, fmt.Errorf("column %q must appear in GROUP BY clause", e.Chain[len(e.Chain)-1].ID))
 					return e, true
 				case "out", "g":
 				default:
@@ -33,7 +34,7 @@ func replaceGroupings(t *translator, in sem.Expr, groupings []exprloc) (sem.Expr
 			// turned into AggRefs before this is called.
 			panic(e)
 		case *sem.AggRef:
-			return sem.NewThis(e.Node, sem.NewPath("g", aggTmp(e.Index))), false
+			return sem.NewThis(e.Node, field.NewChain("g", aggTmp(e.Index))), false
 		}
 		return e, false
 	})

--- a/compiler/semantic/schema.go
+++ b/compiler/semantic/schema.go
@@ -395,7 +395,7 @@ func (j *joinUsingScope) star(n ast.Node, table string, path field.Path) ([]*sem
 			return nil, err
 		}
 		p := append(append(path, "left"), left...)
-		this := sem.NewThis(n, sem.NewPath(p...))
+		this := sem.NewThis(n, field.NewChain(p...))
 		out = append(out, this)
 	}
 	var err error
@@ -412,7 +412,7 @@ func (j *joinUsingScope) filterAppend(out []*sem.ThisExpr, rs relScope, n ast.No
 		return nil, err
 	}
 	for _, this := range exprs {
-		if _, skip := j.skip[this.Path[len(this.Path)-1].ID]; !skip {
+		if _, skip := j.skip[this.Chain[len(this.Chain)-1].ID]; !skip {
 			out = append(out, this)
 		}
 	}
@@ -430,7 +430,7 @@ func (s *staticTable) star(n ast.Node, table string, path field.Path) ([]*sem.Th
 	var out []*sem.ThisExpr
 	if table == "" || s.table == table {
 		for _, col := range s.typ.Fields {
-			path := append(sem.NewPath(path...), sem.PathElem{ID: col.Name})
+			path := field.NewChain(path...).Append(col.Name, false)
 			out = append(out, sem.NewThis(n, path))
 		}
 	}
@@ -468,7 +468,7 @@ func (s *selectScope) endScope(n ast.Node, seq sem.Seq) (sem.Seq, *staticTable) 
 	if s.out == nil {
 		return seq, badTable
 	}
-	return valuesExpr(sem.NewThis(n, sem.NewPath("out")), seq), s.out
+	return valuesExpr(sem.NewThis(n, field.NewChain("out")), seq), s.out
 }
 
 func (s *staticTable) endScope(n ast.Node, seq sem.Seq) (sem.Seq, *staticTable) {
@@ -476,7 +476,7 @@ func (s *staticTable) endScope(n ast.Node, seq sem.Seq) (sem.Seq, *staticTable) 
 }
 
 func (d *dynamicTable) this(n ast.Node, path []string) sem.Expr {
-	return sem.NewThis(n, sem.NewPath(path...))
+	return sem.NewThis(n, field.NewChain(path...))
 }
 
 func (j *joinScope) this(n ast.Node, path []string) sem.Expr {
@@ -493,7 +493,7 @@ func (s *selectScope) this(n ast.Node, path []string) sem.Expr {
 }
 
 func (s *staticTable) this(n ast.Node, path []string) sem.Expr {
-	return sem.NewThis(n, sem.NewPath(path...))
+	return sem.NewThis(n, field.NewChain(path...))
 }
 
 func (s *subqueryScope) this(n ast.Node, path []string) sem.Expr {
@@ -531,7 +531,7 @@ func (s *selectScope) resolveTable(n ast.Node, name string, path []string) (sem.
 
 func (s *staticTable) resolveTable(n ast.Node, table string, path []string) (sem.Expr, bool, error) {
 	if s.table == table {
-		return sem.NewThis(n, sem.NewPath(path...)), false, nil
+		return sem.NewThis(n, field.NewChain(path...)), false, nil
 	}
 	return nil, false, nil
 }

--- a/compiler/semantic/scope.go
+++ b/compiler/semantic/scope.go
@@ -198,7 +198,7 @@ func (s *Scope) resolve(t *translator, n ast.Node, path field.Path, inType super
 				return badExpr, t.checker.unknown
 			}
 		}
-		this := sem.NewThis(n, sem.NewPath(append(out, path[1:]...)...))
+		this := sem.NewThis(n, field.NewChain(append(out, path[1:]...)...))
 		return this, t.checker.this(n, this, inType)
 	}
 	if scope, ok := scope.(*selectScope); ok && scope.lateral && inputFirst {
@@ -227,7 +227,7 @@ func (s *Scope) resolve(t *translator, n ast.Node, path field.Path, inType super
 			return badExpr, t.checker.unknown
 		}
 		if out != nil {
-			this := sem.NewThis(n, sem.NewPath(append(out, path[2:]...)...))
+			this := sem.NewThis(n, field.NewChain(append(out, path[2:]...)...))
 			return this, t.checker.this(n, this, inType)
 		}
 		if p, _, _ := scope.resolveTable(n, path[0], nil); p != nil {
@@ -244,7 +244,7 @@ func extend(n ast.Node, e sem.Expr, rest []string) sem.Expr {
 		return e
 	}
 	if this, ok := e.(*sem.ThisExpr); ok {
-		return sem.NewThis(n, sem.NewPath(append(this.Path.IDs(), rest...)...))
+		return sem.NewThis(n, append(this.Chain, field.NewChain(rest...)...))
 	}
 	out := &sem.DotExpr{
 		Node: n,

--- a/compiler/semantic/sem/expr.go
+++ b/compiler/semantic/sem/expr.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/ast"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/scode"
 	"github.com/brimdata/super/sup"
 )
@@ -54,8 +55,9 @@ type (
 	}
 	DotExpr struct {
 		ast.Node
-		LHS Expr
-		RHS string
+		LHS     Expr
+		RHS     string
+		Noneish bool
 	}
 	IndexExpr struct {
 		ast.Node
@@ -119,7 +121,7 @@ type (
 	}
 	ThisExpr struct {
 		ast.Node
-		Path Path
+		Chain field.Chain
 	}
 	TypeExpr struct {
 		ast.Node
@@ -219,31 +221,8 @@ type FuncRef struct {
 
 func (*FuncRef) exprNode() {}
 
-func NewThis(n ast.Node, path Path) *ThisExpr {
-	return &ThisExpr{Node: n, Path: path}
-}
-
-type PathElem struct {
-	ID      string
-	Nullish bool
-}
-
-type Path []PathElem
-
-func (p Path) IDs() []string {
-	path := make([]string, 0, len(p))
-	for _, elem := range p {
-		path = append(path, elem.ID)
-	}
-	return path
-}
-
-func NewPath(ids ...string) Path {
-	path := make([]PathElem, 0, len(ids))
-	for _, id := range ids {
-		path = append(path, PathElem{ID: id})
-	}
-	return path
+func NewThis(n ast.Node, chain field.Chain) *ThisExpr {
+	return &ThisExpr{Node: n, Chain: chain}
 }
 
 func NewBinaryExpr(n ast.Node, op string, lhs, rhs Expr) *BinaryExpr {
@@ -359,9 +338,10 @@ func CopyExpr(e Expr) Expr {
 		}
 	case *DotExpr:
 		return &DotExpr{
-			Node: e.Node,
-			LHS:  CopyExpr(e.LHS),
-			RHS:  e.RHS,
+			Node:    e.Node,
+			LHS:     CopyExpr(e.LHS),
+			RHS:     e.RHS,
+			Noneish: e.Noneish,
 		}
 	case *IndexExpr:
 		return &IndexExpr{
@@ -470,8 +450,8 @@ func CopyExpr(e Expr) Expr {
 		}
 	case *ThisExpr:
 		return &ThisExpr{
-			Node: e.Node,
-			Path: slices.Clone(e.Path),
+			Node:  e.Node,
+			Chain: slices.Clone(e.Chain),
 		}
 	case *TypeExpr:
 		return &TypeExpr{

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/ast"
 	"github.com/brimdata/super/compiler/semantic/sem"
+	"github.com/brimdata/super/pkg/field"
 )
 
 // Analyze a SQL select expression which may have arbitrary nested subqueries
@@ -122,7 +123,7 @@ func (t *translator) sqlSelect(sel *ast.SQLSelect, demand []ast.Expr, seq sem.Se
 		}
 	}
 	if sel.Distinct {
-		seq = t.genDistinct(sem.NewThis(sel, sem.NewPath("out")), seq)
+		seq = t.genDistinct(sem.NewThis(sel, field.NewChain("out")), seq)
 	}
 	return seq, scope
 }
@@ -176,7 +177,7 @@ func (t *translator) formProjection(scope *selectScope, in []ast.SQLAsExpr, inTy
 			}
 			for _, p := range paths {
 				typ := t.checker.this(star, p, inType)
-				out = append(out, column{name: dedup(scores, t.asName(as.Label, nil, p.Path.IDs())), semExpr: p, typ: typ, astExpr: as.Expr})
+				out = append(out, column{name: dedup(scores, t.asName(as.Label, nil, p.Chain.Path())), semExpr: p, typ: typ, astExpr: as.Expr})
 			}
 			continue
 		}
@@ -242,7 +243,7 @@ func (t *translator) emitProjection(columns []column, grouped bool, seq sem.Seq)
 			&sem.FieldElem{
 				Node:  loc,
 				Name:  in,
-				Value: sem.NewThis(loc, sem.NewPath(in)),
+				Value: sem.NewThis(loc, field.NewChain(in)),
 			},
 			&sem.FieldElem{
 				Node: loc,
@@ -263,7 +264,7 @@ func (t *translator) genAggregate(loc ast.Loc, scope *selectScope, seq sem.Seq) 
 	for k, agg := range scope.aggs {
 		a := sem.Assignment{
 			Node: agg.Node,
-			LHS:  sem.NewThis(agg.Node, sem.NewPath(aggTmp(k))),
+			LHS:  sem.NewThis(agg.Node, field.NewChain(aggTmp(k))),
 			RHS:  agg,
 		}
 		aggCols = append(aggCols, a)
@@ -272,7 +273,7 @@ func (t *translator) genAggregate(loc ast.Loc, scope *selectScope, seq sem.Seq) 
 	for k, e := range scope.groupings {
 		keyCols = append(keyCols, sem.Assignment{
 			Node: e.loc,
-			LHS:  sem.NewThis(loc, sem.NewPath(groupTmp(k))),
+			LHS:  sem.NewThis(loc, field.NewChain(groupTmp(k))),
 			RHS:  e.expr,
 		})
 	}
@@ -412,7 +413,7 @@ func mapColumns(sctx *super.Context, in *super.TypeRecord, alias *ast.TableAlias
 			elems = append(elems, &sem.FieldElem{
 				Node:  alias.Columns[k],
 				Name:  out[k],
-				Value: sem.NewThis(alias.Columns[k], sem.NewPath(in.Fields[k].Name)),
+				Value: sem.NewThis(alias.Columns[k], field.NewChain(in.Fields[k].Name)),
 			})
 			fields = append(fields, super.NewField(out[k], in.Fields[k].Type))
 		}
@@ -633,8 +634,8 @@ func (t *translator) sqlJoinCond(cond ast.JoinCond, typ super.Type) sem.Expr {
 				t.error(id, fmt.Errorf("column %q in USING clause does not exist in right table", id.Name))
 				continue
 			}
-			lhs := sem.NewThis(id, sem.NewPath(append([]string{"left"}, left...)...))
-			rhs := sem.NewThis(id, sem.NewPath(append([]string{"right"}, right...)...))
+			lhs := sem.NewThis(id, field.NewChain(append([]string{"left"}, left...)...))
+			rhs := sem.NewThis(id, field.NewChain(append([]string{"right"}, right...)...))
 			exprs = append(exprs, sem.NewBinaryExpr(id, "==", lhs, rhs))
 		}
 		if len(exprs) == 0 {
@@ -710,7 +711,7 @@ func (t *translator) resolveOrdinalOuter(ts tableScope, n ast.Node, prefix strin
 		} else {
 			path = []string{ts.typ.Fields[col-1].Name}
 		}
-		return sem.NewThis(n, sem.NewPath(path...))
+		return sem.NewThis(n, field.NewChain(path...))
 	default:
 		panic(ts)
 	}

--- a/compiler/sfmt/dag.go
+++ b/compiler/sfmt/dag.go
@@ -165,7 +165,7 @@ func (c *canonDAG) expr(e dag.Expr, parent string) {
 		c.close()
 		c.write(")")
 	case *dag.ThisExpr:
-		c.fieldpath(e.Path)
+		c.fieldchain(e.Chain)
 	case *dag.TypeExpr:
 		if typ, err := super.LookupPrimitiveByID(e.ID); err == nil {
 			c.write("<%s>", super.PrimitiveName(typ))
@@ -250,7 +250,7 @@ func (c *canonDAG) vectorElems(elems []dag.VectorElem) {
 
 func isDAGThis(e dag.Expr) bool {
 	if this, ok := e.(*dag.ThisExpr); ok {
-		if len(this.Path) == 0 {
+		if len(this.Chain) == 0 {
 			return true
 		}
 	}

--- a/compiler/sfmt/shared.go
+++ b/compiler/sfmt/shared.go
@@ -2,6 +2,7 @@ package sfmt
 
 import (
 	"github.com/brimdata/super/compiler/ast"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/sup"
 )
 
@@ -22,22 +23,25 @@ func (s *shared) literal(e ast.Primitive) {
 	}
 }
 
-func (s *shared) fieldpath(path []string) {
-	if len(path) == 0 {
+func (s *shared) fieldchain(chain field.Chain) {
+	if len(chain) == 0 {
 		s.write("this")
 		return
 	}
-	for k, elem := range path {
-		if sup.IsIdentifier(elem) {
+	for k, elem := range chain {
+		if elem.Noneish {
+			s.write("?")
+		}
+		if sup.IsIdentifier(elem.ID) {
 			if k != 0 {
 				s.write(".")
 			}
-			s.write(elem)
+			s.write(elem.ID)
 		} else {
 			if k == 0 {
 				s.write("this")
 			}
-			s.write("[%q]", elem)
+			s.write("[%q]", elem.ID)
 		}
 	}
 }

--- a/compiler/sfmt/ztests/dot.yaml
+++ b/compiler/sfmt/ztests/dot.yaml
@@ -1,10 +1,15 @@
 script: |
   super compile -C -dag 'values {nested:[{field:1}]} | nested[1].field == 1'
-
+  echo ===
+  super compile -C -dag 'values x?.y' -
 outputs:
   - name: stdout
     data: |
       null
       | values {nested:[{field:1}]}
       | where nested[1]["field"]==1
+      | output main
+      ===
+      file stdio:stdin
+      | values x?.y
       | output main

--- a/pkg/field/chain.go
+++ b/pkg/field/chain.go
@@ -1,0 +1,32 @@
+package field
+
+type ChainElem struct {
+	ID      string
+	Noneish bool
+}
+
+type Chain []ChainElem
+
+func NewChain(ids ...string) Chain {
+	path := make([]ChainElem, 0, len(ids))
+	for _, id := range ids {
+		path = append(path, ChainElem{ID: id})
+	}
+	return path
+}
+
+func (c Chain) Append(id string, noneish bool) Chain {
+	return append(c, ChainElem{id, noneish})
+}
+
+func (c Chain) Path() Path {
+	path := make([]string, 0, len(c))
+	for _, elem := range c {
+		path = append(path, elem.ID)
+	}
+	return path
+}
+
+func (c Chain) String() string {
+	return c.Path().String()
+}

--- a/pkg/field/chain.go
+++ b/pkg/field/chain.go
@@ -8,11 +8,11 @@ type ChainElem struct {
 type Chain []ChainElem
 
 func NewChain(ids ...string) Chain {
-	path := make([]ChainElem, 0, len(ids))
+	chain := make([]ChainElem, 0, len(ids))
 	for _, id := range ids {
-		path = append(path, ChainElem{ID: id})
+		chain = append(chain, ChainElem{ID: id})
 	}
-	return path
+	return chain
 }
 
 func (c Chain) Append(id string, noneish bool) Chain {

--- a/pkg/field/field.go
+++ b/pkg/field/field.go
@@ -51,6 +51,10 @@ func (p Path) HasPrefixIn(set []Path) bool {
 	return slices.ContainsFunc(set, p.HasPrefix)
 }
 
+func (p Path) Chain() Chain {
+	return NewChain([]string(p)...)
+}
+
 func Dotted(s string) Path {
 	return strings.Split(s, ".")
 }


### PR DESCRIPTION
This commit adds a data structure for optional chaining indication in a set of fields that comprise a path.  field.Chain is like field.Path except each path element includes a boolean indicate whether the dereference operation should he noneish (i.e., "?.") or not (i.e., ".").

This is needed by the forthcoming PRs that will implement proper handling of none values and eliminate the need for error("missing").  The placeholder noneish booleans in dag.ThisExpr and sem.ThisExpr will be used in these subsequent PRs.