### PR TITLE
handle missing fields in SQL as null

### DIFF
--- a/book/src/super-sql/sql/join.md
+++ b/book/src/super-sql/sql/join.md
@@ -99,7 +99,7 @@ JOIN U ON x=z
 ---
 
 _Left outer join_
-```mdtest-spq-skip
+```mdtest-spq
 # spq
 WITH T(x,y) AS (
     VALUES (1,2), (3,4), (5,6)
@@ -114,15 +114,15 @@ ORDER BY x
 # input
 
 # expected output
-{x:1,y:2,z:error("missing")}
+{x:1,y:2,z:null}
 {x:3,y:4,z:3}
-{x:5,y:6,z:error("missing")}
+{x:5,y:6,z:null}
 ```
 
 ---
 
 _Right outer join_
-```mdtest-spq-skip
+```mdtest-spq
 # spq
 WITH T(x,y) AS (
     VALUES (1,2), (3,4), (5,6)
@@ -138,7 +138,7 @@ ORDER BY x
 
 # expected output
 {x:3,y:4,z:3}
-{x:error("missing"),y:error("missing"),z:2}
+{x:null,y:null,z:2}
 ```
 
 ---

--- a/book/src/super-sql/sql/values.md
+++ b/book/src/super-sql/sql/values.md
@@ -59,15 +59,15 @@ FROM (VALUES ('hello, world'),('to be or not to be')) T(message)
 
 ---
 
-_Column variation filled in with missing values_
-```mdtest-spq-skip
+_Column variation filled in with null values_
+```mdtest-spq
 # spq
 SELECT * FROM (VALUES (1,2),(3)) T(x,y)
 # input
 
 # expected output
 {x:1,y:2}
-{x:3,y:error("missing")}
+{x:3,y:null}
 ```
 
 ---

--- a/book/src/super-sql/sql/values.md
+++ b/book/src/super-sql/sql/values.md
@@ -69,5 +69,3 @@ SELECT * FROM (VALUES (1,2),(3)) T(x,y)
 {x:1,y:2}
 {x:3,y:null}
 ```
-
----

--- a/compiler/dag/expr.go
+++ b/compiler/dag/expr.go
@@ -66,6 +66,7 @@ type (
 		LHS     Expr   `json:"lhs"`
 		RHS     string `json:"rhs"`
 		Noneish bool   `json:"noneish"`
+		Nullish bool   `json:"nullish"`
 	}
 	IndexExpr struct {
 		Kind  string `json:"kind" unpack:""`

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -599,11 +599,11 @@ func liftFilterOps(seq dag.Seq) dag.Seq {
 						return newErrorMissing()
 					}
 					// Copy spread so f and y don't share dag.Exprs.
-					e, liftOK = addPathToExpr(dag.CopyExpr(spread), this.Chain.Path())
+					e, liftOK = addPathToExpr(dag.CopyExpr(spread), this.Chain)
 					return e
 				}
 				// Copy e1 so f and y don't share dag.Exprs.
-				e, liftOK = addPathToExpr(dag.CopyExpr(e1), this.Chain.Path()[1:])
+				e, liftOK = addPathToExpr(dag.CopyExpr(e1), this.Chain[1:])
 				return e
 			})
 			if liftOK {
@@ -644,10 +644,10 @@ func mergeValuesOps(seq dag.Seq) dag.Seq {
 					if v1TopLevelSpread == nil {
 						return newErrorMissing()
 					}
-					e, mergeOK = addPathToExpr(v1TopLevelSpread, this.Chain.Path())
+					e, mergeOK = addPathToExpr(v1TopLevelSpread, this.Chain)
 					return e
 				}
-				e, mergeOK = addPathToExpr(v1Expr, this.Chain.Path()[1:])
+				e, mergeOK = addPathToExpr(v1Expr, this.Chain[1:])
 				return e
 			}
 			var mergedOp dag.Op
@@ -703,8 +703,8 @@ func hasThisWithEmptyPath(v any) bool {
 //   - It returns a dag.This when possible.
 //   - It descends to a dag.RecordExpr.Elem when possible.
 //   - It returns false when it cannot descend to a dag.RecordExpr.Elem.
-func addPathToExpr(e dag.Expr, path []string) (dag.Expr, bool) {
-	if len(path) == 0 {
+func addPathToExpr(e dag.Expr, chain field.Chain) (dag.Expr, bool) {
+	if len(chain) == 0 {
 		return e, true
 	}
 	switch e := e.(type) {
@@ -713,14 +713,14 @@ func addPathToExpr(e dag.Expr, path []string) (dag.Expr, bool) {
 		for _, elem := range slices.Backward(e.Elems) {
 			switch elem := elem.(type) {
 			case *dag.Field:
-				if elem.Name != path[0] {
+				if elem.Name != chain[0].ID {
 					continue
 				}
 				if spread != nil {
 					// Don't know which will win.
 					return e, false
 				}
-				return addPathToExpr(elem.Value, path[1:])
+				return addPathToExpr(elem.Value, chain[1:])
 			case *dag.Spread:
 				if spread != nil {
 					// Don't know which will win.
@@ -732,12 +732,12 @@ func addPathToExpr(e dag.Expr, path []string) (dag.Expr, bool) {
 		if spread == nil {
 			return e, false
 		}
-		return addPathToExpr(spread.Expr, path)
+		return addPathToExpr(spread.Expr, chain)
 	case *dag.ThisExpr:
-		return dag.NewThis(slices.Concat(e.Chain, field.NewChain(path...))), true
+		return dag.NewThis(slices.Concat(e.Chain, chain)), true
 	}
-	for _, elem := range path {
-		e = &dag.DotExpr{Kind: "DotExpr", LHS: e, RHS: elem}
+	for _, elem := range chain {
+		e = &dag.DotExpr{Kind: "DotExpr", LHS: e, RHS: elem.ID, Noneish: elem.Noneish, Nullish: elem.Nullish}
 	}
 	return e, true
 }

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -599,11 +599,11 @@ func liftFilterOps(seq dag.Seq) dag.Seq {
 						return newErrorMissing()
 					}
 					// Copy spread so f and y don't share dag.Exprs.
-					e, liftOK = addPathToExpr(dag.CopyExpr(spread), this.Chain)
+					e, liftOK = addChainToExpr(dag.CopyExpr(spread), this.Chain)
 					return e
 				}
 				// Copy e1 so f and y don't share dag.Exprs.
-				e, liftOK = addPathToExpr(dag.CopyExpr(e1), this.Chain[1:])
+				e, liftOK = addChainToExpr(dag.CopyExpr(e1), this.Chain[1:])
 				return e
 			})
 			if liftOK {
@@ -644,10 +644,10 @@ func mergeValuesOps(seq dag.Seq) dag.Seq {
 					if v1TopLevelSpread == nil {
 						return newErrorMissing()
 					}
-					e, mergeOK = addPathToExpr(v1TopLevelSpread, this.Chain)
+					e, mergeOK = addChainToExpr(v1TopLevelSpread, this.Chain)
 					return e
 				}
-				e, mergeOK = addPathToExpr(v1Expr, this.Chain[1:])
+				e, mergeOK = addChainToExpr(v1Expr, this.Chain[1:])
 				return e
 			}
 			var mergedOp dag.Op
@@ -690,20 +690,20 @@ func hasThisWithEmptyPath(v any) bool {
 	return found
 }
 
-// addPathToExpr is roughly equivalent to this:
+// addChainToExpr is roughly equivalent to this:
 //
-//	func simpleAddPathToExpr((e dag.Expr, path []string) dag.Expr {
+//	func simpleAddChainToExpr((e dag.Expr, path []string) dag.Expr {
 //	   for _, elem := range path {
 //	       e = &dag.Dot{Kind: "Dot", LHS: e, RHS: elem}
 //	   }
 //	   return e
 //	}
 //
-// addPathToExpr differs in a few ways:
+// addChainToExpr differs in a few ways:
 //   - It returns a dag.This when possible.
 //   - It descends to a dag.RecordExpr.Elem when possible.
 //   - It returns false when it cannot descend to a dag.RecordExpr.Elem.
-func addPathToExpr(e dag.Expr, chain field.Chain) (dag.Expr, bool) {
+func addChainToExpr(e dag.Expr, chain field.Chain) (dag.Expr, bool) {
 	if len(chain) == 0 {
 		return e, true
 	}
@@ -720,7 +720,7 @@ func addPathToExpr(e dag.Expr, chain field.Chain) (dag.Expr, bool) {
 					// Don't know which will win.
 					return e, false
 				}
-				return addPathToExpr(elem.Value, chain[1:])
+				return addChainToExpr(elem.Value, chain[1:])
 			case *dag.Spread:
 				if spread != nil {
 					// Don't know which will win.
@@ -732,7 +732,7 @@ func addPathToExpr(e dag.Expr, chain field.Chain) (dag.Expr, bool) {
 		if spread == nil {
 			return e, false
 		}
-		return addPathToExpr(spread.Expr, chain)
+		return addChainToExpr(spread.Expr, chain)
 	case *dag.ThisExpr:
 		return dag.NewThis(slices.Concat(e.Chain, chain)), true
 	}

--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -155,7 +155,7 @@ func (b *Builder) compileVamDotExpr(dot *dag.DotExpr) (vamexpr.Evaluator, error)
 	if err != nil {
 		return nil, err
 	}
-	return vamexpr.NewDotExpr(b.sctx(), record, dot.RHS, dot.Noneish), nil
+	return vamexpr.NewDotExpr(b.sctx(), record, dot.RHS, dot.Noneish, dot.Nullish), nil
 }
 
 func (b *Builder) compileVamIndexExpr(idx *dag.IndexExpr) (vamexpr.Evaluator, error) {

--- a/compiler/semantic/dagen.go
+++ b/compiler/semantic/dagen.go
@@ -402,6 +402,7 @@ func (d *dagen) expr(e sem.Expr) dag.Expr {
 			LHS:     d.expr(e.LHS),
 			RHS:     e.RHS,
 			Noneish: e.Noneish,
+			Nullish: e.Nullish,
 		}
 	case *sem.IndexExpr:
 		return &dag.IndexExpr{

--- a/compiler/semantic/schema.go
+++ b/compiler/semantic/schema.go
@@ -395,7 +395,7 @@ func (j *joinUsingScope) star(n ast.Node, table string, path field.Path) ([]*sem
 			return nil, err
 		}
 		p := append(append(path, "left"), left...)
-		this := sem.NewThis(n, field.NewChain(p...))
+		this := sem.NewThis(n, field.NewChainNullish(p...))
 		out = append(out, this)
 	}
 	var err error
@@ -430,7 +430,7 @@ func (s *staticTable) star(n ast.Node, table string, path field.Path) ([]*sem.Th
 	var out []*sem.ThisExpr
 	if table == "" || s.table == table {
 		for _, col := range s.typ.Fields {
-			path := field.NewChain(path...).Append(col.Name, false)
+			path := field.NewChainNullish(path...).AppendNullish(col.Name)
 			out = append(out, sem.NewThis(n, path))
 		}
 	}

--- a/compiler/semantic/scope.go
+++ b/compiler/semantic/scope.go
@@ -198,7 +198,7 @@ func (s *Scope) resolve(t *translator, n ast.Node, path field.Path, inType super
 				return badExpr, t.checker.unknown
 			}
 		}
-		this := sem.NewThis(n, field.NewChain(append(out, path[1:]...)...))
+		this := sem.NewThis(n, field.NewChainNullish(append(out, path[1:]...)...))
 		return this, t.checker.this(n, this, inType)
 	}
 	if scope, ok := scope.(*selectScope); ok && scope.lateral && inputFirst {
@@ -227,7 +227,7 @@ func (s *Scope) resolve(t *translator, n ast.Node, path field.Path, inType super
 			return badExpr, t.checker.unknown
 		}
 		if out != nil {
-			this := sem.NewThis(n, field.NewChain(append(out, path[2:]...)...))
+			this := sem.NewThis(n, field.NewChainNullish(append(out, path[2:]...)...))
 			return this, t.checker.this(n, this, inType)
 		}
 		if p, _, _ := scope.resolveTable(n, path[0], nil); p != nil {
@@ -244,7 +244,7 @@ func extend(n ast.Node, e sem.Expr, rest []string) sem.Expr {
 		return e
 	}
 	if this, ok := e.(*sem.ThisExpr); ok {
-		return sem.NewThis(n, append(this.Chain, field.NewChain(rest...)...))
+		return sem.NewThis(n, append(this.Chain, field.NewChainNullish(rest...)...))
 	}
 	out := &sem.DotExpr{
 		Node: n,
@@ -253,9 +253,10 @@ func extend(n ast.Node, e sem.Expr, rest []string) sem.Expr {
 	}
 	for _, f := range rest[1:] {
 		out = &sem.DotExpr{
-			Node: n,
-			LHS:  out,
-			RHS:  f,
+			Node:    n,
+			LHS:     out,
+			RHS:     f,
+			Nullish: true,
 		}
 	}
 	return out

--- a/compiler/semantic/sem/expr.go
+++ b/compiler/semantic/sem/expr.go
@@ -58,6 +58,7 @@ type (
 		LHS     Expr
 		RHS     string
 		Noneish bool
+		Nullish bool
 	}
 	IndexExpr struct {
 		ast.Node
@@ -336,6 +337,7 @@ func CopyExpr(e Expr) Expr {
 			LHS:     CopyExpr(e.LHS),
 			RHS:     e.RHS,
 			Noneish: e.Noneish,
+			Nullish: e.Nullish,
 		}
 	case *IndexExpr:
 		return &IndexExpr{

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -177,7 +177,7 @@ func (t *translator) formProjection(scope *selectScope, in []ast.SQLAsExpr, inTy
 			}
 			for _, p := range paths {
 				typ := t.checker.this(star, p, inType)
-				out = append(out, column{name: dedup(scores, t.asName(as.Label, nil, p.Chain.Path())), semExpr: p, typ: typ, astExpr: as.Expr})
+				out = append(out, column{name: dedup(scores, t.asName(as.Label, nil, p.Chain.Path())), semExpr: t.nullcheck(star, p), typ: typ, astExpr: as.Expr})
 			}
 			continue
 		}
@@ -185,6 +185,11 @@ func (t *translator) formProjection(scope *selectScope, in []ast.SQLAsExpr, inTy
 		out = append(out, column{name: dedup(scores, t.asName(as.Label, as.Expr, nil)), astExpr: as.Expr, lateral: lateral})
 	}
 	return out
+}
+
+func (t *translator) nullcheck(loc ast.Node, e sem.Expr) sem.Expr {
+	null := sem.NewLiteral(loc, super.NewValue(super.TypeNull, nil), t.defs)
+	return sem.NewBinaryExpr(loc, "??", sem.NewCall(loc, "ok", []sem.Expr{e}), null)
 }
 
 func (t *translator) asName(label *ast.ID, expr ast.Expr, path []string) string {
@@ -413,7 +418,7 @@ func mapColumns(sctx *super.Context, in *super.TypeRecord, alias *ast.TableAlias
 			elems = append(elems, &sem.FieldElem{
 				Node:  alias.Columns[k],
 				Name:  out[k],
-				Value: sem.NewThis(alias.Columns[k], field.NewChain(in.Fields[k].Name)),
+				Value: sem.NewThis(alias.Columns[k], field.NewChainNullish(in.Fields[k].Name)),
 			})
 			fields = append(fields, super.NewField(out[k], in.Fields[k].Type))
 		}
@@ -634,8 +639,8 @@ func (t *translator) sqlJoinCond(cond ast.JoinCond, typ super.Type) sem.Expr {
 				t.error(id, fmt.Errorf("column %q in USING clause does not exist in right table", id.Name))
 				continue
 			}
-			lhs := sem.NewThis(id, field.NewChain(append([]string{"left"}, left...)...))
-			rhs := sem.NewThis(id, field.NewChain(append([]string{"right"}, right...)...))
+			lhs := sem.NewThis(id, field.NewChainNullish(append([]string{"left"}, left...)...))
+			rhs := sem.NewThis(id, field.NewChainNullish(append([]string{"right"}, right...)...))
 			exprs = append(exprs, sem.NewBinaryExpr(id, "==", lhs, rhs))
 		}
 		if len(exprs) == 0 {
@@ -711,7 +716,7 @@ func (t *translator) resolveOrdinalOuter(ts tableScope, n ast.Node, prefix strin
 		} else {
 			path = []string{ts.typ.Fields[col-1].Name}
 		}
-		return sem.NewThis(n, field.NewChain(path...))
+		return sem.NewThis(n, field.NewChainNullish(path...))
 	default:
 		panic(ts)
 	}

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -177,7 +177,7 @@ func (t *translator) formProjection(scope *selectScope, in []ast.SQLAsExpr, inTy
 			}
 			for _, p := range paths {
 				typ := t.checker.this(star, p, inType)
-				out = append(out, column{name: dedup(scores, t.asName(as.Label, nil, p.Chain.Path())), semExpr: t.nullcheck(star, p), typ: typ, astExpr: as.Expr})
+				out = append(out, column{name: dedup(scores, t.asName(as.Label, nil, p.Chain.Path())), semExpr: p, typ: typ, astExpr: as.Expr})
 			}
 			continue
 		}
@@ -185,11 +185,6 @@ func (t *translator) formProjection(scope *selectScope, in []ast.SQLAsExpr, inTy
 		out = append(out, column{name: dedup(scores, t.asName(as.Label, as.Expr, nil)), astExpr: as.Expr, lateral: lateral})
 	}
 	return out
-}
-
-func (t *translator) nullcheck(loc ast.Node, e sem.Expr) sem.Expr {
-	null := sem.NewLiteral(loc, super.NewValue(super.TypeNull, nil), t.defs)
-	return sem.NewBinaryExpr(loc, "??", sem.NewCall(loc, "ok", []sem.Expr{e}), null)
 }
 
 func (t *translator) asName(label *ast.ID, expr ast.Expr, path []string) string {

--- a/compiler/sfmt/shared.go
+++ b/compiler/sfmt/shared.go
@@ -31,22 +31,26 @@ func (s *shared) fieldchain(chain field.Chain) {
 		return
 	}
 	for k, elem := range chain {
-		if elem.Noneish {
-			s.write("?")
-		}
-		if elem.Nullish {
-			s.write("??")
-		}
-		if sup.IsIdentifier(elem.ID) {
-			if k != 0 {
-				s.write(".")
-			}
-			s.write(elem.ID)
-		} else {
+		if elem.Noneish || elem.Nullish {
 			if k == 0 {
 				s.write("this")
 			}
-			s.write("[%q]", elem.ID)
+			if elem.Noneish {
+				s.write("?")
+			} else {
+				s.write("!")
+			}
+			if k == 0 {
+				s.write(".")
+			}
+		}
+		if k != 0 {
+			s.write(".")
+		}
+		if sup.IsIdentifier(elem.ID) {
+			s.write(elem.ID)
+		} else {
+			s.write("`%s`", elem.ID)
 		}
 	}
 }

--- a/compiler/sfmt/shared.go
+++ b/compiler/sfmt/shared.go
@@ -34,6 +34,9 @@ func (s *shared) fieldchain(chain field.Chain) {
 		if elem.Noneish {
 			s.write("?")
 		}
+		if elem.Nullish {
+			s.write("??")
+		}
 		if sup.IsIdentifier(elem.ID) {
 			if k != 0 {
 				s.write(".")

--- a/compiler/sfmt/ztests/parallel.yaml
+++ b/compiler/sfmt/ztests/parallel.yaml
@@ -9,7 +9,7 @@ outputs:
       | fork
         (
           aggregate
-              count:=count() by x:=this["@foo"]
+              count:=count() by x:=`@foo`
         )
         (
           aggregate

--- a/compiler/ztests/merge-values.yaml
+++ b/compiler/ztests/merge-values.yaml
@@ -49,7 +49,7 @@ outputs:
       ===
       file f unordered fields a,b
       | aggregate
-          t0:=max(b) by k0:=a
+          t0:=max(??b) by k0:=??a
       | aggregate
           min:=min(t0) by a:=k0
       | output main

--- a/compiler/ztests/merge-values.yaml
+++ b/compiler/ztests/merge-values.yaml
@@ -49,7 +49,7 @@ outputs:
       ===
       file f unordered fields a,b
       | aggregate
-          t0:=max(??b) by k0:=??a
+          t0:=max(this!.b) by k0:=this!.a
       | aggregate
           min:=min(t0) by a:=k0
       | output main

--- a/compiler/ztests/sql/agg-dups.yaml
+++ b/compiler/ztests/sql/agg-dups.yaml
@@ -6,9 +6,9 @@ outputs:
     data: |
       null
       | values {c0:1}, {c0:2}
-      | values {a:??c0}
+      | values {a:this!.c0}
       | aggregate
-          t0:=max(??a)
+          t0:=max(this!.a)
       | values {g:this,out:{max:t0,max_1:t0}}
       | sort g.t0 asc nulls last
       | values out

--- a/compiler/ztests/sql/agg-dups.yaml
+++ b/compiler/ztests/sql/agg-dups.yaml
@@ -6,9 +6,9 @@ outputs:
     data: |
       null
       | values {c0:1}, {c0:2}
-      | values {a:c0}
+      | values {a:??c0}
       | aggregate
-          t0:=max(a)
+          t0:=max(??a)
       | values {g:this,out:{max:t0,max_1:t0}}
       | sort g.t0 asc nulls last
       | values out

--- a/compiler/ztests/sql/as-implied.yaml
+++ b/compiler/ztests/sql/as-implied.yaml
@@ -31,9 +31,9 @@ outputs:
       {x:4,y:4,z:2}
       ===
       file t.json format json fields a
-      | values {"a+1":a+1,"a+2":a+2,"a+1_1":a+1,"a+3":a+3,"a+1_2":a+1}
+      | values {"a+1":??a+1,"a+2":??a+2,"a+1_1":??a+1,"a+3":??a+3,"a+1_2":??a+1}
       | output main
       ===
       file t.json format json fields a
-      | values {"a+1":a+1,"a+1_1":a+1}
+      | values {"a+1":??a+1,"a+1_1":??a+1}
       | output main

--- a/compiler/ztests/sql/as-implied.yaml
+++ b/compiler/ztests/sql/as-implied.yaml
@@ -31,9 +31,9 @@ outputs:
       {x:4,y:4,z:2}
       ===
       file t.json format json fields a
-      | values {"a+1":??a+1,"a+2":??a+2,"a+1_1":??a+1,"a+3":??a+3,"a+1_2":??a+1}
+      | values {"a+1":this!.a+1,"a+2":this!.a+2,"a+1_1":this!.a+1,"a+3":this!.a+3,"a+1_2":this!.a+1}
       | output main
       ===
       file t.json format json fields a
-      | values {"a+1":??a+1,"a+1_1":??a+1}
+      | values {"a+1":this!.a+1,"a+1_1":this!.a+1}
       | output main

--- a/compiler/ztests/sql/join-filter-pullup.yaml
+++ b/compiler/ztests/sql/join-filter-pullup.yaml
@@ -23,14 +23,14 @@ outputs:
       | fork
         (
           values {id:1,team:"badgers"}
-          | where ??team=="badgers"
+          | where this!.team=="badgers"
         )
         (
           values {id:1,team_id:1,player:"blake",position:"P"}
-          | where ??position=="P"
+          | where this!.position=="P"
         )
-      | inner hashjoin as {left,right} on ??id==??team_id
-      | values {id:??left??.id,team:??left??.team,id_1:??right??.id,team_id:??right??.team_id,player:??right??.player,position:??right??.position}
+      | inner hashjoin as {left,right} on this!.id==this!.team_id
+      | values {id:this!.left!.id,team:this!.left!.team,id_1:this!.right!.id,team_id:this!.right!.team_id,player:this!.right!.player,position:this!.right!.position}
       | output main
       // ===
       null
@@ -39,19 +39,19 @@ outputs:
           fork
             (
               values {a1:1}
-              | where ??a1 in [1,5,9] and ??a1 in set[1,5,9]
+              | where this!.a1 in [1,5,9] and this!.a1 in set[1,5,9]
             )
             (
               values {a2:1}
-              | where ??a2==1 or ??a2==2
+              | where this!.a2==1 or this!.a2==2
             )
           | cross join as {left,right}
         )
         (
           values {a3:1}
-          | where ??a3 in {c0:1,c1:5,c2:[9,11]}
+          | where this!.a3 in {c0:1,c1:5,c2:[9,11]}
         )
       | cross join as {left,right}
       | where 1==1
-      | values {a1:??left??.left??.a1,a2:??left??.right??.a2,a3:??right??.a3}
+      | values {a1:this!.left!.left!.a1,a2:this!.left!.right!.a2,a3:this!.right!.a3}
       | output main

--- a/compiler/ztests/sql/join-filter-pullup.yaml
+++ b/compiler/ztests/sql/join-filter-pullup.yaml
@@ -30,7 +30,7 @@ outputs:
           | where ??position=="P"
         )
       | inner hashjoin as {left,right} on ??id==??team_id
-      | values {id:ok(left.id)??null,team:ok(left.team)??null,id_1:ok(right.id)??null,team_id:ok(right.team_id)??null,player:ok(right.player)??null,position:ok(right.position)??null}
+      | values {id:??left??.id,team:??left??.team,id_1:??right??.id,team_id:??right??.team_id,player:??right??.player,position:??right??.position}
       | output main
       // ===
       null
@@ -53,5 +53,5 @@ outputs:
         )
       | cross join as {left,right}
       | where 1==1
-      | values {a1:ok(left.left.a1)??null,a2:ok(left.right.a2)??null,a3:ok(right.a3)??null}
+      | values {a1:??left??.left??.a1,a2:??left??.right??.a2,a3:??right??.a3}
       | output main

--- a/compiler/ztests/sql/join-filter-pullup.yaml
+++ b/compiler/ztests/sql/join-filter-pullup.yaml
@@ -23,14 +23,14 @@ outputs:
       | fork
         (
           values {id:1,team:"badgers"}
-          | where team=="badgers"
+          | where ??team=="badgers"
         )
         (
           values {id:1,team_id:1,player:"blake",position:"P"}
-          | where position=="P"
+          | where ??position=="P"
         )
-      | inner hashjoin as {left,right} on id==team_id
-      | values {id:left.id,team:left.team,id_1:right.id,team_id:right.team_id,player:right.player,position:right.position}
+      | inner hashjoin as {left,right} on ??id==??team_id
+      | values {id:ok(left.id)??null,team:ok(left.team)??null,id_1:ok(right.id)??null,team_id:ok(right.team_id)??null,player:ok(right.player)??null,position:ok(right.position)??null}
       | output main
       // ===
       null
@@ -39,19 +39,19 @@ outputs:
           fork
             (
               values {a1:1}
-              | where a1 in [1,5,9] and a1 in set[1,5,9]
+              | where ??a1 in [1,5,9] and ??a1 in set[1,5,9]
             )
             (
               values {a2:1}
-              | where a2==1 or a2==2
+              | where ??a2==1 or ??a2==2
             )
           | cross join as {left,right}
         )
         (
           values {a3:1}
-          | where a3 in {c0:1,c1:5,c2:[9,11]}
+          | where ??a3 in {c0:1,c1:5,c2:[9,11]}
         )
       | cross join as {left,right}
       | where 1==1
-      | values {a1:left.left.a1,a2:left.right.a2,a3:right.a3}
+      | values {a1:ok(left.left.a1)??null,a2:ok(left.right.a2)??null,a3:ok(right.a3)??null}
       | output main

--- a/compiler/ztests/sql/join-nulls.yaml
+++ b/compiler/ztests/sql/join-nulls.yaml
@@ -1,9 +1,7 @@
 # from issue 5984
 
 script: |
-  super -f parquet -o integers.parquet integers.sup
-  super -f parquet -o integers2.parquet integers2.sup
-  super -s -c "SELECT * FROM integers.parquet LEFT OUTER JOIN integers2.parquet ON integers.i=integers2.k ORDER BY i;"
+  super -s -c "SELECT * FROM integers.sup LEFT OUTER JOIN integers2.sup ON integers.i=integers2.k ORDER BY i;"
 
 inputs:
   - name: integers.sup

--- a/compiler/ztests/sql/join-nulls.yaml
+++ b/compiler/ztests/sql/join-nulls.yaml
@@ -1,0 +1,24 @@
+# from issue 5984
+
+script: |
+  super -f parquet -o integers.parquet integers.sup
+  super -f parquet -o integers2.parquet integers2.sup
+  super -s -c "SELECT * FROM integers.parquet LEFT OUTER JOIN integers2.parquet ON integers.i=integers2.k ORDER BY i;"
+
+inputs:
+  - name: integers.sup
+    data: |
+      {i:1::int32,j:2::int32}
+      {i:2::int32,j:3::int32}
+      {i:3::int32,j:4::int32}
+  - name: integers2.sup
+    data: |
+      {k:1::int32,l:10::int32}
+      {k:2::int32,l:20::int32}
+
+outputs:
+  - name: stdout
+    data: |
+      {i:1::int32,j:2::int32,k:1::int32,l:10::int32}
+      {i:2::int32,j:3::int32,k:2::int32,l:20::int32}
+      {i:3::int32,j:4::int32,k:null,l:null}

--- a/compiler/ztests/sql/select-missing.yaml
+++ b/compiler/ztests/sql/select-missing.yaml
@@ -12,9 +12,3 @@ output: |
   {y:2}
   {y:null}
 
----
-
-spq: SELECT * FROM (VALUES (1,2)) AS T(x,y) GROUP BY T.x, T.y
-
-output: |
-  {x:1,y:2}

--- a/compiler/ztests/sql/select-missing.yaml
+++ b/compiler/ztests/sql/select-missing.yaml
@@ -1,0 +1,13 @@
+spq: SELECT T.y FROM (VALUES (1,2),(3)) T(x,y)
+
+output: |
+  {y:2}
+  {y:null}
+
+---
+
+spq: SELECT y FROM (VALUES (1,2),(3)) T(x,y)
+
+output: |
+  {y:2}
+  {y:null}

--- a/compiler/ztests/sql/select-missing.yaml
+++ b/compiler/ztests/sql/select-missing.yaml
@@ -11,3 +11,10 @@ spq: SELECT y FROM (VALUES (1,2),(3)) T(x,y)
 output: |
   {y:2}
   {y:null}
+
+---
+
+spq: SELECT * FROM (VALUES (1,2)) AS T(x,y) GROUP BY T.x, T.y
+
+output: |
+  {x:1,y:2}

--- a/compiler/ztests/sql/select-star-group-by.yaml
+++ b/compiler/ztests/sql/select-star-group-by.yaml
@@ -1,0 +1,12 @@
+spq: SELECT * FROM (VALUES (1,2)) AS T(x,y) GROUP BY T.x, T.y
+
+output: |
+  {x:1,y:2}
+
+---
+
+spq: SELECT * FROM (VALUES (1,2), (3)) AS T(x,y) GROUP BY T.x, T.y
+
+output: |
+  {x:1,y:2}
+  {x:3,y:null}

--- a/compiler/ztests/sql/select-star-static.yaml
+++ b/compiler/ztests/sql/select-star-static.yaml
@@ -27,9 +27,9 @@ outputs:
     data: |
       null
       | values {c0:1,c1:2,c2:3}
-      | values {a:??c0,b:??c1,c:??c2}
+      | values {a:this!.c0,b:this!.c1,c:this!.c2}
       | values {in:this}
-      | values {in:in,out:{a:??in??.a,a_1:??in??.a,b:??in??.b,c:??in??.c}}
+      | values {in:in,out:{a:this!.in!.a,a_1:this!.in!.a,b:this!.in!.b,c:this!.in!.c}}
       | values out
       | output main
       // ===
@@ -37,15 +37,15 @@ outputs:
       | fork
         (
           values {c0:1,c1:"dodgers"}
-          | values {id:??c0,team:??c1}
+          | values {id:this!.c0,team:this!.c1}
         )
         (
           values {c0:1,c1:1,c2:"ted"}
-          | values {id:??c0,team_id:??c1,player:??c2}
+          | values {id:this!.c0,team_id:this!.c1,player:this!.c2}
         )
-      | inner join as {left,right} on ??left??.id==??right??.team_id
+      | inner join as {left,right} on this!.left!.id==this!.right!.team_id
       | values {in:this}
-      | values {in:in,out:{id:??in??.left??.id,team:??in??.left??.team,id_1:??in??.right??.id,team_id:??in??.right??.team_id,player:??in??.right??.player}}
+      | values {in:in,out:{id:this!.in!.left!.id,team:this!.in!.left!.team,id_1:this!.in!.right!.id,team_id:this!.in!.right!.team_id,player:this!.in!.right!.player}}
       | values out
       | output main
       // ===
@@ -53,17 +53,17 @@ outputs:
       | fork
         (
           values {c0:1,c1:2,c2:"a"}
-          | values {aid:??c0,bid:??c1,a:??c2}
+          | values {aid:this!.c0,bid:this!.c1,a:this!.c2}
         )
         (
           values {c0:1,c1:2,c2:"b"}
-          | values {aid:??c0,bid:??c1,b:??c2}
+          | values {aid:this!.c0,bid:this!.c1,b:this!.c2}
         )
-      | inner join as {left,right} on ??left??.aid==??right??.aid and ??left??.bid==??right??.bid
+      | inner join as {left,right} on this!.left!.aid==this!.right!.aid and this!.left!.bid==this!.right!.bid
       | values {in:this}
-      | values {in:in,out:{aid:??in??.left??.aid,bid:??in??.left??.bid,a:??in??.left??.a,b:??in??.right??.b}}
+      | values {in:in,out:{aid:this!.in!.left!.aid,bid:this!.in!.left!.bid,a:this!.in!.left!.a,b:this!.in!.right!.b}}
       | values out
       | values {in:this}
-      | values {in:in,out:{aid:??in??.aid,bid:??in??.bid,a:??in??.a,b:??in??.b}}
+      | values {in:in,out:{aid:this!.in!.aid,bid:this!.in!.bid,a:this!.in!.a,b:this!.in!.b}}
       | values out
       | output main

--- a/compiler/ztests/sql/select-star-static.yaml
+++ b/compiler/ztests/sql/select-star-static.yaml
@@ -27,9 +27,9 @@ outputs:
     data: |
       null
       | values {c0:1,c1:2,c2:3}
-      | values {a:c0,b:c1,c:c2}
+      | values {a:??c0,b:??c1,c:??c2}
       | values {in:this}
-      | values {in:in,out:{a:in.a,a_1:in.a,b:in.b,c:in.c}}
+      | values {in:in,out:{a:??in??.a,a_1:ok(in.a)??null,b:ok(in.b)??null,c:ok(in.c)??null}}
       | values out
       | output main
       // ===
@@ -37,15 +37,15 @@ outputs:
       | fork
         (
           values {c0:1,c1:"dodgers"}
-          | values {id:c0,team:c1}
+          | values {id:??c0,team:??c1}
         )
         (
           values {c0:1,c1:1,c2:"ted"}
-          | values {id:c0,team_id:c1,player:c2}
+          | values {id:??c0,team_id:??c1,player:??c2}
         )
-      | inner join as {left,right} on left.id==right.team_id
+      | inner join as {left,right} on ??left??.id==??right??.team_id
       | values {in:this}
-      | values {in:in,out:{id:in.left.id,team:in.left.team,id_1:in.right.id,team_id:in.right.team_id,player:in.right.player}}
+      | values {in:in,out:{id:ok(in.left.id)??null,team:ok(in.left.team)??null,id_1:ok(in.right.id)??null,team_id:ok(in.right.team_id)??null,player:ok(in.right.player)??null}}
       | values out
       | output main
       // ===
@@ -53,17 +53,17 @@ outputs:
       | fork
         (
           values {c0:1,c1:2,c2:"a"}
-          | values {aid:c0,bid:c1,a:c2}
+          | values {aid:??c0,bid:??c1,a:??c2}
         )
         (
           values {c0:1,c1:2,c2:"b"}
-          | values {aid:c0,bid:c1,b:c2}
+          | values {aid:??c0,bid:??c1,b:??c2}
         )
-      | inner join as {left,right} on left.aid==right.aid and left.bid==right.bid
+      | inner join as {left,right} on ??left??.aid==??right??.aid and ??left??.bid==??right??.bid
       | values {in:this}
-      | values {in:in,out:{aid:in.left.aid,bid:in.left.bid,a:in.left.a,b:in.right.b}}
+      | values {in:in,out:{aid:ok(in.left.aid)??null,bid:ok(in.left.bid)??null,a:ok(in.left.a)??null,b:ok(in.right.b)??null}}
       | values out
       | values {in:this}
-      | values {in:in,out:{aid:in.aid,bid:in.bid,a:in.a,b:in.b}}
+      | values {in:in,out:{aid:ok(in.aid)??null,bid:ok(in.bid)??null,a:ok(in.a)??null,b:ok(in.b)??null}}
       | values out
       | output main

--- a/compiler/ztests/sql/select-star-static.yaml
+++ b/compiler/ztests/sql/select-star-static.yaml
@@ -29,7 +29,7 @@ outputs:
       | values {c0:1,c1:2,c2:3}
       | values {a:??c0,b:??c1,c:??c2}
       | values {in:this}
-      | values {in:in,out:{a:??in??.a,a_1:ok(in.a)??null,b:ok(in.b)??null,c:ok(in.c)??null}}
+      | values {in:in,out:{a:??in??.a,a_1:??in??.a,b:??in??.b,c:??in??.c}}
       | values out
       | output main
       // ===
@@ -45,7 +45,7 @@ outputs:
         )
       | inner join as {left,right} on ??left??.id==??right??.team_id
       | values {in:this}
-      | values {in:in,out:{id:ok(in.left.id)??null,team:ok(in.left.team)??null,id_1:ok(in.right.id)??null,team_id:ok(in.right.team_id)??null,player:ok(in.right.player)??null}}
+      | values {in:in,out:{id:??in??.left??.id,team:??in??.left??.team,id_1:??in??.right??.id,team_id:??in??.right??.team_id,player:??in??.right??.player}}
       | values out
       | output main
       // ===
@@ -61,9 +61,9 @@ outputs:
         )
       | inner join as {left,right} on ??left??.aid==??right??.aid and ??left??.bid==??right??.bid
       | values {in:this}
-      | values {in:in,out:{aid:ok(in.left.aid)??null,bid:ok(in.left.bid)??null,a:ok(in.left.a)??null,b:ok(in.right.b)??null}}
+      | values {in:in,out:{aid:??in??.left??.aid,bid:??in??.left??.bid,a:??in??.left??.a,b:??in??.right??.b}}
       | values out
       | values {in:this}
-      | values {in:in,out:{aid:ok(in.aid)??null,bid:ok(in.bid)??null,a:ok(in.a)??null,b:ok(in.b)??null}}
+      | values {in:in,out:{aid:??in??.aid,bid:??in??.bid,a:??in??.a,b:??in??.b}}
       | values out
       | output main

--- a/pkg/field/chain.go
+++ b/pkg/field/chain.go
@@ -3,6 +3,7 @@ package field
 type ChainElem struct {
 	ID      string
 	Noneish bool
+	Nullish bool
 }
 
 type Chain []ChainElem
@@ -15,8 +16,16 @@ func NewChain(ids ...string) Chain {
 	return chain
 }
 
+func NewChainNullish(ids ...string) Chain {
+	chain := make([]ChainElem, 0, len(ids))
+	for _, id := range ids {
+		chain = append(chain, ChainElem{ID: id, Nullish: true})
+	}
+	return chain
+}
+
 func (c Chain) Append(id string, noneish bool) Chain {
-	return append(c, ChainElem{id, noneish})
+	return append(c, ChainElem{id, noneish, false})
 }
 
 func (c Chain) Path() Path {

--- a/pkg/field/chain.go
+++ b/pkg/field/chain.go
@@ -28,6 +28,10 @@ func (c Chain) Append(id string, noneish bool) Chain {
 	return append(c, ChainElem{id, noneish, false})
 }
 
+func (c Chain) AppendNullish(id string) Chain {
+	return append(c, ChainElem{id, false, true})
+}
+
 func (c Chain) Path() Path {
 	path := make([]string, 0, len(c))
 	for _, elem := range c {

--- a/runtime/vam/expr/dot.go
+++ b/runtime/vam/expr/dot.go
@@ -22,23 +22,28 @@ type DotExpr struct {
 	entity  Evaluator
 	key     string
 	noneish bool
+<<<<<<< HEAD
 	okPush  bool
+=======
+	nullish bool
+>>>>>>> 7c021ad3e (handle missing fields in SQL as null)
 }
 
-func NewDotExpr(sctx *super.Context, record Evaluator, field string, noneish bool) *DotExpr {
+func NewDotExpr(sctx *super.Context, record Evaluator, field string, noneish, nullish bool) *DotExpr {
 	return &DotExpr{
 		sctx:    sctx,
 		defuse:  NewDefuse(sctx),
 		entity:  record,
 		key:     field,
 		noneish: noneish,
+		nullish: nullish,
 	}
 }
 
 func NewDottedExpr(sctx *super.Context, f field.Chain) Evaluator {
 	ret := Evaluator(&This{})
 	for _, elem := range f {
-		ret = NewDotExpr(sctx, ret, elem.ID, elem.Noneish)
+		ret = NewDotExpr(sctx, ret, elem.ID, elem.Noneish, elem.Nullish)
 	}
 	return ret
 }
@@ -47,12 +52,17 @@ func (d *DotExpr) Eval(vec vector.Any) vector.Any {
 	return vector.Apply(vector.ApplyNone, d.eval, d.entity.Eval(vec))
 }
 
+<<<<<<< HEAD
 func (d *DotExpr) eval(outerVecs ...vector.Any) vector.Any {
 	vec := outerVecs[0]
 	var missing bool
 	eval := func(innerVecs ...vector.Any) vector.Any {
 		switch val := vector.Under(innerVecs[0]).(type) {
-		case *vector.None:
+	case *vector.Null:
+		if d.nullish {
+			return val
+		}
+				case *vector.None:
 			return val
 		case *vector.Record:
 			i, ok := val.Typ.IndexOfField(d.key)
@@ -75,6 +85,37 @@ func (d *DotExpr) eval(outerVecs ...vector.Any) vector.Any {
 						typvals.Append(typ)
 						continue
 					}
+=======
+func (d *DotExpr) eval(vecs ...vector.Any) vector.Any {
+	switch val := vector.Under(vector.Super(vecs[0])).(type) {
+	case *vector.Null:
+		if d.nullish {
+			return val
+		}
+	case *vector.None:
+		return val
+	case *vector.Record:
+		i, ok := val.Typ.IndexOfField(d.field)
+		if !ok {
+			if d.noneish {
+				return vector.NewNone(val.Len())
+			}
+			if d.nullish {
+				return vector.NewNull(val.Len())
+			}
+			return vector.NewWrappedError(d.sctx, fmt.Sprintf("no such field %s", sup.QuotedName(d.field)), val)
+		}
+		return val.Fields[i]
+	case *vector.TypeValue:
+		var errs []uint32
+		typvals := vector.NewTypeValueEmpty()
+		for i := range val.Len() {
+			typ := val.Value(i)
+			if typ, ok := super.TypeUnder(typ).(*super.TypeRecord); ok {
+				if typ, ok := typ.TypeOfField(d.field); ok {
+					typvals.Append(typ)
+					continue
+>>>>>>> 7c021ad3e (handle missing fields in SQL as null)
 				}
 				errs = append(errs, i)
 			}
@@ -91,9 +132,12 @@ func (d *DotExpr) eval(outerVecs ...vector.Any) vector.Any {
 			dot := "."
 			if d.noneish {
 				dot = "?."
-			}
-			return vector.NewWrappedError(d.sctx, fmt.Sprintf("'%s': applied to non-record", dot), innerVecs[0])
+	} else if d.nullish {
+		dot = "??."
+	}
+				return vector.NewWrappedError(d.sctx, fmt.Sprintf("'%s': applied to non-record", dot), innerVecs[0])
 		}
+<<<<<<< HEAD
 	}
 	out := vector.Apply(vector.ApplyRipFusions|vector.ApplyRipUnions, eval, vec)
 	// If there were any structured errors or none values (e.g., because we hit a none
@@ -122,4 +166,23 @@ func hasNone(vec vector.Any) bool {
 		return slices.IndexFunc(vec.Values, hasNone) >= 0
 	}
 	return false
+=======
+		if len(errs) > 0 {
+			return vector.NewCombinedError(d.sctx, fmt.Sprintf("no such field %s", sup.QuotedName(d.field)), typvals, val, errs)
+		}
+		return typvals
+	case *vector.Map:
+		keyVec := vector.NewConstString(d.field, val.Len())
+		return indexMap(d.sctx, val, keyVec)
+	case *vector.View:
+		return vector.Pick(d.eval(val.Any), val.Index)
+	}
+	dot := "."
+	if d.noneish {
+		dot = "?."
+	} else if d.nullish {
+		dot = "??."
+	}
+	return vector.NewWrappedError(d.sctx, fmt.Sprintf("'%s': applied to non-record", dot), vecs[0])
+>>>>>>> 7c021ad3e (handle missing fields in SQL as null)
 }

--- a/runtime/vam/expr/dot.go
+++ b/runtime/vam/expr/dot.go
@@ -22,11 +22,8 @@ type DotExpr struct {
 	entity  Evaluator
 	key     string
 	noneish bool
-<<<<<<< HEAD
-	okPush  bool
-=======
 	nullish bool
->>>>>>> 7c021ad3e (handle missing fields in SQL as null)
+	okPush  bool
 }
 
 func NewDotExpr(sctx *super.Context, record Evaluator, field string, noneish, nullish bool) *DotExpr {
@@ -52,21 +49,23 @@ func (d *DotExpr) Eval(vec vector.Any) vector.Any {
 	return vector.Apply(vector.ApplyNone, d.eval, d.entity.Eval(vec))
 }
 
-<<<<<<< HEAD
 func (d *DotExpr) eval(outerVecs ...vector.Any) vector.Any {
 	vec := outerVecs[0]
 	var missing bool
 	eval := func(innerVecs ...vector.Any) vector.Any {
 		switch val := vector.Under(innerVecs[0]).(type) {
-	case *vector.Null:
-		if d.nullish {
-			return val
-		}
-				case *vector.None:
+		case *vector.Null:
+			if d.nullish {
+				return val
+			}
+		case *vector.None:
 			return val
 		case *vector.Record:
 			i, ok := val.Typ.IndexOfField(d.key)
 			if !ok {
+				if d.nullish {
+					return vector.NewNull(val.Len())
+				}
 				missing = true
 				return vector.NewWrappedError(d.sctx, fmt.Sprintf("no such field %s", sup.QuotedName(d.key)), innerVecs[0])
 			}
@@ -85,37 +84,6 @@ func (d *DotExpr) eval(outerVecs ...vector.Any) vector.Any {
 						typvals.Append(typ)
 						continue
 					}
-=======
-func (d *DotExpr) eval(vecs ...vector.Any) vector.Any {
-	switch val := vector.Under(vector.Super(vecs[0])).(type) {
-	case *vector.Null:
-		if d.nullish {
-			return val
-		}
-	case *vector.None:
-		return val
-	case *vector.Record:
-		i, ok := val.Typ.IndexOfField(d.field)
-		if !ok {
-			if d.noneish {
-				return vector.NewNone(val.Len())
-			}
-			if d.nullish {
-				return vector.NewNull(val.Len())
-			}
-			return vector.NewWrappedError(d.sctx, fmt.Sprintf("no such field %s", sup.QuotedName(d.field)), val)
-		}
-		return val.Fields[i]
-	case *vector.TypeValue:
-		var errs []uint32
-		typvals := vector.NewTypeValueEmpty()
-		for i := range val.Len() {
-			typ := val.Value(i)
-			if typ, ok := super.TypeUnder(typ).(*super.TypeRecord); ok {
-				if typ, ok := typ.TypeOfField(d.field); ok {
-					typvals.Append(typ)
-					continue
->>>>>>> 7c021ad3e (handle missing fields in SQL as null)
 				}
 				errs = append(errs, i)
 			}
@@ -128,16 +96,14 @@ func (d *DotExpr) eval(vecs ...vector.Any) vector.Any {
 			return indexMap(d.sctx, val, keyVec)
 		case *vector.View:
 			return vector.Pick(d.eval(val.Any), val.Index)
-		default:
-			dot := "."
-			if d.noneish {
-				dot = "?."
-	} else if d.nullish {
-		dot = "??."
-	}
-				return vector.NewWrappedError(d.sctx, fmt.Sprintf("'%s': applied to non-record", dot), innerVecs[0])
 		}
-<<<<<<< HEAD
+		dot := "."
+		if d.noneish {
+			dot = "?."
+		} else if d.nullish {
+			dot = "??."
+		}
+		return vector.NewWrappedError(d.sctx, fmt.Sprintf("'%s': applied to non-record", dot), innerVecs[0])
 	}
 	out := vector.Apply(vector.ApplyRipFusions|vector.ApplyRipUnions, eval, vec)
 	// If there were any structured errors or none values (e.g., because we hit a none
@@ -166,23 +132,4 @@ func hasNone(vec vector.Any) bool {
 		return slices.IndexFunc(vec.Values, hasNone) >= 0
 	}
 	return false
-=======
-		if len(errs) > 0 {
-			return vector.NewCombinedError(d.sctx, fmt.Sprintf("no such field %s", sup.QuotedName(d.field)), typvals, val, errs)
-		}
-		return typvals
-	case *vector.Map:
-		keyVec := vector.NewConstString(d.field, val.Len())
-		return indexMap(d.sctx, val, keyVec)
-	case *vector.View:
-		return vector.Pick(d.eval(val.Any), val.Index)
-	}
-	dot := "."
-	if d.noneish {
-		dot = "?."
-	} else if d.nullish {
-		dot = "??."
-	}
-	return vector.NewWrappedError(d.sctx, fmt.Sprintf("'%s': applied to non-record", dot), vecs[0])
->>>>>>> 7c021ad3e (handle missing fields in SQL as null)
 }

--- a/runtime/vam/expr/dot.go
+++ b/runtime/vam/expr/dot.go
@@ -97,13 +97,13 @@ func (d *DotExpr) eval(outerVecs ...vector.Any) vector.Any {
 		case *vector.View:
 			return vector.Pick(d.eval(val.Any), val.Index)
 		}
-		dot := "."
+		op := "."
 		if d.noneish {
-			dot = "?."
+			op = "?."
 		} else if d.nullish {
-			dot = "??."
+			op = "??."
 		}
-		return vector.NewWrappedError(d.sctx, fmt.Sprintf("'%s': applied to non-record", dot), innerVecs[0])
+		return vector.NewWrappedError(d.sctx, fmt.Sprintf("'%s': applied to non-record", op), innerVecs[0])
 	}
 	out := vector.Apply(vector.ApplyRipFusions|vector.ApplyRipUnions, eval, vec)
 	// If there were any structured errors or none values (e.g., because we hit a none

--- a/runtime/ztests/op/aggregate/count-star.yaml
+++ b/runtime/ztests/op/aggregate/count-star.yaml
@@ -6,4 +6,4 @@ input: |
   {a:null}
 
 output: |
-  {c1:3,c2:3,c3:2}
+  {c1:3,c2:3,c3:1}


### PR DESCRIPTION
This commit improves SQL semantics in the face of missing fields by turning them into nulls and adding a nullish coalescing variant of the . operator to propagate nulls in a path expression.  This operator is inserted by the semantic pass and is not user visible.  It is displayed in DAG output as "??.".

To make this work, we fixed a problem in the optimizer where the flags in field.Chain weren't being propagated.

This also fixed a problem in agg functions like count which are supposed to ignore nulls.  The change to change-star.yaml reflects this, where this test is now has a SQL-compatible result.

Closes #5984