### PR TITLE
add native implementation for noneish coalescing operator

### DIFF
--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -112,6 +112,8 @@ func (b *Builder) compileVamBinary(e *dag.BinaryExpr) (vamexpr.Evaluator, error)
 		return vamexpr.NewCompare(b.sctx(), op, lhs, rhs), nil
 	case "+", "-", "*", "/", "%":
 		return vamexpr.NewArith(b.sctx(), op, lhs, rhs), nil
+	case "??":
+		return vamexpr.NewNoneish(b.sctx(), lhs, rhs), nil
 	default:
 		return nil, fmt.Errorf("invalid binary operator %s", op)
 	}

--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -113,7 +113,7 @@ func (b *Builder) compileVamBinary(e *dag.BinaryExpr) (vamexpr.Evaluator, error)
 	case "+", "-", "*", "/", "%":
 		return vamexpr.NewArith(b.sctx(), op, lhs, rhs), nil
 	case "??":
-		return vamexpr.NewNoneish(b.sctx(), lhs, rhs), nil
+		return vamexpr.NewNoneish(lhs, rhs), nil
 	default:
 		return nil, fmt.Errorf("invalid binary operator %s", op)
 	}

--- a/compiler/semantic/checker.go
+++ b/compiler/semantic/checker.go
@@ -441,6 +441,8 @@ func (c *checker) binary(op string, loc, lloc, rloc ast.Node, lhs, rhs super.Typ
 		return c.plus(loc, lhs, rhs)
 	case "-", "*", "/", "%":
 		return c.arithmetic(lloc, rloc, lhs, rhs)
+	case "??":
+		return c.fuse([]super.Type{lhs, rhs})
 	default:
 		panic(op)
 	}
@@ -939,18 +941,6 @@ func hasString(typ super.Type) bool {
 		return true
 	case *super.TypeUnion:
 		return slices.ContainsFunc(typ.Types, hasString)
-	}
-	return false
-}
-
-func hasNone(typ super.Type) bool {
-	switch typ := super.TypeUnder(typ).(type) {
-	case *super.TypeError:
-		return isUnknown(typ)
-	case *super.TypeOfNone:
-		return true
-	case *super.TypeUnion:
-		return slices.ContainsFunc(typ.Types, hasNone)
 	}
 	return false
 }

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -606,15 +606,6 @@ func (t *translator) binaryExpr(e *ast.BinaryExpr, inType super.Type) (sem.Expr,
 			Tag:  "concat",
 			Args: []sem.Expr{lhs, rhs},
 		}, super.TypeString
-	case "??":
-		t.noneish(e.LHS, lhsType)
-		t.expr(e.RHS, rhsType)
-		//XXX we use coalesce for now and will have a dedicated operator in a subsequent PR
-		return &sem.CallExpr{
-			Node: e,
-			Tag:  "coalesce",
-			Args: []sem.Expr{lhs, rhs},
-		}, t.checker.unknown //XXX this should be union of LHS and RHS
 	case "not in":
 		t.checker.in(e, e.LHS, e.RHS, lhsType, rhsType)
 		return sem.NewUnaryExpr(e, "!", sem.NewBinaryExpr(e, "in", lhs, rhs)), super.TypeBool
@@ -636,12 +627,6 @@ func (t *translator) binaryExpr(e *ast.BinaryExpr, inType super.Type) (sem.Expr,
 func (t *translator) stringy(loc ast.Node, typ super.Type) {
 	if !hasString(typ) {
 		t.error(loc, errors.New("expected type string"))
-	}
-}
-
-func (t *translator) noneish(loc ast.Node, typ super.Type) {
-	if !hasNone(typ) {
-		t.error(loc, errors.New("none check used with expression that cannot be none"))
 	}
 }
 

--- a/runtime/vam/expr/noneish.go
+++ b/runtime/vam/expr/noneish.go
@@ -1,0 +1,31 @@
+package expr
+
+import (
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/vector"
+)
+
+type Noneish struct {
+	lhs Evaluator
+	rhs Evaluator
+}
+
+func NewNoneish(sctx *super.Context, lhs, rhs Evaluator) *Noneish {
+	return &Noneish{lhs, rhs}
+}
+
+func (i *Noneish) Eval(this vector.Any) vector.Any {
+	lhs := i.lhs.Eval(this)
+	rhs := i.rhs.Eval(this)
+	return vector.Apply(vector.ApplyRipUnions, i.eval, lhs, rhs)
+}
+
+func (i *Noneish) eval(vecs ...vector.Any) vector.Any {
+	lhs := vecs[0]
+	rhs := vecs[1]
+	under := vector.Under(vector.Super(lhs))
+	if typ := under.Type(); typ == super.TypeNone || typ == super.TypeNull {
+		return rhs
+	}
+	return lhs
+}

--- a/runtime/vam/expr/noneish.go
+++ b/runtime/vam/expr/noneish.go
@@ -1,7 +1,6 @@
 package expr
 
 import (
-	"github.com/brimdata/super"
 	"github.com/brimdata/super/vector"
 )
 
@@ -10,7 +9,7 @@ type Noneish struct {
 	rhs Evaluator
 }
 
-func NewNoneish(sctx *super.Context, lhs, rhs Evaluator) *Noneish {
+func NewNoneish(lhs, rhs Evaluator) *Noneish {
 	return &Noneish{lhs, rhs}
 }
 
@@ -23,8 +22,7 @@ func (i *Noneish) Eval(this vector.Any) vector.Any {
 func (i *Noneish) eval(vecs ...vector.Any) vector.Any {
 	lhs := vecs[0]
 	rhs := vecs[1]
-	under := vector.Under(vector.Super(lhs))
-	if typ := under.Type(); typ == super.TypeNone || typ == super.TypeNull {
+	if k := vector.Super(lhs).Kind(); k == vector.KindNull || k == vector.KindNone {
 		return rhs
 	}
 	return lhs

--- a/runtime/vam/op/values.go
+++ b/runtime/vam/op/values.go
@@ -31,7 +31,7 @@ func (v *Values) Pull(done bool) (vector.Any, error) {
 		}
 		vals := make([]vector.Any, 0, len(v.exprs))
 		for _, e := range v.exprs {
-			vals = append(vals, vector.DeoptionWithMissing(v.sctx, e.Eval(val)))
+			vals = append(vals, e.Eval(val))
 		}
 		if len(vals) == 1 {
 			return vals[0], nil

--- a/runtime/ztests/expr/dot.yaml
+++ b/runtime/ztests/expr/dot.yaml
@@ -19,7 +19,7 @@ output: |
   1
   1
   error("missing")
-  error("missing")
+  none
   error("missing")
   error("missing")
   error("missing")

--- a/runtime/ztests/expr/noneish.yaml
+++ b/runtime/ztests/expr/noneish.yaml
@@ -1,0 +1,8 @@
+spq: 'values none ?? 1, error(1) ?? 2, null ?? 3, none ?? none, 4 ?? 5'
+
+output: |
+  1
+  error(1)
+  3
+  none
+  4

--- a/runtime/ztests/expr/optional-fields.yaml
+++ b/runtime/ztests/expr/optional-fields.yaml
@@ -7,9 +7,9 @@ input: |
 
 output: |
   1
-  "foo"
+  "foo"::(string|none)
   1
-  error("missing")
+  none::(string|none)
   1
   1
 
@@ -92,8 +92,8 @@ input: |
   {b?:none::string}
 
 output: |
-  "foo"
-  error("missing")
+  "foo"::(string|none)
+  none::(string|none)
 
 ---
 
@@ -103,7 +103,7 @@ input: |
   {b?:none::string}
 
 output: |
-  error("missing")
+  none::(string|none)
 
 ---
 
@@ -114,8 +114,8 @@ input: |
   {b?:none::string}
 
 output: |
-  error("missing")
-  error("missing")
+  none::(string|none)
+  none::(string|none)
 
 ---
 
@@ -125,7 +125,7 @@ input: |
   {b?:"foo"}
 
 output: |
-  "foo"
+  "foo"::(string|none)
 
 ---
 
@@ -159,8 +159,6 @@ input: |
   {a?:{b:1}}
   {a?:none::{b:int64}}
 
-# XXX this should not be missing and will be fixed in a subsequent PR
-
 output: |
   1
-  error("missing")
+  none

--- a/runtime/ztests/expr/recursive-types.yaml
+++ b/runtime/ztests/expr/recursive-types.yaml
@@ -59,6 +59,6 @@ input: |
   {val:"2",next?:{val:"3",next?:none::List}::List}::List
 
 output: |
-  error("missing")
   type List={val:string,next?:List}
-  {val:"3",next?:none::List}::List
+  none::(List|none)
+  {val:"3",next?:none::List}::List::(List|none)


### PR DESCRIPTION
This commit change the "??" operator to use a native implementation instead of SQL coalesce.  It returns the RHS only when the LHS is null or none, which differs from coalesce(lhs,rhs).

We also changed values to no longer deoption its output.  This means option types are preserved in the output and none values can show up as standalone entities.

Some of the tests now cause error("missing") to show up as nones. In a subsequent PR, all of the error("missing") cases will go away and operators that do not expect nones will generate stuctured errors when encountered.