### PR TITLE
ztest to confirm default terminal output formats

### DIFF
--- a/cmd/super/ztests/terminal-output-format.yaml
+++ b/cmd/super/ztests/terminal-output-format.yaml
@@ -1,0 +1,18 @@
+script: |
+  if [ "$(uname -s)" = Darwin ]; then
+    onterm() { script -q -e /dev/null "$@" < /dev/null; }
+  else
+    onterm() { script -q -e -c "$(printf '%q ' "$@")" /dev/null < /dev/null; }
+  fi
+
+  super db -q -db db init
+  super db -q -db db create p1
+
+  onterm super -color=false -c 'values {a:1}'
+  onterm super db -db db -color=false -c 'values {a:1}'
+  onterm super db -db db ls -color=false
+
+outputs:
+  - name: stdout
+    regexp: |
+      (?s)\{a:1\}.*\{a:1\}.*p1 \w{27} key ts order desc.*


### PR DESCRIPTION
As noted in #7289, writing a ztest to confirm the default output formats on a terminal is challenging. But since we regressed in this area in both #7287 and #7075, I asked Claude to come up with a minimally hacky way to cover this, and I've simplified it to what's here. It's not the prettiest since I needed to adapt to some differences in the `script` tool between macOS and Linux and then use regexp to deal with the extra characters that show up in the raw output capture, but I did confirm that the test fails at the commits right before #7287 and #7075.