### PR TITLE
Fix typos/misspellings in user-visible command text

### DIFF
--- a/cmd/super/db/compile/command.go
+++ b/cmd/super/db/compile/command.go
@@ -20,7 +20,7 @@ The primary difference here is that "from" operators on a database work with dat
 stored in the database whereas "from" operators on file system work with local files.
 In both cases, "from" can also retrieve data from HTTP APIs via URL.
 
-See the "super compile" command help for futher information.
+See the "super compile" command help for further information.
 `,
 	New: New,
 }

--- a/compiler/semantic/checker.go
+++ b/compiler/semantic/checker.go
@@ -344,7 +344,7 @@ func (c *checker) expr(typ super.Type, e sem.Expr) super.Type {
 		lambdaType := c.expr(elemType, e.Lambda)
 		errs := c.popErrs()
 		if len(errs) != 0 {
-			c.error(errs[0].loc, fmt.Errorf("in functon called from map: %w", errs[0].err))
+			c.error(errs[0].loc, fmt.Errorf("in function called from map: %w", errs[0].err))
 		}
 		return lambdaType
 	case *sem.MapExpr:

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -892,7 +892,7 @@ func (t *translator) semMapCall(call *ast.CallExpr, args []sem.Expr, argTypes []
 	e, typ := t.resolver.resolveCall(call.Args[1], ref.ID, mapArgs, mapTypes)
 	errs := t.checker.popErrs()
 	for _, err := range errs {
-		t.error(err.loc, fmt.Errorf("in functon called from map: %w", err.err))
+		t.error(err.loc, fmt.Errorf("in function called from map: %w", err.err))
 	}
 	if callExpr, ok := e.(*sem.CallExpr); ok {
 		return &sem.MapCallExpr{

--- a/compiler/semantic/ztests/checker-map-func-type.yaml
+++ b/compiler/semantic/ztests/checker-map-func-type.yaml
@@ -3,6 +3,6 @@ spq: |
   values map([1,2], &f)
 
 error: |
-  in functon called from map: indexed entity is not indexable at line 1, column 9:
+  in function called from map: indexed entity is not indexable at line 1, column 9:
   fn f(a):a[1]
           ~

--- a/runtime/sam/expr/function/bytes.go
+++ b/runtime/sam/expr/function/bytes.go
@@ -45,7 +45,7 @@ func (h *Hex) Call(args []super.Value) super.Value {
 	case super.IDString:
 		b, err := hex.DecodeString(super.DecodeString(val.Bytes()))
 		if err != nil {
-			return h.sctx.WrapError("hex: string argument is not hexidecimal", val)
+			return h.sctx.WrapError("hex: string argument is not hexadecimal", val)
 		}
 		return super.NewBytes(b)
 	default:

--- a/runtime/vam/expr/function/bytes.go
+++ b/runtime/vam/expr/function/bytes.go
@@ -78,7 +78,7 @@ func (h *Hex) Call(args ...vector.Any) vector.Any {
 			}
 			out.Append(bytes)
 		}
-		err := vector.NewWrappedError(h.sctx, "hex: string argument is not hexidecimal", errvals)
+		err := vector.NewWrappedError(h.sctx, "hex: string argument is not hexadecimal", errvals)
 		return vector.NewDynamic(tags, []vector.Any{out, err})
 	default:
 		return vector.NewWrappedError(h.sctx, "hex: argument must a bytes or string type", val)

--- a/runtime/vam/op/robot.go
+++ b/runtime/vam/op/robot.go
@@ -113,7 +113,7 @@ func (o *Robot) nextPuller() (vio.Puller, error) {
 }
 
 func (o *Robot) errOnVal(vec vector.Any) vio.Puller {
-	out := vector.NewWrappedError(o.rctx.Sctx, "from ecountered non-string input", vec)
+	out := vector.NewWrappedError(o.rctx.Sctx, "from encountered non-string input", vec)
 	return vio.NewPuller(out)
 }
 

--- a/runtime/ztests/expr/function/hex.yaml
+++ b/runtime/ztests/expr/function/hex.yaml
@@ -9,6 +9,6 @@ input: |
 output: |
   0x68656c6c6f20776f726c64
   "68656c6c6f20776f726c64"
-  error({message:"hex: string argument is not hexidecimal",on:"foo"})
+  error({message:"hex: string argument is not hexadecimal",on:"foo"})
   null
 

--- a/sup/analyzer.go
+++ b/sup/analyzer.go
@@ -467,7 +467,7 @@ func (a *Analyzer) decorate(val Value, typ super.Type) (Value, error) {
 	case *Error:
 		return a.decorateError(val, typ)
 	case *Fusion:
-		return nil, fmt.Errorf("fusion values cannt be decorated: %q", FormatType(typ))
+		return nil, fmt.Errorf("fusion values cannot be decorated: %q", FormatType(typ))
 	case *Union:
 		return a.decorateUnion(val, typ)
 	default:


### PR DESCRIPTION
When enabling `codespell` on the book docs (#7245), I did a one-time check on the source code as well and turned up these typos/misspellings that are present in user-visible error messages and help text. Corresponding ztests are also fixed.

## Out of scope

The same `codespell` run surfaced plenty of similar mistakes in other places in the code such as comments. I've heard consensus from the Dev team that there's no desire to see those fixed right now, but if folks change their mind, just say the word and I'll put up a PR to cover those as well.