### PR TITLE
cli/outputflags: fix another output heuristic bug

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -65,11 +65,9 @@ func (f *Flags) SetFlagsWithFormat(fs *flag.FlagSet, format string) {
 	f.Format = format
 }
 
-const initialDefaultFormat = "csup"
-
 func (f *Flags) SetFormatFlags(fs *flag.FlagSet) {
 	if f.DefaultFormat == "" {
-		f.DefaultFormat = initialDefaultFormat
+		f.DefaultFormat = "csup"
 	}
 	fs.StringVar(&f.Format, "f", f.DefaultFormat, "format for output data [arrows,bsup,csup,csv,db,json,line,parquet,sup,table,tsv,zeek]")
 	fs.BoolVar(&f.forceBinary, "B", false, "allow Super Binary to be sent to a terminal output")
@@ -102,8 +100,8 @@ func (f *Flags) Init() error {
 	if f.outputFile == "-" {
 		f.outputFile = ""
 	}
-	if f.outputFile == "" && f.split == "" && f.Format == initialDefaultFormat && !f.forceBinary &&
-		terminal.IsTerminalFile(os.Stdout) {
+	if f.outputFile == "" && f.split == "" && f.Format == f.DefaultFormat &&
+		isBinary(f.Format) && !f.forceBinary && terminal.IsTerminalFile(os.Stdout) {
 		f.Format = "sup"
 		f.SUP.Pretty = 0
 	}
@@ -111,6 +109,10 @@ func (f *Flags) Init() error {
 		sbuf.PullerBatchValues = 1
 	}
 	return nil
+}
+
+func isBinary(fmt string) bool {
+	return fmt == "arrows" || fmt == "bsup" || fmt == "csup" || fmt == "parquet"
 }
 
 func (f *Flags) FileName() string {


### PR DESCRIPTION
"super db -c ..." should write SUP to the terminal but instead writes its default format, BSUP, because the heuristic in outputflags.SetFormatFlags assumes CSUP is the only binary format. Change the heuristic to be aware of our other binary formats.

This doesn't include a test because we don't have a straighforward way to provide access to a terminal.

Fixes #7287.

I also verified that #7075 remains fixed.