### PR TITLE
compiler/optimizer: fix panic on a bare "this" in a join key

### DIFF
--- a/compiler/optimizer/join.go
+++ b/compiler/optimizer/join.go
@@ -160,8 +160,13 @@ func equiJoinKeyExprs(e dag.Expr, leftAlias, rightAlias string) (left, right dag
 // firstThisPathComponent returns the first component common to every dag.This.Path
 // in e and a Boolean indicating whether such a common first component exists.
 func firstThisPathComponent(e dag.Expr) (prefix string, ok bool) {
+	// A bare "this" has no first path component, so it disqualifies e.  Latch
+	// that rather than clearing ok, which a later chained "this" would set again.
+	var bare bool
 	walkT(reflect.ValueOf(e), func(t dag.ThisExpr) dag.ThisExpr {
-		if prefix == "" {
+		if len(t.Chain) == 0 {
+			bare = true
+		} else if prefix == "" {
 			prefix = t.Chain[0].ID
 			ok = true
 		} else if prefix != t.Chain[0].ID {
@@ -169,7 +174,7 @@ func firstThisPathComponent(e dag.Expr) (prefix string, ok bool) {
 		}
 		return t
 	})
-	return prefix, ok
+	return prefix, ok && !bare
 }
 
 // stripFirstThisPathComponent removes the first component of every dag.This.Path in e.

--- a/compiler/ztests/join-hash-key-is-this.yaml
+++ b/compiler/ztests/join-hash-key-is-this.yaml
@@ -1,0 +1,60 @@
+# A join key expression containing a bare "this" has no common first path
+# component, so the join must not be converted to a hash join.  The first query
+# is the panic from issue 6971; the second mixes a bare "this" with a chained
+# one in the same key expression, which panics in stripFirstThisPathComponent
+# unless firstThisPathComponent latches the bare case.
+#
+# Both expected DAGs show a named query used as a SQL table inlined into the ON
+# expression as a subquery, which is the issue 6622 binding bug and is not fixed
+# here; they will need regenerating when it is.
+script: |
+  super compile -O -C "
+    let a = (values [{id:1}] | unnest this)
+    let b = (values [{id:2}] | unnest this)
+    SELECT a.id FROM a JOIN b ON a.id = b.id
+  "
+  echo // ===
+  super compile -O -C "
+    let c = (values [{id:1}] | unnest this)
+    let t1 = (values {id:1})
+    let t2 = (values {id:1})
+    SELECT p.id FROM t1 AS p JOIN t2 AS q ON p.id = c.id + q.id
+  "
+
+outputs:
+  - name: stdout
+    data: |
+      null
+      | fork
+        (
+          values [{id:1}]
+          | unnest this
+        )
+        (
+          values [{id:2}]
+          | unnest this
+        )
+      | inner join as {left,right} on (
+          values [{id:1}]
+          | unnest this)["id"]==(
+          values [{id:2}]
+          | unnest this)["id"]
+      | values {in:this}
+      | values {id:(
+        values [{id:1}]
+        | unnest this)["id"]}
+      | output main
+      // ===
+      null
+      | fork
+        (
+          values {id:1}
+        )
+        (
+          values {id:1}
+        )
+      | inner join as {left,right} on left.id==(
+          values [{id:1}]
+          | unnest this)["id"]+right.id
+      | values {id:left.id}
+      | output main


### PR DESCRIPTION
Fixes the panic reported in #6971, and the same panic in #6622.

`firstThisPathComponent` reads `t.Chain[0].ID` for every `dag.ThisExpr` it walks
without checking that `Chain` is non-empty, so a bare `this` anywhere in a join
key expression takes down the optimizer:

```
panic: runtime error: index out of range [0] with length 0
...
github.com/brimdata/super/compiler/optimizer.firstThisPathComponent.func1
	compiler/optimizer/join.go:165
```

A bare `this` gets in there because a named query used as a SQL table is bound as
an expression subquery in the `ON` clause instead of as the table, so the
subquery body, and the `this` inside it, ends up in the condition that
`replaceJoinWithHashJoin` walks. That is the binding bug @mccanne describes in
#6622; this is the optimizer guard he wondered about in the same comment.

A bare `this` has no first path component, which is exactly the "no common first
component" case the function already documents, so returning `ok == false` puts
both callers back on the non-hash join path. That can only cost a nested-loop
plan where a hash join was possible, never a wrong answer.

This cannot regress anything that works today: every branch of the old closure
indexed `t.Chain[0]`, so any bare `this` reaching this walk panicked
unconditionally. The only inputs whose result changes are the ones that used to
crash.

The guard has to latch rather than just clear `ok`. With a plain `ok = false`, a
chained `this` walked after a bare one re-sets `prefix` and `ok`, and
`stripFirstThisPathComponent` then panics with `slice bounds out of range [1:0]`.
The second case in the new ztest covers that; it panics without the latch.

I left the `prefix == ""` sentinel alone. It conflates "unset" with a genuinely
empty first component, which looks reachable via `this[""]`, but that is a
wrong-answer bug rather than a crash and orthogonal to this one. Happy to fold in
a `seen` flag if you would rather have both in one go.

Scope: this only removes the crash. The binding problem is untouched, so the
query in #6971 now compiles and runs but returns no rows rather than joined rows.
That part is pre-existing and independent of the panic. It reproduces on main
with no panic at all:

```
$ super -c "let a = (values {id:1,x:'p'}, {id:2,x:'q'})
            let b = (values {id:1,y:'Y'})
            SELECT a.x, b.y FROM a JOIN b ON a.id = b.id"
$
```

Ran `make fmt`, `make vet`, `make test-unit` and `make test-system` locally. The
only failures are the three `version.yaml` tests, which fail in any clone without
tags.

For transparency: I used an AI assistant while working on this. I reproduced the
panic, wrote and ran the tests, and checked the reasoning myself.