### PR TITLE
vector: don't store arg reference in fusionValueBuilder.Write

### DIFF
--- a/vector/valuebuilder.go
+++ b/vector/valuebuilder.go
@@ -2,6 +2,7 @@ package vector
 
 import (
 	"net/netip"
+	"slices"
 
 	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/brimdata/super"
@@ -283,7 +284,7 @@ func newFusionValueBuilder(typ *super.TypeFusion) ValueBuilder {
 func (f *fusionValueBuilder) Write(bytes scode.Bytes) {
 	it := bytes.Iter()
 	f.values.Write(it.Next())
-	f.subtypes = append(f.subtypes, it.Next())
+	f.subtypes = append(f.subtypes, slices.Clone(it.Next()))
 }
 
 func (f *fusionValueBuilder) Build(sctx *super.Context) Any {


### PR DESCRIPTION
ValueBuilder.Write callers must relinquish ownership of its scode.Bytes argument because fusionValueBuilder.Write stores a reference to that argument's backing array.  The same holds for DynamicValueBuilder.Write callers and its super.Value argument because that method calls ValueBuilder.Write.  Allow callers of both methods to retain argument ownership by changing fusionValueBuilder.Write to store a copy of its argument rather than a reference.

#7255 needs this.